### PR TITLE
Fix clang-18 compilation error

### DIFF
--- a/core/test/qa_plugins_test.cpp
+++ b/core/test/qa_plugins_test.cpp
@@ -23,15 +23,12 @@ public:
     builtin_multiply() = delete;
 
     template<typename Arg, typename ArgV = std::remove_cvref_t<Arg>>
-        requires(not std::is_same_v<Arg, T> and not std::is_same_v<Arg, builtin_multiply<T>>)
-    explicit builtin_multiply(Arg &&) {}
+    requires(not std::is_same_v<Arg, T> and not std::is_same_v<Arg, builtin_multiply<T>>)
+    explicit builtin_multiply(Arg&&) {}
 
     explicit builtin_multiply(T factor, std::string name = gr::this_source_location()) : _factor(factor) { this->set_name(name); }
 
-    [[nodiscard]] constexpr auto
-    processOne(T a) const noexcept {
-        return a * _factor;
-    }
+    [[nodiscard]] constexpr auto processOne(T a) const noexcept { return a * _factor; }
 };
 
 ENABLE_REFLECTION_FOR_TEMPLATE(builtin_multiply, in, out);
@@ -39,13 +36,10 @@ ENABLE_REFLECTION_FOR_TEMPLATE(builtin_multiply, in, out);
 struct TestContext {
     gr::PluginLoader loader;
 
-    TestContext() : loader(gr::globalBlockRegistry(), std::vector<std::filesystem::path>{ "core/test/plugins", "test/plugins", "plugins" }) {
-        gr::registerBlock<builtin_multiply, double, float>(gr::globalBlockRegistry());
-    }
+    TestContext() : loader(gr::globalBlockRegistry(), std::vector<std::filesystem::path>{"core/test/plugins", "test/plugins", "plugins"}) { gr::registerBlock<builtin_multiply, double, float>(gr::globalBlockRegistry()); }
 };
 
-TestContext &
-context() {
+TestContext& context() {
     static TestContext instance;
     return instance;
 }
@@ -65,23 +59,23 @@ const boost::ut::suite PluginLoaderTests = [] {
 
     "GoodPlugins"_test = [] {
         expect(!context().loader.plugins().empty());
-        for (const auto &plugin : context().loader.plugins()) {
+        for (const auto& plugin : context().loader.plugins()) {
             expect(plugin->metadata->plugin_name.starts_with("Good"));
         }
     };
 
     "BadPlugins"_test = [] {
         expect(!context().loader.failed_plugins().empty());
-        for (const auto &plugin : context().loader.failed_plugins()) {
+        for (const auto& plugin : context().loader.failed_plugins()) {
             expect(plugin.first.ends_with("bad_plugin.so"));
         }
     };
 
     "KnownBlocksList"_test = [] {
         auto       known = context().loader.knownBlocks();
-        std::array requireds{ names::cout_sink, names::fixed_source, names::divide, names::multiply };
+        std::array requireds{names::cout_sink, names::fixed_source, names::divide, names::multiply};
 
-        for (const auto &required : requireds) {
+        for (const auto& required : requireds) {
             expect(std::ranges::find(known, required) != known.end());
         }
     };
@@ -92,8 +86,10 @@ const boost::ut::suite BlockInstantiationTests = [] {
     using namespace gr;
 
     "KnownBlocksParameterizations"_test = [] {
-        expect(std::ranges::contains(context().loader.knownBlockParameterizations(names::fixed_source), "double"));
-        expect(std::ranges::contains(context().loader.knownBlockParameterizations(names::convert), "double,float"));
+        const auto blockParams1 = context().loader.knownBlockParameterizations(names::fixed_source);
+        expect(std::ranges::find(blockParams1, "double") != blockParams1.end());
+        const auto blockParams2 = context().loader.knownBlockParameterizations(names::convert);
+        expect(std::ranges::find(blockParams2, "double,float") != blockParams2.end());
     };
 
     "KnownBlocksInstantiate"_test = [] {
@@ -153,25 +149,25 @@ const boost::ut::suite BasicPluginBlocksConnectionTests = [] {
         gr::Graph testGraph;
 
         // Instantiate the node that is defined in a plugin
-        auto &block_source = context().loader.instantiateInGraph(testGraph, names::fixed_source, "double");
+        auto& block_source = context().loader.instantiateInGraph(testGraph, names::fixed_source, "double");
 
         // Instantiate a built-in node in a static way
         gr::property_map block_multiply_1_params;
         block_multiply_1_params["factor"] = 2.0;
-        auto &block_multiply_double       = testGraph.emplaceBlock<builtin_multiply<double>>(block_multiply_1_params);
+        auto& block_multiply_double       = testGraph.emplaceBlock<builtin_multiply<double>>(block_multiply_1_params);
 
         // Instantiate a built-in node via the plugin loader
-        auto &block_multiply_float = context().loader.instantiateInGraph(testGraph, names::builtin_multiply, "float");
+        auto& block_multiply_float = context().loader.instantiateInGraph(testGraph, names::builtin_multiply, "float");
 
-        auto &block_convert_to_float  = context().loader.instantiateInGraph(testGraph, names::convert, "double,float");
-        auto &block_convert_to_double = context().loader.instantiateInGraph(testGraph, names::convert, "float,double");
+        auto& block_convert_to_float  = context().loader.instantiateInGraph(testGraph, names::convert, "double,float");
+        auto& block_convert_to_double = context().loader.instantiateInGraph(testGraph, names::convert, "float,double");
 
         //
         std::size_t      repeats = 10;
         gr::property_map block_sink_params;
         block_sink_params["total_count"] = 100UZ;
         auto  block_sink_load            = context().loader.instantiate(names::cout_sink, "double", block_sink_params);
-        auto &block_sink                 = testGraph.addBlock(std::move(block_sink_load));
+        auto& block_sink                 = testGraph.addBlock(std::move(block_sink_load));
 
         auto connection_1 = testGraph.connect(block_source, 0, block_multiply_double, 0);
         auto connection_2 = testGraph.connect(block_multiply_double, 0, block_convert_to_float, 0);
@@ -196,5 +192,4 @@ const boost::ut::suite BasicPluginBlocksConnectionTests = [] {
     };
 };
 
-int
-main() { /* not needed for UT */ }
+int main() { /* not needed for UT */ }


### PR DESCRIPTION
Fix clang-18 compilation error: use std::ranges::find instead of std::ranges::contains.