### PR TITLE
refactored & simplified Settings.hpp and pmtv format

### DIFF
--- a/core/include/gnuradio-4.0/Tag.hpp
+++ b/core/include/gnuradio-4.0/Tag.hpp
@@ -5,8 +5,7 @@
 
 #include <pmtv/pmt.hpp>
 
-#include <pmtv/format.hpp>
-
+#include <gnuradio-4.0/meta/formatter.hpp>
 #include <gnuradio-4.0/meta/utils.hpp>
 
 #include "reflection.hpp"

--- a/meta/test/qa_formatter.cpp
+++ b/meta/test/qa_formatter.cpp
@@ -12,77 +12,82 @@ namespace gr::meta::test {
 const boost::ut::suite complexFormatter = [] {
     using namespace boost::ut;
     using namespace std::literals::complex_literals;
+    using namespace std::literals::string_literals;
+
     using C                                = std::complex<double>;
     "fmt::formatter<std::complex<T>>"_test = [] {
-        expect("(1+1i)" == fmt::format("{}", C(1., +1.)));
-        expect("(1-1i)" == fmt::format("{}", C(1., -1.)));
-        expect("1" == fmt::format("{}", C(1., 0.)));
-        expect("(1.234+1.12346e+12i)" == fmt::format("{}", C(1.234, 1123456789012)));
-        expect("(1+1i)" == fmt::format("{:g}", C(1., +1.)));
-        expect("(1-1i)" == fmt::format("{:g}", C(1., -1.)));
-        expect("1" == fmt::format("{:g}", C(1., 0.)));
-        expect("(1.12346e+12+1.234i)" == fmt::format("{:g}", C(1123456789012, 1.234)));
-        expect("1.12346e+12" == fmt::format("{:g}", C(1123456789012, 0)));
-        expect("(1.234+1.12346e+12i)" == fmt::format("{:g}", C(1.234, 1123456789012)));
-        expect("(1.12346E+12+1.234i)" == fmt::format("{:G}", C(1123456789012, 1.234)));
-        expect("1.12346E+12" == fmt::format("{:G}", C(1123456789012, 0)));
-        expect("(1.234+1.12346E+12i)" == fmt::format("{:G}", C(1.234, 1123456789012)));
+        expect(eq("(1+1i)"s, fmt::format("{}", C(1., +1.))));
+        expect(eq("(1-1i)"s, fmt::format("{}", C(1., -1.))));
+        expect(eq("1"s, fmt::format("{}", C(1., 0.))));
+        expect(eq("(1.234+1.12346e+12i)"s, fmt::format("{}", C(1.234, 1123456789012))));
+        expect(eq("(1+1i)"s, fmt::format("{:g}", C(1., +1.))));
+        expect(eq("(1-1i)"s, fmt::format("{:g}", C(1., -1.))));
+        expect(eq("1"s, fmt::format("{:g}", C(1., 0.))));
+        expect(eq("(1.12346e+12+1.234i)"s, fmt::format("{:g}", C(1123456789012, 1.234))));
+        expect(eq("1.12346e+12"s, fmt::format("{:g}", C(1123456789012, 0))));
+        expect(eq("(1.234+1.12346e+12i)"s, fmt::format("{:g}", C(1.234, 1123456789012))));
+        expect(eq("(1.12346E+12+1.234i)"s, fmt::format("{:G}", C(1123456789012, 1.234))));
+        expect(eq("1.12346E+12"s, fmt::format("{:G}", C(1123456789012, 0))));
+        expect(eq("(1.234+1.12346E+12i)"s, fmt::format("{:G}", C(1.234, 1123456789012))));
 
-        expect("(1.000000+1.000000i)" == fmt::format("{:f}", C(1., +1.)));
-        expect("(1.000000-1.000000i)" == fmt::format("{:f}", C(1., -1.)));
-        expect("1.000000" == fmt::format("{:f}", C(1., 0.)));
-        expect("(1.000000+1.000000i)" == fmt::format("{:F}", C(1., +1.)));
-        expect("(1.000000-1.000000i)" == fmt::format("{:F}", C(1., -1.)));
-        expect("1.000000" == fmt::format("{:F}", C(1., 0.)));
+        expect(eq("(1.000000+1.000000i)"s, fmt::format("{:f}", C(1., +1.))));
+        expect(eq("(1.000000-1.000000i)"s, fmt::format("{:f}", C(1., -1.))));
+        expect(eq("1.000000"s, fmt::format("{:f}", C(1., 0.))));
+        expect(eq("(1.000000+1.000000i)"s, fmt::format("{:F}", C(1., +1.))));
+        expect(eq("(1.000000-1.000000i)"s, fmt::format("{:F}", C(1., -1.))));
+        expect(eq("1.000000"s, fmt::format("{:F}", C(1., 0.))));
 
-        expect("(1.000000e+00+1.000000e+00i)" == fmt::format("{:e}", C(1., +1.)));
-        expect("(1.000000e+00-1.000000e+00i)" == fmt::format("{:e}", C(1., -1.)));
-        expect("1.000000e+00" == fmt::format("{:e}", C(1., 0.)));
-        expect("(1.000000E+00+1.000000E+00i)" == fmt::format("{:E}", C(1., +1.)));
-        expect("(1.000000E+00-1.000000E+00i)" == fmt::format("{:E}", C(1., -1.)));
-        expect("1.000000E+00" == fmt::format("{:E}", C(1., 0.)));
+        expect(eq("(1.000000e+00+1.000000e+00i)"s, fmt::format("{:e}", C(1., +1.))));
+        expect(eq("(1.000000e+00-1.000000e+00i)"s, fmt::format("{:e}", C(1., -1.))));
+        expect(eq("1.000000e+00"s, fmt::format("{:e}", C(1., 0.))));
+        expect(eq("(1.000000E+00+1.000000E+00i)"s, fmt::format("{:E}", C(1., +1.))));
+        expect(eq("(1.000000E+00-1.000000E+00i)"s, fmt::format("{:E}", C(1., -1.))));
+        expect(eq("1.000000E+00"s, fmt::format("{:E}", C(1., 0.))));
     };
 };
 
 const boost::ut::suite uncertainValueFormatter = [] {
     using namespace boost::ut;
     using namespace std::literals::complex_literals;
+    using namespace std::literals::string_literals;
     using UncertainDouble  = gr::UncertainValue<double>;
     using UncertainComplex = gr::UncertainValue<std::complex<double>>;
 
     "fmt::formatter<gr::meta::UncertainValue<T>>"_test = [] {
         // Test with UncertainValue<double>
-        expect("(1.23 ± 0.45)" == fmt::format("{}", UncertainDouble{ 1.23, 0.45 }));
-        expect("(3.14 ± 0.01)" == fmt::format("{}", UncertainDouble{ 3.14, 0.01 }));
-        expect("(0 ± 0)" == fmt::format("{}", UncertainDouble{ 0, 0 }));
+        expect(eq("(1.23 ± 0.45)"s, fmt::format("{}", UncertainDouble{1.23, 0.45})));
+        expect(eq("(3.14 ± 0.01)"s, fmt::format("{}", UncertainDouble{3.14, 0.01})));
+        expect(eq("(0 ± 0)"s, fmt::format("{}", UncertainDouble{0, 0})));
 
         // Test with UncertainValue<std::complex<double>>
-        expect("((1+2i) ± (0.1+0.2i))" == fmt::format("{}", UncertainComplex{ { 1, 2 }, { 0.1, 0.2 } }));
-        expect("((3.14+1.59i) ± (0.01+0.02i))" == fmt::format("{}", UncertainComplex{ { 3.14, 1.59 }, { 0.01, 0.02 } }));
-        expect("(0 ± 0)" == fmt::format("{}", UncertainComplex{ { 0, 0 }, { 0, 0 } }));
+        expect(eq("((1+2i) ± (0.1+0.2i))"s, fmt::format("{}", UncertainComplex{{1, 2}, {0.1, 0.2}})));
+        expect(eq("((3.14+1.59i) ± (0.01+0.02i))"s, fmt::format("{}", UncertainComplex{{3.14, 1.59}, {0.01, 0.02}})));
+        expect(eq("(0 ± 0)"s, fmt::format("{}", UncertainComplex{{0, 0}, {0, 0}})));
     };
 };
 
 const boost::ut::suite propertyMapFormatter = [] {
     using namespace boost::ut;
+    using namespace std::literals::string_literals;
 
     "fmt::formatter<gr::property_map>"_test = [] {
-        gr::property_map pmInt{ { "key0", 0 }, { "key1", 1 }, { "key2", 2 } };
-        expect("{ key0: 0, key1: 1, key2: 2 }" == fmt::format("{}", pmInt));
+        gr::property_map pmInt{{"key0", 0}, {"key1", 1}, {"key2", 2}};
+        expect(eq("{ key0: 0, key1: 1, key2: 2 }"s, fmt::format("{}", pmInt)));
 
-        gr::property_map pmFloat{ { "key0", 0.01f }, { "key1", 1.01f }, { "key2", 2.01f } };
-        expect("{ key0: 0.01, key1: 1.01, key2: 2.01 }" == fmt::format("{}", pmFloat));
+        gr::property_map pmFloat{{"key0", 0.01f}, {"key1", 1.01f}, {"key2", 2.01f}};
+        expect(eq("{ key0: 0.01, key1: 1.01, key2: 2.01 }"s, fmt::format("{}", pmFloat)));
     };
 };
 
 const boost::ut::suite vectorBoolFormatter = [] {
     using namespace boost::ut;
+    using namespace std::literals::string_literals;
 
     "fmt::formatter<vector<bool>>"_test = [] {
-        std::vector<bool> boolVector{ true, false, true };
-        expect("[true, false, true]" == fmt::format("{}", boolVector));
-        expect("[true, false, true]" == fmt::format("{:c}", boolVector));
-        expect("[true false true]" == fmt::format("{:s}", boolVector));
+        std::vector<bool> boolVector{true, false, true};
+        expect(eq("[true, false, true]"s, fmt::format("{}", boolVector)));
+        expect(eq("[true, false, true]"s, fmt::format("{:c}", boolVector)));
+        expect(eq("[true false true]"s, fmt::format("{:s}", boolVector)));
     };
 };
 
@@ -102,6 +107,4 @@ const boost::ut::suite expectedFormatter = [] {
 
 } // namespace gr::meta::test
 
-int
-main() { /* tests are statically executed */
-}
+int main() { /* tests are statically executed */ }


### PR DESCRIPTION
## Details:

* code and templating structure (via and in response to -ftime-trace analysis)
* replaced std::ranges::find(..) by more compile-time friendly version
* replaced std::sort by binary-search+merge-sort
* added non-inline to methods to avoid unnecessary compile-time optimisations
* optimised custom pmtv formatted by reducing the `std::visit(...)` pattern (not yet fully eliminated.

Compile-time differences (~4% ... hoped to be more, but it's a start).

**before:**
```text
real    20m21.229s
user    89m12.953s
sys     3m8.205s
```

**this PR:**
```text
real    19m33.855s
user    85m44.586s
sys     3m35.693s
```

ClangAnalyser profile with this PR (based on Clang's `-ftime-trace` feature) in the `./build` directory:
```bash
ClangBuildAnalyzer --all . gr4_all_before.bin; ClangBuildAnalyzer --analyze gr4_all_before.bin > gr4_all_before.txt
```
**before:**  [gr4_all_before.txt](https://github.com/user-attachments/files/16884919/gr4_all_before.txt)
```text
Analyzing build trace from 'gr4_all_before.bin'...
**** Time summary:
Compilation (184 times):
  Parsing (frontend):         2265.8 s
  Codegen & opts (backend):   8065.3 s
  [..]
```
**after:** [gr4_all_after.txt](https://github.com/user-attachments/files/16875660/gr4_all_after.txt)
```text
Analyzing build trace from 'gr4_all_after.bin'...
**** Time summary:
Compilation (184 times):
  Parsing (frontend):         2121.1 s
  Codegen & opts (backend):   4473.3 s
  [..]
```