### PR TITLE
suppressing deprecation warnings for  atomic_load_explicit and atomic_compare_exchange_weak methods

### DIFF
--- a/core/include/gnuradio-4.0/ClaimStrategy.hpp
+++ b/core/include/gnuradio-4.0/ClaimStrategy.hpp
@@ -106,11 +106,6 @@ concept ClaimStrategyLike = requires(T /*const*/ t, const Sequence::signed_index
     { t.publish(offset, nSlotsToClaim) } -> std::same_as<void>;
 };
 
-namespace claim_strategy::util {
-constexpr unsigned floorlog2(std::size_t x) { return x == 1 ? 0 : 1 + floorlog2(x >> 1); }
-constexpr unsigned ceillog2(std::size_t x) { return x == 1 ? 0 : floorlog2(x - 1) + 1; }
-} // namespace claim_strategy::util
-
 template<std::size_t SIZE = std::dynamic_extent, WaitStrategyLike TWaitStrategy = BusySpinWaitStrategy>
 class alignas(hardware_constructive_interference_size) SingleThreadedStrategy {
     using signed_index_type = Sequence::signed_index_type;

--- a/core/include/gnuradio-4.0/Sequence.hpp
+++ b/core/include/gnuradio-4.0/Sequence.hpp
@@ -90,6 +90,16 @@ inline signed_index_type getMinimumSequence(const std::vector<std::shared_ptr<Se
     return minimum;
 }
 
+// TODO: Revisit this code once libc++ adds support for `std::atomic<std::shared_ptr<std::vector<std::shared_ptr<Sequence>>>>`.
+// Currently, suppressing deprecation warnings for `std::atomic_load_explicit` and `std::atomic_compare_exchange_weak` methods.
+// Note: While `std::atomic<std::shared_ptr<std::vector<std::shared_ptr<Sequence>>>>` is compatible with GCC, it is not yet supported by libc++.
+// This workaround is necessary to maintain compatibility and avoid deprecation warnings in GCC. For more details, see the following example implementation:
+// https://godbolt.org/z/xxWbs659o
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 inline void addSequences(std::shared_ptr<std::vector<std::shared_ptr<Sequence>>>& sequences, const Sequence& cursor, const std::vector<std::shared_ptr<Sequence>>& sequencesToAdd) {
     signed_index_type                                       cursorSequence;
     std::shared_ptr<std::vector<std::shared_ptr<Sequence>>> updatedSequences;
@@ -152,6 +162,9 @@ inline bool removeSequence(std::shared_ptr<std::vector<std::shared_ptr<Sequence>
 
     return numToRemove != 0;
 }
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
 } // namespace detail
 


### PR DESCRIPTION
Currently, suppressing deprecation warnings for `std::atomic_load_explicit` and `std::atomic_compare_exchange_weak` methods. Note: While `std::atomic<std::shared_ptr<std::vector<std::shared_ptr<Sequence>>>>` is compatible with GCC, it is not yet supported by libc++.
This workaround is necessary to maintain compatibility and avoid deprecation warnings in GCC. For more details, see the following example implementation: https://godbolt.org/z/xxWbs659o

Revisit this code once libc++ adds support for `std::atomic<std::shared_ptr<std::vector<std::shared_ptr<Sequence>>>>`.
