### PR TITLE
Performance optimization for MultiProducerStrategy

### DIFF
--- a/core/include/gnuradio-4.0/AtomicBitset.hpp
+++ b/core/include/gnuradio-4.0/AtomicBitset.hpp
@@ -1,0 +1,132 @@
+#ifndef GNURADIO_ATOMICBITSET_HPP
+#define GNURADIO_ATOMICBITSET_HPP
+
+#include <vector>
+
+#ifndef forceinline
+// use this for hot-spots only <-> may bloat code size, not fit into cache and consequently slow down execution
+#define forceinline inline __attribute__((always_inline))
+#endif
+
+namespace gr {
+/*
+ * `AtomicBitset` is a lock-free, thread-safe bitset.
+ * It allows for efficient and thread-safe manipulation of individual bits.
+ * For bulk set or reset atomic operation is guaranteed per individual bit (word).
+ */
+template<std::size_t Size = std::dynamic_extent>
+class AtomicBitset {
+    static_assert(Size > 0, "Size must be greater than 0");
+    static constexpr bool isSizeDynamic = Size == std::dynamic_extent;
+
+    static constexpr std::size_t _bitsPerWord  = sizeof(size_t) * 8UZ;
+    static constexpr std::size_t _nStaticWords = isSizeDynamic ? 1UZ : (Size + _bitsPerWord - 1UZ) / _bitsPerWord;
+
+    // using DynamicArrayType = std::unique_ptr<std::atomic<std::size_t>[]>;
+    using DynamicArrayType = std::vector<std::atomic<std::size_t>>;
+    using StaticArrayType  = std::array<std::atomic<std::size_t>, _nStaticWords>;
+    using ArrayType        = std::conditional_t<isSizeDynamic, DynamicArrayType, StaticArrayType>;
+
+    std::size_t _size = Size;
+    ArrayType   _bits;
+
+public:
+    AtomicBitset()
+    requires(!isSizeDynamic)
+    {
+        for (auto& word : _bits) {
+            word.store(0UL, std::memory_order_relaxed);
+        }
+    }
+
+    explicit AtomicBitset(std::size_t size = 0UZ)
+    requires(isSizeDynamic)
+        : _size(size), _bits(std::vector<std::atomic<std::size_t>>(size)) {
+        // assert(size > 0UZ);
+        for (std::size_t i = 0; i < _size; i++) {
+            _bits[i].store(0UL, std::memory_order_relaxed);
+        }
+    }
+
+    void set(std::size_t bitPosition, bool value) {
+        assert(bitPosition < _size);
+        const std::size_t wordIndex = bitPosition / _bitsPerWord;
+        const std::size_t bitIndex  = bitPosition % _bitsPerWord;
+        const std::size_t mask      = 1UL << bitIndex;
+
+        std::size_t oldBits;
+        std::size_t newBits;
+        do {
+            oldBits = _bits[wordIndex].load(std::memory_order_relaxed);
+            newBits = value ? (oldBits | mask) : (oldBits & ~mask);
+        } while (!_bits[wordIndex].compare_exchange_weak(oldBits, newBits, std::memory_order_release, std::memory_order_relaxed));
+    }
+
+    void set(std::size_t begin, std::size_t end, bool value) {
+        assert(begin <= end && end <= _size); // [begin, end)
+
+        std::size_t       beginWord   = begin / _bitsPerWord;
+        std::size_t       endWord     = end / _bitsPerWord;
+        const std::size_t beginOffset = begin % _bitsPerWord;
+        const std::size_t endOffset   = end % _bitsPerWord;
+
+        if (begin == end) {
+            return;
+        } else if (beginWord == endWord) {
+            // the range is within a single word
+            setBitsInWord(beginWord, beginOffset, endOffset, value);
+        } else {
+            // leading bits in the first word
+            if (beginOffset != 0) {
+                setBitsInWord(beginWord, beginOffset, _bitsPerWord, value);
+                beginWord++;
+            }
+            // trailing bits in the last word
+            if (endOffset != 0) {
+                setBitsInWord(endWord, 0, endOffset, value);
+            }
+            endWord--;
+            // whole words in the middle
+            for (std::size_t wordIndex = beginWord; wordIndex <= endWord; ++wordIndex) {
+                setFullWord(wordIndex, value);
+            }
+        }
+    }
+
+    void set(std::size_t bitPosition) { set(bitPosition, true); }
+
+    void set(std::size_t begin, std::size_t end) { set(begin, end, true); }
+
+    void reset(std::size_t bitPosition) { set(bitPosition, false); }
+
+    void reset(std::size_t begin, std::size_t end) { set(begin, end, false); }
+
+    bool test(std::size_t bitPosition) const {
+        assert(bitPosition < _size);
+        const std::size_t wordIndex = bitPosition / _bitsPerWord;
+        const std::size_t bitIndex  = bitPosition % _bitsPerWord;
+        const std::size_t mask      = 1UL << bitIndex;
+
+        return (_bits[wordIndex].load(std::memory_order_acquire) & mask) != 0;
+    }
+
+    [[nodiscard]] constexpr std::size_t size() const { return _size; }
+
+private:
+    void setBitsInWord(std::size_t wordIndex, std::size_t begin, std::size_t end, bool value) {
+        assert(begin < end && end <= _bitsPerWord);
+        const std::size_t mask = (end == _bitsPerWord) ? ~((1UL << begin) - 1) : ((1UL << end) - 1) & ~((1UL << begin) - 1);
+        std::size_t       oldBits;
+        std::size_t       newBits;
+        do {
+            oldBits = _bits[wordIndex].load(std::memory_order_relaxed);
+            newBits = value ? (oldBits | mask) : (oldBits & ~mask);
+        } while (!_bits[wordIndex].compare_exchange_weak(oldBits, newBits, std::memory_order_release, std::memory_order_relaxed));
+    }
+
+    forceinline void setFullWord(std::size_t wordIndex, bool value) { _bits[wordIndex].store(value ? ~0UL : 0UL, std::memory_order_release); }
+};
+
+} // namespace gr
+
+#endif // GNURADIO_ATOMICBITSET_HPP

--- a/core/include/gnuradio-4.0/CircularBuffer.hpp
+++ b/core/include/gnuradio-4.0/CircularBuffer.hpp
@@ -335,15 +335,15 @@ class CircularBuffer {
                 _parent->_buffer->_claimStrategy.publish(_parent->_offset, _parent->nSamplesPublished());
                 _parent->_offset += static_cast<signed_index_type>(_parent->nSamplesPublished());
 #ifndef NDEBUG
-                if constexpr (isMultiThreadedStrategy()) {
+                if constexpr (isMultiProducerStrategy()) {
                     if (!isFullyPublished()) {
-                        fmt::print(stderr, "CircularBuffer::multiple_writer::PublishableOutputRange() - did not publish {} samples\n", _parent->_internalSpan.size() - _parent->_nSamplesPublished);
+                        fmt::print(stderr, "CircularBuffer::MultiWriter::PublishableOutputRange() - did not publish {} samples\n", _parent->_internalSpan.size() - _parent->_nSamplesPublished);
                         std::abort();
                     }
 
                 } else {
                     if (!_parent->_internalSpan.empty() && !isPublished()) {
-                        fmt::print(stderr, "CircularBuffer::single_writer::PublishableOutputRange() - omitted publish call for {} reserved samples\n", _parent->_internalSpan.size());
+                        fmt::print(stderr, "CircularBuffer::SingleWriter::PublishableOutputRange() - omitted publish call for {} reserved samples\n", _parent->_internalSpan.size());
                         std::abort();
                     }
                 }
@@ -370,7 +370,7 @@ class CircularBuffer {
         [[nodiscard]] constexpr std::size_t              samplesToPublish() const noexcept { return _parent->_nSamplesPublished; }
         [[nodiscard]] constexpr bool                     isPublished() const noexcept { return _parent->_isRangePublished; }
         [[nodiscard]] constexpr bool                     isFullyPublished() const noexcept { return _parent->_internalSpan.size() == _parent->_nSamplesPublished; }
-        [[nodiscard]] constexpr static bool              isMultiThreadedStrategy() noexcept { return std::is_base_of_v<MultiThreadedStrategy<SIZE, TWaitStrategy>, ClaimType>; }
+        [[nodiscard]] constexpr static bool              isMultiProducerStrategy() noexcept { return std::is_base_of_v<MultiProducerStrategy<SIZE, TWaitStrategy>, ClaimType>; }
         [[nodiscard]] constexpr static SpanReleasePolicy spanReleasePolicy() noexcept { return policy; }
 
         constexpr void publish(std::size_t nSamplesToPublish) noexcept {
@@ -478,7 +478,7 @@ class CircularBuffer {
 
     private:
         constexpr void checkIfCanReserveAndAbortIfNeeded() const noexcept {
-            if constexpr (std::is_base_of_v<MultiThreadedStrategy<SIZE, TWaitStrategy>, ClaimType>) {
+            if constexpr (std::is_base_of_v<MultiProducerStrategy<SIZE, TWaitStrategy>, ClaimType>) {
                 if (_internalSpan.size() - _nSamplesPublished != 0) {
                     fmt::print(stderr,
                         "An error occurred: The method CircularBuffer::MultiWriter::reserve() was invoked for the second time in succession, "

--- a/core/include/gnuradio-4.0/Port.hpp
+++ b/core/include/gnuradio-4.0/Port.hpp
@@ -670,10 +670,14 @@ public:
             return false;
         }
         {
-            auto outTags     = tagWriter().reserve(1UZ);
-            outTags[0].index = _cachedTag.index;
-            outTags[0].map   = _cachedTag.map;
-            outTags.publish(1UZ);
+            PublishableSpan auto outTags = tagWriter().tryReserve(1UZ);
+            if (!outTags.empty()) {
+                outTags[0].index = _cachedTag.index;
+                outTags[0].map   = _cachedTag.map;
+                outTags.publish(1UZ);
+            } else {
+                return false;
+            }
         }
 
         _cachedTag.reset();

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -32,6 +32,7 @@ function(add_app_test TEST_NAME)
 endfunction()
 
 add_ut_test(qa_buffer)
+add_ut_test(qa_AtomicBitset)
 add_ut_test(qa_DynamicBlock)
 add_ut_test(qa_DynamicPort)
 add_ut_test(qa_HierBlock)

--- a/core/test/qa_AtomicBitset.cpp
+++ b/core/test/qa_AtomicBitset.cpp
@@ -1,0 +1,177 @@
+#include <algorithm>
+#include <array>
+#include <complex>
+#include <numeric>
+#include <ranges>
+#include <tuple>
+
+#include <boost/ut.hpp>
+
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+
+#include <gnuradio-4.0/Buffer.hpp>
+#include <gnuradio-4.0/BufferSkeleton.hpp>
+#include <gnuradio-4.0/CircularBuffer.hpp>
+#include <gnuradio-4.0/HistoryBuffer.hpp>
+#include <gnuradio-4.0/Sequence.hpp>
+#include <gnuradio-4.0/WaitStrategy.hpp>
+
+template<typename TBitset>
+void runAtomicBitsetTest(TBitset& bitset, std::size_t bitsetSize) {
+    using namespace boost::ut;
+
+    expect(eq(bitset.size(), bitsetSize)) << fmt::format("Bitset size should be {}", bitsetSize);
+
+    // test default values
+    for (std::size_t i = 0; i < bitset.size(); i++) {
+        expect(!bitset.test(i)) << fmt::format("Bit {} should be false", i);
+    }
+
+    // set true for test positions
+    std::vector<std::size_t> testPositions = {0UZ, 1UZ, 5UZ, 31UZ, 32UZ, 47UZ, 63UZ, 64UZ, 100UZ, 127UZ};
+    for (const std::size_t pos : testPositions) {
+        bitset.set(pos);
+    }
+
+    // only test positions should be set
+    for (std::size_t i = 0; i < bitset.size(); i++) {
+        if (std::ranges::find(testPositions, i) != testPositions.end()) {
+            expect(bitset.test(i)) << fmt::format("Bit {} should be set", i);
+        } else {
+            expect(!bitset.test(i)) << fmt::format("Bit {} should be false", i);
+        }
+    }
+
+    // reset test positions
+    for (const std::size_t pos : testPositions) {
+        bitset.reset(pos);
+    }
+
+    // all positions should be reset
+    for (std::size_t i = 0; i < bitset.size(); i++) {
+        expect(!bitset.test(i)) << fmt::format("Bit {} should be false", i);
+    }
+
+    // Bulk operations
+    std::vector<std::pair<std::size_t, std::size_t>> testPositionsBulk = {{10UZ, 20UZ}, {10UZ, 10UZ}, {50UZ, 70UZ}, {0UZ, 127UZ}, {0UZ, 128UZ}, {63UZ, 64UZ}, {127UZ, 128UZ}, {0UZ, 1UZ}, {128UZ, 128UZ}};
+    for (const auto& pos : testPositionsBulk) {
+        bitset.set(pos.first, pos.second);
+
+        for (std::size_t i = 0; i < bitset.size(); ++i) {
+            if (i >= pos.first && i < pos.second) {
+                expect(bitset.test(i)) << fmt::format("Bulk [{},{}) Bit {} should be true", pos.first, pos.second, i);
+            } else {
+                expect(!bitset.test(i)) << fmt::format("Bulk [{},{}) Bit {} should be false", pos.first, pos.second, i);
+            }
+        }
+
+        // all positions should be reset
+        bitset.reset(pos.first, pos.second);
+        for (std::size_t i = 0; i < bitset.size(); i++) {
+            expect(!bitset.test(i)) << fmt::format("Bulk [{},{}) Bit {} should be false", pos.first, pos.second, i);
+        }
+    }
+
+#if not defined(__EMSCRIPTEN__) && not defined(NDEBUG)
+    expect(aborts([&] { bitset.set(bitsetSize); })) << "Setting bit should throw an assertion.";
+    expect(aborts([&] { bitset.reset(bitsetSize); })) << "Resetting bit should throw an assertion.";
+    expect(aborts([&] { bitset.test(bitsetSize); })) << "Testing bit should throw an assertion.";
+    // bulk operations
+    expect(aborts([&] { bitset.set(100UZ, 200UZ); })) << "Setting bulk bits should throw an assertion.";
+    expect(aborts([&] { bitset.reset(100UZ, 200UZ); })) << "Resetting bulk bits should throw an assertion.";
+    expect(aborts([&] { bitset.set(200UZ, 100UZ); })) << "Setting bulk begin > end should throw an assertion.";
+    expect(aborts([&] { bitset.reset(200UZ, 100UZ); })) << "Resetting bulk begin > end should throw an assertion.";
+#endif
+}
+
+const boost::ut::suite AtomicBitsetTests = [] {
+    using namespace boost::ut;
+    using namespace gr;
+    using namespace gr::detail;
+
+    "basics set/reset/test"_test = []() {
+        auto dynamicBitset = AtomicBitset<>(128UZ);
+        runAtomicBitsetTest(dynamicBitset, 128UZ);
+
+        auto staticBitset = AtomicBitset<128UZ>();
+        runAtomicBitsetTest(staticBitset, 128UZ);
+    };
+
+    "multithreads"_test = [] {
+        constexpr std::size_t    bitsetSize = 256UZ;
+        constexpr std::size_t    nThreads   = 16UZ;
+        constexpr std::size_t    nRepeats   = 100UZ;
+        AtomicBitset<bitsetSize> bitset;
+        std::vector<std::thread> threads;
+
+        for (std::size_t iThread = 0; iThread < nThreads; iThread++) {
+            threads.emplace_back([&] {
+                for (std::size_t iR = 0; iR < nRepeats; iR++) {
+                    for (std::size_t i = 0; i < bitsetSize; i++) {
+                        if (i < bitsetSize / 2) {
+                            bitset.set(i);
+                            bitset.reset(i);
+                            std::ignore = bitset.test(i);
+                        } else {
+                            bitset.reset(i);
+                            bitset.set(i);
+                            std::ignore = bitset.test(i);
+                        }
+                    }
+                }
+            });
+        }
+
+        for (auto& thread : threads) {
+            thread.join();
+        }
+
+        // Verify final state: first half should be reset, second half should be set
+        for (std::size_t i = 0; i < bitsetSize; i++) {
+            if (i < bitsetSize / 2) {
+                expect(!bitset.test(i)) << std::format("Bit {} should be reset", i);
+            } else {
+                expect(bitset.test(i)) << std::format("Bit {} should be set", i);
+            }
+        }
+    };
+
+    "multithreads bulk"_test = [] {
+        constexpr std::size_t    bitsetSize = 2000UZ;
+        constexpr std::size_t    nThreads   = 10UZ;
+        constexpr std::size_t    chunkSize  = bitsetSize / nThreads;
+        constexpr std::size_t    nRepeats   = 1000UZ;
+        AtomicBitset<bitsetSize> bitset;
+        std::vector<std::thread> threads;
+
+        for (std::size_t iThread = 0; iThread < nThreads; iThread++) {
+            threads.emplace_back([&bitset, iThread] {
+                for (std::size_t iR = 0; iR < nRepeats; iR++) {
+                    if (iThread % 2 == 0) {
+                        bitset.set(iThread * chunkSize, (iThread + 1) * chunkSize);
+                        bitset.reset(iThread * chunkSize, (iThread + 1) * chunkSize);
+                    } else {
+                        bitset.reset(iThread * chunkSize, (iThread + 1) * chunkSize);
+                        bitset.set(iThread * chunkSize, (iThread + 1) * chunkSize);
+                    }
+                }
+            });
+        }
+
+        for (auto& thread : threads) {
+            thread.join();
+        }
+
+        // Verify final state
+        for (std::size_t i = 0; i < bitsetSize; i++) {
+            if ((i / chunkSize) % 2 == 0) {
+                expect(!bitset.test(i)) << std::format("Bit {} should be reset", i);
+            } else {
+                expect(bitset.test(i)) << std::format("Bit {} should be set", i);
+            }
+        }
+    };
+};
+
+int main() { /* not needed for UT */ }

--- a/core/test/qa_buffer.cpp
+++ b/core/test/qa_buffer.cpp
@@ -109,102 +109,6 @@ const boost::ut::suite BasicConceptsTests = [] {
     } | CircularBufferTypesToTest();
 };
 
-template<typename TBitset>
-void runAtomicBitsetTest(TBitset& bitset, std::size_t bitsetSize) {
-    using namespace boost::ut;
-
-    expect(eq(bitset.size(), bitsetSize)) << fmt::format("Bitset size should be {}", bitsetSize);
-
-    // test default values
-    for (std::size_t i = 0; i < bitset.size(); i++) {
-        expect(!bitset.test(i)) << fmt::format("Bit {} should be false", i);
-    }
-
-    // set true for test positions
-    std::vector<std::size_t> testPositions = {0UZ, 1UZ, 5UZ, 31UZ, 32UZ, 47UZ, 63UZ, 64UZ, 100UZ, 127UZ};
-    for (const std::size_t pos : testPositions) {
-        bitset.set(pos);
-    }
-
-    // only test positions should be set
-    for (std::size_t i = 0; i < bitset.size(); i++) {
-        if (std::ranges::find(testPositions, i) != testPositions.end()) {
-            expect(bitset.test(i)) << fmt::format("Bit {} should be set", i);
-        } else {
-            expect(!bitset.test(i)) << fmt::format("Bit {} should be false", i);
-        }
-    }
-
-    // reset test positions
-    for (const std::size_t pos : testPositions) {
-        bitset.reset(pos);
-    }
-
-    // all positions should be reset
-    for (std::size_t i = 0; i < bitset.size(); i++) {
-        expect(!bitset.test(i)) << fmt::format("Bit {} should be false", i);
-    }
-
-#if not defined(__EMSCRIPTEN__) && not defined(NDEBUG)
-    expect(aborts([&] { bitset.set(bitsetSize); })) << "Setting bit should throw an assertion.";
-    expect(aborts([&] { bitset.reset(bitsetSize); })) << "Resetting bit should throw an assertion.";
-    expect(aborts([&] { bitset.test(bitsetSize); })) << "Testing bit should throw an assertion.";
-#endif
-}
-
-const boost::ut::suite AtomicBitsetTests = [] {
-    using namespace boost::ut;
-    using namespace gr;
-    using namespace gr::detail;
-
-    "basics set/reset/test"_test = []() {
-        auto dynamicBitset = AtomicBitset<>(128UZ);
-        runAtomicBitsetTest(dynamicBitset, 128UZ);
-
-        auto staticBitset = AtomicBitset<128UZ>();
-        runAtomicBitsetTest(staticBitset, 128UZ);
-    };
-
-    "multithreads"_test = [] {
-        constexpr std::size_t    bitsetSize = 256UZ;
-        constexpr std::size_t    nThreads   = 16UZ;
-        constexpr std::size_t    nRepeats   = 100UZ;
-        AtomicBitset<bitsetSize> bitset;
-        std::vector<std::thread> threads;
-
-        for (std::size_t iThread = 0; iThread < nThreads; iThread++) {
-            threads.emplace_back([&] {
-                for (std::size_t iR = 0; iR < nRepeats; iR++) {
-                    for (std::size_t i = 0; i < bitsetSize; i++) {
-                        if (i < bitsetSize / 2) {
-                            bitset.set(i);
-                            bitset.reset(i);
-                            std::ignore = bitset.test(i);
-                        } else {
-                            bitset.reset(i);
-                            bitset.set(i);
-                            std::ignore = bitset.test(i);
-                        }
-                    }
-                }
-            });
-        }
-
-        for (auto& thread : threads) {
-            thread.join();
-        }
-
-        // Verify final state: first half should be reset, second half should be set
-        for (std::size_t i = 0; i < bitsetSize; i++) {
-            if (i < bitsetSize / 2) {
-                expect(!bitset.test(i)) << std::format("Bit {} should be reset", i);
-            } else {
-                expect(bitset.test(i)) << std::format("Bit {} should be set", i);
-            }
-        }
-    };
-};
-
 const boost::ut::suite SequenceTests = [] {
     using namespace boost::ut;
 
@@ -501,7 +405,6 @@ const boost::ut::suite CircularBufferTests = [] {
                 expect(eq(reader.nSamplesConsumed(), 0UZ));
             }
         }
-
         // basic expert writer api
         for (int k = 0; k < 3; k++) {
             // case 0: write fully reserved data


### PR DESCRIPTION
Performance optimization for MultiProducerStrategy
* AtomicBitset bulk set/reset
* Rename to Single(Multi)ProducerStrategy
* Eliminate usage of reserve(), use tryReserve() instead
* Remove warnings


### Some results of `bm_Buffer test.

#### AtomicBitset without bulk set/reset
```text
┌──────────────────benchmark:──────────────────┬──────┬──CPU branch misses───┬─ops/s─┬──mean──┬─<CPU-I>─┬───CPU cache misses────┬─stddev─┬─#N─┬─CTX-SW─┬─total time─┬──min───┬─median─┬──max───┐
│                                              │ SKIP │                      │       │        │         │                       │        │    │        │            │        │        │        │
│    POSIX: 1 producers -< 1  >-> 1 consumers  │ PASS │ 63.3k / 546k = 11.6% │ 25.8M │  39 ms │    317m │  13.3k / 100k = 13.2% │   8 ms │ 8  │   105  │     310 ms │  31 ms │  36 ms │  58 ms │
│    POSIX: 1 producers -< 1  >-> 2 consumers  │ PASS │ 80.0k / 606k = 13.2% │ 16.7M │  60 ms │    352m │  71.5k / 170k = 42.0% │   4 ms │ 8  │   112  │     478 ms │  54 ms │  61 ms │  64 ms │
│    POSIX: 1 producers -< 1  >-> 4 consumers  │ PASS │ 84.8k / 622k = 13.6% │ 11.3M │  88 ms │    362m │  87.3k / 194k = 44.9% │   5 ms │ 8  │   120  │     706 ms │  81 ms │  91 ms │  93 ms │
│    POSIX: 2 producers -< 1  >-> 1 consumers  │ PASS │ 92.9k / 678k = 13.7% │  6.8M │ 146 ms │    397m │   104k / 230k = 45.1% │  16 ms │ 8  │   132  │       1  s │ 129 ms │ 142 ms │ 183 ms │
│    POSIX: 2 producers -< 1  >-> 2 consumers  │ PASS │ 95.6k / 707k = 13.5% │  6.4M │ 156 ms │    412m │  94.0k / 218k = 43.1% │  17 ms │ 8  │   140  │       1  s │ 138 ms │ 157 ms │ 184 ms │
│    POSIX: 2 producers -< 1  >-> 4 consumers  │ PASS │  114k / 848k = 13.4% │  6.2M │ 161 ms │    493m │   102k / 248k = 41.2% │  18 ms │ 8  │   164  │       1  s │ 138 ms │ 154 ms │ 196 ms │
│    POSIX: 4 producers -< 1  >-> 1 consumers  │ PASS │  108k / 814k = 13.3% │  5.5M │ 183 ms │    473m │  94.1k / 243k = 38.7% │   5 ms │ 8  │   172  │       1  s │ 177 ms │ 183 ms │ 191 ms │
│    POSIX: 4 producers -< 1  >-> 2 consumers  │ PASS │  104k / 774k = 13.5% │  5.2M │ 191 ms │    450m │   108k / 264k = 40.9% │   3 ms │ 8  │   176  │       2  s │ 184 ms │ 192 ms │ 194 ms │
│    POSIX: 4 producers -< 1  >-> 4 consumers  │ PASS │ 170k / 1.22M = 14.0% │  3.5M │ 282 ms │    711m │   206k / 466k = 44.2% │  16 ms │ 8  │   296  │       2  s │ 256 ms │ 282 ms │ 305 ms │
├──────────────────────────────────────────────┼──────┼──────────────────────┼───────┼────────┼─────────┼───────────────────────┼────────┼────┼────────┼────────────┼────────┼────────┼────────┤
│    POSIX: 1 producers -<1024>-> 1 consumers  │ PASS │ 29.6k / 263k = 11.3% │  8.2G │ 122 us │    153m │ 1.47k / 7.21k = 20.4% │ 154 us │ 8  │     5  │     976 us │  31 us │  32 us │ 506 us │
│    POSIX: 1 producers -<1024>-> 2 consumers  │ PASS │ 33.9k / 303k = 11.2% │  2.3G │ 432 us │    177m │ 3.82k / 13.4k = 28.4% │ 987 us │ 8  │     8  │       3 ms │  40 us │  44 us │   3 ms │
│    POSIX: 1 producers -<1024>-> 4 consumers  │ PASS │ 47.0k / 405k = 11.6% │  3.7G │ 273 us │    237m │ 1.68k / 14.4k = 11.6% │ 213 us │ 8  │    13  │       2 ms │ 156 us │ 158 us │ 815 us │
│    POSIX: 2 producers -<1024>-> 1 consumers  │ PASS │ 60.1k / 525k = 11.4% │  144M │   7 ms │    306m │ 2.72k / 61.2k =  4.4% │  34 us │ 8  │    72  │      56 ms │   7 ms │   7 ms │   7 ms │
│    POSIX: 2 producers -<1024>-> 2 consumers  │ PASS │ 60.1k / 525k = 11.4% │  144M │   7 ms │    306m │ 2.97k / 62.0k =  4.8% │ 101 us │ 8  │    72  │      55 ms │   7 ms │   7 ms │   7 ms │
│    POSIX: 2 producers -<1024>-> 4 consumers  │ PASS │ 60.6k / 529k = 11.5% │  146M │   7 ms │    308m │ 3.25k / 63.6k =  5.1% │ 303 us │ 8  │    72  │      55 ms │   6 ms │   7 ms │   7 ms │
│    POSIX: 4 producers -<1024>-> 1 consumers  │ PASS │ 59.1k / 515k = 11.5% │  217M │   5 ms │    300m │ 2.45k / 56.2k =  4.4% │  15 us │ 8  │    64  │      37 ms │   5 ms │   5 ms │   5 ms │
│    POSIX: 4 producers -<1024>-> 2 consumers  │ PASS │ 58.4k / 509k = 11.5% │  220M │   5 ms │    297m │ 1.84k / 54.5k =  3.4% │  87 us │ 8  │    64  │      36 ms │   4 ms │   5 ms │   5 ms │
│    POSIX: 4 producers -<1024>-> 4 consumers  │ PASS │ 58.4k / 510k = 11.5% │  218M │   5 ms │    297m │ 1.89k / 55.2k =  3.4% │  10 us │ 8  │    64  │      37 ms │   5 ms │   5 ms │   5 ms │
├──────────────────────────────────────────────┼──────┼──────────────────────┼───────┼────────┼─────────┼───────────────────────┼────────┼────┼────────┼────────────┼────────┼────────┼────────┤

```

#### AtomicBitset with bulk  set/reset
```text
┌──────────────────benchmark:──────────────────┬──────┬──CPU branch misses───┬─ops/s─┬──mean──┬─<CPU-I>─┬───CPU cache misses────┬─stddev─┬─#N─┬─CTX-SW─┬─total time─┬──min───┬─median─┬──max───┐
│                                              │ SKIP │                      │       │        │         │                       │        │    │        │            │        │        │        │
│    POSIX: 1 producers -< 1  >-> 1 consumers  │ PASS │ 68.8k / 591k = 11.6% │ 27.7M │  36 ms │    345m │  18.1k / 107k = 17.0% │ 496 us │ 8  │   104  │     289 ms │  35 ms │  36 ms │  37 ms │
│    POSIX: 1 producers -< 1  >-> 2 consumers  │ PASS │ 80.2k / 625k = 12.8% │ 18.0M │  55 ms │    366m │  62.2k / 165k = 37.8% │   6 ms │ 8  │   111  │     444 ms │  42 ms │  59 ms │  61 ms │
│    POSIX: 1 producers -< 1  >-> 4 consumers  │ PASS │ 80.6k / 624k = 12.9% │ 11.2M │  89 ms │    364m │  60.1k / 165k = 36.4% │   6 ms │ 8  │   120  │     712 ms │  79 ms │  90 ms │  95 ms │
│    POSIX: 2 producers -< 1  >-> 1 consumers  │ PASS │ 85.4k / 641k = 13.3% │  6.4M │ 157 ms │    373m │  82.3k / 198k = 41.5% │  21 ms │ 8  │   132  │       1  s │ 130 ms │ 145 ms │ 184 ms │
│    POSIX: 2 producers -< 1  >-> 2 consumers  │ PASS │ 92.0k / 691k = 13.3% │  6.1M │ 163 ms │    405m │  91.8k / 222k = 41.3% │  20 ms │ 8  │   137  │       1  s │ 143 ms │ 168 ms │ 191 ms │
│    POSIX: 2 producers -< 1  >-> 4 consumers  │ PASS │  113k / 851k = 13.3% │  6.1M │ 165 ms │    497m │   107k / 252k = 42.3% │  14 ms │ 8  │   161  │       1  s │ 137 ms │ 168 ms │ 183 ms │
│    POSIX: 4 producers -< 1  >-> 1 consumers  │ PASS │  110k / 805k = 13.6% │  5.6M │ 177 ms │    468m │   112k / 263k = 42.7% │  12 ms │ 8  │   169  │       1  s │ 163 ms │ 177 ms │ 198 ms │
│    POSIX: 4 producers -< 1  >-> 2 consumers  │ PASS │ 84.6k / 733k = 11.5% │  5.5M │ 183 ms │    427m │  12.1k / 137k =  8.8% │   4 ms │ 8  │   147  │       1  s │ 178 ms │ 183 ms │ 189 ms │
│    POSIX: 4 producers -< 1  >-> 4 consumers  │ PASS │ 124k / 1.09M = 11.3% │  3.6M │ 281 ms │    635m │  8.88k / 222k =  4.0% │   7 ms │ 8  │   248  │       2  s │ 266 ms │ 283 ms │ 291 ms │
├──────────────────────────────────────────────┼──────┼──────────────────────┼───────┼────────┼─────────┼───────────────────────┼────────┼────┼────────┼────────────┼────────┼────────┼────────┤
│    POSIX: 1 producers -<1024>-> 1 consumers  │ PASS │ 24.7k / 230k = 10.8% │ 23.5G │  43 us │    134m │ 1.38k / 4.44k = 31.2% │  43 us │ 8  │     1  │     341 us │  26 us │  27 us │ 156 us │
│    POSIX: 1 producers -<1024>-> 2 consumers  │ PASS │ 32.7k / 301k = 10.9% │ 10.1G │  99 us │    176m │ 1.23k / 6.12k = 20.0% │ 150 us │ 8  │     3  │     793 us │  39 us │  43 us │ 495 us │
│    POSIX: 1 producers -<1024>-> 4 consumers  │ PASS │ 51.8k / 448k = 11.6% │  3.9G │ 254 us │    262m │ 1.36k / 14.4k =  9.5% │ 211 us │ 8  │    12  │       2 ms │ 155 us │ 156 us │ 799 us │
│    POSIX: 2 producers -<1024>-> 1 consumers  │ PASS │ 58.7k / 508k = 11.5% │  1.2G │ 864 us │    297m │ 1.78k / 29.5k =  6.1% │ 150 us │ 8  │    33  │       7 ms │ 805 us │ 808 us │   1 ms │
│    POSIX: 2 producers -<1024>-> 2 consumers  │ PASS │ 56.8k / 493k = 11.5% │  1.2G │ 869 us │    288m │ 1.59k / 28.9k =  5.5% │ 148 us │ 8  │    33  │       7 ms │ 806 us │ 808 us │   1 ms │
│    POSIX: 2 producers -<1024>-> 4 consumers  │ PASS │ 55.7k / 484k = 11.5% │  1.1G │ 912 us │    283m │ 2.68k / 30.8k =  8.7% │ 180 us │ 8  │    34  │       7 ms │ 805 us │ 810 us │   1 ms │
│    POSIX: 4 producers -<1024>-> 1 consumers  │ PASS │ 55.5k / 483k = 11.5% │  1.2G │ 856 us │    282m │ 1.64k / 29.9k =  5.5% │ 154 us │ 8  │    33  │       7 ms │ 775 us │ 806 us │   1 ms │
│    POSIX: 4 producers -<1024>-> 2 consumers  │ PASS │ 63.8k / 554k = 11.5% │  700M │   1 ms │    323m │ 2.13k / 42.5k =  5.0% │ 422 us │ 8  │    45  │      11 ms │   1 ms │   1 ms │   3 ms │
│    POSIX: 4 producers -<1024>-> 4 consumers  │ PASS │ 70.9k / 615k = 11.5% │  729M │   1 ms │    359m │ 1.67k / 39.1k =  4.3% │ 238 us │ 8  │    43  │      11 ms │   1 ms │   1 ms │   2 ms │
├──────────────────────────────────────────────┼──────┼──────────────────────┼───────┼────────┼─────────┼───────────────────────┼────────┼────┼────────┼────────────┼────────┼────────┼────────┤

```
