### PR TITLE
add LGPLv3 linking exception for header-only GR4

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,22 @@
+This software is licensed under the LGPLv3, included below.
+
+As a special exception to the GNU Lesser General Public License version 3
+("LGPL3"), the copyright holders of this Library give you permission to
+convey to a third party a Combined Work that links statically or dynamically
+to this Library without providing any Minimal Corresponding Source or
+Minimal Application Code as set out in 4d or providing the installation
+information set out in section 4e, provided that you comply with the other
+provisions of LGPL3 and provided that you meet, for the Application the
+terms and conditions of the license(s) which apply to the Application.
+
+Except as stated in this special exception, the provisions of LGPL3 will
+continue to comply in full to this Library. If you modify this Library, you
+may apply this exception to your version of this Library, but you are not
+obliged to do so. If you do not wish to do so, delete this exception
+statement from your version. This exception does not (and cannot) modify any
+license terms which apply to the Application, with which you must still
+comply.
+
                    GNU LESSER GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If you want to start working on the GNURadio 4.0 source, the [DEVELOPMENT.md](DE
 
 ## License and Copyright
 
-Unless otherwise noted: SPDX-License-Identifier: LGPL-3.0-or-later
+Unless otherwise noted: SPDX-License-Identifier: LGPL-3.0-linking-exception
 All code contributions to GNU Radio will be integrated into a library under the LGPL, ensuring it remains free/libre (FLOSS) for both personal and commercial use, without further constraints on either.
 For details on how to contribute, please consult: [CONTRIBUTING.md](CONTRIBUTING.md)
 


### PR DESCRIPTION
This commit adds the LGPLv3 linking exception to handle GR4 as a header-only library. The exception allows proprietary applications to link and use GR4 without disclosing their source code, addressing legal and operational constraints (e.g., in government or security-sensitive applications).

This is particularly important since traditional dynamic or static linking isn't applicable in header-only libraries. Modifications to GR4 itself remain LGPL-compliant, ensuring continued adherence to copyleft and FLOSS principles while enabling wider adoption.

By including this exception, we aim to increase the flexibility for adoption by public organisations, critical infrastructure, and industry partners, while maintaining the core FLOSS principles.