### PR TITLE
Implement CtxSettings, use instead of BasicSettings.

### DIFF
--- a/core/include/gnuradio-4.0/Block.hpp
+++ b/core/include/gnuradio-4.0/Block.hpp
@@ -21,6 +21,7 @@
 #include <gnuradio-4.0/annotated.hpp> // This needs to be included after fmt/format.h, as it defines formatters only if FMT_FORMAT_H_ is defined
 #include <gnuradio-4.0/reflection.hpp>
 #include <gnuradio-4.0/Settings.hpp>
+#include <gnuradio-4.0/Transactions.hpp>
 
 #include <gnuradio-4.0/LifeCycle.hpp>
 
@@ -496,7 +497,7 @@ protected:
     Tag  _mergedInputTag{};
 
     // intermediate non-real-time<->real-time setting states
-    std::unique_ptr<SettingsBase> _settings = std::make_unique<BasicSettings<Derived>>(self());
+    std::unique_ptr<SettingsBase> _settings = std::make_unique<CtxSettings<Derived>>(self());
 
     [[nodiscard]] constexpr auto &
     self() noexcept {
@@ -530,7 +531,7 @@ public:
     Block() noexcept(false) : Block({}) {} // N.B. throws in case of on contract violations
 
     Block(std::initializer_list<std::pair<const std::string, pmtv::pmt>> init_parameter) noexcept(false) // N.B. throws in case of on contract violations
-        : _settings(std::make_unique<BasicSettings<Derived>>(*static_cast<Derived *>(this))) {           // N.B. safe delegated use of this (i.e. not used during construction)
+        : _settings(std::make_unique<CtxSettings<Derived>>(*static_cast<Derived *>(this))) {             // N.B. safe delegated use of this (i.e. not used during construction)
 
         // check Block<T> contracts
         checkBlockContracts<decltype(*static_cast<Derived *>(this))>();
@@ -907,7 +908,7 @@ public:
                 inputPorts<PortType::STREAM>(&self()));
 
         if (!mergedInputTag().map.empty()) {
-            settings().autoUpdate(mergedInputTag().map); // apply tags as new settings if matching
+            settings().autoUpdate(mergedInputTag()); // apply tags as new settings if matching
             if constexpr (Derived::tag_policy == TagPropagationPolicy::TPP_ALL_TO_ALL) {
                 for_each_port([this](PortLike auto &outPort) noexcept { outPort.publishTag(mergedInputTag().map, 0); }, outputPorts<PortType::STREAM>(&self()));
             }

--- a/core/include/gnuradio-4.0/Graph_yaml_importer.hpp
+++ b/core/include/gnuradio-4.0/Graph_yaml_importer.hpp
@@ -180,7 +180,7 @@ load_grc(PluginLoader &loader, const std::string &yaml_source) {
                     // clang-format on
 
                 } else {
-                    const auto &value                   = kv.second.as<std::string>();
+                    const auto &value                    = kv.second.as<std::string>();
                     currentBlock->metaInformation()[key] = value;
                 }
             }

--- a/core/include/gnuradio-4.0/Transactions.hpp
+++ b/core/include/gnuradio-4.0/Transactions.hpp
@@ -42,20 +42,46 @@ class CtxSettings : public SettingsBase {
      * The predicate will be called until it returns "true" (a match is found), or until it returns std::nullopt,
      * which indicates that no matches were found and there is no chance of matching anything in a further round.
      */
-    using MatchPredicate = std::function<std::optional<bool>(const property_map &, const property_map &, std::size_t)>;
+    using MatchPredicate = std::function<std::optional<bool>(const pmtv::pmt &, const pmtv::pmt &, std::size_t)>;
 
-    TBlock                                       *_block = nullptr;
-    mutable std::mutex                            _lock{};
-    property_map                                  _active{};
-    property_map                                  _staged{};
-    std::set<std::string, std::less<>>            _auto_update{};
-    std::set<std::string, std::less<>>            _auto_forward{};
-    std::unordered_map<SettingsCtx, property_map> _settings{};
-    property_map                                  _default_settings{};
-    MatchPredicate                                _match_pred = nullMatchPred;
+    // pmtv::pmt comparison is needed to use it as a key of std::map
+    struct PMTCompare {
+        bool
+        operator()(const pmtv::pmt &lhs, const pmtv::pmt &rhs) const {
+            // If the types are different, cast rhs to the type of lhs and compare
+            if (lhs.index() != rhs.index()) {
+                // TODO: throw if types are not the same?
+                return lhs.index() < rhs.index();
+            } else {
+                return std::visit(
+                        [&](const auto &left) -> bool {
+                            using T = std::decay_t<decltype(left)>;
+                            if constexpr ((pmtv::String<T> || pmtv::Scalar<T>) && !pmtv::Complex<T>) {
+                                return left < std::get<T>(rhs);
+                            } else {
+                                throw gr::exception("Invalid CtxSettings context type " + std::string(typeid(T).name()));
+                            }
+                            return false;
+                        },
+                        lhs);
+            }
+        }
+    };
+
+    TBlock            *_block = nullptr;
+    mutable std::mutex _lock{};
+    property_map       _activeParameters{};
+    // key is SettingsCtx.context, value: queue of parameters with the same SettingsCtx.context but for different time
+    mutable std::map<pmtv::pmt, std::vector<std::pair<SettingsCtx, property_map>>, PMTCompare> _storedParameters{};
+    property_map                                                                               _defaultParameters{};
+    std::set<std::string, std::less<>>                                                         _allWritableMembers{};   // all `isWritableMember` class members
+    std::map<pmtv::pmt, std::set<std::string, std::less<>>, PMTCompare>                        _autoUpdateParameters{}; // for each SettingsCtx.context auto updated members are store separately
+    std::set<std::string, std::less<>>                                                         _autoForwardParameters{};
+    MatchPredicate                                                                             _matchPred = nullMatchPred;
+    pmtv::pmt                                                                                  _activeCtx = "";
 
 public:
-    explicit CtxSettings(TBlock &block, MatchPredicate matchPred = nullMatchPred) noexcept : SettingsBase(), _block(&block), _match_pred(matchPred) {
+    explicit CtxSettings(TBlock &block, MatchPredicate matchPred = nullMatchPred) noexcept : SettingsBase(), _block(&block), _matchPred(matchPred) {
         if constexpr (requires { &TBlock::settingsChanged; }) { // if settingsChanged is defined
             static_assert(HasSettingsChangedCallback<TBlock>, "if provided, settingsChanged must have either a `(const property_map& old, property_map& new, property_map& fwd)`"
                                                               "or `(const property_map& old, property_map& new)` paremeter signatures.");
@@ -72,7 +98,13 @@ public:
                 } -> std::same_as<property_map>;
             };
 
-            auto iterate_over_member = [&](auto member) {
+            if constexpr (hasMetaInfo && requires(TBlock t) { t.description; }) {
+                static_assert(std::is_same_v<std::remove_cvref_t<unwrap_if_wrapped_t<decltype(TBlock::description)>>, std::string_view>);
+                _block->meta_information.value["description"] = std::string(_block->description);
+            }
+
+            // handle meta-information for UI and other non-processing-related purposes
+            auto processOneMember = [&](auto member) {
                 using RawType         = std::remove_cvref_t<decltype(member(*_block))>;
                 using Type            = unwrap_if_wrapped_t<RawType>;
                 const auto memberName = std::string(get_display_name(member));
@@ -84,16 +116,17 @@ public:
                     _block->meta_information.value[memberName + "::visible"]       = RawType::visible();
                 }
 
-                // detect whether field has one of the kDefaultTags signature
-                if constexpr (traits::port::is_not_any_port_or_collection<Type> && !std::is_const_v<Type> && is_writable(member) && settings::isSupportedType<Type>()) {
+                // detect whether field has one of the DEFAULT_TAGS signature
+                if constexpr (settings::isWritableMember<Type>(member)) {
                     if constexpr (std::ranges::find(gr::tag::kDefaultTags, std::string_view(get_display_name_const(member).c_str())) != gr::tag::kDefaultTags.cend()) {
-                        _auto_forward.emplace(memberName);
+                        _autoForwardParameters.emplace(memberName);
                     }
-                    _auto_update.emplace(memberName);
+                    _allWritableMembers.emplace(memberName);
                 }
             };
-            processMembers<TBlock>(iterate_over_member);
+            processMembers<TBlock>(processOneMember);
         }
+        addStoredParameters(property_map(), SettingsCtx(0ULL, ""));
     }
 
     constexpr CtxSettings(const CtxSettings &other) noexcept : SettingsBase(other) {
@@ -127,12 +160,14 @@ public:
         SettingsBase::swap(other);
         std::swap(_block, other._block);
         std::scoped_lock lock(_lock, other._lock);
-        std::swap(_active, other._active);
-        std::swap(_staged, other._staged);
-        std::swap(_settings, other._settings);
-        std::swap(_auto_update, other._auto_update);
-        std::swap(_auto_forward, other._auto_forward);
-        std::swap(_match_pred, other._match_pred);
+        std::swap(_activeParameters, other._activeParameters);
+        std::swap(_storedParameters, other._storedParameters);
+        std::swap(_defaultParameters, other._defaultParameters);
+        std::swap(_allWritableMembers, other._allWritableMembers);
+        std::swap(_autoUpdateParameters, other._autoUpdateParameters);
+        std::swap(_autoForwardParameters, other._autoForwardParameters);
+        std::swap(_matchPred, other._matchPred);
+        std::swap(_activeCtx, other._activeCtx);
     }
 
     [[nodiscard]] property_map
@@ -140,19 +175,27 @@ public:
         property_map ret;
         if constexpr (refl::is_reflectable<TBlock>()) {
             std::lock_guard lg(_lock);
+            if (ctx.time == 0ULL) {
+                ctx.time = settings::convertTimePointToUint64Ns(std::chrono::system_clock::now());
+            }
+            property_map newParameters = getBestMatchStoredParameters(ctx);
+            if (_autoUpdateParameters.find(ctx.context) == _autoUpdateParameters.end()) {
+                _autoUpdateParameters[ctx.context] = _allWritableMembers;
+            }
+
             for (const auto &[key, value] : parameters) {
-                bool is_set              = false;
-                auto iterate_over_member = [&, this](auto member) {
+                bool isSet            = false;
+                auto processOneMember = [&, this](auto member) {
                     using Type = unwrap_if_wrapped_t<std::remove_cvref_t<decltype(member(*_block))>>;
-                    if constexpr (traits::port::is_not_any_port_or_collection<Type> && !std::is_const_v<Type> && is_writable(member) && settings::isSupportedType<Type>()) {
+                    if constexpr (settings::isWritableMember<Type>(member)) {
                         const auto fieldName = std::string_view(get_display_name(member));
                         if (fieldName == key && std::holds_alternative<Type>(value)) {
-                            if (_auto_update.contains(key)) {
-                                _auto_update.erase(key);
+                            if (_autoUpdateParameters[ctx.context].contains(key)) {
+                                _autoUpdateParameters[ctx.context].erase(key);
                             }
-                            //_staged.insert_or_assign(key, value);
+                            newParameters.insert_or_assign(key, value);
                             SettingsBase::_changed.store(true);
-                            is_set = true;
+                            isSet = true;
                         }
                         if (fieldName == key && !std::holds_alternative<Type>(value)) {
                             throw std::invalid_argument([&key, &value] { // lazy evaluation
@@ -164,37 +207,36 @@ public:
                         }
                     }
                 };
-                processMembers<TBlock>(iterate_over_member);
-                if (!is_set) {
+                processMembers<TBlock>(processOneMember);
+                if (!isSet) {
                     ret.insert_or_assign(key, pmtv::pmt(value));
                 }
             }
+            addStoredParameters(newParameters, ctx);
         }
 
         // copy items that could not be matched to the node's meta_information map (if available)
         if constexpr (requires(TBlock t) {
                           {
-                              unwrap_if_wrapped_t<decltype(t.metaInformation)> {}
+                              unwrap_if_wrapped_t<decltype(t.meta_information)> {}
                           } -> std::same_as<property_map>;
                       }) {
-            updateMaps(ret, _block->metaInformation);
+            updateMaps(ret, _block->meta_information);
         }
-
-        _settings[ctx] = parameters;
-        _settings[{}]  = parameters;
 
         return ret; // N.B. returns those <key:value> parameters that could not be set
     }
 
     void
     storeDefaults() override {
-        this->storeDefaultSettings(_default_settings);
+        this->storeDefaultSettings(_defaultParameters);
     }
 
     void
     resetDefaults() override {
-        _settings.clear();
-        _staged     = _default_settings;
+        _storedParameters.clear();
+        _autoUpdateParameters.clear();
+        addStoredParameters(_defaultParameters, SettingsCtx(settings::convertTimePointToUint64Ns(std::chrono::system_clock::now()), ""));
         std::ignore = applyStagedParameters();
         if constexpr (HasSettingsResetCallback<TBlock>) {
             _block->reset();
@@ -202,75 +244,110 @@ public:
     }
 
     void
-    autoUpdate(const property_map &parameters, SettingsCtx = {}) override {
+    autoUpdate(const Tag &tag) override {
         if constexpr (refl::is_reflectable<TBlock>()) {
+            SettingsCtx ctx = createSettingsCtxFromTag(tag);
+
+            const auto bestMatchCtx = findBestMatchCtx(ctx.context);
+            // if no best match context is found just ignore and return
+            if (bestMatchCtx == std::nullopt) {
+                return;
+            }
+            const auto &autoUpdateParameters = _autoUpdateParameters.find(bestMatchCtx.value());
+            if (autoUpdateParameters == _autoUpdateParameters.end()) {
+                return;
+            }
+
+            property_map        newParameters = getBestMatchStoredParameters(ctx);
+            const property_map &parameters    = tag.map;
             for (const auto &[key, value] : parameters) {
-                auto iterate_over_member = [&](auto member) {
+                auto processOneMember = [&](auto member) {
                     using Type = unwrap_if_wrapped_t<std::remove_cvref_t<decltype(member(*_block))>>;
-                    if constexpr (traits::port::is_not_any_port_or_collection<Type> && !std::is_const_v<Type> && is_writable(member) && settings::isSupportedType<Type>()) {
-                        if (_auto_update.contains(key) && std::string(get_display_name(member)) == key && std::holds_alternative<Type>(value)) {
-                            _staged.insert_or_assign(key, value);
+                    if constexpr (settings::isWritableMember<Type>(member)) {
+                        if (autoUpdateParameters->second.contains(key) && std::string(get_display_name(member)) == key && std::holds_alternative<Type>(value)) {
+                            newParameters.insert_or_assign(key, value);
                             SettingsBase::_changed.store(true);
                         }
                     }
                 };
-                processMembers<TBlock>(iterate_over_member);
+                processMembers<TBlock>(processOneMember);
             }
+            addStoredParameters(newParameters, SettingsCtx(ctx.time, bestMatchCtx.value()));
+            _activeCtx = bestMatchCtx.value();
         }
     }
 
     [[nodiscard]] const property_map
-    stagedParameters() const noexcept override {
+    stagedParameters(SettingsCtx ctx = {}) const noexcept override {
         std::lock_guard lg(_lock);
-        return _staged;
+        return hasStoredParameters(ctx) ? getBestMatchStoredParameters(ctx) : property_map();
     }
 
     [[nodiscard]] property_map
-    get(std::span<const std::string> parameter_keys = {}, SettingsCtx ctx = {}) const noexcept override {
+    get(std::span<const std::string> parameterKeys = {}) const noexcept override {
         std::lock_guard lg(_lock);
-        property_map    ret;
-
-        if (_settings.empty()) {
-            return ret;
+        if (parameterKeys.empty()) {
+            return _activeParameters;
         }
-
-        if (_settings.contains(ctx)) {
-            // is there an exact match?
-            const auto &exact_match = _settings.at(ctx);
-            ret                     = exact_match;
-        } else {
-            // try the match predicate instead
-            const auto &match = bestMatch(ctx.context);
-            ret               = match.value_or(ret);
+        property_map ret;
+        for (const auto &key : parameterKeys) {
+            if (_activeParameters.contains(key)) {
+                ret.insert_or_assign(key, _activeParameters.at(key));
+            }
         }
-
-        // return only the needed values
-        std::ignore = std::erase_if(ret, [&](const auto &i) { return std::find(parameter_keys.begin(), parameter_keys.end(), i.first) == parameter_keys.end(); });
         return ret;
     }
 
     [[nodiscard]] std::optional<pmtv::pmt>
-    get(const std::string &parameter_key, SettingsCtx ctx = {}) const noexcept override {
-        auto res = get(std::array<std::string, 1>({ parameter_key }), ctx);
-        if (res.contains(parameter_key)) {
-            return res.at(parameter_key);
+    get(const std::string &parameterKey) const noexcept override {
+        auto res = get(std::array<std::string, 1>({ parameterKey }));
+        if (res.contains(parameterKey)) {
+            return res.at(parameterKey);
         } else {
             return std::nullopt;
         }
     }
 
-    [[nodiscard]] std::set<std::string, std::less<>> &
-    autoUpdateParameters() noexcept override {
-        return _auto_update;
+    [[nodiscard]] property_map
+    getStored(std::span<const std::string> parameterKeys = {}, SettingsCtx ctx = {}) const noexcept override {
+        std::lock_guard     lg(_lock);
+        const property_map &allBestMatchParameters = this->getBestMatchStoredParameters(ctx);
+
+        if (parameterKeys.empty()) {
+            return allBestMatchParameters;
+        }
+        property_map ret;
+        for (const auto &key : parameterKeys) {
+            if (allBestMatchParameters.contains(key)) {
+                ret.insert_or_assign(key, allBestMatchParameters.at(key));
+            }
+        }
+        return ret;
+    }
+
+    [[nodiscard]] std::optional<pmtv::pmt>
+    getStored(const std::string &parameterKey, SettingsCtx ctx = {}) const noexcept override {
+        auto res = getStored(std::array<std::string, 1>({ parameterKey }), ctx);
+        if (res.contains(parameterKey)) {
+            return res.at(parameterKey);
+        } else {
+            return std::nullopt;
+        }
+    }
+
+    [[nodiscard]] std::set<std::string, std::less<>>
+    autoUpdateParameters(SettingsCtx ctx = {}) noexcept override {
+        auto bestMatchCtx = findBestMatchCtx(ctx.context);
+        return bestMatchCtx == std::nullopt ? std::set<std::string, std::less<>>() : _autoUpdateParameters[bestMatchCtx.value()];
     }
 
     [[nodiscard]] std::set<std::string, std::less<>> &
     autoForwardParameters() noexcept override {
-        return _auto_forward;
+        return _autoForwardParameters;
     }
 
     [[nodiscard]] ApplyStagedParametersResult
-    applyStagedParameters() noexcept override {
+    applyStagedParameters(std::uint64_t currentTime = 0ULL) noexcept override {
         ApplyStagedParametersResult result;
         if constexpr (refl::is_reflectable<TBlock>()) {
             std::lock_guard lg(_lock);
@@ -281,26 +358,26 @@ public:
                 storeDefaultSettings(oldSettings);
             }
 
+            const SettingsCtx  activeSettingsCtx{ currentTime, _activeCtx };
+            const property_map bestMatchParameters = getBestMatchStoredParameters(activeSettingsCtx);
+
             // check if reset of settings should be performed
-            if (_staged.contains(gr::tag::RESET_DEFAULTS)) {
-                _staged.clear();
+            if (bestMatchParameters.contains(gr::tag::RESET_DEFAULTS)) {
                 resetDefaults();
             }
 
             // update staged and forward parameters based on member properties
             property_map staged;
-            for (const auto &[localKey, localStaged_value] : _staged) {
-                const auto &key                  = localKey;
-                const auto &staged_value         = localStaged_value;
-                auto        apply_member_changes = [&key, &staged, &result, &staged_value, this](auto member) {
+            for (const auto &[key, stagedValue] : bestMatchParameters) {
+                auto applyOneMemberChanges = [&key, &staged, &result, &stagedValue, this](auto member) {
                     using RawType = std::remove_cvref_t<decltype(member(*_block))>;
                     using Type    = unwrap_if_wrapped_t<RawType>;
-                    if constexpr (traits::port::is_not_any_port_or_collection<Type> && !std::is_const_v<Type> && is_writable(member) && settings::isSupportedType<Type>()) {
-                        if (std::string(get_display_name(member)) == key && std::holds_alternative<Type>(staged_value)) {
+                    if constexpr (settings::isWritableMember<Type>(member)) {
+                        if (std::string(get_display_name(member)) == key && std::holds_alternative<Type>(stagedValue)) {
                             if constexpr (is_annotated<RawType>()) {
-                                if (member(*_block).validate_and_set(std::get<Type>(staged_value))) {
+                                if (member(*_block).validate_and_set(std::get<Type>(stagedValue))) {
                                     if constexpr (HasSettingsChangedCallback<TBlock>) {
-                                        staged.insert_or_assign(key, staged_value);
+                                        staged.insert_or_assign(key, stagedValue);
                                     } else {
                                         std::ignore = staged; // help clang to see why staged is not unused
                                     }
@@ -308,65 +385,64 @@ public:
                                     // TODO: replace with pmt error message on msgOut port (to note: clang compiler bug/issue)
 #if !defined(__EMSCRIPTEN__) && !defined(__clang__)
                                     fmt::print(stderr, " cannot set field {}({})::{} = {} to {} due to limit constraints [{}, {}] validate func is {} defined\n", //
-                                               _block->unique_name, _block->name, member(*_block), std::get<Type>(staged_value),                                  //
+                                               _block->unique_name, _block->name, member(*_block), std::get<Type>(stagedValue),                                   //
                                                std::string(get_display_name(member)), RawType::LimitType::MinRange,
                                                RawType::LimitType::MaxRange, //
                                                RawType::LimitType::ValidatorFunc == nullptr ? "not" : "");
 #else
                                     fmt::print(stderr, " cannot set field {}({})::{} = {} to {} due to limit constraints [{}, {}] validate func is {} defined\n", //
-                                               "_block->uniqueName", "_block->name", member(*_block), std::get<Type>(staged_value),                               //
+                                               "_block->uniqueName", "_block->name", member(*_block), std::get<Type>(stagedValue),                                //
                                                std::string(get_display_name(member)), RawType::LimitType::MinRange,
                                                RawType::LimitType::MaxRange, //
                                                RawType::LimitType::ValidatorFunc == nullptr ? "not" : "");
 #endif
                                 }
                             } else {
-                                member(*_block) = std::get<Type>(staged_value);
-                                result.appliedParameters.insert_or_assign(key, staged_value);
+                                member(*_block) = std::get<Type>(stagedValue);
+                                result.appliedParameters.insert_or_assign(key, stagedValue);
                                 if constexpr (HasSettingsChangedCallback<TBlock>) {
-                                    staged.insert_or_assign(key, staged_value);
+                                    staged.insert_or_assign(key, stagedValue);
                                 } else {
                                     std::ignore = staged; // help clang to see why staged is not unused
                                 }
                             }
                         }
-                        if (_auto_forward.contains(key)) {
-                            result.forwardParameters.insert_or_assign(key, staged_value);
+                        if (_autoForwardParameters.contains(key)) {
+                            result.forwardParameters.insert_or_assign(key, stagedValue);
                         }
                     }
                 };
-                processMembers<TBlock>(apply_member_changes);
+                processMembers<TBlock>(applyOneMemberChanges);
             }
 
             // update active parameters
-            auto update_active = [this](auto member) {
+            auto updateActive = [this](auto member) {
                 using Type = unwrap_if_wrapped_t<std::remove_cvref_t<decltype(member(*_block))>>;
-                if constexpr (is_readable(member) && settings::isSupportedType<Type>()) {
-                    _active.insert_or_assign(get_display_name(member), pmtv::pmt(member(*_block)));
+                if constexpr (settings::isReadableMember<Type>(member)) {
+                    _activeParameters.insert_or_assign(get_display_name(member), static_cast<Type>(member(*_block)));
                 }
             };
-            processMembers<TBlock>(update_active);
+            processMembers<TBlock>(updateActive);
 
             // invoke user-callback function if staged is not empty
             if (!staged.empty()) {
-                if constexpr (requires { _block->settingsChanged(/* old settings */ _active, /* new settings */ staged); }) {
+                if constexpr (requires { _block->settingsChanged(/* old settings */ _activeParameters, /* new settings */ staged); }) {
                     _block->settingsChanged(/* old settings */ oldSettings, /* new settings */ staged);
-                } else if constexpr (requires { _block->settingsChanged(/* old settings */ _active, /* new settings */ staged, /* new forward settings */ result.forwardParameters); }) {
+                } else if constexpr (requires { _block->settingsChanged(/* old settings */ _activeParameters, /* new settings */ staged, /* new forward settings */ result.forwardParameters); }) {
                     _block->settingsChanged(/* old settings */ oldSettings, /* new settings */ staged, /* new forward settings */ result.forwardParameters);
                 }
             }
 
-            if (_staged.contains(gr::tag::STORE_DEFAULTS)) {
+            if (bestMatchParameters.contains(gr::tag::STORE_DEFAULTS)) {
                 storeDefaults();
             }
 
             if constexpr (HasSettingsResetCallback<TBlock>) {
-                if (_staged.contains(gr::tag::RESET_DEFAULTS)) {
+                if (bestMatchParameters.contains(gr::tag::RESET_DEFAULTS)) {
                     _block->reset();
                 }
             }
-
-            _staged.clear();
+            removeExpiredStoredParameters(activeSettingsCtx);
         }
 
         SettingsBase::_changed.store(false);
@@ -377,48 +453,164 @@ public:
     updateActiveParameters() noexcept override {
         if constexpr (refl::is_reflectable<TBlock>()) {
             std::lock_guard lg(_lock);
-            auto            iterate_over_member = [&, this](auto member) {
+            auto            processOneMember = [&, this](auto member) {
                 using Type = unwrap_if_wrapped_t<std::remove_cvref_t<decltype(member(*_block))>>;
-
-                if constexpr (is_readable(member) && settings::isSupportedType<Type>()) {
-                    _active.insert_or_assign(get_display_name_const(member).str(), member(*_block));
+                if constexpr (settings::isReadableMember<Type>(member)) {
+                    _activeParameters.insert_or_assign(get_display_name_const(member).str(), member(*_block));
                 }
             };
-            processMembers<TBlock>(iterate_over_member);
+            processMembers<TBlock>(processOneMember);
         }
     }
 
 private:
-    std::optional<property_map>
-    bestMatch(const property_map &context) const {
+    [[nodiscard]] std::optional<pmtv::pmt>
+    findBestMatchCtx(const pmtv::pmt &contextToSearch) const {
+        if (_storedParameters.empty()) {
+            return std::nullopt;
+        }
+
+        // exact match
+        if (_storedParameters.find(contextToSearch) != _storedParameters.end()) {
+            return contextToSearch;
+        }
+
         // retry until we either get a match or std::nullopt
         for (std::size_t attempt = 0;; ++attempt) {
-            for (const auto &i : _settings) {
-                const auto matchres = _match_pred(i.first.context, context, attempt);
-                if (!matchres) {
+            for (const auto &i : _storedParameters) {
+                const auto matches = _matchPred(i.first, contextToSearch, attempt);
+                if (!matches) {
                     return std::nullopt;
-                } else if (*matchres) {
-                    return i.second;
+                } else if (*matches) {
+                    return i.first; // return the best matched SettingsCtx.context
                 }
             }
         }
+        return std::nullopt;
+    }
+
+    [[nodiscard]] bool
+    hasStoredParameters(const SettingsCtx &ctx) const {
+        const auto bestMatchCtx = findBestMatchCtx(ctx.context);
+        if (bestMatchCtx == std::nullopt) {
+            return false;
+        }
+        return !_storedParameters[bestMatchCtx.value()].empty();
+    }
+
+    [[nodiscard]] property_map
+    getBestMatchStoredParameters(const SettingsCtx &ctx) const {
+        const auto bestMatchCtx = findBestMatchCtx(ctx.context);
+        if (bestMatchCtx == std::nullopt) {
+            return property_map();
+        }
+        const auto &vec = _storedParameters[bestMatchCtx.value()];
+        if (vec.empty()) {
+            return property_map();
+        }
+        if (ctx.time == 0ULL || vec.back().first.time <= ctx.time) {
+            return vec.back().second;
+        } else {
+            auto lower = std::ranges::lower_bound(vec, ctx.time, {}, [](const auto &a) { return a.first.time; });
+            if (lower == vec.end()) {
+                return vec.back().second;
+            } else {
+                if (lower->first.time == ctx.time) {
+                    return lower->second;
+                } else if (lower != vec.begin()) {
+                    --lower;
+                    return lower->second;
+                }
+            }
+        }
+        return property_map();
+    }
+
+    void
+    addStoredParameters(const property_map &newParameters, const SettingsCtx &ctx) {
+        _storedParameters[ctx.context].push_back({ ctx, newParameters });
+        auto &vec = _storedParameters[ctx.context];
+        std::sort(vec.begin(), vec.end(), [](const auto &a, const auto &b) { return a.first.time < b.first.time; });
+
+        if (_autoUpdateParameters.find(ctx.context) == _autoUpdateParameters.end()) {
+            _autoUpdateParameters[ctx.context] = _allWritableMembers;
+        }
+    }
+
+    void
+    removeExpiredStoredParameters(const SettingsCtx &ctx) {
+        const auto bestMatchCtx = findBestMatchCtx(ctx.context);
+        if (bestMatchCtx == std::nullopt) {
+            return;
+        }
+        auto &vec = _storedParameters[bestMatchCtx.value()];
+        if (vec.empty()) {
+            return;
+        }
+        if (ctx.time == 0ULL || vec.back().first.time <= ctx.time) {
+            vec.clear();
+        } else {
+            auto lower = std::ranges::lower_bound(vec, ctx.time, {}, [](const auto &a) { return a.first.time; });
+            if (lower == vec.end()) {
+                vec.clear();
+            } else {
+                if (lower->first.time == ctx.time) {
+                    vec.erase(vec.begin(), lower + 1);
+                } else if (lower != vec.begin()) {
+                    vec.erase(vec.begin(), lower);
+                }
+            }
+        }
+    }
+
+    [[nodiscard]] SettingsCtx
+    createSettingsCtxFromTag(const Tag &tag) const {
+        // If TRIGGER_META_INFO is not present then context =_activeCtx, time = now()
+        // If CONTEXT is not present then context =_activeCtx
+        // IF TRIGGER_TIME is not present then time = now()
+
+        const property_map &parameters = tag.map;
+        SettingsCtx         ctx(0ULL, _activeCtx);
+
+        // update if trigger_meta_info is present
+        if (parameters.contains(gr::tag::TRIGGER_META_INFO.shortKey())) {
+            const pmtv::pmt &pmtMetaInfo = parameters.at(std::string(gr::tag::TRIGGER_META_INFO.shortKey()));
+            if (std::holds_alternative<property_map>(pmtMetaInfo)) {
+                const property_map &metaInfo = std::get<property_map>(pmtMetaInfo);
+
+                // update context if present
+                if (metaInfo.contains(std::string(gr::tag::CONTEXT.shortKey()))) {
+                    ctx.context = metaInfo.at(std::string(gr::tag::CONTEXT.shortKey()));
+                }
+            }
+        }
+
+        // update trigger time if present
+        if (parameters.contains(gr::tag::TRIGGER_TIME.shortKey())) {
+            const pmtv::pmt &pmtTimeUtcNs = parameters.at(std::string(gr::tag::TRIGGER_TIME.shortKey()));
+            if (std::holds_alternative<uint64_t>(pmtTimeUtcNs)) {
+                ctx.time = std::get<uint64_t>(pmtTimeUtcNs);
+            }
+        }
+
+        if (ctx.time == 0ULL) {
+            ctx.time = settings::convertTimePointToUint64Ns(std::chrono::system_clock::now());
+        }
+        return ctx;
     }
 
     void
     storeDefaultSettings(property_map &oldSettings) {
         // take a copy of the field -> map value of the old settings
         if constexpr (refl::is_reflectable<TBlock>()) {
-            auto iterate_over_member = [&, this](auto member) {
+            auto processOneMember = [&, this](auto member) {
                 using Type = unwrap_if_wrapped_t<std::remove_cvref_t<decltype(member(*_block))>>;
 
-                if constexpr (is_readable(member) && settings::isSupportedType<Type>()) {
+                if constexpr (settings::isReadableMember<Type>(member)) {
                     oldSettings.insert_or_assign(get_display_name(member), pmtv::pmt(member(*_block)));
                 }
             };
-            if constexpr (detail::HasBaseType<TBlock>) {
-                refl::util::for_each(refl::reflect<typename std::remove_cvref_t<TBlock>::base_t>().members, iterate_over_member);
-            }
-            refl::util::for_each(refl::reflect<TBlock>().members, iterate_over_member);
+            processMembers<TBlock>(processOneMember);
         }
     }
 

--- a/core/test/qa_grc.cpp
+++ b/core/test/qa_grc.cpp
@@ -14,8 +14,8 @@
 
 template<typename T>
 struct ArraySource : public gr::Block<ArraySource<T>> {
-    std::array<gr::PortOut<T>, 2> outA;
-    std::array<gr::PortOut<T>, 2> outB;
+    std::array<gr::PortOut<T>, 2> outA{};
+    std::array<gr::PortOut<T>, 2> outB{};
 
     template<typename PublishableSpan1, typename PublishableSpan2>
     gr::work::Status
@@ -30,7 +30,7 @@ template<typename T>
 struct ArraySink : public gr::Block<ArraySink<T>> {
     std::array<gr::PortIn<T>, 2>                                     inA;
     std::array<gr::PortIn<T>, 2>                                     inB;
-    gr::Annotated<bool, "bool setting">                              bool_setting = false;
+    gr::Annotated<bool, "bool setting">                              bool_setting{ false };
     gr::Annotated<std::string, "String setting">                     string_setting;
     gr::Annotated<std::vector<bool>, "Bool vector setting">          bool_vector;
     gr::Annotated<std::vector<std::string>, "String vector setting"> string_vector;
@@ -204,11 +204,10 @@ connections:
         const auto graph_source = std::string(test_grc);
 
         try {
-            const auto context = getContext();
-
-            auto graph_1            = gr::load_grc(context->loader, graph_source);
-            auto graph_saved_source = gr::save_grc(graph_1);
-            auto graph_2            = gr::load_grc(context->loader, graph_saved_source);
+            const auto context            = getContext();
+            auto       graph_1            = gr::load_grc(context->loader, graph_source);
+            auto       graph_saved_source = gr::save_grc(graph_1);
+            auto       graph_2            = gr::load_grc(context->loader, graph_saved_source);
             expect(eq(collectBlocks(graph_1), collectBlocks(graph_2)));
             expect(eq(collectEdges(graph_1), collectEdges(graph_2)));
         } catch (const std::string &e) {
@@ -288,5 +287,4 @@ connections:
 } // namespace gr::qa_grc_test
 
 int
-main() { /* tests are statically executed */
-}
+main() { /* tests are statically executed */ }


### PR DESCRIPTION
This PR includes the implementation of `CtxSettings`, which will  replace the existing `BasicSettings`. 

Several tasks need to be addressed following this PR to fully integrate `CtxSettings` into the codebase:
1) Remove Base Settings Class and `BasicSettings`. The old `BasicSettings` and its base class need to be removed to eliminate redundancy and avoid confusion.
2) Eliminate usage of `unique_ptr` for Block::_settings
3) Update function names to clearly indicate they are associated with `CtxSettings`, enhancing code readability.
4) Expand Unit Testing. Add comprehensive unit tests specifically targeting `CtxSettings` .
5)  `using MatchPredicate = std::function<std::optional<bool>(const pmtv::pmt &, const pmtv::pmt &, std::size_t)>;`
replace this with the new matcher structure. See [here](https://github.com/fair-acc/gnuradio4/blob/filterStreamToDataSet/core/include/gnuradio-4.0/TriggerMatcher.hpp) for details.