### PR TITLE
suppress GCC -Wmissing-field-initializers warning and add gcc-13 (backward compatibility)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,9 @@ jobs:
           - cc: gcc-14
             cxx: g++-14
             cmake_flags: "-DADDRESS_SANITIZER=ON"
+          - cc: gcc-13
+            cxx: g++-13
+            cmake_flags: "-DADDRESS_SANITIZER=OFF"
           - cc: clang-18,
             cxx: clang++-18
             cmake_flags: "-DCMAKE_LINKER=/usr/bin/clang-18"

--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -67,6 +67,7 @@ function(set_project_warnings project_name)
           -Wno-interference-size # suppress ABI compatibility warnings for hardware inferred size
           -Wno-maybe-uninitialized # false positives if asan is enabled: https://gcc.gnu.org/bugzilla//show_bug.cgi?id=1056h6
           -fconcepts-diagnostics-depth=3
+          -Wno-missing-field-initializers # confusing warning which is not what most users expect: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96868#c3
           )
 
   if(MSVC)

--- a/core/include/gnuradio-4.0/BlockModel.hpp
+++ b/core/include/gnuradio-4.0/BlockModel.hpp
@@ -347,13 +347,11 @@ private:
 
 public:
     BlockWrapper() : BlockWrapper(gr::property_map()) {}
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmissing-field-initializers" // GCC14 has an issue w.r.t. detecting that the derived field members (notably Port<...>) are initialised
     explicit BlockWrapper(gr::property_map initParameter) : _block(std::move(initParameter)) {
         initMessagePorts();
         _dynamicPortsLoader = std::bind(&BlockWrapper::dynamicPortLoader, this);
     }
-#pragma GCC diagnostic pop
+
     BlockWrapper(const BlockWrapper& other)            = delete;
     BlockWrapper(BlockWrapper&& other)                 = delete;
     BlockWrapper& operator=(const BlockWrapper& other) = delete;

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,7 +23,7 @@ ENV JAVA_HOME=/opt/java/openjdk \
 # && wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && add-apt-repository 'deb http://apt.llvm.org/mantic/ llvm-toolchain-mantic-18 main'
 # && wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null && echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main' | tee -a /etc/apt/sources.list.d/kitware.list >/dev/null
 RUN apt-get update -y \
-    && apt-get install --no-install-recommends -qqy wget gpg ca-certificates software-properties-common bash locales python3-pip npm sudo cmake git make ninja-build clang-18 libc++-18-dev libc++abi-18-dev gdb lldb-18 gcc-14 g++-14 \
+    && apt-get install --no-install-recommends -qqy wget gpg ca-certificates software-properties-common bash locales python3-pip npm sudo cmake git make ninja-build clang-18 libc++-18-dev libc++abi-18-dev gdb lldb-18 gcc-13 g++-13 gcc-14 g++-14 \
     && locale-gen en_US.UTF-8 && echo 'LANG="en_US.UTF-8"'>/etc/default/locale \
     && useradd -m -g users user \
     && echo user ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/user && chmod 0440 /etc/sudoers.d/user \


### PR DESCRIPTION
 * `-Wmissing-field-initializers warning` is a confusing warning which is probably not what most users expect.
    For details see: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96868#c3

* added gcc-13 target (backwards compatibility) since gcc-14 isn't as widely available on some older Linux distributions and embedded systems yet.
  This is to be phased out ~2025 (maintenance overhead, missing features etc. in gcc-13)
