### PR TITLE
CircularBuffer: do not reset empty PublishableOutputRange

### DIFF
--- a/core/include/gnuradio-4.0/CircularBuffer.hpp
+++ b/core/include/gnuradio-4.0/CircularBuffer.hpp
@@ -288,9 +288,6 @@ class CircularBuffer {
 
         PublishableOutputRange() = delete;
         explicit PublishableOutputRange(Writer<U>* parent) noexcept : _parent(parent) {
-            _parent->_index        = 0UZ;
-            _parent->_offset       = 0;
-            _parent->_internalSpan = std::span<T>();
             _parent->_rangesCounter++;
         };
         explicit constexpr PublishableOutputRange(Writer<U>* parent, std::size_t index, signed_index_type sequence, std::size_t nSlotsToClaim) noexcept : _parent(parent) {


### PR DESCRIPTION
When an empty PublishableOutputRange is requested, do not reset the index, offet and internal span of the buffer.

This solution was suggested by @drslebedev to fix bugs in which the buffer state would become corrupted and report negative values (casted to uint64_t) for the available number of elements, etc.

---

I have tested this change on the gr4-packet-modem codebase and everything seems to work correctly with the single-threaded scheduler. Things that mysteriously failed before now work. All the QA tests in gr4-packet-modem and gnuradio4 pass. There are still some things in gr4-packet-modem that don't work with the multi-threaded scheduler, but probably the problem is unrelated.