### PR TITLE
Auto update policy when context is not found in stored settings.

### DIFF
--- a/core/include/gnuradio-4.0/Transactions.hpp
+++ b/core/include/gnuradio-4.0/Transactions.hpp
@@ -30,6 +30,16 @@ namespace gr {
 
 static auto nullMatchPred = [](auto, auto, auto) { return std::nullopt; };
 
+namespace settings {
+/**
+ * Policy for handling Settings Auto Update when `context` is not found in storedParameters.
+ */
+enum class AutoUpdatePolicy {
+    Ignore,     // do nothing when context is not in storedParameters
+    AddToStored // Add the new context to storedParameters with empty parameters and apply any new changes present in the Tag
+};
+} // namespace settings
+
 template<typename TBlock>
 class CtxSettings : public SettingsBase {
     /**
@@ -77,8 +87,9 @@ class CtxSettings : public SettingsBase {
     std::set<std::string, std::less<>>                                                         _allWritableMembers{};   // all `isWritableMember` class members
     std::map<pmtv::pmt, std::set<std::string, std::less<>>, PMTCompare>                        _autoUpdateParameters{}; // for each SettingsCtx.context auto updated members are store separately
     std::set<std::string, std::less<>>                                                         _autoForwardParameters{};
-    MatchPredicate                                                                             _matchPred = nullMatchPred;
-    pmtv::pmt                                                                                  _activeCtx = "";
+    MatchPredicate                                                                             _matchPred        = nullMatchPred;
+    pmtv::pmt                                                                                  _activeCtx        = "";
+    settings::AutoUpdatePolicy                                                                 _autoUpdatePolicy = settings::AutoUpdatePolicy::AddToStored;
 
 public:
     explicit CtxSettings(TBlock &block, MatchPredicate matchPred = nullMatchPred) noexcept : SettingsBase(), _block(&block), _matchPred(matchPred) {
@@ -248,15 +259,17 @@ public:
         if constexpr (refl::is_reflectable<TBlock>()) {
             SettingsCtx ctx = createSettingsCtxFromTag(tag);
 
-            const auto bestMatchCtx = findBestMatchCtx(ctx.context);
-            // if no best match context is found just ignore and return
+            auto bestMatchCtx = findBestMatchCtx(ctx.context);
             if (bestMatchCtx == std::nullopt) {
-                return;
+                if (_autoUpdatePolicy == settings::AutoUpdatePolicy::AddToStored) {
+                    bestMatchCtx = ctx.context;
+                } else if (_autoUpdatePolicy == settings::AutoUpdatePolicy::Ignore) {
+                    return;
+                }
             }
-            const auto &autoUpdateParameters = _autoUpdateParameters.find(bestMatchCtx.value());
-            if (autoUpdateParameters == _autoUpdateParameters.end()) {
-                return;
-            }
+
+            const auto  found                = _autoUpdateParameters.find(bestMatchCtx.value());
+            const auto &autoUpdateParameters = found == _autoUpdateParameters.end() ? _allWritableMembers : found->second;
 
             property_map        newParameters = getBestMatchStoredParameters(ctx);
             const property_map &parameters    = tag.map;
@@ -264,7 +277,7 @@ public:
                 auto processOneMember = [&](auto member) {
                     using Type = unwrap_if_wrapped_t<std::remove_cvref_t<decltype(member(*_block))>>;
                     if constexpr (settings::isWritableMember<Type>(member)) {
-                        if (autoUpdateParameters->second.contains(key) && std::string(get_display_name(member)) == key && std::holds_alternative<Type>(value)) {
+                        if (autoUpdateParameters.contains(key) && std::string(get_display_name(member)) == key && std::holds_alternative<Type>(value)) {
                             newParameters.insert_or_assign(key, value);
                             SettingsBase::_changed.store(true);
                         }


### PR DESCRIPTION
 This PR contains implementation of the `AutoUpdatePolicy` when context is not found in stored settings.
Two possible options are available: `AddToStored` and `Ignore`.
