### PR TITLE
Performance optimization for MultiThreadedStrategy

### DIFF
--- a/core/benchmarks/bm_Buffer.cpp
+++ b/core/benchmarks/bm_Buffer.cpp
@@ -22,8 +22,7 @@ using namespace gr;
 #include <pthread.h>
 #include <sched.h>
 
-void
-setCpuAffinity(const int cpuID) // N.B. pthread is not portable
+void setCpuAffinity(const int cpuID) // N.B. pthread is not portable
 {
     const std::size_t nCPU = std::thread::hardware_concurrency();
     // fmt::print("set CPU affinity to core {}\n", cpuID % nCPU);
@@ -38,23 +37,18 @@ setCpuAffinity(const int cpuID) // N.B. pthread is not portable
     std::this_thread::sleep_for(std::chrono::milliseconds(20)); // to force re-scheduling
 }
 #else
-void
-setCpuAffinity(const int cpuID) {}
+void setCpuAffinity(const int cpuID) {}
 #endif
 #else
-void
-setCpuAffinity(const int /*cpuID*/) {}
+void setCpuAffinity(const int /*cpuID*/) {}
 #endif
 
-enum class WriteApi { via_lambda, via_split_request_publish_RAII };
-
-template<WriteApi PublisherAPI = WriteApi::via_lambda, typename T = int>
-void
-testNewAPI(Buffer auto &buffer, const std::size_t vector_length, const std::size_t min_samples, const std::size_t nProducer, const std::size_t nConsumer, const std::string_view name) {
+template<typename T = int>
+void runTest(BufferLike auto& buffer, const std::size_t vectorLength, const std::size_t minSamples, const std::size_t nProducer, const std::size_t nConsumer, const std::string_view name) {
     gr::meta::precondition(nProducer > 0);
     gr::meta::precondition(nConsumer > 0);
 
-    constexpr int n_repeat = 8;
+    constexpr int nRepeat = 8;
 
     std::barrier barrier(static_cast<std::ptrdiff_t>(nProducer + nConsumer + 1));
 
@@ -66,21 +60,19 @@ testNewAPI(Buffer auto &buffer, const std::size_t vector_length, const std::size
             // set thread affinity
             setCpuAffinity(threadID++);
             barrier.arrive_and_wait();
-            for (int rep = 0; rep < n_repeat; ++rep) {
-                BufferWriter auto writer           = buffer.new_writer();
-                std::size_t       nSamplesProduced = 0;
+            for (int rep = 0; rep < nRepeat; ++rep) {
+                BufferWriterLike auto writer           = buffer.new_writer();
+                std::size_t           nSamplesProduced = 0;
                 barrier.arrive_and_wait();
-                while (nSamplesProduced <= (min_samples + nProducer - 1) / nProducer) {
-                    if constexpr (PublisherAPI == WriteApi::via_lambda) {
-                        writer.publish([](auto &) {}, vector_length);
-                    } else if constexpr (PublisherAPI == WriteApi::via_split_request_publish_RAII) {
-                        auto data = writer.reserve(vector_length);
-
-                        data.publish(vector_length);
+                while (nSamplesProduced <= (minSamples + nProducer - 1) / nProducer) {
+                    PublishableSpan auto data = writer.reserve(vectorLength);
+                    if (!data.empty()) {
+                        data.publish(vectorLength);
+                        nSamplesProduced += vectorLength;
                     } else {
-                        static_assert(gr::meta::always_false<T>, "unknown PublisherAPI case");
+                        // std::this_thread::yield();
+                        // std::this_thread::sleep_for(std::chrono::milliseconds(10));
                     }
-                    nSamplesProduced += vector_length;
                 }
                 barrier.arrive_and_wait();
             }
@@ -93,15 +85,15 @@ testNewAPI(Buffer auto &buffer, const std::size_t vector_length, const std::size
         consumers.emplace_back([&]() {
             setCpuAffinity(threadID++);
             barrier.arrive_and_wait();
-            for (int rep = 0; rep < n_repeat; ++rep) {
-                BufferReader auto reader           = buffer.new_reader();
-                std::size_t       nSamplesConsumed = 0;
+            for (int rep = 0; rep < nRepeat; ++rep) {
+                BufferReaderLike auto reader           = buffer.new_reader();
+                std::size_t           nSamplesConsumed = 0;
                 barrier.arrive_and_wait();
-                while (nSamplesConsumed < min_samples) {
-                    if (reader.available() < vector_length) {
+                while (nSamplesConsumed < minSamples) {
+                    if (reader.available() < vectorLength) {
                         continue;
                     }
-                    const ConsumableSpan auto &input = reader.get(vector_length);
+                    const ConsumableSpan auto& input = reader.get(vectorLength);
                     nSamplesConsumed += input.size();
 
                     if (!input.consume(input.size())) {
@@ -115,49 +107,51 @@ testNewAPI(Buffer auto &buffer, const std::size_t vector_length, const std::size
 
     // all producers and consumer are ready, waiting to give the sign
     barrier.arrive_and_wait();
-    ::benchmark::benchmark<n_repeat>(fmt::format("{:>8}: {} producers -<{:^4}>-> {} consumers", name, nProducer, vector_length, nConsumer), min_samples) = [&]() {
+    ::benchmark::benchmark<nRepeat>(fmt::format("{:>8}: {} producers -<{:^4}>-> {} consumers", name, nProducer, vectorLength, nConsumer), minSamples) = [&]() {
         barrier.arrive_and_wait();
         barrier.arrive_and_wait();
     };
 
     // clean up
-    for (std::thread &thread : producers) thread.join();
-    for (std::thread &thread : consumers) thread.join();
+    for (std::thread& thread : producers) {
+        thread.join();
+    }
+    for (std::thread& thread : consumers) {
+        thread.join();
+    }
 }
 
 inline const boost::ut::suite _buffer_tests = [] {
-    const std::size_t samples = 10'000'000; // minimum number of samples
     enum class BufferStrategy { posix, portable };
 
-    for (WriteApi writerAPI : { WriteApi::via_lambda, WriteApi::via_split_request_publish_RAII }) {
-        for (BufferStrategy strategy : { BufferStrategy::posix, BufferStrategy::portable }) {
-            for (std::size_t veclen : { 1UL, 1024UL }) {
-                if (not(strategy == BufferStrategy::posix and veclen == 1UL)) {
-                    benchmark::results::add_separator();
-                }
-                for (std::size_t nP = 1; nP <= 4; nP *= 2) {
-                    for (std::size_t nR = 1; nR <= 4; nR *= 2) {
-                        const std::size_t size      = std::max(4096UL, veclen) * nR * 10UL;
-                        auto              allocator = std::pmr::polymorphic_allocator<int32_t>();
-                        const bool        is_posix  = strategy == BufferStrategy::posix;
-                        auto              invoke    = [&](auto buffer) {
-                            switch (writerAPI) {
-                            case WriteApi::via_split_request_publish_RAII:
-                                testNewAPI<WriteApi::via_split_request_publish_RAII>(buffer, veclen, samples, nP, nR, is_posix ? "POSIX - RAII writer" : "portable - RAII writer");
-                                break;
-                            case WriteApi::via_lambda:
-                            default: testNewAPI<WriteApi::via_lambda>(buffer, veclen, samples, nP, nR, is_posix ? "POSIX" : "portable"); break;
-                            }
-                        };
-                        if (nP == 1) {
-                            using BufferType   = CircularBuffer<int32_t, std::dynamic_extent, ProducerType::Single>;
-                            Buffer auto buffer = is_posix ? BufferType(size) : BufferType(size, allocator);
-                            invoke(buffer);
-                        } else {
-                            using BufferType   = CircularBuffer<int32_t, std::dynamic_extent, ProducerType::Multi>;
-                            Buffer auto buffer = is_posix ? BufferType(size) : BufferType(size, allocator);
-                            invoke(buffer);
-                        }
+    // Test parameters
+    const std::size_t samples             = 1'000'000; // minimum number of samples
+    const std::size_t maxProducers        = 4;         // maximum number of producers to test, 1-2-4-8 ....
+    const std::size_t maxConsumers        = 4;         // maximum number of consumers to test, 1-2-4-8 ....
+    const std::vector bufferStrategyTests = {
+#ifdef HAS_POSIX_MAP_INTERFACE
+        BufferStrategy::posix,
+#endif
+        BufferStrategy::portable};
+    const std::vector vecLengthTests = {1UL, 1024UL};
+
+    for (const BufferStrategy strategy : bufferStrategyTests) {
+        for (const std::size_t veclen : vecLengthTests) {
+            benchmark::results::add_separator();
+            for (std::size_t nP = 1; nP <= maxProducers; nP *= 2) {
+                for (std::size_t nC = 1; nC <= maxConsumers; nC *= 2) {
+                    const std::size_t size      = std::max(4096UL, veclen) * nC * 10UL;
+                    const bool        isPosix   = strategy == BufferStrategy::posix;
+                    const auto        allocator = (isPosix) ? gr::double_mapped_memory_resource::allocator<int32_t>() : std::pmr::polymorphic_allocator<int32_t>();
+                    auto              invoke    = [&](auto buffer) { runTest(buffer, veclen, samples, nP, nC, isPosix ? "POSIX" : "portable"); };
+                    if (nP == 1) {
+                        using BufferType       = CircularBuffer<int32_t, std::dynamic_extent, ProducerType::Single>;
+                        BufferLike auto buffer = BufferType(size, allocator);
+                        invoke(buffer);
+                    } else {
+                        using BufferType       = CircularBuffer<int32_t, std::dynamic_extent, ProducerType::Multi>;
+                        BufferLike auto buffer = BufferType(size, allocator);
+                        invoke(buffer);
                     }
                 }
             }
@@ -165,6 +159,4 @@ inline const boost::ut::suite _buffer_tests = [] {
     }
 };
 
-int
-main() { /* not needed by the UT framework */
-}
+int main() { /* not needed by the UT framework */ }

--- a/core/include/gnuradio-4.0/Buffer.hpp
+++ b/core/include/gnuradio-4.0/Buffer.hpp
@@ -18,12 +18,11 @@ struct first_template_arg_helper<TemplateType<ValueType, OtherTypes...>> {
 };
 
 template<typename T>
-constexpr auto *
-value_type_helper() {
+constexpr auto* value_type_helper() {
     if constexpr (requires { typename T::value_type; }) {
-        return static_cast<typename T::value_type *>(nullptr);
+        return static_cast<typename T::value_type*>(nullptr);
     } else {
-        return static_cast<typename first_template_arg_helper<T>::value_type *>(nullptr);
+        return static_cast<typename first_template_arg_helper<T>::value_type*>(nullptr);
     }
 }
 
@@ -47,10 +46,10 @@ static_assert(std::is_same_v<double, value_type_t<std::array<double, 42>>>);
 
 // TODO: find a better place for these 3 concepts
 template<typename From, typename To>
-concept convertible_from_lvalue_to = std::convertible_to<const std::remove_cvref_t<From> &, To>;
+concept convertible_from_lvalue_to = std::convertible_to<const std::remove_cvref_t<From>&, To>;
 
 template<typename From, typename To>
-concept convertible_from_rvalue_to = std::convertible_to<std::remove_cvref_t<From> &&, To>;
+concept convertible_from_rvalue_to = std::convertible_to<std::remove_cvref_t<From>&&, To>;
 
 template<typename From, typename To>
 concept convertible_from_lvalue_only = convertible_from_lvalue_to<From, To> && !convertible_from_rvalue_to<From, To>;
@@ -65,16 +64,16 @@ template<typename T>
 concept ConstSpanLvalueLike = convertible_from_lvalue_only<T, std::span<const std::remove_cvref_t<typename T::value_type>>>;
 
 template<typename T>
-concept ConsumableSpan = std::ranges::contiguous_range<T> && ConstSpanLvalueLike<T> && requires(T &s) { s.consume(0); };
+concept ConsumableSpan = std::ranges::contiguous_range<T> && ConstSpanLvalueLike<T> && requires(T& s) { s.consume(0); };
 
 template<typename T>
-concept PublishableSpan = std::ranges::contiguous_range<T> && std::ranges::output_range<T, std::remove_cvref_t<typename T::value_type>> && SpanLike<T> && requires(T &s) { s.publish(0UZ); };
+concept PublishableSpan = std::ranges::contiguous_range<T> && std::ranges::output_range<T, std::remove_cvref_t<typename T::value_type>> && SpanLike<T> && requires(T& s) { s.publish(0UZ); };
 
 // clang-format off
 // disable formatting until clang-format (v16) supporting concepts
 template<class T>
-concept BufferReader = requires(T /*const*/ t, const std::size_t n_items) {
-    { t.get(n_items) } ; // TODO: get() returns CircularBuffer::buffer_reader::ConsumableInputRange
+concept BufferReaderLike = requires(T /*const*/ t, const std::size_t nItems) {
+    { t.get(nItems) } ; // TODO: get() returns CircularBuffer::Reader::ConsumableInputRange
     { t.position() }       -> std::same_as<std::make_signed_t<std::size_t>>;
     { t.available() }      -> std::same_as<std::size_t>;
     { t.buffer() };
@@ -82,27 +81,21 @@ concept BufferReader = requires(T /*const*/ t, const std::size_t n_items) {
     { t.isConsumeRequested()} -> std::same_as<bool>;
 };
 
-template<class Fn, typename T, typename ...Args>
-concept WriterCallback = std::is_invocable_v<Fn, std::span<T>&, std::make_signed_t<std::size_t>, Args...> || std::is_invocable_v<Fn, std::span<T>&, Args...>;
-
 template<class T, typename ...Args>
-concept BufferWriter = requires(T t, const std::size_t n_items, std::pair<std::size_t, std::make_signed_t<std::size_t>> token, Args ...args) {
-    { t.publish([](std::span<util::value_type_t<T>> &/*writable_data*/, Args ...) { /* */ }, n_items, args...) }                                 -> std::same_as<void>;
-    { t.publish([](std::span<util::value_type_t<T>> &/*writable_data*/, std::make_signed_t<std::size_t> /* writePos */, Args ...) { /* */  }, n_items, args...) }   -> std::same_as<void>;
-    { t.try_publish([](std::span<util::value_type_t<T>> &/*writable_data*/, Args ...) { /* */ }, n_items, args...) }                             -> std::same_as<bool>;
-    { t.try_publish([](std::span<util::value_type_t<T>> &/*writable_data*/, std::make_signed_t<std::size_t> /* writePos */, Args ...) { /* */  }, n_items, args...) }-> std::same_as<bool>;
-    { t.reserve(n_items) };// TODO: reserve() returns CircularBuffer::buffer_writer::PublishableOutputRange
+concept BufferWriterLike = requires(T t, const std::size_t nItems) {
+    { t.tryReserve(nItems) };// TODO: tryReserve() returns CircularBuffer::Writer::PublishableOutputRange
+    { t.reserve(nItems) };// TODO: reserve() returns CircularBuffer::Writer::PublishableOutputRange
     { t.available() }         -> std::same_as<std::size_t>;
     { t.buffer() };
     { t.nSamplesPublished()} -> std::same_as<std::size_t>;
 };
 
 template<class T, typename ...Args>
-concept Buffer = requires(T t, const std::size_t min_size, Args ...args) {
+concept BufferLike = requires(T t, const std::size_t min_size, Args ...args) {
     { T(min_size, args...) };
     { t.size() }       -> std::same_as<std::size_t>;
-    { t.new_reader() } -> BufferReader;
-    { t.new_writer() } -> BufferWriter;
+    { t.new_reader() } -> BufferReaderLike;
+    { t.new_writer() } -> BufferWriterLike;
 };
 
 // compile-time unit-tests
@@ -116,16 +109,9 @@ template <typename T, typename... Args>
 using NoSequenceParameter = decltype([](std::span<T>&, Args...) { /* */ });
 } // namespace test
 
-static_assert(!Buffer<test::non_compliant_class<int>>);
-static_assert(!BufferReader<test::non_compliant_class<int>>);
-static_assert(!BufferWriter<test::non_compliant_class<int>>);
-
-static_assert(WriterCallback<test::WithSequenceParameter<int>, int>);
-static_assert(!WriterCallback<test::WithSequenceParameter<int>, int, std::span<bool>>);
-static_assert(WriterCallback<test::WithSequenceParameter<int, std::span<bool>>, int, std::span<bool>>);
-static_assert(WriterCallback<test::NoSequenceParameter<int>, int>);
-static_assert(!WriterCallback<test::NoSequenceParameter<int>, int, std::span<bool>>);
-static_assert(WriterCallback<test::NoSequenceParameter<int, std::span<bool>>, int, std::span<bool>>);
+static_assert(!BufferLike<test::non_compliant_class<int>>);
+static_assert(!BufferReaderLike<test::non_compliant_class<int>>);
+static_assert(!BufferWriterLike<test::non_compliant_class<int>>);
 // clang-format on
 } // namespace gr
 

--- a/core/include/gnuradio-4.0/BufferSkeleton.hpp
+++ b/core/include/gnuradio-4.0/BufferSkeleton.hpp
@@ -19,141 +19,95 @@ namespace gr::test {
  */
 template<typename T>
 class BufferSkeleton {
-    struct buffer_impl {
+    struct BufferImpl {
         const std::size_t _size;
         std::vector<T>    _data;
 
-        buffer_impl() = delete;
-        explicit buffer_impl(const std::size_t min_size) : _size(min_size), _data(_size){};
-        ~buffer_impl() = default;
+        BufferImpl() = delete;
+        explicit BufferImpl(const std::size_t min_size) : _size(min_size), _data(_size){};
+        ~BufferImpl() = default;
     };
 
     template<typename U>
-    class buffer_reader {
-        std::shared_ptr<buffer_impl> _buffer;
+    class Reader {
+        std::shared_ptr<BufferImpl> _buffer;
 
-        buffer_reader() = delete;
+        Reader() = delete;
 
-        explicit buffer_reader(std::shared_ptr<buffer_impl> buffer) : _buffer(buffer) {}
+        explicit Reader(std::shared_ptr<BufferImpl> buffer) : _buffer(buffer) {}
 
         friend BufferSkeleton<T>;
 
     public:
-        [[nodiscard]] BufferSkeleton
-        buffer() const noexcept {
-            return BufferSkeleton(_buffer);
-        };
+        [[nodiscard]] BufferSkeleton buffer() const noexcept { return BufferSkeleton(_buffer); };
 
-        [[nodiscard]] constexpr std::size_t
-        nSamplesConsumed() const noexcept {
-            return 0UZ;
-        };
+        [[nodiscard]] constexpr std::size_t nSamplesConsumed() const noexcept { return 0UZ; };
 
-        [[nodiscard]] constexpr bool
-        isConsumeRequested() const noexcept {
-            return false;
-        }
+        [[nodiscard]] constexpr bool isConsumeRequested() const noexcept { return false; }
 
         template<bool strict_check = true>
-        [[nodiscard]] std::span<const U>
-        get(const std::size_t /* n_requested = 0*/) const noexcept(!strict_check) {
+        [[nodiscard]] std::span<const U> get(const std::size_t /* n_requested = 0*/) const noexcept(!strict_check) {
             return {};
         }
 
         template<bool strict_check = true>
-        [[nodiscard]] bool
-        consume(const std::size_t /* n_items = 1 */) const noexcept(!strict_check) {
+        [[nodiscard]] bool consume(const std::size_t /* n_items = 1 */) const noexcept(!strict_check) {
             return true;
         }
 
-        [[nodiscard]] constexpr std::make_signed_t<std::size_t>
-        position() const noexcept {
-            return -1;
-        }
+        [[nodiscard]] constexpr std::make_signed_t<std::size_t> position() const noexcept { return -1; }
 
-        [[nodiscard]] constexpr std::size_t
-        available() const noexcept {
-            return 0;
-        }
+        [[nodiscard]] constexpr std::size_t available() const noexcept { return 0; }
     };
 
     template<typename U>
-    class buffer_writer {
-        std::shared_ptr<buffer_impl> _buffer;
+    class Writer {
+        std::shared_ptr<BufferImpl> _buffer;
 
-        buffer_writer() = delete;
+        Writer() = delete;
 
-        explicit buffer_writer(std::shared_ptr<buffer_impl> buffer) : _buffer(buffer) {}
+        explicit Writer(std::shared_ptr<BufferImpl> buffer) : _buffer(buffer) {}
 
         friend BufferSkeleton<T>;
 
     public:
-        [[nodiscard]] BufferSkeleton
-        buffer() const noexcept {
-            return BufferSkeleton(_buffer);
-        };
+        [[nodiscard]] BufferSkeleton buffer() const noexcept { return BufferSkeleton(_buffer); };
 
-        [[nodiscard]] constexpr std::size_t
-        nSamplesPublished() const noexcept {
-            return 0UZ;
-        };
+        [[nodiscard]] constexpr std::size_t nSamplesPublished() const noexcept { return 0UZ; };
 
-        [[nodiscard]] constexpr auto
-        reserve(std::size_t n) noexcept -> std::span<U> {
-            return { &_buffer->_data[0], n };
-        }
+        [[nodiscard]] constexpr auto reserve(std::size_t n) noexcept -> std::span<U> { return {&_buffer->_data[0], n}; }
 
-        constexpr void
-        publish(std::pair<std::size_t, std::make_signed<std::size_t>>, std::size_t) const { /* empty */ }
+        [[nodiscard]] constexpr auto tryReserve(std::size_t n) noexcept -> std::span<U> { return {&_buffer->_data[0], n}; }
 
-        template<typename... Args, WriterCallback<U, Args...> Translator>
-        void
-        publish(Translator && /* translator */, std::size_t /* n_slots_to_claim = 1 */, Args &&.../* args */) const noexcept { /* empty */ } // blocks until elements are available
-
-        template<typename... Args, WriterCallback<U, Args...> Translator>
-        [[nodiscard]] bool
-        try_publish(Translator && /* translator */, std::size_t n_slots_to_claim = 1, Args &&.../* args */) const noexcept {
-            return n_slots_to_claim == 0;
-        } // returns false if cannot emplace data -> user may need to retry
-
-        [[nodiscard]] constexpr std::size_t
-        available() const noexcept {
-            return _buffer->_data.size();
-        } // #items that can be written -- dynamic since readers can release in parallel
+        [[nodiscard]] constexpr std::size_t available() const noexcept { return _buffer->_data.size(); } // #items that can be written -- dynamic since readers can release in parallel
     };
 
-    // shared pointer is needed to avoid dangling references to reader/writer
-    // or generating buffer itself
-    std::shared_ptr<buffer_impl> _shared_buffer_ptr;
+    // shared pointer is needed to avoid dangling references to reader/writer or generating buffer itself
+    std::shared_ptr<BufferImpl> _shared_buffer_ptr;
 
-    explicit BufferSkeleton(std::shared_ptr<buffer_impl> shared_buffer_ptr) : _shared_buffer_ptr(shared_buffer_ptr) {}
+    explicit BufferSkeleton(std::shared_ptr<BufferImpl> shared_buffer_ptr) : _shared_buffer_ptr(shared_buffer_ptr) {}
 
 public:
     BufferSkeleton() = delete;
 
-    explicit BufferSkeleton(const std::size_t min_size) : _shared_buffer_ptr(std::make_shared<buffer_impl>(min_size)) {}
+    explicit BufferSkeleton(const std::size_t min_size) : _shared_buffer_ptr(std::make_shared<BufferImpl>(min_size)) {}
 
     ~BufferSkeleton() = default;
 
-    [[nodiscard]] std::size_t
-    size() const {
-        return _shared_buffer_ptr->_data.size();
-    }
+    [[nodiscard]] std::size_t size() const { return _shared_buffer_ptr->_data.size(); }
 
     template<typename WriteDataType = T>
-    BufferReader auto
-    new_reader() {
-        return buffer_reader<WriteDataType>(_shared_buffer_ptr);
+    BufferReaderLike auto new_reader() {
+        return Reader<WriteDataType>(_shared_buffer_ptr);
     }
 
     template<typename ReadDataType = T>
-    BufferWriter auto
-    new_writer() {
-        return buffer_writer<ReadDataType>(_shared_buffer_ptr);
+    BufferWriterLike auto new_writer() {
+        return Writer<ReadDataType>(_shared_buffer_ptr);
     }
 };
 
-static_assert(Buffer<BufferSkeleton<int32_t>>);
+static_assert(BufferLike<BufferSkeleton<int32_t>>);
 
 } // namespace gr::test
 

--- a/core/include/gnuradio-4.0/WaitStrategy.hpp
+++ b/core/include/gnuradio-4.0/WaitStrategy.hpp
@@ -1,10 +1,10 @@
 #ifndef GNURADIO_WAITSTRATEGY_HPP
 #define GNURADIO_WAITSTRATEGY_HPP
 
-#include <condition_variable>
 #include <atomic>
 #include <chrono>
 #include <concepts>
+#include <condition_variable>
 #include <cstdint>
 #include <memory>
 #include <mutex>
@@ -42,7 +42,7 @@ inline constexpr bool hasSignalAllWhenBlocking = requires(T /*const*/ t) {
 static_assert(!hasSignalAllWhenBlocking<int>);
 
 template<typename T>
-concept WaitStrategy = isWaitStrategy<T>;
+concept WaitStrategyLike = isWaitStrategy<T>;
 
 
 
@@ -78,7 +78,7 @@ public:
         _conditionVariable.notify_all();
     }
 };
-static_assert(WaitStrategy<BlockingWaitStrategy>);
+static_assert(WaitStrategyLike<BlockingWaitStrategy>);
 
 /**
  * Busy Spin strategy that uses a busy spin loop for IEventProcessor's waiting on a barrier.
@@ -94,7 +94,7 @@ struct BusySpinWaitStrategy {
         return availableSequence;
     }
 };
-static_assert(WaitStrategy<BusySpinWaitStrategy>);
+static_assert(WaitStrategyLike<BusySpinWaitStrategy>);
 static_assert(!hasSignalAllWhenBlocking<BusySpinWaitStrategy>);
 
 /**
@@ -134,7 +134,7 @@ public:
         return availableSequence;
     }
 };
-static_assert(WaitStrategy<SleepingWaitStrategy>);
+static_assert(WaitStrategyLike<SleepingWaitStrategy>);
 static_assert(!hasSignalAllWhenBlocking<SleepingWaitStrategy>);
 
 struct TimeoutException : public std::runtime_error {
@@ -179,7 +179,7 @@ public:
         _conditionVariable.notify_all();
     }
 };
-static_assert(WaitStrategy<TimeoutBlockingWaitStrategy>);
+static_assert(WaitStrategyLike<TimeoutBlockingWaitStrategy>);
 static_assert(hasSignalAllWhenBlocking<TimeoutBlockingWaitStrategy>);
 
 /**
@@ -210,7 +210,7 @@ public:
         return availableSequence;
     }
 };
-static_assert(WaitStrategy<YieldingWaitStrategy>);
+static_assert(WaitStrategyLike<YieldingWaitStrategy>);
 static_assert(!hasSignalAllWhenBlocking<YieldingWaitStrategy>);
 
 struct NoWaitStrategy {
@@ -219,7 +219,7 @@ struct NoWaitStrategy {
         return sequence;
     }
 };
-static_assert(WaitStrategy<NoWaitStrategy>);
+static_assert(WaitStrategyLike<NoWaitStrategy>);
 static_assert(!hasSignalAllWhenBlocking<NoWaitStrategy>);
 
 
@@ -337,7 +337,7 @@ struct SpinWaitWaitStrategy {
         return availableSequence;
     }
 };
-static_assert(WaitStrategy<SpinWaitWaitStrategy>);
+static_assert(WaitStrategyLike<SpinWaitWaitStrategy>);
 static_assert(!hasSignalAllWhenBlocking<SpinWaitWaitStrategy>);
 
 struct NO_SPIN_WAIT {};
@@ -366,9 +366,7 @@ public:
     void unlock() { _lock.clear(std::memory_order::release); }
 };
 
-
 // clang-format on
 } // namespace gr
-
 
 #endif // GNURADIO_WAITSTRATEGY_HPP

--- a/core/test/qa_Block.cpp
+++ b/core/test/qa_Block.cpp
@@ -546,13 +546,11 @@ void syncOrAsyncTest() {
 
     using BlockType = SyncOrAsyncBlock<float, isInputAsync, isOutputAsync>;
 
-    Graph testGraph;
-    auto& tagSrc     = testGraph.emplaceBlock<TagSource<float>>({{"n_samples_max", n_samples}});
-    auto& asyncBlock = testGraph.emplaceBlock<BlockType>();
-    auto& sink       = testGraph.emplaceBlock<TagSink<float, ProcessFunction::USE_PROCESS_ONE>>();
-
-    const std::string testInfo = fmt::format("syncOrAsyncTest<{}, {}>", isInputAsync, isOutputAsync);
-
+    Graph             testGraph;
+    auto&             tagSrc     = testGraph.emplaceBlock<TagSource<float>>({{"n_samples_max", n_samples}});
+    auto&             asyncBlock = testGraph.emplaceBlock<BlockType>();
+    auto&             sink       = testGraph.emplaceBlock<TagSink<float, ProcessFunction::USE_PROCESS_ONE>>();
+    const std::string testInfo   = fmt::format("syncOrAsyncTest<{}, {}>", isInputAsync, isOutputAsync);
     expect(asyncBlock.in.kIsSynch == !isInputAsync) << testInfo;
     expect(asyncBlock.out.kIsSynch == !isOutputAsync) << testInfo;
 

--- a/core/test/qa_buffer.cpp
+++ b/core/test/qa_buffer.cpp
@@ -17,77 +17,192 @@
 #include <gnuradio-4.0/Sequence.hpp>
 #include <gnuradio-4.0/WaitStrategy.hpp>
 
-template<gr::WaitStrategy auto wait = gr::NoWaitStrategy()>
+template<gr::WaitStrategyLike auto wait = gr::NoWaitStrategy()>
 struct TestStruct {
-    [[nodiscard]] constexpr bool
-    test() const noexcept {
-        return true;
-    }
+    [[nodiscard]] constexpr bool test() const noexcept { return true; }
 };
 
-void
-consumableInputRangeTest1(auto in) {
-    [[maybe_unused]] const auto inFirst = in[0];
-}
+void consumableInputRangeTest1(auto in) { [[maybe_unused]] const auto inFirst = in[0]; }
 
-void
-consumableInputRangeTest2(gr::ConsumableSpan auto in) {
-    [[maybe_unused]] const auto inFirst = in[0];
-}
+void consumableInputRangeTest2(gr::ConsumableSpan auto in) { [[maybe_unused]] const auto inFirst = in[0]; }
 
 template<typename T>
-void
-consumableInputRangeTest3(std::span<const T> in) {
+void consumableInputRangeTest3(std::span<const T> in) {
     [[maybe_unused]] const auto inFirst = in[0];
 }
+
+struct AllocatorPortable {};
+struct AllocatorPosix {};
+using CircularBufferSingle = gr::CircularBuffer<int32_t, std::dynamic_extent, gr::ProducerType::Single>;
+using CircularBufferMulti  = gr::CircularBuffer<int32_t, std::dynamic_extent, gr::ProducerType::Multi>;
+
+template<typename TCircularBuffer, typename TAllocator>
+struct CircularBufferTestTypes {
+    using CircularBuffer = TCircularBuffer;
+    using Allocator      = TAllocator;
+
+    constexpr static bool isMulti = std::is_same_v<TCircularBuffer, CircularBufferMulti>;
+    constexpr static bool isPosix = std::is_same_v<TAllocator, AllocatorPosix>;
+};
+
+using CircularBufferTypesToTest = std::tuple< //
+#ifdef HAS_POSIX_MAP_INTERFACE
+    CircularBufferTestTypes<CircularBufferSingle, AllocatorPosix>, //
+    CircularBufferTestTypes<CircularBufferMulti, AllocatorPosix>,  //
+#endif
+    CircularBufferTestTypes<CircularBufferSingle, AllocatorPortable>, //
+    CircularBufferTestTypes<CircularBufferMulti, AllocatorPortable>>;
 
 const boost::ut::suite BasicConceptsTests = [] {
     using namespace boost::ut;
 
-    "BasicConcepts"_test =
-            []<typename T> {
-                using namespace gr;
-                Buffer auto buffer   = T(1024);
-                auto        typeName = reflection::type_name<T>();
-                // N.B. GE because some buffers need to intrinsically
-                // allocate more to meet e.g. page-size requirements
-                expect(ge(buffer.size(), 1024UZ)) << "for" << typeName;
+    "BasicConcepts"_test = []<typename T> {
+        using namespace gr;
 
-                // compile-time interface tests
-                BufferReader auto reader = buffer.new_reader(); // tests matching read concept
-                BufferWriter auto writer = buffer.new_writer(); // tests matching write concept
+        const auto      allocator = (std::is_same_v<typename T::Allocator, AllocatorPosix>) ? gr::double_mapped_memory_resource::allocator<int32_t>() : std::pmr::polymorphic_allocator<int32_t>();
+        BufferLike auto buffer    = typename T::CircularBuffer(1024, allocator);
 
-                static_assert(std::is_same_v<decltype(reader.buffer().new_reader()), decltype(reader)>);
-                static_assert(std::is_same_v<decltype(reader.buffer().new_writer()), decltype(writer)>);
-                static_assert(std::is_same_v<decltype(writer.buffer().new_writer()), decltype(writer)>);
-                static_assert(std::is_same_v<decltype(writer.buffer().new_reader()), decltype(reader)>);
+        auto typeName = fmt::format("test({}-{})", reflection::type_name<typename T::CircularBuffer>(), reflection::type_name<typename T::Allocator>());
+        fmt::println("BasicConcepts: {}", typeName);
 
-                // runtime interface tests
-                expect(eq(reader.available(), 0UZ));
-                expect(eq(reader.position(), std::make_signed_t<std::size_t>{ kInitialCursorValue }));
-                gr::ConsumableSpan auto data = reader.get(0UZ);
-                expect(nothrow([&data] { expect(eq(data.size(), 0UZ)); })) << typeName << "throws";
-                expect(nothrow([&data] { expect(data.consume(0UZ)); }));
+        // N.B. GE because some buffers need to intrinsically allocate more to meet e.g. page-size requirements
+        expect(ge(buffer.size(), 1024UZ)) << "for " << typeName << "\n";
 
-                expect(writer.available() >= buffer.size());
-                expect(nothrow([&writer] { writer.publish([](const std::span<int32_t> &) { /* noop */ }, 0); }));
-                expect(nothrow([&writer] { writer.publish([](const std::span<int32_t> &, std::int64_t) { /* noop */ }, 0); }));
-                expect(nothrow([&writer] { expect(writer.try_publish([](const std::span<int32_t> &) { /* noop */ }, 0)); }));
-                expect(nothrow([&writer] { expect(writer.try_publish([](const std::span<int32_t> &, std::int64_t) { /* noop */ }, 0)); }));
+        // compile-time interface tests
+        BufferReaderLike auto reader = buffer.new_reader(); // tests matching read concept
+        BufferWriterLike auto writer = buffer.new_writer(); // tests matching write concept
 
-                // alt expert write interface
-                {
-                    auto value = writer.reserve(1);
-                    expect(eq(1LU, value.size())) << "for " << typeName;
-                    value.publish(1);
+        static_assert(std::is_same_v<decltype(reader.buffer().new_reader()), decltype(reader)>);
+        static_assert(std::is_same_v<decltype(reader.buffer().new_writer()), decltype(writer)>);
+        static_assert(std::is_same_v<decltype(writer.buffer().new_writer()), decltype(writer)>);
+        static_assert(std::is_same_v<decltype(writer.buffer().new_reader()), decltype(reader)>);
+
+        // runtime interface tests
+        expect(eq(reader.available(), 0UZ));
+        expect(eq(reader.position(), std::make_signed_t<std::size_t>{kInitialCursorValue}));
+        ConsumableSpan auto cSpan = reader.get(0UZ);
+        expect(nothrow([&cSpan] { expect(eq(cSpan.size(), 0UZ)); })) << typeName << "throws" << "\n";
+        expect(nothrow([&cSpan] { expect(cSpan.consume(0UZ)); }));
+
+        expect(writer.available() >= buffer.size());
+
+        {
+            PublishableSpan auto value = writer.tryReserve(1);
+            expect(eq(1LU, value.size())) << "for " << typeName << "\n";
+            value.publish(1);
+        }
+
+        { // publish remaining slots
+            PublishableSpan auto value = writer.template tryReserve<SpanReleasePolicy::ProcessAll>(1023);
+            expect(eq(1023UZ, value.size())) << "for " << typeName << "\n";
+        }
+
+        if constexpr (!T::isPosix) { // no more available slots, some buffers intrinsically allocate more to meet e.g. page-size requirements
+            PublishableSpan auto value = writer.template tryReserve<SpanReleasePolicy::ProcessAll>(10);
+            expect(eq(0UZ, value.size())) << "for " << typeName << "\n";
+        }
+
+        consumableInputRangeTest1(cSpan);
+        consumableInputRangeTest2(cSpan);
+        // consumableInputRangeTest3(cSpan); // this does not compile
+        consumableInputRangeTest3(static_cast<std::span<const int32_t>>(cSpan));
+    } | CircularBufferTypesToTest();
+};
+
+template<typename TBitset>
+void runAtomicBitsetTest(TBitset& bitset, std::size_t bitsetSize) {
+    using namespace boost::ut;
+
+    expect(eq(bitset.size(), bitsetSize)) << fmt::format("Bitset size should be {}", bitsetSize);
+
+    // test default values
+    for (std::size_t i = 0; i < bitset.size(); i++) {
+        expect(!bitset.test(i)) << fmt::format("Bit {} should be false", i);
+    }
+
+    // set true for test positions
+    std::vector<std::size_t> testPositions = {0UZ, 1UZ, 5UZ, 31UZ, 32UZ, 47UZ, 63UZ, 64UZ, 100UZ, 127UZ};
+    for (const std::size_t pos : testPositions) {
+        bitset.set(pos);
+    }
+
+    // only test positions should be set
+    for (std::size_t i = 0; i < bitset.size(); i++) {
+        if (std::ranges::find(testPositions, i) != testPositions.end()) {
+            expect(bitset.test(i)) << fmt::format("Bit {} should be set", i);
+        } else {
+            expect(!bitset.test(i)) << fmt::format("Bit {} should be false", i);
+        }
+    }
+
+    // reset test positions
+    for (const std::size_t pos : testPositions) {
+        bitset.reset(pos);
+    }
+
+    // all positions should be reset
+    for (std::size_t i = 0; i < bitset.size(); i++) {
+        expect(!bitset.test(i)) << fmt::format("Bit {} should be false", i);
+    }
+
+#if not defined(__EMSCRIPTEN__) && not defined(NDEBUG)
+    expect(aborts([&] { bitset.set(bitsetSize); })) << "Setting bit should throw an assertion.";
+    expect(aborts([&] { bitset.reset(bitsetSize); })) << "Resetting bit should throw an assertion.";
+    expect(aborts([&] { bitset.test(bitsetSize); })) << "Testing bit should throw an assertion.";
+#endif
+}
+
+const boost::ut::suite AtomicBitsetTests = [] {
+    using namespace boost::ut;
+    using namespace gr;
+    using namespace gr::detail;
+
+    "basics set/reset/test"_test = []() {
+        auto dynamicBitset = AtomicBitset<>(128UZ);
+        runAtomicBitsetTest(dynamicBitset, 128UZ);
+
+        auto staticBitset = AtomicBitset<128UZ>();
+        runAtomicBitsetTest(staticBitset, 128UZ);
+    };
+
+    "multithreads"_test = [] {
+        constexpr std::size_t    bitsetSize = 256UZ;
+        constexpr std::size_t    nThreads   = 16UZ;
+        constexpr std::size_t    nRepeats   = 100UZ;
+        AtomicBitset<bitsetSize> bitset;
+        std::vector<std::thread> threads;
+
+        for (std::size_t iThread = 0; iThread < nThreads; iThread++) {
+            threads.emplace_back([&] {
+                for (std::size_t iR = 0; iR < nRepeats; iR++) {
+                    for (std::size_t i = 0; i < bitsetSize; i++) {
+                        if (i < bitsetSize / 2) {
+                            bitset.set(i);
+                            bitset.reset(i);
+                            std::ignore = bitset.test(i);
+                        } else {
+                            bitset.reset(i);
+                            bitset.set(i);
+                            std::ignore = bitset.test(i);
+                        }
+                    }
                 }
-                consumableInputRangeTest1(data);
-                consumableInputRangeTest2(data);
-                // consumableInputRangeTest3(data); // this does not compile
-                consumableInputRangeTest3(static_cast<std::span<const int32_t>>(data));
+            });
+        }
+
+        for (auto& thread : threads) {
+            thread.join();
+        }
+
+        // Verify final state: first half should be reset, second half should be set
+        for (std::size_t i = 0; i < bitsetSize; i++) {
+            if (i < bitsetSize / 2) {
+                expect(!bitset.test(i)) << std::format("Bit {} should be reset", i);
+            } else {
+                expect(bitset.test(i)) << std::format("Bit {} should be set", i);
             }
-            // TODO: remove gr::test::BufferSkeleton<int32_t> from test, need solution to make ConsumableInputRange public
-            | std::tuple<gr::CircularBuffer<int32_t, std::dynamic_extent, gr::ProducerType::Single>, gr::CircularBuffer<int32_t, std::dynamic_extent, gr::ProducerType::Multi>>{ 2, 2 };
+        }
+    };
 };
 
 const boost::ut::suite SequenceTests = [] {
@@ -105,38 +220,38 @@ const boost::ut::suite SequenceTests = [] {
         expect(eq(s1.value(), kInitialCursorValue));
 
         const auto s2 = Sequence(2);
-        expect(eq(s2.value(), signed_index_type{ 2 }));
+        expect(eq(s2.value(), signed_index_type{2}));
 
         expect(nothrow([&s1] { s1.setValue(3); }));
-        expect(eq(s1.value(), signed_index_type{ 3 }));
+        expect(eq(s1.value(), signed_index_type{3}));
 
         expect(nothrow([&s1] { expect(s1.compareAndSet(3, 4)); }));
-        expect(nothrow([&s1] { expect(eq(s1.value(), signed_index_type{ 4 })); }));
+        expect(nothrow([&s1] { expect(eq(s1.value(), signed_index_type{4})); }));
         expect(nothrow([&s1] { expect(!s1.compareAndSet(3, 5)); }));
-        expect(eq(s1.value(), signed_index_type{ 4 }));
+        expect(eq(s1.value(), signed_index_type{4}));
 
-        expect(eq(s1.incrementAndGet(), signed_index_type{ 5 }));
-        expect(eq(s1.value(), signed_index_type{ 5 }));
-        expect(eq(s1.addAndGet(2), signed_index_type{ 7 }));
-        expect(eq(s1.value(), signed_index_type{ 7 }));
+        expect(eq(s1.incrementAndGet(), signed_index_type{5}));
+        expect(eq(s1.value(), signed_index_type{5}));
+        expect(eq(s1.addAndGet(2), signed_index_type{7}));
+        expect(eq(s1.value(), signed_index_type{7}));
 
-        std::shared_ptr<std::vector<std::shared_ptr<Sequence>>> sequences{ std::make_shared<std::vector<std::shared_ptr<Sequence>>>() };
+        std::shared_ptr<std::vector<std::shared_ptr<Sequence>>> sequences{std::make_shared<std::vector<std::shared_ptr<Sequence>>>()};
         expect(eq(gr::detail::getMinimumSequence(*sequences), std::numeric_limits<signed_index_type>::max()));
-        expect(eq(gr::detail::getMinimumSequence(*sequences, 2), signed_index_type{ 2 }));
+        expect(eq(gr::detail::getMinimumSequence(*sequences, 2), signed_index_type{2}));
         sequences->emplace_back(std::make_shared<Sequence>(4));
-        expect(eq(gr::detail::getMinimumSequence(*sequences), signed_index_type{ 4 }));
-        expect(eq(gr::detail::getMinimumSequence(*sequences, 5), signed_index_type{ 4 }));
-        expect(eq(gr::detail::getMinimumSequence(*sequences, 2), signed_index_type{ 2 }));
+        expect(eq(gr::detail::getMinimumSequence(*sequences), signed_index_type{4}));
+        expect(eq(gr::detail::getMinimumSequence(*sequences, 5), signed_index_type{4}));
+        expect(eq(gr::detail::getMinimumSequence(*sequences, 2), signed_index_type{2}));
 
         auto cursor = std::make_shared<Sequence>(10);
         auto s3     = std::make_shared<Sequence>(1);
         expect(eq(sequences->size(), 1UZ));
-        expect(eq(gr::detail::getMinimumSequence(*sequences), signed_index_type{ 4 }));
-        expect(nothrow([&sequences, &cursor, &s3] { gr::detail::addSequences(sequences, *cursor, { s3 }); }));
+        expect(eq(gr::detail::getMinimumSequence(*sequences), signed_index_type{4}));
+        expect(nothrow([&sequences, &cursor, &s3] { gr::detail::addSequences(sequences, *cursor, {s3}); }));
         expect(eq(sequences->size(), 2UZ));
         // newly added sequences are set automatically to the cursor/write position
-        expect(eq(s3->value(), signed_index_type{ 10 }));
-        expect(eq(gr::detail::getMinimumSequence(*sequences), signed_index_type{ 4 }));
+        expect(eq(s3->value(), signed_index_type{10}));
+        expect(eq(gr::detail::getMinimumSequence(*sequences), signed_index_type{4}));
 
         expect(nothrow([&sequences, &cursor] { gr::detail::removeSequence(sequences, cursor); }));
         expect(eq(sequences->size(), 2UZ));
@@ -171,24 +286,24 @@ const boost::ut::suite DoubleMappedAllocatorTests = [] {
 #endif
 
 template<typename Writer, std::size_t N>
-void
-writeVaryingChunkSizes(Writer &writer) {
+void writeVaryingChunkSizes(Writer& writer) {
     std::size_t pos    = 0;
     std::size_t iWrite = 0;
     while (pos < N) {
-        constexpr auto kChunkSizes = std::array{ 1UZ, 2UZ, 3UZ, 5UZ, 7UZ, 42UZ };
-        const auto     chunkSize   = std::min(kChunkSizes[iWrite % kChunkSizes.size()], N - pos);
-        {
-            auto out = writer.reserve(chunkSize);
+        constexpr auto           kChunkSizes = std::array{1UZ, 2UZ, 3UZ, 5UZ, 7UZ, 42UZ};
+        const auto               chunkSize   = std::min(kChunkSizes[iWrite % kChunkSizes.size()], N - pos);
+        gr::PublishableSpan auto out         = writer.tryReserve(chunkSize);
+        if (out.size() != 0) {
             boost::ut::expect(boost::ut::eq(writer.nSamplesPublished(), 0UZ));
-            for (auto i = 0UZ; i < out.size(); i++) {
-                out[i] = { { 0, static_cast<int>(pos + i) } };
+            for (std::size_t i = 0UZ; i < out.size(); i++) {
+                out[i] = {{0, static_cast<int>(pos + i)}};
             }
             out.publish(out.size());
+
             boost::ut::expect(boost::ut::eq(writer.nSamplesPublished(), chunkSize));
+            pos += chunkSize;
+            ++iWrite;
         }
-        pos += chunkSize;
-        ++iWrite;
     }
 }
 
@@ -207,14 +322,14 @@ const boost::ut::suite WaitStrategiesTests = [] {
         expect(isWaitStrategy<YieldingWaitStrategy>);
         expect(not isWaitStrategy<int>);
 
-        expect(WaitStrategy<BlockingWaitStrategy>);
-        expect(WaitStrategy<BusySpinWaitStrategy>);
-        expect(WaitStrategy<SleepingWaitStrategy>);
-        expect(WaitStrategy<SleepingWaitStrategy>);
-        expect(WaitStrategy<SpinWaitWaitStrategy>);
-        expect(WaitStrategy<TimeoutBlockingWaitStrategy>);
-        expect(WaitStrategy<YieldingWaitStrategy>);
-        expect(not WaitStrategy<int>);
+        expect(WaitStrategyLike<BlockingWaitStrategy>);
+        expect(WaitStrategyLike<BusySpinWaitStrategy>);
+        expect(WaitStrategyLike<SleepingWaitStrategy>);
+        expect(WaitStrategyLike<SleepingWaitStrategy>);
+        expect(WaitStrategyLike<SpinWaitWaitStrategy>);
+        expect(WaitStrategyLike<TimeoutBlockingWaitStrategy>);
+        expect(WaitStrategyLike<YieldingWaitStrategy>);
+        expect(not WaitStrategyLike<int>);
 
         TestStruct a;
         expect(a.test());
@@ -226,46 +341,43 @@ const boost::ut::suite UserApiExamples = [] {
 
     "UserApi"_test = [] {
         using namespace gr;
-        Buffer auto buffer = CircularBuffer<int32_t>(1024);
+        BufferLike auto buffer = CircularBuffer<int32_t>(1024);
 
-        BufferWriter auto writer = buffer.new_writer();
+        BufferWriterLike auto writer = buffer.new_writer();
         { // source only write example
-            BufferReader auto localReader = buffer.new_reader();
+            BufferReaderLike auto localReader = buffer.new_reader();
             expect(eq(localReader.available(), 0UZ));
 
-            auto lambda = [](auto w) { // test writer generating consecutive samples
-                static std::size_t offset = 1;
-                std::iota(w.begin(), w.end(), offset);
-                offset += w.size();
-            };
-
             expect(ge(writer.available(), buffer.size()));
-            writer.publish(lambda, 10);
+            {
+                PublishableSpan auto pSpan = writer.tryReserve(10);
+                expect(eq(pSpan.size(), 10UZ));
+                pSpan.publish(10);
+            }
             expect(eq(writer.available(), buffer.size() - 10UZ));
             expect(eq(localReader.available(), 10UZ));
             expect(eq(buffer.n_readers(), 1UZ)); // N.B. circular_buffer<..> specific
         }
         expect(eq(buffer.n_readers(), 0UZ)); // reader not in scope release atomic reader index
 
-        BufferReader auto reader = buffer.new_reader();
+        BufferReaderLike auto reader = buffer.new_reader();
         // reader does not know about previous submitted data as it joined only after
         // data has been written <-> needed for thread-safe joining of readers while writing
         expect(eq(reader.available(), 0UZ));
         // populate with some more data
         for (std::size_t i = 0; i < 3; i++) {
-            const auto demoWriter = [](auto w) {
-                static std::size_t offset = 1;
-                std::iota(w.begin(), w.end(), offset);
-                offset += w.size();
-            };
-            writer.publish(demoWriter, 5); // writer/publish five samples
+            {
+                PublishableSpan auto pSpan = writer.tryReserve(5);
+                expect(eq(pSpan.size(), 5UZ));
+                pSpan.publish(5);
+            }
             expect(eq(reader.available(), (i + 1) * 5)) << fmt::format("iteration: {}", i);
         }
 
         // N.B. here using a simple read-only (sink) example:
         for (int i = 0; reader.available() != 0; i++) {
-            gr::ConsumableSpan auto fixedLength = reader.get(3); // 'std::span<const int32_t> fixedLength' is not allowed explicitly
-            gr::ConsumableSpan auto available   = reader.get();
+            ConsumableSpan auto fixedLength = reader.get(3); // 'std::span<const int32_t> fixedLength' is not allowed explicitly
+            ConsumableSpan auto available   = reader.get();
             fmt::print("iteration {} - fixed-size data[{:2}]: [{}]\n", i, fixedLength.size(), fmt::join(fixedLength, ", "));
             fmt::print("iteration {} - full-size  data[{:2}]: [{}]\n", i, available.size(), fmt::join(available, ", "));
 
@@ -284,185 +396,183 @@ const boost::ut::suite UserApiExamples = [] {
 
 const boost::ut::suite CircularBufferTests = [] {
     using namespace boost::ut;
-    using Allocator = std::pmr::polymorphic_allocator<int32_t>;
+    using namespace gr;
 
-    "CircularBuffer"_test =
-            [](const Allocator &allocator) {
-                using namespace gr;
-                Buffer auto buffer = CircularBuffer<int32_t>(1024, allocator);
-                expect(ge(buffer.size(), 1024u));
+    "CircularBuffer"_test = []<typename T>() {
+        const auto      allocator = (std::is_same_v<typename T::Allocator, AllocatorPosix>) ? gr::double_mapped_memory_resource::allocator<int32_t>() : std::pmr::polymorphic_allocator<int32_t>();
+        BufferLike auto buffer    = typename T::CircularBuffer(1024, allocator);
 
-                BufferWriter auto writer = buffer.new_writer();
-                expect(nothrow([&writer] { expect(eq(writer.buffer().n_readers(), 0UZ)); })); // no reader, just writer
-                BufferReader auto reader = buffer.new_reader();
-                expect(nothrow([&reader] { expect(eq(reader.buffer().n_readers(), 1UZ)); })); // created one reader
+        fmt::println("CircularBufferTest: {}", fmt::format("test({}-{})", gr::meta::type_name<typename T::CircularBuffer>(), gr::meta::type_name<typename T::Allocator>()));
 
-                std::size_t offset = 1;
-                auto        lambda = [&offset](auto w) {
-                    std::iota(w.begin(), w.end(), offset);
-                    offset += w.size();
-                };
+        expect(ge(buffer.size(), 1024u));
 
-                expect(eq(reader.available(), 0UZ));
-                expect(eq(reader.get().size(), 0UZ));
+        BufferWriterLike auto writer = buffer.new_writer();
+        expect(nothrow([&writer] { expect(eq(writer.buffer().n_readers(), 0UZ)); })); // no reader, just writer
+        BufferReaderLike auto reader = buffer.new_reader();
+        expect(nothrow([&reader] { expect(eq(reader.buffer().n_readers(), 1UZ)); })); // created one reader
+
+        expect(eq(reader.available(), 0UZ));
+        expect(eq(reader.get().size(), 0UZ));
 #if not defined(__EMSCRIPTEN__) && not defined(NDEBUG)
-                expect(aborts([&reader] { std::ignore = reader.get(1); }));
+        expect(aborts([&reader] { std::ignore = reader.get(1); }));
 #endif
-                expect(eq(writer.available(), buffer.size()));
-                expect(nothrow([&writer, &lambda, &buffer] { writer.publish(lambda, buffer.size()); })); // fully fill buffer
-
-                expect(eq(writer.available(), 0UZ));
-                expect(eq(reader.available(), buffer.size()));
-                expect(eq(reader.get().size(), buffer.size()));
-                {
-                    auto inSpan = reader.get(2);
-                    expect(eq(inSpan.size(), 2UZ));
-                    expect(eq(reader.nSamplesConsumed(), 0UZ));
-                    {
-                        // Subsequent calls to get(), without calling consume() again, will return maximum of _nSamplesFirstGet (2)
-                        auto inSpan2 = reader.get(3);
-                        expect(eq(inSpan2.size(), 2UZ));
-                        expect(eq(reader.nSamplesConsumed(), 0UZ));
-                        {
-                            auto inSpan3 = reader.get(1);
-                            expect(eq(inSpan3.size(), 1UZ));
-                            expect(eq(reader.nSamplesConsumed(), 0UZ));
-                        }
-                    }
-                    expect(eq(reader.nSamplesConsumed(), 0UZ));
-                    expect(not inSpan.isConsumeRequested());
-
-                    // full buffer: fill buffer need to fail/return 'false'
-                    expect(not writer.try_publish(lambda, buffer.size()));
-
-                    expect(inSpan.consume(0UZ));
-                    expect(inSpan.isConsumeRequested());
-                    expect(eq(reader.nSamplesConsumed(), 0UZ));
-                }
+        expect(eq(writer.available(), buffer.size()));
+        expect(nothrow([&writer, &buffer] {
+            PublishableSpan auto pSpan = writer.tryReserve(buffer.size());
+            pSpan.publish(buffer.size());
+        })); // fully fill buffer
+        expect(eq(writer.available(), 0UZ));
+        expect(eq(reader.available(), buffer.size()));
+        expect(eq(reader.get().size(), buffer.size()));
+        {
+            ConsumableSpan auto inSpan = reader.get(2);
+            expect(eq(inSpan.size(), 2UZ));
+            expect(eq(reader.nSamplesConsumed(), 0UZ));
+            {
+                // Subsequent calls to get(), without calling consume() again, will return maximum of _nSamplesFirstGet (2)
+                ConsumableSpan auto inSpan2 = reader.get(3);
+                expect(eq(inSpan2.size(), 2UZ));
                 expect(eq(reader.nSamplesConsumed(), 0UZ));
-                expect(not reader.isConsumeRequested());
-                expect(eq(reader.available(), buffer.size()));
-
-#if not defined(__EMSCRIPTEN__) && not defined(NDEBUG)
-                expect(aborts([&reader] {
-                    {
-                        auto inSpan4 = reader.get<SpanReleasePolicy::Terminate>(3);
-                        expect(eq(inSpan4.size(), 3UZ));
-                        expect(not inSpan4.isConsumeRequested());
-                    }
-                }));
-#endif
-
                 {
-                    auto inSpan5 = reader.get<SpanReleasePolicy::ProcessNone>(3);
-                    expect(eq(inSpan5.size(), 3UZ));
-                    expect(not inSpan5.isConsumeRequested());
-                }
-                expect(eq(reader.nSamplesConsumed(), 0UZ));
-                expect(not reader.isConsumeRequested());
-                expect(eq(reader.available(), buffer.size()));
-
-                std::size_t inSpan6Size{ 0UZ };
-                {
-                    auto inSpan6 = reader.get<SpanReleasePolicy::ProcessAll>();
-                    inSpan6Size  = inSpan6.size();
-                    expect(eq(inSpan6.size(), reader.available()));
-                    expect(not inSpan6.isConsumeRequested());
-                }
-                expect(eq(reader.nSamplesConsumed(), inSpan6Size));
-                expect(not reader.isConsumeRequested());
-                expect(eq(reader.available(), 0UZ));
-
-                expect(eq(writer.available(), buffer.size()));
-
-                // test buffer wrap around twice
-                std::size_t counter = 1;
-                for (const int _blockSize : { 1, 2, 3, 5, 7, 42 }) {
-                    auto blockSize = static_cast<std::size_t>(_blockSize);
-                    for (std::size_t i = 0; i < buffer.size(); i++) {
-                        if (i != 0) {
-                            expect(eq(reader.nSamplesConsumed(), blockSize));
-                        }
-                        expect(writer.try_publish([&counter](auto &writable) { std::iota(writable.begin(), writable.end(), counter += writable.size()); }, blockSize));
-                        gr::ConsumableSpan auto readable = reader.get(blockSize);
-                        expect(eq(readable.size(), blockSize));
-                        expect(eq(readable.front(), static_cast<int>(counter)));
-                        expect(eq(readable.back(), static_cast<int>(counter + blockSize - 1)));
-                        expect(readable.consume(blockSize));
-                        expect(eq(reader.nSamplesConsumed(), 0UZ));
-                    }
-                }
-
-                // basic expert writer api
-                for (int k = 0; k < 3; k++) {
-                    // case 0: write fully reserved data
-                    {
-                        auto data = writer.reserve(4);
-                        expect(eq(writer.nSamplesPublished(), 0UZ));
-                        for (std::size_t i = 0; i < data.size(); i++) {
-                            data[i] = static_cast<int>(i + 1);
-                        }
-                        data.publish(4);
-                        expect(eq(writer.nSamplesPublished(), 4UZ));
-                    }
-                    gr::ConsumableSpan auto read_data = reader.get();
-                    expect(eq(read_data.size(), 4UZ));
-                    for (std::size_t i = 0; i < read_data.size(); i++) {
-                        expect(eq(static_cast<int>(i + 1), read_data[i])) << "case 0: read index " << i;
-                    }
-                    expect(read_data.consume(4));
-                }
-                for (int k = 0; k < 3; k++) {
-                    // case 1: reserve more than actually written
-                    const auto cursor_initial = buffer.cursor_sequence().value();
-                    {
-                        auto data = writer.reserve(4);
-                        expect(eq(writer.nSamplesPublished(), 0UZ));
-                        for (std::size_t i = 0; i < data.size(); i++) {
-                            data[i] = static_cast<int>(i + 1);
-                        }
-                        data.publish(2);
-                        expect(eq(writer.nSamplesPublished(), 2UZ));
-                    }
-                    const auto cursor_after = buffer.cursor_sequence().value();
-                    expect(eq(cursor_initial + 2, cursor_after)) << fmt::format("cursor sequence moving by two: {} -> {}", cursor_initial, cursor_after);
-                    gr::ConsumableSpan auto read_data = reader.get();
-                    expect(eq(2UZ, read_data.size())) << fmt::format("received {} samples instead of expected 2", read_data.size());
-                    for (std::size_t i = 0; i < read_data.size(); i++) {
-                        expect(eq(static_cast<int>(i + 1), read_data[i])) << "read 1: index " << i;
-                    }
-                    expect(read_data.consume(2));
-                }
-                for (int k = 0; k < 3; k++) {
-                    // case 2: reserve using RAII token
-                    const auto cursor_initial = buffer.cursor_sequence().value();
-                    {
-                        auto data = writer.reserve(4);
-                        expect(eq(writer.nSamplesPublished(), 0UZ));
-                        std::span<int32_t> span = data; // tests conversion operator
-                        for (std::size_t i = 0; i < data.size(); i++) {
-                            data[i] = static_cast<int>(i + 1);
-                            expect(eq(data[i], span[i]));
-                        }
-                        data.publish(2);
-                        expect(eq(writer.nSamplesPublished(), 2UZ));
-                    }
-                    const auto cursor_after = buffer.cursor_sequence().value();
-                    expect(eq(cursor_initial + 2, cursor_after)) << fmt::format("cursor sequence moving by two: {} -> {}", cursor_initial, cursor_after);
-                    gr::ConsumableSpan auto read_data = reader.get();
-                    expect(eq(2UZ, read_data.size())) << fmt::format("received {} samples instead of expected 2", read_data.size());
-                    for (std::size_t i = 0; i < read_data.size(); i++) {
-                        expect(eq(static_cast<int>(i + 1), read_data[i])) << "read 1: index " << i;
-                    }
-                    expect(read_data.consume(2));
+                    ConsumableSpan auto inSpan3 = reader.get(1);
+                    expect(eq(inSpan3.size(), 1UZ));
+                    expect(eq(reader.nSamplesConsumed(), 0UZ));
                 }
             }
-            | std::vector{
-#ifdef HAS_POSIX_MAP_INTERFACE
-                  gr::double_mapped_memory_resource::allocator<int32_t>(),
+            expect(eq(reader.nSamplesConsumed(), 0UZ));
+            expect(!inSpan.isConsumeRequested());
+
+            expect(inSpan.consume(0UZ));
+            expect(inSpan.isConsumeRequested());
+            expect(eq(reader.nSamplesConsumed(), 0UZ));
+        }
+        expect(eq(reader.nSamplesConsumed(), 0UZ));
+        expect(!reader.isConsumeRequested());
+        expect(eq(reader.available(), buffer.size()));
+
+#if not defined(__EMSCRIPTEN__) && not defined(NDEBUG)
+        expect(aborts([&reader] {
+            {
+                ConsumableSpan auto inSpan4 = reader.template get<SpanReleasePolicy::Terminate>(3);
+                expect(eq(inSpan4.size(), 3UZ));
+                expect(!inSpan4.isConsumeRequested());
+            }
+        }));
 #endif
-                  Allocator()
-              };
+        {
+            ConsumableSpan auto inSpan5 = reader.template get<SpanReleasePolicy::ProcessNone>(3);
+            expect(eq(inSpan5.size(), 3UZ));
+            expect(!inSpan5.isConsumeRequested());
+        }
+        expect(eq(reader.nSamplesConsumed(), 0UZ));
+        expect(!reader.isConsumeRequested());
+        expect(eq(reader.available(), buffer.size()));
+        std::size_t inSpan6Size{0UZ};
+        {
+            ConsumableSpan auto inSpan6 = reader.template get<SpanReleasePolicy::ProcessAll>();
+            inSpan6Size                 = inSpan6.size();
+            expect(eq(inSpan6.size(), reader.available()));
+            expect(!inSpan6.isConsumeRequested());
+        }
+        expect(eq(reader.nSamplesConsumed(), inSpan6Size));
+        expect(!reader.isConsumeRequested());
+        expect(eq(reader.available(), 0UZ));
+
+        expect(eq(writer.available(), buffer.size()));
+
+        // test buffer wrap around twice
+        std::size_t counter = 1;
+        for (const int _blockSize : {1, 2, 3, 5, 7, 42}) {
+            auto blockSize = static_cast<std::size_t>(_blockSize);
+            for (std::size_t i = 0; i < buffer.size(); i++) {
+                if (i != 0) {
+                    expect(eq(reader.nSamplesConsumed(), blockSize));
+                }
+                {
+                    PublishableSpan auto pSpan = writer.template tryReserve<SpanReleasePolicy::ProcessAll>(blockSize);
+                    expect(eq(pSpan.size(), blockSize));
+                    std::iota(pSpan.begin(), pSpan.end(), counter += pSpan.size());
+                }
+                gr::ConsumableSpan auto cSpan = reader.get(blockSize);
+                expect(eq(cSpan.size(), blockSize));
+                expect(eq(cSpan.front(), static_cast<int>(counter)));
+                expect(eq(cSpan.back(), static_cast<int>(counter + blockSize - 1)));
+                expect(cSpan.consume(blockSize));
+                expect(eq(reader.nSamplesConsumed(), 0UZ));
+            }
+        }
+
+        // basic expert writer api
+        for (int k = 0; k < 3; k++) {
+            // case 0: write fully reserved data
+            {
+                PublishableSpan auto pSpan = writer.tryReserve(4);
+                expect(eq(pSpan.size(), 4UZ));
+                expect(eq(writer.nSamplesPublished(), 0UZ));
+                for (std::size_t i = 0; i < pSpan.size(); i++) {
+                    pSpan[i] = static_cast<int>(i + 1);
+                }
+                pSpan.publish(4);
+                expect(eq(writer.nSamplesPublished(), 4UZ));
+            }
+            ConsumableSpan auto cSpan = reader.get();
+            expect(eq(cSpan.size(), 4UZ));
+            for (std::size_t i = 0; i < cSpan.size(); i++) {
+                expect(eq(static_cast<int>(i + 1), cSpan[i])) << "case 0: read index " << i;
+            }
+            expect(cSpan.consume(4));
+        }
+
+        if constexpr (!T::isMulti) { // MultiThreaded does not allow to publish less than reserved
+            for (int k = 0; k < 3; k++) {
+                // case 1: reserve more than actually written
+                const auto cursor_initial = buffer.cursor_sequence().value();
+                {
+                    PublishableSpan auto pSpan = writer.tryReserve(4);
+                    expect(eq(pSpan.size(), 4UZ));
+                    expect(eq(writer.nSamplesPublished(), 0UZ));
+                    for (std::size_t i = 0; i < pSpan.size(); i++) {
+                        pSpan[i] = static_cast<int>(i + 1);
+                    }
+                    pSpan.publish(2);
+                    expect(eq(writer.nSamplesPublished(), 2UZ));
+                }
+                const auto cursor_after = buffer.cursor_sequence().value();
+                expect(eq(cursor_initial + 2, cursor_after)) << fmt::format("cursor sequence moving by two: {} -> {}", cursor_initial, cursor_after);
+                ConsumableSpan auto cSpan = reader.get();
+                expect(eq(2UZ, cSpan.size())) << fmt::format("received {} samples instead of expected 2", cSpan.size());
+                for (std::size_t i = 0; i < cSpan.size(); i++) {
+                    expect(eq(static_cast<int>(i + 1), cSpan[i])) << "read 1: index " << i;
+                }
+                expect(cSpan.consume(2));
+            }
+
+            for (int k = 0; k < 3; k++) {
+                // case 2: reserve using RAII token
+                const auto cursor_initial = buffer.cursor_sequence().value();
+                {
+                    PublishableSpan auto pSpan = writer.tryReserve(4);
+                    expect(eq(pSpan.size(), 4UZ));
+                    expect(eq(writer.nSamplesPublished(), 0UZ));
+                    std::span<int32_t> span = pSpan; // tests conversion operator
+                    for (std::size_t i = 0; i < pSpan.size(); i++) {
+                        pSpan[i] = static_cast<int>(i + 1);
+                        expect(eq(pSpan[i], span[i]));
+                    }
+                    pSpan.publish(2);
+                    expect(eq(writer.nSamplesPublished(), 2UZ));
+                }
+                const auto cursor_after = buffer.cursor_sequence().value();
+                expect(eq(cursor_initial + 2, cursor_after)) << fmt::format("cursor sequence moving by two: {} -> {}", cursor_initial, cursor_after);
+                ConsumableSpan auto cSpan = reader.get();
+                expect(eq(2UZ, cSpan.size())) << fmt::format("received {} samples instead of expected 2", cSpan.size());
+                for (std::size_t i = 0; i < cSpan.size(); i++) {
+                    expect(eq(static_cast<int>(i + 1), cSpan[i])) << "read 1: index " << i;
+                }
+                expect(cSpan.consume(2));
+            }
+        }
+    } | CircularBufferTypesToTest();
 
     "MultiProducerStdMapSingleWriter"_test = [] {
         // Using std::map exposed some race conditions in the multi-producer buffer implementation
@@ -470,9 +580,9 @@ const boost::ut::suite CircularBufferTests = [] {
         // with single reader)
         gr::CircularBuffer<std::map<int, int>, std::dynamic_extent, gr::ProducerType::Multi> buffer(1024);
 
-        gr::BufferWriter auto writer  = buffer.new_writer();
-        gr::BufferReader auto reader1 = buffer.new_reader();
-        gr::BufferReader auto reader2 = buffer.new_reader();
+        gr::BufferWriterLike auto writer  = buffer.new_writer();
+        gr::BufferReaderLike auto reader1 = buffer.new_reader();
+        gr::BufferReaderLike auto reader2 = buffer.new_reader();
 
         constexpr auto kWrites      = 200000UZ;
         auto           writerThread = std::thread(&writeVaryingChunkSizes<decltype(writer), kWrites>, std::ref(writer));
@@ -506,9 +616,9 @@ const boost::ut::suite CircularBufferTests = [] {
         constexpr auto kWrites   = 20000UZ;
 
         gr::CircularBuffer<std::map<int, int>, std::dynamic_extent, gr::ProducerType::Multi> buffer(1024);
-        using WriterType              = decltype(buffer.new_writer());
-        gr::BufferReader auto reader1 = buffer.new_reader();
-        gr::BufferReader auto reader2 = buffer.new_reader();
+        using WriterType                  = decltype(buffer.new_writer());
+        gr::BufferReaderLike auto reader1 = buffer.new_reader();
+        gr::BufferReaderLike auto reader2 = buffer.new_reader();
 
         std::vector<WriterType> writers;
         for (std::size_t i = 0; i < kNWriters; i++) {
@@ -526,7 +636,7 @@ const boost::ut::suite CircularBufferTests = [] {
             std::size_t read = 0;
             while (read < kWrites * kNWriters) {
                 auto in = reader.get().get();
-                for (const auto &map : in) {
+                for (const auto& map : in) {
                     auto vIt = map.find(0);
                     expect(vIt != map.end());
                     if (vIt == map.end()) {
@@ -537,7 +647,9 @@ const boost::ut::suite CircularBufferTests = [] {
                     expect(le(value, static_cast<int>(kWrites)));
                     const auto nextIt = std::ranges::find(next, value);
                     expect(nextIt != next.end());
-                    if (nextIt == next.end()) continue;
+                    if (nextIt == next.end()) {
+                        continue;
+                    }
                     *nextIt = value + 1;
                 }
                 read += in.size();
@@ -555,62 +667,40 @@ const boost::ut::suite CircularBufferTests = [] {
     };
 };
 
-const boost::ut::suite CircularBufferExceptionTests = [] {
-    using namespace boost::ut;
-    "CircularBufferExceptions"_test = [] {
-        using namespace gr;
-        Buffer auto buffer = CircularBuffer<int32_t>(1024);
-        expect(ge(buffer.size(), 1024u));
-
-        BufferWriter auto writer = buffer.new_writer();
-        BufferReader auto reader = buffer.new_reader();
-
-#if not __EMSCRIPTEN__ // expect(throws(..)) not working with UT/Emscripten
-        expect(throws<std::exception>([&writer] { writer.publish([](auto &) { throw std::exception(); }); }));
-        expect(throws<std::exception>([&writer] { writer.publish([](auto &) { throw ""; }); }));
-        expect(throws<std::exception>([&writer] { writer.try_publish([](auto &) { throw std::exception(); }); }));
-        expect(throws<std::runtime_error>([&writer] { writer.try_publish([](auto &) { throw " "; }); }));
-#endif
-
-        expect(eq(reader.available(), 0UZ)); // needed otherwise buffer write will not be called
-    };
-};
-
 const boost::ut::suite UserDefinedTypeCasting = [] {
     using namespace boost::ut;
     "UserDefinedTypeCasting"_test = [] {
         using namespace gr;
-        Buffer auto buffer = CircularBuffer<std::complex<float>>(1024);
+        BufferLike auto buffer = CircularBuffer<std::complex<float>>(1024);
         expect(ge(buffer.size(), 1024u));
 
-        BufferWriter auto writer = buffer.new_writer();
-        BufferReader auto reader = buffer.new_reader();
-
-        writer.publish(
-                [](auto &w) {
-                    w[0] = std::complex(1.0f, -1.0f);
-                    w[1] = std::complex(2.0f, -2.0f);
-                },
-                2);
+        BufferWriterLike auto writer = buffer.new_writer();
+        BufferReaderLike auto reader = buffer.new_reader();
+        {
+            PublishableSpan auto pSpan = writer.tryReserve<SpanReleasePolicy::ProcessAll>(2);
+            expect(eq(pSpan.size(), 2UZ));
+            pSpan[0] = std::complex(1.0f, -1.0f);
+            pSpan[1] = std::complex(2.0f, -2.0f);
+        }
         expect(eq(reader.available(), 2UZ));
         {
-            ConsumableSpan auto data = reader.get(reader.available());
-            expect(eq(data.size(), 2UZ));
+            ConsumableSpan auto cSpan = reader.get(reader.available());
+            expect(eq(cSpan.size(), 2UZ));
 
-            auto const const_bytes = std::as_bytes(static_cast<std::span<const std::complex<float>>>(data));
-            expect(eq(const_bytes.size(), data.size() * sizeof(std::complex<float>)));
+            auto const const_bytes = std::as_bytes(static_cast<std::span<const std::complex<float>>>(cSpan));
+            expect(eq(const_bytes.size(), cSpan.size() * sizeof(std::complex<float>)));
 
-            auto convertToFloatSpan = [](std::span<const std::complex<float>> &c) -> std::span<const float> {
-                return { reinterpret_cast<const float *>(c.data()), c.size() * 2 }; // NOSONAR(cpp:S3630) //NOPMD needed
+            auto convertToFloatSpan = [](std::span<const std::complex<float>>& c) -> std::span<const float> {
+                return {reinterpret_cast<const float*>(c.data()), c.size() * 2}; // NOSONAR(cpp:S3630) //NOPMD needed
             };
-            auto floatArray = convertToFloatSpan(data);
+            auto floatArray = convertToFloatSpan(cSpan);
             expect(eq(floatArray[0], +1.0f));
             expect(eq(floatArray[1], -1.0f));
             expect(eq(floatArray[2], +2.0f));
             expect(eq(floatArray[3], -2.0f));
 
-            expect(data.consume(data.size()));
-            expect(eq(reader.available(), data.size()));
+            expect(cSpan.consume(cSpan.size()));
+            expect(eq(reader.available(), cSpan.size()));
         }
         expect(eq(reader.available(), 0UZ)); // needed otherwise buffer write will not be called
     };
@@ -630,41 +720,40 @@ const boost::ut::suite StreamTagConcept = [] {
         };
 
         expect(eq(sizeof(buffer_tag), 64UZ)) << "tag size";
-        Buffer auto buffer    = CircularBuffer<int32_t>(1024);
-        Buffer auto tagBuffer = CircularBuffer<buffer_tag>(32);
+        BufferLike auto buffer    = CircularBuffer<int32_t>(1024);
+        BufferLike auto tagBuffer = CircularBuffer<buffer_tag>(32);
         expect(ge(buffer.size(), 1024u));
         expect(ge(tagBuffer.size(), 32u));
 
-        BufferWriter auto writer    = buffer.new_writer();
-        BufferReader auto reader    = buffer.new_reader();
-        BufferWriter auto tagWriter = tagBuffer.new_writer();
-        BufferReader auto tagReader = tagBuffer.new_reader();
+        BufferWriterLike auto writer    = buffer.new_writer();
+        BufferReaderLike auto reader    = buffer.new_reader();
+        BufferWriterLike auto tagWriter = tagBuffer.new_writer();
+        BufferReaderLike auto tagReader = tagBuffer.new_reader();
 
         for (int i = 0; i < 3; i++) { // write-only worker (source) mock-up
-            auto lambda = [&tagWriter](auto w, std::int64_t writePosition) {
-                static std::size_t offset = 1;
-                std::iota(w.begin(), w.end(), offset);
-                offset += w.size();
+            PublishableSpan auto pSpan = writer.tryReserve<SpanReleasePolicy::ProcessAll>(10);
+            expect(eq(pSpan.size(), 10UZ));
+            static std::size_t offset = 1;
+            std::iota(pSpan.begin(), pSpan.end(), offset);
+            offset += pSpan.size();
 
-                // read/generated by some method (e.g. reading another buffer)
-                tagWriter.publish([&writePosition](auto &writeTag) { writeTag[0] = { writePosition, fmt::format("<tag data at index {:3}>", writePosition) }; }, 1);
-            };
-
-            writer.publish(lambda, 10); // optional return param.
+            PublishableSpan auto pSpanTag = tagWriter.tryReserve<SpanReleasePolicy::ProcessAll>(1);
+            expect(eq(pSpanTag.size(), 1UZ));
+            pSpanTag[0] = {static_cast<int64_t>(offset), fmt::format("<tag data at index {:3}>", offset)};
         }
 
         { // read-only worker (sink) mock-up
             fmt::print("read position: {}\n", reader.position());
-            const ConsumableSpan auto readData = reader.get(reader.available());
-            const ConsumableSpan auto tags     = tagReader.get(tagReader.available());
+            const ConsumableSpan auto cSpanData = reader.get(reader.available());
+            const ConsumableSpan auto cSpanTags = tagReader.get(tagReader.available());
 
-            fmt::print("received {} tags\n", tags.size());
-            for (auto &readTag : tags) {
+            fmt::print("received {} tags\n", cSpanTags.size());
+            for (auto& readTag : cSpanTags) {
                 fmt::print("stream-tag @{:3}: '{}'\n", readTag.index, readTag.data);
             }
 
-            expect(readData.consume(readData.size()));
-            expect(tags.consume(tags.size())); // N.B. consume tag based on expiry
+            expect(cSpanData.consume(cSpanData.size()));
+            expect(cSpanTags.consume(cSpanTags.size())); // N.B. consume tag based on expiry
         }
     };
 };
@@ -677,35 +766,34 @@ const boost::ut::suite NonPowerTwoTests = [] {
         using Type                     = std::vector<int>;
         constexpr std::size_t typeSize = sizeof(std::vector<int>);
         expect(not std::has_single_bit(typeSize)) << "type is non-power-of-two";
-        Buffer auto buffer = CircularBuffer<Type>(1024);
+        BufferLike auto buffer = CircularBuffer<Type>(1024);
         expect(ge(buffer.size(), 1024u));
 
-        BufferWriter auto writer = buffer.new_writer();
-        BufferReader auto reader = buffer.new_reader();
+        BufferWriterLike auto writer = buffer.new_writer();
+        BufferReaderLike auto reader = buffer.new_reader();
 
         const auto genSamples = [&buffer, &writer] {
             for (std::size_t i = 0UZ; i < buffer.size() - 10UZ; i++) { // write-only worker (source) mock-up
-                auto lambda = [](auto vectors) {
-                    static int offset = 0;
-                    for (auto &vector : vectors) {
-                        vector.resize(1);
-                        vector[0] = offset++;
-                    }
-                };
-                writer.publish(lambda); // optional return param.
+                PublishableSpan auto pSpan = writer.tryReserve<SpanReleasePolicy::ProcessAll>(1);
+                expect(eq(pSpan.size(), 1UZ));
+                static int offset = 0;
+                for (auto& vector : pSpan) {
+                    vector.resize(1);
+                    vector[0] = offset++;
+                }
             }
         };
 
         const auto readSamples = [&reader] {
             while (reader.available()) {
-                const ConsumableSpan auto vectorData = reader.get(reader.available());
-                for (auto &vector : vectorData) {
+                const ConsumableSpan auto cSpan = reader.get(reader.available());
+                for (auto& vector : cSpan) {
                     static int offset = -1;
                     expect(eq(vector.size(), 1u)) << "vector size == 1";
                     expect(eq(vector[0] - offset, 1)) << "vector offset == 1";
                     offset = vector[0];
                 }
-                expect(vectorData.consume(vectorData.size()));
+                expect(cSpan.consume(cSpan.size()));
             }
         };
 
@@ -721,9 +809,9 @@ const boost::ut::suite HistoryBufferTest = [] {
     using namespace boost::ut;
     using namespace gr;
 
-    "HistoryBuffer<double>"_test = [](const std::size_t &capacity) {
+    "HistoryBuffer<double>"_test = [](const std::size_t& capacity) {
         HistoryBuffer<int> hb(capacity);
-        const auto        &const_hb = hb; // tests const access
+        const auto&        const_hb = hb; // tests const access
         expect(eq(hb.capacity(), capacity));
         expect(eq(hb.size(), 0UZ));
 
@@ -742,36 +830,36 @@ const boost::ut::suite HistoryBufferTest = [] {
         expect(eq(hb.at(1), static_cast<int>(capacity))) << "checked access the previous sample";
         expect(eq(const_hb.at(0), static_cast<int>(capacity + 1))) << "checked const access the last/actual sample";
         expect(eq(const_hb.at(1), static_cast<int>(capacity))) << "checked const access the previous sample";
-    } | std::vector<std::size_t>{ 5, 3, 10 };
+    } | std::vector<std::size_t>{5, 3, 10};
 
     "HistoryBuffer - range tests"_test = [] {
         HistoryBuffer<int> hb(5);
-        hb.push_back_bulk(std::array{ 1, 2, 3 });
-        hb.push_back_bulk(std::vector{ 4, 5, 6 });
+        hb.push_back_bulk(std::array{1, 2, 3});
+        hb.push_back_bulk(std::vector{4, 5, 6});
         expect(eq(hb.capacity(), 5UZ));
         expect(eq(hb.size(), 5UZ));
 
-        auto equal = [](const auto &range1, const auto &range2) { // N.B. TODO replacement until libc++ fully supports ranges
+        auto equal = [](const auto& range1, const auto& range2) { // N.B. TODO replacement until libc++ fully supports ranges
             return std::equal(range1.begin(), range1.end(), range2.begin(), range2.end());
         };
 
-        expect(equal(hb.get_span(0, 3), std::vector{ 6, 5, 4 })) << fmt::format("failed - got [{}]", fmt::join(hb.get_span(0, 3), ", "));
-        expect(equal(hb.get_span(1, 3), std::vector{ 5, 4, 3 })) << fmt::format("failed - got [{}]", fmt::join(hb.get_span(1, 3), ", "));
+        expect(equal(hb.get_span(0, 3), std::vector{6, 5, 4})) << fmt::format("failed - got [{}]", fmt::join(hb.get_span(0, 3), ", "));
+        expect(equal(hb.get_span(1, 3), std::vector{5, 4, 3})) << fmt::format("failed - got [{}]", fmt::join(hb.get_span(1, 3), ", "));
 
-        expect(equal(hb.get_span(0), std::vector{ 6, 5, 4, 3, 2 })) << fmt::format("failed - got [{}]", fmt::join(hb.get_span(0), ", "));
-        expect(equal(hb.get_span(1), std::vector{ 5, 4, 3, 2 })) << fmt::format("failed - got [{}]", fmt::join(hb.get_span(1), ", "));
+        expect(equal(hb.get_span(0), std::vector{6, 5, 4, 3, 2})) << fmt::format("failed - got [{}]", fmt::join(hb.get_span(0), ", "));
+        expect(equal(hb.get_span(1), std::vector{5, 4, 3, 2})) << fmt::format("failed - got [{}]", fmt::join(hb.get_span(1), ", "));
 
         std::vector<int> forward_bracket;
         for (std::size_t i = 0; i < hb.size(); i++) {
             forward_bracket.push_back(hb[i]);
         }
-        expect(equal(forward_bracket, std::vector{ 6, 5, 4, 3, 2 })) << fmt::format("failed - got [{}]", fmt::join(forward_bracket, ", "));
+        expect(equal(forward_bracket, std::vector{6, 5, 4, 3, 2})) << fmt::format("failed - got [{}]", fmt::join(forward_bracket, ", "));
 
         std::vector<int> forward(hb.begin(), hb.end());
-        expect(equal(forward, std::vector{ 6, 5, 4, 3, 2 })) << fmt::format("failed - got [{}]", fmt::join(forward, ", "));
+        expect(equal(forward, std::vector{6, 5, 4, 3, 2})) << fmt::format("failed - got [{}]", fmt::join(forward, ", "));
 
         std::vector<int> reverse(hb.rbegin(), hb.rend());
-        expect(equal(reverse, std::vector{ 2, 3, 4, 5, 6 })) << fmt::format("failed - got [{}]", fmt::join(reverse, ", "));
+        expect(equal(reverse, std::vector{2, 3, 4, 5, 6})) << fmt::format("failed - got [{}]", fmt::join(reverse, ", "));
 
         expect(equal(std::vector(hb.cbegin(), hb.cend()), std::vector(hb.begin(), hb.end()))) << "const non-const iterator equivalency";
         expect(equal(std::vector(hb.crbegin(), hb.crend()), std::vector(hb.rbegin(), hb.rend()))) << "const non-const iterator equivalency";
@@ -796,7 +884,7 @@ const boost::ut::suite HistoryBufferTest = [] {
 
         // Create a history buffer of size 1
         HistoryBuffer<int> hb_one(1);
-        const auto        &const_hb_one = hb_one; // tests const access
+        const auto&        const_hb_one = hb_one; // tests const access
         expect(eq(hb_one.capacity(), 1UZ));
         expect(eq(hb_one.size(), 0UZ));
         hb_one.push_back(41);
@@ -810,12 +898,12 @@ const boost::ut::suite HistoryBufferTest = [] {
 
         // Push more elements than buffer size
         HistoryBuffer<int> hb_overflow(5);
-        auto               in = std::vector{ 1, 2, 3, 4, 5, 6 };
+        auto               in = std::vector{1, 2, 3, 4, 5, 6};
         hb_overflow.push_back_bulk(in.begin(), in.end());
         expect(eq(hb_overflow[0], 6));
-        hb_overflow.push_back_bulk(std::vector{ 7, 8, 9 });
+        hb_overflow.push_back_bulk(std::vector{7, 8, 9});
         expect(eq(hb_overflow[0], 9));
-        hb_overflow.push_back_bulk(std::array{ 10, 11, 12 });
+        hb_overflow.push_back_bulk(std::array{10, 11, 12});
         expect(eq(hb_overflow[0], 12));
 
         // Test with different types, e.g., double
@@ -828,10 +916,10 @@ const boost::ut::suite HistoryBufferTest = [] {
 
         expect(nothrow([&hb_double] { hb_double.reset(); })) << "reset (default) does not throw";
         expect(eq(hb_double.size(), 0UZ));
-        expect(std::all_of(hb_double.begin(), hb_double.end(), [](const auto &elem) { return elem == 0.0; }));
+        expect(std::all_of(hb_double.begin(), hb_double.end(), [](const auto& elem) { return elem == 0.0; }));
         expect(nothrow([&hb_double] { hb_double.reset(2.0); })) << "reset (2.0) does not throw";
-        const auto &const_hb_double = hb_double; // tests const access
-        expect(std::all_of(const_hb_double.begin(), const_hb_double.end(), [](const auto &elem) { return elem == 2.0; }));
+        const auto& const_hb_double = hb_double; // tests const access
+        expect(std::all_of(const_hb_double.begin(), const_hb_double.end(), [](const auto& elem) { return elem == 2.0; }));
 
         for (std::size_t i = 0UZ; i < hb_double.capacity(); ++i) {
             expect(eq(2.0, hb_double.data()[i]));
@@ -839,10 +927,9 @@ const boost::ut::suite HistoryBufferTest = [] {
         }
 
         static_assert(!std::is_const_v<std::remove_pointer_t<decltype(hb_double.data())>>, "is non-const");
-        const auto &const_buffer = hb_double;
+        const auto& const_buffer = hb_double;
         static_assert(std::is_const_v<std::remove_pointer_t<decltype(const_buffer.data())>>, "is const");
     };
 };
 
-int
-main() { /* not needed for UT */ }
+int main() { /* not needed for UT */ }


### PR DESCRIPTION
The bm_Buffer benchmark test indicated significant performance degradation for the multi-producer case following this commit: https://github.com/fair-acc/gnuradio4/commit/5bd3eed14076427b1d50997ae6c2a77863876121.

The `CircularBuffer` was significantly updated, it uses newly developed `AtomicBitset` to check for available slots.

Other changes:
* Remove CircularBuffer::Writer::publish() and update unit tests accordingly.
* `reserve()` and `tryReserve()`. Some functions still use blocking `reserve()`.
* Fix the issue with the unintentionally disabled `HAS_POSIX_MAP_INTERFACE`.
* Updated `qa_buffer` to always test four variants: Multi-Posix, Multi-Portable, Single-Posix, Single-Portable.

Known issues:
* `warning: implicit conversion changes signedness: 'signed_index_type' (aka 'long') to 'std::size_t' (aka 'unsigned long')` will be fixed when one changes the type of `signed_index_type` to `index_type` in one of the next PR.
* `reserve()` vs. `tryReserve()`
* `bm_Buffer` test does not work with `tryReserve()`
* Protection agains `std::size_t` overflow -> can be implemented together with changing `signed_index_type` from signed to unsigned
* `AtomicBitset` extend with bulk operations
* Add _readMinCursorCached to improve performance
* Review `Sequence::compareAndSet()`


Special thanks to @RalphSteinhagen and @wirew0rm for their help and discussions during work on this PR.


Performance results:
```text
all micro-benchmarks passed:
┌──────────────────benchmark:──────────────────┬──────┬──CPU branch misses───┬─ops/s─┬──mean──┬─<CPU-I>─┬────CPU cache misses────┬─stddev─┬─#N─┬─CTX-SW─┬─total time─┬──min───┬─median─┬──max───┐
│                                              │ SKIP │                      │       │        │         │                        │        │    │        │            │        │        │        │
│    POSIX: 1 producers -< 1  >-> 1 consumers  │ PASS │ 59.8k / 519k = 11.5% │ 25.7M │  39 ms │    302m │   11.9k / 101k = 11.8% │   5 ms │ 8  │   105  │     312 ms │  36 ms │  37 ms │  53 ms │
│    POSIX: 1 producers -< 1  >-> 2 consumers  │ PASS │ 75.7k / 666k = 11.4% │ 18.8M │  53 ms │    387m │ 5.35k / 100.0k =  5.4% │ 709 us │ 8  │   112  │     425 ms │  52 ms │  53 ms │  55 ms │
│    POSIX: 1 producers -< 1  >-> 4 consumers  │ PASS │ 71.6k / 617k = 11.6% │ 12.3M │  82 ms │    359m │   18.5k / 122k = 15.2% │   3 ms │ 8  │   120  │     653 ms │  79 ms │  81 ms │  88 ms │
│    POSIX: 2 producers -< 1  >-> 1 consumers  │ PASS │ 70.8k / 586k = 12.1% │  5.9M │ 170 ms │    341m │   37.1k / 154k = 24.1% │  22 ms │ 8  │   135  │       1  s │ 136 ms │ 182 ms │ 192 ms │
│    POSIX: 2 producers -< 1  >-> 2 consumers  │ PASS │ 74.5k / 641k = 11.6% │  5.6M │ 178 ms │    372m │   15.1k / 132k = 11.5% │  10 ms │ 8  │   138  │       1  s │ 153 ms │ 182 ms │ 185 ms │
│    POSIX: 2 producers -< 1  >-> 4 consumers  │ PASS │ 85.4k / 741k = 11.5% │  5.6M │ 179 ms │    431m │   8.81k / 118k =  7.4% │   1 ms │ 8  │   136  │       1  s │ 177 ms │ 178 ms │ 181 ms │
│    POSIX: 4 producers -< 1  >-> 1 consumers  │ PASS │ 88.4k / 744k = 11.9% │  5.1M │ 195 ms │    433m │   35.7k / 162k = 22.1% │   3 ms │ 8  │   149  │       2  s │ 189 ms │ 196 ms │ 199 ms │
│    POSIX: 4 producers -< 1  >-> 2 consumers  │ PASS │ 97.6k / 852k = 11.5% │  5.3M │ 190 ms │    496m │   8.51k / 142k =  6.0% │  10 ms │ 8  │   161  │       2  s │ 178 ms │ 194 ms │ 202 ms │
│    POSIX: 4 producers -< 1  >-> 4 consumers  │ PASS │ 142k / 1.24M = 11.4% │  3.5M │ 289 ms │    725m │   12.1k / 222k =  5.5% │   6 ms │ 8  │   267  │       2  s │ 275 ms │ 291 ms │ 293 ms │
├──────────────────────────────────────────────┼──────┼──────────────────────┼───────┼────────┼─────────┼────────────────────────┼────────┼────┼────────┼────────────┼────────┼────────┼────────┤
│    POSIX: 1 producers -<1024>-> 1 consumers  │ PASS │ 33.2k / 298k = 11.1% │  3.3G │ 299 us │    173m │  1.59k / 10.8k = 14.8% │ 582 us │ 8  │     9  │       2 ms │  24 us │  25 us │   2 ms │
│    POSIX: 1 producers -<1024>-> 2 consumers  │ PASS │ 32.4k / 297k = 10.9% │ 10.1G │  99 us │    173m │  1.43k / 7.32k = 19.5% │ 150 us │ 8  │     3  │     789 us │  40 us │  43 us │ 496 us │
│    POSIX: 1 producers -<1024>-> 4 consumers  │ PASS │ 52.6k / 454k = 11.6% │  3.9G │ 253 us │    265m │  1.56k / 15.5k = 10.1% │ 212 us │ 8  │    12  │       2 ms │ 155 us │ 156 us │ 801 us │
│    POSIX: 2 producers -<1024>-> 1 consumers  │ PASS │ 65.0k / 561k = 11.6% │  219M │   5 ms │    328m │  6.44k / 62.4k = 10.3% │  48 us │ 8  │    64  │      36 ms │   4 ms │   5 ms │   5 ms │
│    POSIX: 2 producers -<1024>-> 2 consumers  │ PASS │ 59.2k / 511k = 11.6% │  217M │   5 ms │    298m │  6.63k / 62.0k = 10.7% │  19 us │ 8  │    64  │      37 ms │   5 ms │   5 ms │   5 ms │
│    POSIX: 2 producers -<1024>-> 4 consumers  │ PASS │ 71.1k / 614k = 11.6% │  224M │   4 ms │    359m │  4.78k / 54.5k =  8.8% │ 261 us │ 8  │    64  │      36 ms │   4 ms │   5 ms │   5 ms │
│    POSIX: 4 producers -<1024>-> 1 consumers  │ PASS │ 67.8k / 586k = 11.6% │  315M │   3 ms │    342m │  5.20k / 55.5k =  9.4% │ 541 us │ 8  │    57  │      25 ms │   3 ms │   3 ms │   5 ms │
│    POSIX: 4 producers -<1024>-> 2 consumers  │ PASS │ 72.8k / 629k = 11.6% │  313M │   3 ms │    367m │  4.20k / 51.4k =  8.2% │ 508 us │ 8  │    57  │      26 ms │   3 ms │   3 ms │   5 ms │
│    POSIX: 4 producers -<1024>-> 4 consumers  │ PASS │ 67.1k / 583k = 11.5% │  329M │   3 ms │    340m │  4.27k / 55.7k =  7.7% │  21 us │ 8  │    56  │      24 ms │   3 ms │   3 ms │   3 ms │
├──────────────────────────────────────────────┼──────┼──────────────────────┼───────┼────────┼─────────┼────────────────────────┼────────┼────┼────────┼────────────┼────────┼────────┼────────┤
│ portable: 1 producers -< 1  >-> 1 consumers  │ PASS │ 69.7k / 605k = 11.5% │ 28.0M │  36 ms │    353m │   12.3k / 103k = 11.9% │ 777 us │ 8  │   104  │     286 ms │  35 ms │  36 ms │  37 ms │
│ portable: 1 producers -< 1  >-> 2 consumers  │ PASS │ 66.9k / 530k = 12.6% │ 17.0M │  59 ms │    308m │   47.1k / 146k = 32.4% │   6 ms │ 8  │   112  │     472 ms │  53 ms │  57 ms │  67 ms │
│ portable: 1 producers -< 1  >-> 4 consumers  │ PASS │ 69.7k / 606k = 11.5% │  8.2M │ 122 ms │    352m │   7.67k / 114k =  6.7% │   4 ms │ 8  │   128  │     973 ms │ 112 ms │ 124 ms │ 126 ms │
│ portable: 2 producers -< 1  >-> 1 consumers  │ PASS │ 77.6k / 533k = 14.5% │  6.5M │ 155 ms │    310m │    106k / 223k = 47.5% │  13 ms │ 8  │   129  │       1  s │ 142 ms │ 151 ms │ 187 ms │
│ portable: 2 producers -< 1  >-> 2 consumers  │ PASS │ 71.1k / 625k = 11.4% │  5.5M │ 183 ms │    364m │   7.00k / 122k =  5.7% │   3 ms │ 8  │   136  │       1  s │ 177 ms │ 185 ms │ 187 ms │
│ portable: 2 producers -< 1  >-> 4 consumers  │ PASS │ 86.5k / 759k = 11.4% │  5.5M │ 182 ms │    442m │   4.40k / 117k =  3.7% │   4 ms │ 8  │   142  │       1  s │ 178 ms │ 182 ms │ 188 ms │
│ portable: 4 producers -< 1  >-> 1 consumers  │ PASS │ 86.2k / 755k = 11.4% │  5.1M │ 198 ms │    439m │   19.2k / 138k = 13.9% │   6 ms │ 8  │   155  │       2  s │ 186 ms │ 201 ms │ 206 ms │
│ portable: 4 producers -< 1  >-> 2 consumers  │ PASS │ 93.6k / 815k = 11.5% │  4.9M │ 205 ms │    474m │   8.79k / 140k =  6.3% │   3 ms │ 8  │   163  │       2  s │ 202 ms │ 204 ms │ 210 ms │
│ portable: 4 producers -< 1  >-> 4 consumers  │ PASS │ 137k / 1.21M = 11.4% │  3.6M │ 275 ms │    703m │   13.2k / 224k =  5.9% │  23 ms │ 8  │   264  │       2  s │ 217 ms │ 284 ms │ 292 ms │
├──────────────────────────────────────────────┼──────┼──────────────────────┼───────┼────────┼─────────┼────────────────────────┼────────┼────┼────────┼────────────┼────────┼────────┼────────┤
│ portable: 1 producers -<1024>-> 1 consumers  │ PASS │ 58.8k / 503k = 11.7% │  2.3G │ 430 us │    294m │  1.63k / 17.3k =  9.4% │ 581 us │ 8  │    16  │       3 ms │ 154 us │ 288 us │   2 ms │
│ portable: 1 producers -<1024>-> 2 consumers  │ PASS │ 59.4k / 510k = 11.6% │  3.4G │ 294 us │    298m │  1.55k / 15.0k = 10.3% │ 221 us │ 8  │    14  │       2 ms │ 153 us │ 155 us │ 799 us │
│ portable: 1 producers -<1024>-> 4 consumers  │ PASS │ 57.3k / 491k = 11.7% │  3.2G │ 315 us │    287m │  1.91k / 20.4k =  9.3% │  68 us │ 8  │    17  │       3 ms │ 288 us │ 289 us │ 495 us │
│ portable: 2 producers -<1024>-> 1 consumers  │ PASS │ 64.7k / 564k = 11.5% │  146M │   7 ms │    329m │  2.36k / 65.8k =  3.6% │  33 us │ 8  │    72  │      55 ms │   7 ms │   7 ms │   7 ms │
│ portable: 2 producers -<1024>-> 2 consumers  │ PASS │ 62.5k / 546k = 11.4% │  145M │   7 ms │    318m │  1.97k / 62.2k =  3.2% │  40 us │ 8  │    72  │      55 ms │   7 ms │   7 ms │   7 ms │
│ portable: 2 producers -<1024>-> 4 consumers  │ PASS │ 72.5k / 630k = 11.5% │  146M │   7 ms │    367m │  1.67k / 64.8k =  2.6% │  22 us │ 8  │    72  │      55 ms │   7 ms │   7 ms │   7 ms │
│ portable: 4 producers -<1024>-> 1 consumers  │ PASS │ 76.1k / 660k = 11.5% │  224M │   4 ms │    385m │  1.88k / 57.8k =  3.3% │ 237 us │ 8  │    65  │      36 ms │   4 ms │   5 ms │   5 ms │
│ portable: 4 producers -<1024>-> 2 consumers  │ PASS │ 74.2k / 645k = 11.5% │  225M │   4 ms │    377m │  2.75k / 54.2k =  5.1% │   1 ms │ 8  │    64  │      36 ms │   3 ms │   5 ms │   7 ms │
│ portable: 4 producers -<1024>-> 4 consumers  │ PASS │ 75.9k / 659k = 11.5% │  218M │   5 ms │    385m │  3.10k / 55.5k =  5.6% │  66 us │ 8  │    65  │      37 ms │   5 ms │   5 ms │   5 ms │
└──────────────────────────────────────────────┴──────┴──────────────────────┴───────┴────────┴─────────┴────────────────────────┴────────┴────┴────────┴────────────┴────────┴────────┴────────┘

```
