### PR TITLE
Add support to store UncertainValue samples for TagMonitor and TagSink 

### DIFF
--- a/blocks/testing/include/gnuradio-4.0/testing/TagMonitors.hpp
+++ b/blocks/testing/include/gnuradio-4.0/testing/TagMonitors.hpp
@@ -225,14 +225,17 @@ struct TagMonitor : public Block<TagMonitor<T, UseProcessVariant>> {
     PortIn<T>  in;
     PortOut<T> out;
 
-    std::vector<T> samples{};
-    gr::Size_t     n_samples_expected{0};
-    gr::Size_t     n_samples_produced{0}; // for infinite samples the counter wraps around back to 0
-    float          sample_rate = 1000.0f;
-    std::string    signal_name;
-    bool           log_tags        = true;
-    bool           log_samples     = true;
-    bool           verbose_console = false;
+    // Currently, UncertainValue is not supported in Settings. For now, just remove the error part and store only values.
+    using TDataTypeStored = UncertainValueType_t<T>;
+
+    std::vector<TDataTypeStored> samples{};
+    gr::Size_t                   n_samples_expected{0};
+    gr::Size_t                   n_samples_produced{0}; // for infinite samples the counter wraps around back to 0
+    float                        sample_rate = 1000.0f;
+    std::string                  signal_name;
+    bool                         log_tags        = true;
+    bool                         log_samples     = true;
+    bool                         verbose_console = false;
 
     std::vector<Tag> _tags{};
 
@@ -260,7 +263,11 @@ struct TagMonitor : public Block<TagMonitor<T, UseProcessVariant>> {
             }
         }
         if (log_samples) {
-            samples.emplace_back(input);
+            if constexpr (UncertainValueLike<T>) {
+                samples.emplace_back(input.value);
+            } else {
+                samples.emplace_back(input);
+            }
         }
         n_samples_produced++;
         return input;
@@ -283,9 +290,19 @@ struct TagMonitor : public Block<TagMonitor<T, UseProcessVariant>> {
             if constexpr (gr::meta::any_simd<V>) {
                 alignas(stdx::memory_alignment_v<stdx::native_simd<T>>) std::array<T, V::size()> mem = {};
                 input.copy_to(&mem[0], stdx::vector_aligned);
-                samples.insert(samples.end(), mem.begin(), mem.end());
+                if constexpr (UncertainValueLike<T>) {
+                    for (const auto& item : mem) {
+                        samples.emplace_back(item.value);
+                    }
+                } else {
+                    samples.insert(samples.end(), mem.begin(), mem.end());
+                }
             } else {
-                samples.emplace_back(input);
+                if constexpr (UncertainValueLike<T>) {
+                    samples.emplace_back(input.value);
+                } else {
+                    samples.emplace_back(input);
+                }
             }
         }
         if constexpr (gr::meta::any_simd<V>) {
@@ -310,7 +327,13 @@ struct TagMonitor : public Block<TagMonitor<T, UseProcessVariant>> {
         }
 
         if (log_samples) {
-            samples.insert(samples.cend(), input.begin(), input.end());
+            if constexpr (UncertainValueLike<T>) {
+                for (const auto& item : input) {
+                    samples.emplace_back(item.value);
+                }
+            } else {
+                samples.insert(samples.end(), input.begin(), input.end());
+            }
         }
 
         n_samples_produced += static_cast<gr::Size_t>(input.size());
@@ -325,14 +348,17 @@ struct TagSink : public Block<TagSink<T, UseProcessVariant>> {
     using ClockSourceType = std::chrono::system_clock;
     PortIn<T> in;
 
-    std::vector<T> samples{};
-    gr::Size_t     n_samples_expected{0};
-    gr::Size_t     n_samples_produced{0}; // for infinite samples the counter wraps around back to 0
-    float          sample_rate = 1000.0f;
-    std::string    signal_name;
-    bool           log_tags        = true;
-    bool           log_samples     = true;
-    bool           verbose_console = false;
+    // Currently, UncertainValue is not supported in Settings. For now, just remove the error part and store only values.
+    using TDataTypeStored = UncertainValueType_t<T>;
+
+    std::vector<TDataTypeStored> samples{};
+    gr::Size_t                   n_samples_expected{0};
+    gr::Size_t                   n_samples_produced{0}; // for infinite samples the counter wraps around back to 0
+    float                        sample_rate = 1000.0f;
+    std::string                  signal_name;
+    bool                         log_tags        = true;
+    bool                         log_samples     = true;
+    bool                         verbose_console = false;
 
     std::vector<Tag> _tags{};
 
@@ -366,7 +392,11 @@ struct TagSink : public Block<TagSink<T, UseProcessVariant>> {
             }
         }
         if (log_samples) {
-            samples.emplace_back(input);
+            if constexpr (UncertainValueLike<T>) {
+                samples.emplace_back(input.value);
+            } else {
+                samples.emplace_back(input);
+            }
         }
         n_samples_produced++;
         if (n_samples_expected > 0 && n_samples_produced >= n_samples_expected) {
@@ -388,7 +418,13 @@ struct TagSink : public Block<TagSink<T, UseProcessVariant>> {
             }
         }
         if (log_samples) {
-            samples.insert(samples.cend(), input.begin(), input.end());
+            if constexpr (UncertainValueLike<T>) {
+                for (const auto& item : input) {
+                    samples.emplace_back(item.value);
+                }
+            } else {
+                samples.insert(samples.end(), input.begin(), input.end());
+            }
         }
         n_samples_produced += static_cast<gr::Size_t>(input.size());
         return n_samples_expected > 0 && n_samples_produced >= n_samples_expected ? work::Status::DONE : work::Status::OK;


### PR DESCRIPTION
 Add support to store UncertainValue samples for TagMonitor and TagSink by removing error part.
This is neede for some unit tests.