### PR TITLE
feature: propagate `DONE` to and disconnect from upstream blocks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,7 +212,7 @@ else()
 endif()
 
 set(PYTHON_AVAILABLE OFF)
-if(Python3_FOUND)
+if (Python3_FOUND AND NOT EMSCRIPTEN)
     execute_process(
             COMMAND ${Python3_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/CheckNumPy.py"
             RESULT_VARIABLE NUMPY_NOT_FOUND

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,19 +98,20 @@ if (EMSCRIPTEN)
     )
     add_link_options(
             "SHELL:-s ALLOW_MEMORY_GROWTH=1"
+            "SHELL:-s ASSERTIONS=1"
             "SHELL:-s INITIAL_MEMORY=256MB"
-            "SHELL:-s MAXIMUM_MEMORY=1GB"
-            "SHELL:-s SAFE_HEAP=1"
-            "SHELL:-s ASSERTIONS=2"
-            "SHELL:-s STACK_OVERFLOW_CHECK=2"
-            "SHELL:-g"  # enable debugging information
-            "SHELL:-gsource-map"
-            "SHELL:--profiling-funcs"
-            "SHELL:--emit-symbol-map"
+            # "SHELL:-s SAFE_HEAP=1" # additional for debug
+            # "SHELL:-s ASSERTIONS=2" # additional for debug
+            # "SHELL:-s STACK_OVERFLOW_CHECK=2" # additional for debug
+            # "SHELL:-g" # additional for debug
+            # "SHELL:-gsource-map" # additional for debug
+            # "SHELL:--profiling-funcs" # additional for debug
+            # "SHELL:--emit-symbol-map" # additional for debug
             -fwasm-exceptions
             -pthread
-            "SHELL:-s PTHREAD_POOL_SIZE=30"
+            "SHELL:-s PTHREAD_POOL_SIZE=60"
             "SHELL:-s FETCH=1"
+            "SHELL:-s WASM=1" # output as web-assembly
     )
 endif ()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,14 +94,23 @@ if (EMSCRIPTEN)
     add_compile_options(
         -fwasm-exceptions
         -pthread
+            -g
     )
     add_link_options(
-        "SHELL:-s ALLOW_MEMORY_GROWTH=1"
-        -fwasm-exceptions
-        -pthread
-        "SHELL:-s PTHREAD_POOL_SIZE=30"
-        "SHELL:-s FETCH=1"
-        "SHELL:-s ASSERTIONS=1"
+            "SHELL:-s ALLOW_MEMORY_GROWTH=1"
+            "SHELL:-s INITIAL_MEMORY=256MB"
+            "SHELL:-s MAXIMUM_MEMORY=1GB"
+            "SHELL:-s SAFE_HEAP=1"
+            "SHELL:-s ASSERTIONS=2"
+            "SHELL:-s STACK_OVERFLOW_CHECK=2"
+            "SHELL:-g"  # enable debugging information
+            "SHELL:-gsource-map"
+            "SHELL:--profiling-funcs"
+            "SHELL:--emit-symbol-map"
+            -fwasm-exceptions
+            -pthread
+            "SHELL:-s PTHREAD_POOL_SIZE=30"
+            "SHELL:-s FETCH=1"
     )
 endif ()
 

--- a/blocks/basic/include/gnuradio-4.0/basic/clock_source.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/clock_source.hpp
@@ -138,9 +138,10 @@ public:
 
         if (samplesToNextTag < samplesToNextTimeTag) {
             if (next_tag < tags.size() && samplesToNextTag <= samplesToProduce) {
-                const auto tagDeltaIndex = tags[next_tag].index - static_cast<Tag::signed_index_type>(n_samples_produced); // position w.r.t. start of this chunk
+                const auto signedSamplesProduced = static_cast<Tag::signed_index_type>(n_samples_produced);
+                const auto tagDeltaIndex         = tags[next_tag].index - signedSamplesProduced; // position w.r.t. start of this chunk
                 if (verbose_console) {
-                    gr::testing::print_tag(tags[next_tag], fmt::format("{}::processBulk(...)\t publish tag at  {:6}", this->name, n_samples_produced + tagDeltaIndex));
+                    gr::testing::print_tag(tags[next_tag], fmt::format("{}::processBulk(...)\t publish tag at  {:6}", this->name, signedSamplesProduced + tagDeltaIndex));
                 }
                 out.publishTag(tags[next_tag].map, tagDeltaIndex);
                 samplesToProduce = samplesToNextTag;
@@ -154,7 +155,7 @@ public:
                 if (verbose_console) {
                     fmt::println("{}::processBulk(...)\t publish tag-time at  {:6}, time:{}ns", this->name, samplesToNextTimeTag, tag_times[next_time_tag]);
                 }
-                out.publishTag(metaInfo, samplesToNextTimeTag);
+                out.publishTag(metaInfo, static_cast<Tag::signed_index_type>(samplesToNextTimeTag));
                 samplesToProduce = samplesToNextTimeTag;
                 next_time_tag++;
             }

--- a/blocks/basic/include/gnuradio-4.0/basic/common_blocks.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/common_blocks.hpp
@@ -63,7 +63,7 @@ struct MultiAdder : public gr::Block<MultiAdder<T>> {
     std::vector<gr::PortIn<T>> inputs;
     gr::PortOut<T>             out;
 
-    gr::Annotated<gr::Size_t, "n_inputs", gr::Visible, gr::Doc<"variable number of inputs">, gr::Limits<1U, 32U>> n_inputs = 0U;
+    gr::Annotated<gr::Size_t, "n_inputs", gr::Visible, gr::Doc<"variable number of inputs">, gr::Limits<1U, 32U>> n_inputs{ 0U };
 
     void
     settingsChanged(const gr::property_map &old_settings, const gr::property_map &new_settings) {

--- a/blocks/http/include/gnuradio-4.0/http/HttpBlock.hpp
+++ b/blocks/http/include/gnuradio-4.0/http/HttpBlock.hpp
@@ -255,7 +255,10 @@ public:
                 _type = magic_enum::enum_cast<gr::http::RequestType>(type, magic_enum::case_insensitive).value_or(_type);
             }
             // other setting changes are hot-swappable without restarting the Client
-            startThread();
+            if (_thread) {
+                stopThread();
+                startThread();
+            }
         }
     }
 

--- a/blocks/testing/include/gnuradio-4.0/testing/NullSources.hpp
+++ b/blocks/testing/include/gnuradio-4.0/testing/NullSources.hpp
@@ -1,0 +1,203 @@
+#ifndef GNURADIO_NULLSOURCES_HPP
+#define GNURADIO_NULLSOURCES_HPP
+
+#include <gnuradio-4.0/Block.hpp>
+#include <gnuradio-4.0/BlockRegistry.hpp>
+#include <gnuradio-4.0/DataSet.hpp>
+#include <gnuradio-4.0/reflection.hpp>
+
+namespace gr::testing {
+
+template<typename T>
+struct NullSource : public gr::Block<NullSource<T>> {
+    using Description = Doc<R""(A source block that emits zeros or type-specified default value continuously.
+Used mainly for testing and benchmarking where a consistent and predictable output is essential.
+Ideal for scenarios that require a simple, low-overhead source of consistent values.)"">;
+
+    gr::PortOut<T> out;
+
+    [[nodiscard]] constexpr T
+    processOne() const noexcept {
+        return T{};
+    }
+};
+
+static_assert(gr::BlockLike<NullSource<float>>);
+
+template<typename T>
+struct ConstantSource : public gr::Block<ConstantSource<T>> {
+    using Description = Doc<R""(A source block that emits a constant default value for each output sample.
+This block counts the number of samples emitted and optionally halts after reaching a specified maximum.
+Commonly used for testing and simulations where consistent output and finite execution are required.)"">;
+
+    gr::PortOut<T> out;
+
+    Annotated<T, "default value", Visible, Doc<"default value for each sample">>                  default_value{};
+    Annotated<gr::Size_t, "max samples", Doc<"count>n_samples_max -> signal DONE (0: infinite)">> n_samples_max = 0U;
+    Annotated<gr::Size_t, "count", Doc<"sample count (diagnostics only)">>                        count         = 0U;
+
+    void
+    reset() {
+        count = 0U;
+    }
+
+    [[nodiscard]] constexpr T
+    processOne() noexcept {
+        count++;
+        if (n_samples_max > 0 && count >= n_samples_max) {
+            this->requestStop();
+        }
+        return default_value;
+    }
+};
+
+static_assert(gr::BlockLike<ConstantSource<float>>);
+
+template<typename T>
+    requires(std::is_arithmetic_v<T>)
+struct CountingSource : public gr::Block<CountingSource<T>> {
+    using Description = Doc<R""(A source block that emits an increasing sequence starting from a specified default value.
+This block counts the number of samples emitted and optionally halts after reaching a specified maximum.
+Commonly used for testing and simulations where consistent output and finite execution are required.)"">;
+
+    gr::PortOut<T> out;
+
+    Annotated<T, "default value", Visible, Doc<"default value for each sample">>                  default_value{};
+    Annotated<gr::Size_t, "max samples", Doc<"count>n_samples_max -> signal DONE (0: infinite)">> n_samples_max = 0U;
+    Annotated<gr::Size_t, "count", Doc<"sample count (diagnostics only)">>                        count         = 0U;
+
+    void
+    reset() {
+        count = 0U;
+    }
+
+    [[nodiscard]] constexpr T
+    processOne() noexcept {
+        count++;
+        if (n_samples_max > 0 && count >= n_samples_max) {
+            this->requestStop();
+        }
+        return default_value + T(count);
+    }
+};
+
+static_assert(gr::BlockLike<CountingSource<float>>);
+
+template<typename T>
+struct Copy : public gr::Block<Copy<T>> {
+    using Description = Doc<R""(A block that passes/copies input samples directly to its output without modification.
+Commonly used used to isolate parts of a flowgraph, manage buffer sizes, or simply duplicate the signal path.)"">;
+
+    gr::PortIn<T>  in;
+    gr::PortOut<T> out;
+
+    template<gr::meta::t_or_simd<T> V>
+    [[nodiscard]] constexpr auto
+    processOne(V input) const noexcept {
+        return input;
+    }
+};
+
+static_assert(gr::BlockLike<Copy<float>>);
+
+template<typename T>
+struct HeadBlock : public gr::Block<HeadBlock<T>> { // TODO confirm naming: while known in GR3, the semantic name seems to be odd. (Maybe add an alias?!)
+    using Description = Doc<R""(Limits the number of output samples by copying the first N items from the input to the output and then signaling completion.
+Commonly used to control data flow in systems where precise sample counts are critical, such as in file recording or when executing flow graphs without a GUI.)"">;
+
+    gr::PortIn<T>  in;
+    gr::PortOut<T> out;
+
+    Annotated<gr::Size_t, "max samples", Doc<"count>n_samples_max -> signal DONE (0: infinite)">> n_samples_max = 0U;
+    Annotated<gr::Size_t, "count", Doc<"sample count (diagnostics only)">>                        count         = 0U;
+
+    void
+    reset() {
+        count = 0U;
+    }
+
+    [[nodiscard]] constexpr auto
+    processOne(T input) noexcept {
+        count++;
+        if (n_samples_max > 0 && count >= n_samples_max) {
+            this->requestStop();
+        }
+        return input;
+    }
+};
+
+static_assert(gr::BlockLike<HeadBlock<float>>);
+
+template<typename T>
+struct NullSink : public gr::Block<NullSink<T>> {
+    using Description = Doc<R""(A sink block that consumes and discards all input samples without producing any output.
+Used primarily for absorbing data in a flow graph where output processing is unnecessary.
+Commonly used for testing, performance benchmarking, and in scenarios where signal flow needs to be terminated without external effects.)"">;
+
+    gr::PortIn<T> in;
+
+    template<gr::meta::t_or_simd<T> V>
+    void
+    processOne(V) const noexcept {}
+};
+
+static_assert(gr::BlockLike<NullSink<float>>);
+
+template<typename T>
+struct CountingSink : public gr::Block<CountingSink<T>> {
+    using Description = Doc<R""(A sink block that consumes and discards a fixed number of input samples, after which it signals the flow graph to halt.
+This block is used to control execution in systems requiring precise input processing without data output, similar to how a 'HeadBlock' manages output samples.
+Commonly used for testing scenarios and signal termination where output is unnecessary but precise input count control is needed.)"">;
+
+    gr::PortIn<T> in;
+
+    Annotated<gr::Size_t, "max samples", Doc<"count>n_samples_max -> signal DONE (0: infinite)">> n_samples_max = 0U;
+    Annotated<gr::Size_t, "count", Doc<"sample count (diagnostics only)">>                        count         = 0U;
+
+    void
+    reset() {
+        count = 0U;
+    }
+
+    template<gr::meta::t_or_simd<T> V>
+    void
+    processOne(V) noexcept {
+        if constexpr (stdx::is_simd_v<V>) {
+            count += V::size();
+        } else {
+            count++;
+        }
+        if (n_samples_max > 0 && count >= n_samples_max) {
+            this->requestStop();
+        }
+    }
+};
+
+static_assert(gr::BlockLike<CountingSink<float>>);
+
+} // namespace gr::testing
+
+ENABLE_REFLECTION_FOR_TEMPLATE(gr::testing::NullSource, out);
+ENABLE_REFLECTION_FOR_TEMPLATE(gr::testing::ConstantSource, out, n_samples_max, count);
+ENABLE_REFLECTION_FOR_TEMPLATE(gr::testing::CountingSource, out, n_samples_max, count);
+ENABLE_REFLECTION_FOR_TEMPLATE(gr::testing::Copy, in, out);
+ENABLE_REFLECTION_FOR_TEMPLATE(gr::testing::HeadBlock, in, out, n_samples_max, count);
+ENABLE_REFLECTION_FOR_TEMPLATE(gr::testing::NullSink, in);
+ENABLE_REFLECTION_FOR_TEMPLATE(gr::testing::CountingSink, in, n_samples_max, count);
+
+const inline auto registerNullSources
+        = gr::registerBlock<gr::testing::NullSource, uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, std::complex<float>, std::complex<double>, std::string,
+                            gr::Packet<float>, gr::Packet<double>, gr::Tensor<float>, gr::Tensor<double>, gr::DataSet<float>, gr::DataSet<double>>(gr::globalBlockRegistry())
+        | gr::registerBlock<gr::testing::ConstantSource, uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, std::complex<float>, std::complex<double>,
+                            std::string, gr::Packet<float>, gr::Packet<double>, gr::Tensor<float>, gr::Tensor<double>, gr::DataSet<float>, gr::DataSet<double>>(gr::globalBlockRegistry())
+        | gr::registerBlock<gr::testing::CountingSource, uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double>(gr::globalBlockRegistry())
+        | gr::registerBlock<gr::testing::Copy, uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, std::complex<float>, std::complex<double>, std::string,
+                            gr::Packet<float>, gr::Packet<double>, gr::Tensor<float>, gr::Tensor<double>, gr::DataSet<float>, gr::DataSet<double>>(gr::globalBlockRegistry())
+        | gr::registerBlock<gr::testing::HeadBlock, uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, std::complex<float>, std::complex<double>, std::string,
+                            gr::Packet<float>, gr::Packet<double>, gr::Tensor<float>, gr::Tensor<double>, gr::DataSet<float>, gr::DataSet<double>>(gr::globalBlockRegistry())
+        | gr::registerBlock<gr::testing::NullSink, uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, std::complex<float>, std::complex<double>, std::string,
+                            gr::Packet<float>, gr::Packet<double>, gr::Tensor<float>, gr::Tensor<double>, gr::DataSet<float>, gr::DataSet<double>>(gr::globalBlockRegistry())
+        | gr::registerBlock<gr::testing::CountingSink, uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, std::complex<float>, std::complex<double>, std::string,
+                            gr::Packet<float>, gr::Packet<double>, gr::Tensor<float>, gr::Tensor<double>, gr::DataSet<float>, gr::DataSet<double>>(gr::globalBlockRegistry());
+
+#endif // GNURADIO_NULLSOURCES_HPP

--- a/core/include/gnuradio-4.0/Block.hpp
+++ b/core/include/gnuradio-4.0/Block.hpp
@@ -434,7 +434,8 @@ public:
     A<RatioValue, "denominator", Doc<"Bottom of resampling ratio (<1: Decimate, >1: Interpolate, =1: No change)">, Limits<1UL, std::numeric_limits<RatioValue>::max()>> denominator
             = Resampling::kDenominator;
     using StrideValue = std::conditional_t<StrideControl::kIsConst, const gr::Size_t, gr::Size_t>;
-    A<StrideValue, "stride", Doc<"samples between data processing. <N for overlap, >N for skip, =0 for back-to-back.">> stride = StrideControl::kStride;
+    A<StrideValue, "stride", Doc<"samples between data processing. <N for overlap, >N for skip, =0 for back-to-back.">>                               stride             = StrideControl::kStride;
+    A<bool, "disconnect on done", Doc<"if block has no downstream consumers, it declares itself 'DONE', and severs connections to upstream blocks.">> disconnect_on_done = true;
 
     gr::Size_t strideCounter = 0UL; // leftover stride from previous calls
 
@@ -1423,10 +1424,41 @@ protected:
                 break;
             }
         }
-        if (nOutSamplesBeforeRequestedStop > 0) {
-            return ProcessOneResult{ OK, nOutSamplesBeforeRequestedStop, nOutSamplesBeforeRequestedStop };
+        return ProcessOneResult{ lifecycle::isShuttingDown(this->state()) ? DONE : OK, nSamplesToProcess, std::min(nSamplesToProcess, nOutSamplesBeforeRequestedStop) };
+    }
+
+    [[nodiscard]] bool
+    hasNoDownStreamConnectedChildren() const noexcept {
+        std::size_t nMandatoryChildren          = 0UZ;
+        std::size_t nMandatoryConnectedChildren = 0UZ;
+        for_each_port(
+                [&nMandatoryChildren, &nMandatoryConnectedChildren]<PortLike Port>(const Port &outputPort) {
+                    if constexpr (!Port::isOptional()) {
+                        nMandatoryChildren++;
+                        if (outputPort.isConnected()) {
+                            nMandatoryConnectedChildren++;
+                        }
+                    }
+                },
+                outputPorts<PortType::STREAM>(&self()));
+        return nMandatoryChildren > 0UZ && nMandatoryConnectedChildren == 0UZ;
+    }
+
+    constexpr void
+    disconnectFromUpStreamParents() noexcept {
+        using TInputTypes = traits::block::stream_input_port_types<Derived>;
+        if constexpr (TInputTypes::size.value > 0UZ) {
+            if (!disconnect_on_done) {
+                return;
+            }
+            for_each_port(
+                    []<PortLike Port>(Port &inputPort) {
+                        if (inputPort.isConnected()) {
+                            std::ignore = inputPort.disconnect();
+                        }
+                    },
+                    inputPorts<PortType::STREAM>(&self()));
         }
-        return ProcessOneResult{ OK, nSamplesToProcess, nSamplesToProcess };
     }
 
     void
@@ -1507,7 +1539,15 @@ protected:
             }
         }
 
+        using TOutputTypes = traits::block::stream_output_port_types<Derived>;
+        if constexpr (TOutputTypes::size.value > 0UZ) {
+            if (disconnect_on_done && hasNoDownStreamConnectedChildren()) {
+                this->requestStop(); // no dependent non-optional children, should stop processing
+            }
+        }
+
         if (this->state() == lifecycle::State::STOPPED) {
+            disconnectFromUpStreamParents();
             return { requested_work, 0UZ, work::Status::DONE };
         }
 
@@ -1541,7 +1581,7 @@ protected:
                 updateInputAndOutputTags();
                 applyChangedSettings();
                 forwardTags();
-                return { requested_work, 0UZ, DONE };
+                return { requested_work, 0UZ, work::Status::DONE };
             }
             return { requested_work, 0UZ, resampledOut == 0 ? INSUFFICIENT_OUTPUT_ITEMS : INSUFFICIENT_INPUT_ITEMS };
         }
@@ -1586,8 +1626,9 @@ protected:
                     });
                 } else {                                                 // Non-SIMD loop
                     if constexpr (HasConstProcessOneFunction<Derived>) { // processOne is const -> can process whole batch similar to SIMD-ised call
-                        invokeUserProvidedFunction("invokeProcessOnePure",
-                                                   [&ret, &inputSpans, &outputSpans, &processedIn, this] noexcept(HasNoexceptProcessOneFunction<Derived>) { ret = invokeProcessOnePure(inputSpans, outputSpans, processedIn); });
+                        invokeUserProvidedFunction("invokeProcessOnePure", [&ret, &inputSpans, &outputSpans, &processedIn, this] noexcept(HasNoexceptProcessOneFunction<Derived>) {
+                            ret = invokeProcessOnePure(inputSpans, outputSpans, processedIn);
+                        });
                     } else { // processOne isn't const i.e. not a pure function w/o side effects -> need to evaluate state after each sample
                         const auto result = invokeProcessOneNonConst(inputSpans, outputSpans, processedIn);
                         ret               = result.status;
@@ -1896,7 +1937,7 @@ template<typename Derived, typename... Arguments>
 inline std::atomic_size_t Block<Derived, Arguments...>::_uniqueIdCounter{ 0UZ };
 } // namespace gr
 
-ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T, typename... Arguments), (gr::Block<T, Arguments...>), numerator, denominator, stride, unique_name, name, meta_information);
+ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T, typename... Arguments), (gr::Block<T, Arguments...>), numerator, denominator, stride, disconnect_on_done, unique_name, name, meta_information);
 
 namespace gr {
 

--- a/core/include/gnuradio-4.0/DataSet.hpp
+++ b/core/include/gnuradio-4.0/DataSet.hpp
@@ -65,6 +65,7 @@ concept DataSetLike = TensorLike<T> && requires(T t, const std::size_t n_items) 
 
     // signal data storage
     requires std::is_same_v<decltype(t.signal_names), std::vector<std::string>>;
+    requires std::is_same_v<decltype(t.signal_quantities), std::vector<std::string>>;
     requires std::is_same_v<decltype(t.signal_units), std::vector<std::string>>;
     requires std::is_same_v<decltype(t.signal_values), std::vector<typename T::value_type>>;
     requires std::is_same_v<decltype(t.signal_errors), std::vector<typename T::value_type>>;
@@ -92,11 +93,12 @@ struct DataSet {
     tensor_layout_type        layout{};  // row-major, column-major, “special”
 
     // signal data storage:
-    std::vector<std::string>    signal_names{};  // size = extents[0]
-    std::vector<std::string>    signal_units{};  // size = extents[0]
-    std::vector<T>              signal_values{}; // size = \PI_i extents[i]
-    std::vector<T>              signal_errors{}; // size = \PI_i extents[i] or '0' if not applicable
-    std::vector<std::vector<T>> signal_ranges{}; // [[min_0, max_0], [min_1, max_1], …] used for communicating, for example, HW limits
+    std::vector<std::string>    signal_names{};      // size = extents[0]
+    std::vector<std::string>    signal_quantities{}; // size = extents[0]
+    std::vector<std::string>    signal_units{};      // size = extents[0]
+    std::vector<T>              signal_values{};     // size = \PI_i extents[i]
+    std::vector<T>              signal_errors{};     // size = \PI_i extents[i] or '0' if not applicable
+    std::vector<std::vector<T>> signal_ranges{};     // [[min_0, max_0], [min_1, max_1], …] used for communicating, for example, HW limits
 
     // meta data
     std::vector<pmt_map>          meta_information{};
@@ -144,6 +146,9 @@ static_assert(PacketLike<Packet<double>>, "Packet<std::byte> concept conformity"
 
 } // namespace gr
 
-ENABLE_REFLECTION_FOR_TEMPLATE(gr::DataSet, timestamp, axis_names, axis_units, axis_values, extents, layout, signal_names, signal_units, signal_values, signal_errors, signal_ranges, meta_information,
-                               timing_events)
+ENABLE_REFLECTION_FOR_TEMPLATE(gr::DataSet, timestamp, axis_names, axis_units, axis_values, extents, layout, signal_names, signal_quantities, signal_units, signal_values, signal_errors, signal_ranges,
+                               meta_information, timing_events)
+ENABLE_REFLECTION_FOR_TEMPLATE(gr::Tensor, timestamp, extents, layout, signal_values, signal_errors, meta_information)
+ENABLE_REFLECTION_FOR_TEMPLATE(gr::Packet, timestamp, signal_values, meta_information)
+
 #endif // GNURADIO_DATASET_HPP

--- a/core/include/gnuradio-4.0/Scheduler.hpp
+++ b/core/include/gnuradio-4.0/Scheduler.hpp
@@ -217,6 +217,9 @@ protected:
                 something_happened = true;
             }
         }
+#ifdef __EMSCRIPTEN__
+        std::this_thread::sleep_for(std::chrono::microseconds(10u)); // workaround for incomplete std::atomic implementation (at least it seems for nodejs)
+#endif
         return { requestedWorkAllBlocks, performedWorkAllBlocks, something_happened ? work::Status::OK : work::Status::DONE };
     }
 

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -17,7 +17,7 @@ function(setup_test TEST_NAME)
     if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU") # limited to gcc due to a Ubuntu packaging bug of libc++, see https://github.com/llvm/llvm-project/issues/59432
         target_compile_options(${TEST_NAME} PRIVATE -fsanitize=address) # for testing consider enabling -D_GLIBCXX_DEBUG and -D_GLIBCXX_SANITIZE_VECTOR
         target_link_options(${TEST_NAME} PRIVATE -fsanitize=address) # for testing consider enabling -D_GLIBCXX_DEBUG and -D_GLIBCXX_SANITIZE_VECTOR
-    endif()
+    endif ()
 
     setup_test_no_asan(${TEST_NAME})
 endfunction()

--- a/core/test/qa_Settings.cpp
+++ b/core/test/qa_Settings.cpp
@@ -234,17 +234,17 @@ const boost::ut::suite SettingsTests = [] {
         // define basic Sink->TestBlock->Sink flow graph
         auto &src = testGraph.emplaceBlock<Source<float>>({ { "sample_rate", 42.f }, { "n_samples_max", n_samples } });
         expect(eq(src.n_samples_max, n_samples)) << "check map constructor";
-        expect(eq(src.settings().autoUpdateParameters().size(), 3UL));
+        expect(eq(src.settings().autoUpdateParameters().size(), 4UL));
         expect(eq(src.settings().autoForwardParameters().size(), 1UL)); // sample_rate
         auto &block1 = testGraph.emplaceBlock<TestBlock<float>>({ { "name", "TestBlock#1" } });
         auto &block2 = testGraph.emplaceBlock<TestBlock<float>>({ { "name", "TestBlock#2" } });
         auto &sink   = testGraph.emplaceBlock<Sink<float>>();
-        expect(eq(sink.settings().autoUpdateParameters().size(), 6UL));
+        expect(eq(sink.settings().autoUpdateParameters().size(), 7UL));
         expect(eq(sink.settings().autoForwardParameters().size(), 1UL)); // sample_rate
 
         block1.context = "Test Context";
         block1.settings().updateActiveParameters();
-        expect(eq(block1.settings().autoUpdateParameters().size(), 7UL));
+        expect(eq(block1.settings().autoUpdateParameters().size(), 8UL));
         expect(eq(block1.settings().autoForwardParameters().size(), 2UL));
         // need to add 'n_samples_max' to forwarding list for the block to automatically forward it
         // as the 'n_samples_max' tag is not part of the canonical 'gr::tag::DEFAULT_TAGS' list
@@ -266,7 +266,7 @@ const boost::ut::suite SettingsTests = [] {
         expect(block1.settings().get(keys1).empty());
         expect(block1.settings().get(keys2).empty());
         expect(block1.settings().get(keys3).empty());
-        expect(eq(block1.settings().get().size(), 12UL));
+        expect(eq(block1.settings().get().size(), 13UL));
 
         // set non-existent setting
         expect(not block1.settings().changed()) << "settings not changed";
@@ -341,27 +341,25 @@ const boost::ut::suite SettingsTests = [] {
         "empty"_test = [] {
             auto block = TestBlock<float>();
             block.init(block.progress, block.ioThreadPool); // N.B. self-assign existing progress and thread-pool (just for unit-tests)
-            expect(eq(block.settings().get().size(), 12UL));
+            expect(eq(block.settings().get().size(), 13UL));
             expect(eq(std::get<float>(*block.settings().get("scaling_factor")), 1.f));
         };
 
-#if !defined(__clang_major__) && __clang_major__ <= 15
         "with init parameter"_test = [] {
             auto block = TestBlock<float>({ { "scaling_factor", 2.f } });
             expect(eq(block.settings().stagedParameters().size(), 1u));
             block.init(block.progress, block.ioThreadPool); // N.B. self-assign existing progress and thread-pool (just for unit-tests)
             expect(eq(block.settings().stagedParameters().size(), 0u));
             block.settings().updateActiveParameters();
-            expect(eq(block.settings().get().size(), 12UL));
+            expect(eq(block.settings().get().size(), 13UL));
             expect(eq(block.scaling_factor, 2.f));
             expect(eq(std::get<float>(*block.settings().get("scaling_factor")), 2.f));
         };
-#endif
 
         "empty via graph"_test = [] {
             Graph testGraph;
             auto &block = testGraph.emplaceBlock<TestBlock<float>>();
-            expect(eq(block.settings().get().size(), 12UL));
+            expect(eq(block.settings().get().size(), 13UL));
             expect(eq(block.scaling_factor, 1.f));
             expect(eq(std::get<float>(*block.settings().get("scaling_factor")), 1.f));
         };
@@ -369,7 +367,7 @@ const boost::ut::suite SettingsTests = [] {
         "with init parameter via graph"_test = [] {
             Graph testGraph;
             auto &block = testGraph.emplaceBlock<TestBlock<float>>({ { "scaling_factor", 2.f } });
-            expect(eq(block.settings().get().size(), 12UL));
+            expect(eq(block.settings().get().size(), 13UL));
             expect(eq(block.scaling_factor, 2.f));
             expect(eq(std::get<float>(*block.settings().get("scaling_factor")), 2.f));
         };
@@ -379,7 +377,7 @@ const boost::ut::suite SettingsTests = [] {
         Graph testGraph;
         auto &block = testGraph.emplaceBlock<TestBlock<float>>();
         block.settings().updateActiveParameters();
-        expect(eq(block.settings().get().size(), 12UL));
+        expect(eq(block.settings().get().size(), 13UL));
 
         block.debug    = true;
         const auto val = block.settings().set({ { "vector_setting", std::vector{ 42.f, 2.f, 3.f } }, { "string_vector_setting", std::vector<std::string>{ "A", "B", "C" } } });
@@ -497,7 +495,7 @@ const boost::ut::suite AnnotationTests = [] {
     using namespace std::literals;
 
     "basic node annotations"_test = [] {
-        Graph testGraph;
+        Graph             testGraph;
         TestBlock<float> &block = testGraph.emplaceBlock<TestBlock<float>>();
         expect(gr::blockDescription<TestBlock<float>>().find(std::string_view(TestBlock<float>::Description::value)) != std::string_view::npos);
         expect(eq(std::get<std::string>(block.meta_information.value.at("description")), std::string(TestBlock<float>::Description::value))) << "type-erased block description";
@@ -659,5 +657,4 @@ connections:
 };
 
 int
-main() { /* tests are statically executed */
-}
+main() { /* tests are statically executed */ }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,7 @@ ENV JAVA_HOME=/opt/java/openjdk \
     LC_ALL=en_US.UTF-8 \
     CMAKE_MAKE_PROGRAM=ninja \
     EMSDK_HOME=/opt/emsdk \
-    EMSDK_VERSION=3.1.44
+    EMSDK_VERSION=3.1.52
 
 # Install compilers, package managers and build-tools
 # As we are using the the ubuntu prerelease llvm and cmake are fresh enough, readd these if the version is not sufficient anymore

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,7 @@ ENV JAVA_HOME=/opt/java/openjdk \
     LC_ALL=en_US.UTF-8 \
     CMAKE_MAKE_PROGRAM=ninja \
     EMSDK_HOME=/opt/emsdk \
-    EMSDK_VERSION=3.1.52
+    EMSDK_VERSION=3.1.56
 
 # Install compilers, package managers and build-tools
 # As we are using the the ubuntu prerelease llvm and cmake are fresh enough, readd these if the version is not sufficient anymore


### PR DESCRIPTION
  1. When a block detects that it is no longer required (i.e., it has no downstream consumers), this feature ensures that the block declares itself 'DONE' and severs connections to upstream blocks. This feature is controlled by the Block<T>::disconnect_on_done parameter (default: true)

  2. added `buffer().n_writers()` interface tracking the number of writers and when a buffer and/or two or more ports are not connected anymore. Makes the first item simpler/cleaner.

  3. added some documented default blocks in-line with GR3: NullSource, NullSink, Copy, HeadBlock, CountingSource, CountingSink -- naming of the 'HeadBlock' -- while ubiquitously used in GR3 -- should be discussed with the architecture team because of semantics.