### PR TITLE
compile-time improvements - for_each std::tuple -> std::array

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
             cxx: g++-14
           - cc: clang-18,
             cxx: clang++-18
-            cmake_flags: "-DCMAKE_LINKER=/usr/bin/clang-17"
+            cmake_flags: "-DCMAKE_LINKER=/usr/bin/clang-18"
           - cmake_wrapper: emcmake
             cc: emcc
             cmake_flags: "-DENABLE_COVERAGE=OFF -DCMAKE_CROSSCOMPILING_EMULATOR=${SYSTEM_NODE}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,17 @@ if (NOT DEFINED GR_TOPLEVEL_PROJECT)
     endif ()
 endif ()
 
+# Use ccache if found and enabled
+find_program(CCACHE_PROGRAM ccache)
+option(USE_CCACHE "Use ccache if available" ON)
+if (CCACHE_PROGRAM AND USE_CCACHE)
+    message(STATUS "ccache found and will be used")
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK "${CCACHE_PROGRAM}")
+else ()
+    message(STATUS "ccache will not be used")
+endif ()
+
 set(CMAKE_EXT_DEP_WARNING_GUARD "")
 if(DISABLE_EXTERNAL_DEPS_WARNINGS) # enable warnings for external dependencies
     set(CMAKE_EXT_DEP_WARNING_GUARD SYSTEM)
@@ -64,8 +75,8 @@ endif()
 string(REPLACE ";" " " ALL_COMPILER_FLAGS "${ALL_COMPILER_FLAGS}")
 
 if(CMAKE_CXX_COMPILER_ID MATCHES ".*Clang") # set default C++ STL to Clang's libc++ when using Clang
-    add_compile_options(-stdlib=libc++ -fcolor-diagnostics)
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++ -lc++")
+    add_compile_options(-stdlib=libc++ -fcolor-diagnostics -ftime-trace)
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++ -lc++ -ftime-trace")
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     add_compile_options(-fdiagnostics-color=always)
 endif()

--- a/ClangBuildAnalyzer.ini
+++ b/ClangBuildAnalyzer.ini
@@ -1,0 +1,35 @@
+# ClangBuildAnalyzer reads ClangBuildAnalyzer.ini file from the working directory
+# when invoked, and various aspects of reporting can be configured this way.
+# This file example is setup to be exactly like what the defaults are.
+
+# How many of most expensive things are reported?
+[counts]
+
+# files that took most time to parse
+fileParse = 10
+# files that took most time to generate code for
+fileCodegen = 10
+# functions that took most time to generate code for
+function = 30
+# header files that were most expensive to include
+header = 10
+# for each expensive header, this many include paths to it are shown
+headerChain = 5
+# templates that took longest to instantiate
+template = 30
+
+
+# Minimum times (in ms) for things to be recorded into trace
+[minTimes]
+
+# parse/codegen for a file
+file = 20
+
+[misc]
+
+# Maximum length of symbol names printed; longer names will get truncated
+maxNameLength = 1000 
+
+# Only print "root" headers in expensive header report, i.e.
+# only headers that are directly included by at least one source file
+onlyRootHeaders = true

--- a/core/include/gnuradio-4.0/Settings.hpp
+++ b/core/include/gnuradio-4.0/Settings.hpp
@@ -306,15 +306,11 @@ public:
                     _block->meta_information.value[memberName + "::visible"]       = RawType::visible();
                 }
 
-                // detect whether field has one of the DEFAULT_TAGS signature
+                // detect whether field has one of the kDefaultTags signature
                 if constexpr (traits::port::is_not_any_port_or_collection<Type> && !std::is_const_v<Type> && is_writable(member) && settings::isSupportedType<Type>()) {
-                    meta::tuple_for_each(
-                            [&memberName, this](auto &&default_tag) {
-                                if (default_tag.shortKey() == memberName) {
-                                    _auto_forward.emplace(memberName);
-                                }
-                            },
-                            gr::tag::DEFAULT_TAGS);
+                    if constexpr (std::ranges::find(gr::tag::kDefaultTags, std::string_view(get_display_name_const(member).c_str())) != gr::tag::kDefaultTags.cend()) {
+                        _auto_forward.emplace(memberName);
+                    }
                     _auto_update.emplace(memberName);
                 }
             };

--- a/core/include/gnuradio-4.0/Tag.hpp
+++ b/core/include/gnuradio-4.0/Tag.hpp
@@ -46,10 +46,10 @@ namespace gr {
  * ```
  */
 enum class TagPropagationPolicy {
-    TPP_DONT = 0,       /*!< Scheduler doesn't propagate tags from in- to output. The block itself is free to insert tags. */
+    TPP_DONT       = 0, /*!< Scheduler doesn't propagate tags from in- to output. The block itself is free to insert tags. */
     TPP_ALL_TO_ALL = 1, /*!< Propagate tags from all in- to all outputs. The scheduler takes care of that. */
     TPP_ONE_TO_ONE = 2, /*!< Propagate tags from n. input to n. output. Requires same number of in- and outputs */
-    TPP_CUSTOM = 3      /*!< Like TPP_DONT, but signals the block it should implement application-specific forwarding behaviour. */
+    TPP_CUSTOM     = 3  /*!< Like TPP_DONT, but signals the block it should implement application-specific forwarding behaviour. */
 };
 
 using property_map = pmtv::map_t;
@@ -246,8 +246,9 @@ inline EM_CONSTEXPR_STATIC DefaultTag<"reset_default", bool, "", "reset block st
 inline EM_CONSTEXPR_STATIC DefaultTag<"store_default", bool, "", "store block settings as default"> STORE_DEFAULTS;
 inline EM_CONSTEXPR_STATIC DefaultTag<"end_of_stream", bool, "", "end of stream, receiver should change to DONE state"> END_OF_STREAM;
 
-inline constexpr std::tuple DEFAULT_TAGS = { SAMPLE_RATE,    SIGNAL_NAME,       SIGNAL_UNIT, SIGNAL_MIN,     SIGNAL_MAX,     TRIGGER_NAME, TRIGGER_TIME,
-                                             TRIGGER_OFFSET, TRIGGER_META_INFO, CONTEXT,     RESET_DEFAULTS, STORE_DEFAULTS, END_OF_STREAM };
+inline constexpr std::array<std::string_view, 14> kDefaultTags = { "sample_rate",  "signal_name",    "signal_quantity",   "signal_unit", "signal_min",    "signal_max",    "trigger_name",
+                                                                   "trigger_time", "trigger_offset", "trigger_meta_info", "context",     "reset_default", "store_default", "end_of_stream" };
+
 } // namespace tag
 
 } // namespace gr

--- a/core/include/gnuradio-4.0/Transactions.hpp
+++ b/core/include/gnuradio-4.0/Transactions.hpp
@@ -84,15 +84,11 @@ public:
                     _block->meta_information.value[memberName + "::visible"]       = RawType::visible();
                 }
 
-                // detect whether field has one of the DEFAULT_TAGS signature
+                // detect whether field has one of the kDefaultTags signature
                 if constexpr (traits::port::is_not_any_port_or_collection<Type> && !std::is_const_v<Type> && is_writable(member) && settings::isSupportedType<Type>()) {
-                    meta::tuple_for_each(
-                            [&memberName, this](auto &&default_tag) {
-                                if (default_tag.shortKey() == memberName) {
-                                    _auto_forward.emplace(memberName);
-                                }
-                            },
-                            gr::tag::DEFAULT_TAGS);
+                    if constexpr (std::ranges::find(gr::tag::kDefaultTags, std::string_view(get_display_name_const(member).c_str())) != gr::tag::kDefaultTags.cend()) {
+                        _auto_forward.emplace(memberName);
+                    }
                     _auto_update.emplace(memberName);
                 }
             };

--- a/core/test/qa_Settings.cpp
+++ b/core/test/qa_Settings.cpp
@@ -247,7 +247,7 @@ const boost::ut::suite SettingsTests = [] {
         expect(eq(block1.settings().autoUpdateParameters().size(), 8UL));
         expect(eq(block1.settings().autoForwardParameters().size(), 2UL));
         // need to add 'n_samples_max' to forwarding list for the block to automatically forward it
-        // as the 'n_samples_max' tag is not part of the canonical 'gr::tag::DEFAULT_TAGS' list
+        // as the 'n_samples_max' tag is not part of the canonical 'gr::tag::kDefaultTags' list
         block1.settings().autoForwardParameters().emplace("n_samples_max");
         expect(eq(block1.settings().autoForwardParameters().size(), 3UL));
         // same check for block2


### PR DESCRIPTION
  * eliminated looping over a tuple and for_each (expensive to instantiate) and to use a straight `std::array<std::string_view, ...> kDefaultTags` instead. The latter can also be evaluated during compile-time.
  * added ccache support (can be disabled) which should help for local development that needs to switch between branches.
  
Comparative timings for the qa_Scheduler unit-tests:

Before (full parallel build):
```text
real    8m43.031s
user    51m13.146s
sys     2m13.891s
```
ClangBuildAnalyzer output for `qa_scheduler` [before](https://github.com/fair-acc/gnuradio4/files/15384756/qa_scheduler_analysis_before.txt)


After:
```text
real    6m52.364s
user    42m5.309s
sys     1m41.661s
```
ClangBuildAnalyzer output for `qa_scheduler`  [after](https://github.com/fair-acc/gnuradio4/files/15384765/qa_scheduler_analysis_after.txt)

Visualisation of the remaining traces:
![image](https://github.com/fair-acc/gnuradio4/assets/46007894/5994cc9b-6f9c-4708-b3f4-19056d8fcc8d)

  * remaining compile-time hot spots:
     * `BlockRegistry.hpp:25:16`: lambda to instantiate each block for a given stream type
     * `Graph.hpp:323:31`: nested lambdas in `BlockWrapper::createDynamicPortsLoader()`
     * `fmt::format_to ... rva::variant<...>...`: pmt-related printouts
  * some preliminary findings:
     * clang performs 2x better than gcc w.r.t. compile-times but produces similar (the same) asm output
     * (especially recursive) lambdas seem to be more compile-time expensive than free-standing functions/methods
     * looping over `std::array` is cheaper as over `std::tuple` (where applicable).
     * initial pre-compiled headers do not seem to have a large positive effect (at least on the chosen unit-test)
     
### Some thoughts, ideas, and next steps:
 
 * [ ] simplify `BlockRegistry` and `BlockWrapper` to only support minimal API (notably constructors)
 * [ ] test roll-out `<gnuradio-4.0/core.hpp>` PCH -> goal: one include dependency for blocklib developer
 * [ ] use `__attribute__((noinline))` to prevent non-performance critical code being inlined/optimised on global scope
 * [ ] roll out at least three additional pipe-lines for: `-fsanitize=address`, `-fsanitize=undefined`, `-fsanitize=thread` (combine where possible)
 * [ ] centrally suppress plugin system for local/non-runtime builds (e.g. for unit-tests, static/compile-time graphs) ... tbd.
 * ...
 
raw `-ftime-trace` traces:
[qa_Scheduler.cpp.before.json.zip](https://github.com/fair-acc/gnuradio4/files/15384968/qa_Scheduler.cpp.before.json.zip)
[qa_Scheduler.cpp.after.json.zip](https://github.com/fair-acc/gnuradio4/files/15384969/qa_Scheduler.cpp.after.json.zip)
