### PR TITLE
doc: manually add contributors [ci skip]

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -12,5 +12,68 @@
   "wrapperTemplate": "\n<table>\n  <tbody><%= bodyContent %>  </tbody>\n<%= tableFooterContent %></table>\n\n",
   "linkToUsage": true,
   "skipCi": true,
-  "contributors": []
+  "contributors": [
+    {
+      "login": "mormj",
+      "name": "mormj",
+      "avatar_url": "https://avatars.githubusercontent.com/u/34754695?v=4",
+      "profile": "https://github.com/mormj",
+      "contributions": [
+        "design"
+      ]
+    },
+    {
+      "login": "ivan-cukic",
+      "name": "Ivan Čukić",
+      "avatar_url": "https://avatars.githubusercontent.com/u/90119?v=4",
+      "profile": "http://cukic.co",
+      "contributions": [
+        "code",
+        "design",
+        "review"
+      ]
+    },
+    {
+      "login": "mattkretz",
+      "name": "Matthias Kretz",
+      "avatar_url": "https://avatars.githubusercontent.com/u/3306474?v=4",
+      "profile": "https://mattkretz.github.io/",
+      "contributions": [
+        "code",
+        "design",
+        "review"
+      ]
+    },
+    {
+      "login": "wirew0rm",
+      "name": "Alexander Krimm",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1202371?v=4",
+      "profile": "https://github.com/wirew0rm",
+      "contributions": [
+        "code",
+        "design",
+        "review"
+      ]
+    },
+    {
+      "login": "frankosterfeld",
+      "name": "Frank Osterfeld",
+      "avatar_url": "https://avatars.githubusercontent.com/u/483854?v=4",
+      "profile": "https://github.com/frankosterfeld",
+      "contributions": [
+        "code",
+        "design",
+        "review"
+      ]
+    },
+    {
+      "login": "cafeclimber",
+      "name": "Bailey Campbell",
+      "avatar_url": "https://avatars.githubusercontent.com/u/10188900?v=4",
+      "profile": "https://github.com/cafeclimber",
+      "contributions": [
+        "doc"
+      ]
+    }
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 </p>
 
 [![License](https://img.shields.io/badge/License-LGPL%203.0-blue.svg)](https://opensource.org/licenses/LGPL-3.0)
-![CMake](https://github.com/fair-acc/gnuradio4/workflows/CMake/badge.svg)
-[![All Contributors](https://img.shields.io/github/all-contributors/fair-acc/gnuradio4?color=ee8449&style=flat-square)](#contributors)
+![CMake](https://github.com/fair-acc/gnuradio4/workflows/CMake/badge.svg) <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+[![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors-) <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 # GNU Radio 4.0 prototype
 


### PR DESCRIPTION
Manually adds all contributors which were previously added via the all-contributors app, but where the PRs were not automatically rebased. The README should be updated the next time the app will update any contribution.