### PR TITLE
Coverage: configure Sonarcube exclusions

### DIFF
--- a/.github/workflows/restyled.yml
+++ b/.github/workflows/restyled.yml
@@ -1,0 +1,23 @@
+name: Restyled
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  restyled:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - uses: restyled-io/actions/setup@v4
+      - id: restyler
+        uses: restyled-io/actions/run@v4
+        with:
+          fail-on-differences: true
+

--- a/algorithm/include/gnuradio-4.0/algorithm/ImChart.hpp
+++ b/algorithm/include/gnuradio-4.0/algorithm/ImChart.hpp
@@ -25,8 +25,8 @@
 #pragma GCC diagnostic pop
 #endif
 
-#include "gnuradio-4.0/meta/utils.hpp"
 #include "gnuradio-4.0/meta/reflection.hpp"
+#include "gnuradio-4.0/meta/utils.hpp"
 #include <bitset>
 #include <iostream>
 
@@ -36,63 +36,45 @@ class Color {
 public:
     enum class Type : std::uint8_t { Default, Blue, Red, Green, Yellow, Magenta, Cyan, LightBlue, LightRed, LightGreen, LightYellow, LightMagenta, LightCyan, White, LightGray, DarkGray, Black };
 
-    [[nodiscard]] constexpr static const char *
-    get(Type colour) noexcept {
-        for (const auto &[colType, colStr] : Colors) {
-            if (colType == colour) return colStr;
+    [[nodiscard]] constexpr static const char* get(Type colour) noexcept {
+        for (const auto& [colType, colStr] : Colors) {
+            if (colType == colour) {
+                return colStr;
+            }
         }
         return Colors[0].second; // fallback, should not happen if Colors array is correctly defined.
     }
 
-    [[nodiscard]] constexpr static const char *
-    get(std::size_t index) noexcept {
-        return Colors[index % Colors.size()].second;
-    }
+    [[nodiscard]] constexpr static const char* get(std::size_t index) noexcept { return Colors[index % Colors.size()].second; }
 
-    [[nodiscard]] constexpr static uint8_t
-    getIndex(Type colour) noexcept {
-        return static_cast<uint8_t>(colour);
-    }
+    [[nodiscard]] constexpr static uint8_t getIndex(Type colour) noexcept { return static_cast<uint8_t>(colour); }
 
-    [[nodiscard]] constexpr static Type
-    next(Type colour) noexcept {
-        return magic_enum::enum_next_value_circular(colour);
-    }
+    [[nodiscard]] constexpr static Type next(Type colour) noexcept { return magic_enum::enum_next_value_circular(colour); }
 
-    [[nodiscard]] constexpr static Type
-    prev(Type colour) noexcept {
-        return magic_enum::enum_prev_value_circular(colour);
-    }
+    [[nodiscard]] constexpr static Type prev(Type colour) noexcept { return magic_enum::enum_prev_value_circular(colour); }
 
 private:
-    constexpr static std::array<std::pair<Type, const char *>, 17UZ> Colors = {
-        std::make_pair(Type::Default, "\x1B[39m"), //
-        std::make_pair(Type::Blue, "\x1B[34m"),         std::make_pair(Type::Red, "\x1B[31m"),       std::make_pair(Type::Green, "\x1B[32m"),      std::make_pair(Type::Yellow, "\x1B[33m"),
-        std::make_pair(Type::Magenta, "\x1B[35m"),      std::make_pair(Type::Cyan, "\x1B[36m"), //
-        std::make_pair(Type::LightBlue, "\x1B[94m"),    std::make_pair(Type::LightRed, "\x1B[91m"),  std::make_pair(Type::LightGreen, "\x1B[92m"), std::make_pair(Type::LightYellow, "\x1B[93m"),
-        std::make_pair(Type::LightMagenta, "\x1B[95m"), std::make_pair(Type::LightCyan, "\x1B[96m"), //
-        std::make_pair(Type::White, "\x1B[97m"),        std::make_pair(Type::LightGray, "\x1B[37m"), std::make_pair(Type::DarkGray, "\x1B[90m"),   std::make_pair(Type::Black, "\x1B[30m")
-    };
+    constexpr static std::array<std::pair<Type, const char*>, 17UZ> Colors = {std::make_pair(Type::Default, "\x1B[39m"),                                                                                                                                                                   //
+        std::make_pair(Type::Blue, "\x1B[34m"), std::make_pair(Type::Red, "\x1B[31m"), std::make_pair(Type::Green, "\x1B[32m"), std::make_pair(Type::Yellow, "\x1B[33m"), std::make_pair(Type::Magenta, "\x1B[35m"), std::make_pair(Type::Cyan, "\x1B[36m"),                               //
+        std::make_pair(Type::LightBlue, "\x1B[94m"), std::make_pair(Type::LightRed, "\x1B[91m"), std::make_pair(Type::LightGreen, "\x1B[92m"), std::make_pair(Type::LightYellow, "\x1B[93m"), std::make_pair(Type::LightMagenta, "\x1B[95m"), std::make_pair(Type::LightCyan, "\x1B[96m"), //
+        std::make_pair(Type::White, "\x1B[97m"), std::make_pair(Type::LightGray, "\x1B[37m"), std::make_pair(Type::DarkGray, "\x1B[90m"), std::make_pair(Type::Black, "\x1B[30m")};
 };
 
 struct LinearAxisTransform {
     template<std::floating_point T>
-    [[nodiscard]] static constexpr std::size_t
-    toScreen(T value, T axisMin, T axisMax, std::size_t screenOffset, std::size_t screenSize) {
+    [[nodiscard]] static constexpr std::size_t toScreen(T value, T axisMin, T axisMax, std::size_t screenOffset, std::size_t screenSize) {
         return screenOffset + static_cast<std::size_t>((value - axisMin) / (axisMax - axisMin) * static_cast<T>(screenSize - screenOffset - 1UZ));
     }
 
     template<std::floating_point T>
-    [[nodiscard]] static constexpr T
-    fromScreen(std::size_t screenCoordinate, T axisMin, T axisMax, std::size_t screenOffset, std::size_t screenSize) {
+    [[nodiscard]] static constexpr T fromScreen(std::size_t screenCoordinate, T axisMin, T axisMax, std::size_t screenOffset, std::size_t screenSize) {
         return axisMin + static_cast<T>(screenCoordinate - screenOffset) / static_cast<T>(screenSize - screenOffset - 1UZ) * (axisMax - axisMin);
     }
 };
 
 struct LogAxisTransform {
     template<typename T>
-    [[nodiscard]] static constexpr std::size_t
-    toScreen(T value, T axisMin, T axisMax, std::size_t screenOffset, std::size_t screenSize) {
+    [[nodiscard]] static constexpr std::size_t toScreen(T value, T axisMin, T axisMax, std::size_t screenOffset, std::size_t screenSize) {
         if (value <= 0 || axisMin <= 0 || axisMax <= axisMin) {
             throw std::invalid_argument(fmt::format("{} not defined for non-positive value {} in [{}, {}].", gr::meta::type_name<LogAxisTransform>(), value, axisMin, axisMax));
         }
@@ -103,8 +85,7 @@ struct LogAxisTransform {
     }
 
     template<std::floating_point T>
-    [[nodiscard]] static constexpr T
-    fromScreen(std::size_t screenCoordinate, T axisMin, T axisMax, std::size_t screenOffset, std::size_t screenSize) {
+    [[nodiscard]] static constexpr T fromScreen(std::size_t screenCoordinate, T axisMin, T axisMax, std::size_t screenOffset, std::size_t screenSize) {
         if (axisMin <= 0UZ || axisMax <= axisMin) {
             throw std::invalid_argument(fmt::format("{} not defined for non-positive ranges [{}, {}].", gr::meta::type_name<LogAxisTransform>(), axisMin, axisMax));
         }
@@ -121,26 +102,22 @@ enum class Style { Braille, Bars, Marker };
 
 namespace detail {
 inline std::vector<std::size_t> optimalTickScreenPositions(std::size_t axisWidth, std::size_t minGapSize = 1) {
-    constexpr std::array preferredDivisors{ 10UZ, 8UZ, 5UZ, 4UZ, 3UZ, 2UZ };
+    constexpr std::array preferredDivisors{10UZ, 8UZ, 5UZ, 4UZ, 3UZ, 2UZ};
     std::size_t          reducedAxisWidth = axisWidth - 1; // because we always require & add the '0'
 
     // checks if preferred divisor evenly divides the 'axisWidth - 1'
     auto validDivisorIt = std::ranges::find_if(preferredDivisors, [&](std::size_t divisor) { return reducedAxisWidth % divisor == 0 && (reducedAxisWidth / divisor) > minGapSize; });
 
     // determine the segment size.
-    std::size_t segmentSize = validDivisorIt != preferredDivisors.end() ? (reducedAxisWidth < 10 ? *validDivisorIt : (reducedAxisWidth / *validDivisorIt))
-                                                                        : reducedAxisWidth; // default -> [0, reducedAxisWidth]
+    std::size_t segmentSize = validDivisorIt != preferredDivisors.end() ? (reducedAxisWidth < 10 ? *validDivisorIt : (reducedAxisWidth / *validDivisorIt)) : reducedAxisWidth; // default -> [0, reducedAxisWidth]
 
     auto tickRange = std::views::iota(0UZ, axisWidth) | std::views::filter([=](auto i) { return i % segmentSize == 0; });
-    return { tickRange.begin(), tickRange.end() };
+    return {tickRange.begin(), tickRange.end()};
 }
 
 } // namespace detail
 
-inline void
-resetView() {
-    fmt::println("\033[2J\033[H");
-}
+inline void resetView() { fmt::println("\033[2J\033[H"); }
 
 /**
  * @brief compact class for ASCII charting in terminal environments, supporting custom dimensions and styles.
@@ -205,28 +182,20 @@ resetView() {
  */
 template<std::size_t screenWidth, std::size_t screenHeight, typename horAxisTransform = LinearAxisTransform, typename verAxisTransform = LinearAxisTransform>
 struct ImChart {
-    std::conditional_t<screenWidth != std::dynamic_extent, const std::size_t, std::size_t>  _screen_width{ screenWidth };
-    std::conditional_t<screenHeight != std::dynamic_extent, const std::size_t, std::size_t> _screen_height{ screenHeight };
+    std::conditional_t<screenWidth != std::dynamic_extent, const std::size_t, std::size_t>  _screen_width{screenWidth};
+    std::conditional_t<screenHeight != std::dynamic_extent, const std::size_t, std::size_t> _screen_height{screenHeight};
 
     //
-    constexpr static std::size_t                   kCellWidth{ 2U };
-    constexpr static std::size_t                   kCellHeight{ 4U };
-    constexpr static std::array<const char *, 256> kBrailleCharacter{
-        "⠀", "⠁", "⠂", "⠃", "⠄", "⠅", "⠆", "⠇", "⠈", "⠉", "⠊", "⠋", "⠌", "⠍", "⠎", "⠏", "⠐", "⠑", "⠒", "⠓", "⠔", "⠕", "⠖", "⠗", "⠘", "⠙", "⠚", "⠛", "⠜", "⠝", "⠞", "⠟", "⠠", "⠡", "⠢", "⠣", "⠤",
-        "⠥", "⠦", "⠧", "⠨", "⠩", "⠪", "⠫", "⠬", "⠭", "⠮", "⠯", "⠰", "⠱", "⠲", "⠳", "⠴", "⠵", "⠶", "⠷", "⠸", "⠹", "⠺", "⠻", "⠼", "⠽", "⠾", "⠿", "⡀", "⡁", "⡂", "⡃", "⡄", "⡅", "⡆", "⡇", "⡈", "⡉",
-        "⡊", "⡋", "⡌", "⡍", "⡎", "⡏", "⡐", "⡑", "⡒", "⡓", "⡔", "⡕", "⡖", "⡗", "⡘", "⡙", "⡚", "⡛", "⡜", "⡝", "⡞", "⡟", "⡠", "⡡", "⡢", "⡣", "⡤", "⡥", "⡦", "⡧", "⡨", "⡩", "⡪", "⡫", "⡬", "⡭", "⡮",
-        "⡯", "⡰", "⡱", "⡲", "⡳", "⡴", "⡵", "⡶", "⡷", "⡸", "⡹", "⡺", "⡻", "⡼", "⡽", "⡾", "⡿", "⢀", "⢁", "⢂", "⢃", "⢄", "⢅", "⢆", "⢇", "⢈", "⢉", "⢊", "⢋", "⢌", "⢍", "⢎", "⢏", "⢐", "⢑", "⢒", "⢓",
-        "⢔", "⢕", "⢖", "⢗", "⢘", "⢙", "⢚", "⢛", "⢜", "⢝", "⢞", "⢟", "⢠", "⢡", "⢢", "⢣", "⢤", "⢥", "⢦", "⢧", "⢨", "⢩", "⢪", "⢫", "⢬", "⢭", "⢮", "⢯", "⢰", "⢱", "⢲", "⢳", "⢴", "⢵", "⢶", "⢷", "⢸",
-        "⢹", "⢺", "⢻", "⢼", "⢽", "⢾", "⢿", "⣀", "⣁", "⣂", "⣃", "⣄", "⣅", "⣆", "⣇", "⣈", "⣉", "⣊", "⣋", "⣌", "⣍", "⣎", "⣏", "⣐", "⣑", "⣒", "⣓", "⣔", "⣕", "⣖", "⣗", "⣘", "⣙", "⣚", "⣛", "⣜", "⣝",
-        "⣞", "⣟", "⣠", "⣡", "⣢", "⣣", "⣤", "⣥", "⣦", "⣧", "⣨", "⣩", "⣪", "⣫", "⣬", "⣭", "⣮", "⣯", "⣰", "⣱", "⣲", "⣳", "⣴", "⣵", "⣶", "⣷", "⣸", "⣹", "⣺", "⣻", "⣼", "⣽", "⣾", "⣿"
-    };
-    constexpr static std::array<std::array<uint8_t, kCellHeight>, kCellWidth> kBrailleDotMap{ { { 0x1, 0x2, 0x4, 0x40 }, { 0x8, 0x10, 0x20, 0x80 } } };
+    constexpr static std::size_t                                              kCellWidth{2U};
+    constexpr static std::size_t                                              kCellHeight{4U};
+    constexpr static std::array<const char*, 256>                             kBrailleCharacter{"⠀", "⠁", "⠂", "⠃", "⠄", "⠅", "⠆", "⠇", "⠈", "⠉", "⠊", "⠋", "⠌", "⠍", "⠎", "⠏", "⠐", "⠑", "⠒", "⠓", "⠔", "⠕", "⠖", "⠗", "⠘", "⠙", "⠚", "⠛", "⠜", "⠝", "⠞", "⠟", "⠠", "⠡", "⠢", "⠣", "⠤", "⠥", "⠦", "⠧", "⠨", "⠩", "⠪", "⠫", "⠬", "⠭", "⠮", "⠯", "⠰", "⠱", "⠲", "⠳", "⠴", "⠵", "⠶", "⠷", "⠸", "⠹", "⠺", "⠻", "⠼", "⠽", "⠾", "⠿", "⡀", "⡁", "⡂", "⡃", "⡄", "⡅", "⡆", "⡇", "⡈", "⡉", "⡊", "⡋", "⡌", "⡍", "⡎", "⡏", "⡐", "⡑", "⡒", "⡓", "⡔", "⡕", "⡖", "⡗", "⡘", "⡙", "⡚", "⡛", "⡜", "⡝", "⡞", "⡟", "⡠", "⡡", "⡢", "⡣", "⡤", "⡥", "⡦", "⡧", "⡨", "⡩", "⡪", "⡫", "⡬", "⡭", "⡮", "⡯", "⡰", "⡱", "⡲", "⡳", "⡴", "⡵", "⡶", "⡷", "⡸", "⡹", "⡺", "⡻", "⡼", "⡽", "⡾", "⡿", "⢀", "⢁", "⢂", "⢃", "⢄", "⢅", "⢆", "⢇", "⢈", "⢉", "⢊", "⢋", "⢌", "⢍", "⢎", "⢏", "⢐", "⢑", "⢒", "⢓", "⢔", "⢕", "⢖", "⢗", "⢘", "⢙", "⢚", "⢛", "⢜", "⢝", "⢞", "⢟", "⢠", "⢡", "⢢", "⢣", "⢤", "⢥", "⢦", "⢧", "⢨", "⢩", "⢪", "⢫", "⢬", "⢭", "⢮", "⢯", "⢰", "⢱", "⢲", "⢳", "⢴", "⢵", "⢶", "⢷", "⢸", "⢹", "⢺", "⢻", "⢼", "⢽", "⢾", "⢿", "⣀", "⣁", "⣂", "⣃", "⣄", "⣅", "⣆", "⣇", "⣈", "⣉", "⣊", "⣋", "⣌", "⣍", "⣎", "⣏", "⣐", "⣑", "⣒", "⣓", "⣔", "⣕", "⣖", "⣗", "⣘", "⣙", "⣚", "⣛", "⣜", "⣝", "⣞", "⣟", "⣠", "⣡", "⣢", "⣣", "⣤", "⣥", "⣦", "⣧", "⣨", "⣩", "⣪", "⣫", "⣬", "⣭", "⣮", "⣯", "⣰", "⣱", "⣲", "⣳", "⣴", "⣵", "⣶", "⣷", "⣸", "⣹", "⣺", "⣻", "⣼", "⣽", "⣾", "⣿"};
+    constexpr static std::array<std::array<uint8_t, kCellHeight>, kCellWidth> kBrailleDotMap{{{0x1, 0x2, 0x4, 0x40}, {0x8, 0x10, 0x20, 0x80}}};
     // bar definitions
-    constexpr static std::array<const char *, 9> kBars{ " ", "▁", "▂", "▃", "▄", "▅", "▆", "▇", "█" };
+    constexpr static std::array<const char*, 9> kBars{" ", "▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"};
     static_assert(static_cast<std::size_t>(std::ranges::distance(kBars)) >= kCellWidth * kCellHeight, "bar definitions must be >= kCellWidth * kCellHeight");
-    constexpr static std::array<const char *, 9> kMarker{ "X", "O", "★", "+", "❖", "◎", "○", "■", "□" };
+    constexpr static std::array<const char*, 9> kMarker{"X", "O", "★", "+", "❖", "◎", "○", "■", "□"};
 
-    constexpr static Color::Type          kFirstColor{ Color::Type::Blue }; // we like blue
+    constexpr static Color::Type          kFirstColor{Color::Type::Blue}; // we like blue
     std::vector<std::vector<std::string>> _screen;
     // _brailleArray is the 2x4 (kCellWidth k CellHeight) oversampled data array that is used
     // to in turn compute the required braille and bar characters that are inserted into the _screen array
@@ -235,7 +204,7 @@ struct ImChart {
     std::vector<std::vector<uint16_t>> _brailleArray;
 
     Color::Type              _lastColor = kFirstColor;
-    std::size_t              _n_datasets{ 0UZ };
+    std::size_t              _n_datasets{0UZ};
     std::vector<std::string> _datasets{};
     std::source_location     _location;
 
@@ -243,23 +212,17 @@ public:
     std::string axis_name_x = "x-axis []";
     std::string axis_name_y = "y-axis []";
     bool        draw_border = false;
-    double      axis_min_x{ 0.0 };
-    double      axis_max_x{ 0.0 };
-    double      axis_min_y{ 0.0 };
-    double      axis_max_y{ 0.0 };
+    double      axis_min_x{0.0};
+    double      axis_max_x{0.0};
+    double      axis_min_y{0.0};
+    double      axis_max_y{0.0};
     std::size_t n_ticks_x = std::min(10LU, screenWidth / 2U);
     std::size_t n_ticks_y = std::min(10LU, screenHeight / 2U);
 
-    constexpr ImChart(std::size_t screenWidth_ = screenWidth, std::size_t screenHeight_ = screenHeight, const std::source_location location = std::source_location::current()) noexcept
-        : _screen_width(screenWidth_)
-        , _screen_height(screenHeight_)
-        , _screen(_screen_height, std::vector<std::string>(_screen_width, " "))
-        , _brailleArray(_screen_width * kCellWidth, std::vector<uint16_t>(_screen_height * kCellHeight, 0UZ))
-        , _location(location) {}
+    constexpr ImChart(std::size_t screenWidth_ = screenWidth, std::size_t screenHeight_ = screenHeight, const std::source_location location = std::source_location::current()) noexcept : _screen_width(screenWidth_), _screen_height(screenHeight_), _screen(_screen_height, std::vector<std::string>(_screen_width, " ")), _brailleArray(_screen_width * kCellWidth, std::vector<uint16_t>(_screen_height * kCellHeight, 0UZ)), _location(location) {}
 
-    explicit ImChart(const std::tuple<std::pair<double, double>, std::pair<double, double>> &init, std::size_t screenWidth_ = screenWidth, std::size_t screenHeight_ = screenHeight)
-        : ImChart(screenWidth_, screenHeight_) {
-        const auto &[xBounds, yBounds] = init;
+    explicit ImChart(const std::tuple<std::pair<double, double>, std::pair<double, double>>& init, std::size_t screenWidth_ = screenWidth, std::size_t screenHeight_ = screenHeight) : ImChart(screenWidth_, screenHeight_) {
+        const auto& [xBounds, yBounds] = init;
         axis_min_x                     = xBounds.first;
         axis_max_x                     = xBounds.second;
         axis_min_y                     = yBounds.first;
@@ -267,8 +230,7 @@ public:
     }
 
     template<Style style = Style::Braille, std::ranges::input_range TContainer1, std::ranges::input_range TContainer2>
-    void
-    draw(const TContainer1 &xValues, const TContainer2 &yValues, std::string_view datasetName = {}) {
+    void draw(const TContainer1& xValues, const TContainer2& yValues, std::string_view datasetName = {}) {
         static_assert(std::is_same_v<std::ranges::range_value_t<TContainer1>, std::ranges::range_value_t<TContainer2>>, "x- and y- range must have same value_type");
         using ValueType = typename std::ranges::range_value_t<TContainer1>;
         static_assert(std::is_arithmetic_v<ValueType>, "collection's value_type must be a arithmetic type!");
@@ -305,7 +267,7 @@ public:
 #endif
 
         // clear braille array
-        std::ranges::for_each(_brailleArray, [](auto &line) { std::ranges::fill(line, 0UZ); });
+        std::ranges::for_each(_brailleArray, [](auto& line) { std::ranges::fill(line, 0UZ); });
         auto updateBrailleArray = [this](const uint16_t oldValue) -> uint16_t {
             uint16_t increment = ((oldValue & 0xFF) + 1UZ) & 0xFF;     // Increment and mask to first byte
             uint16_t colorBit  = ((1UZ << _n_datasets) << 8) & 0xFF00; // Shift to the second byte
@@ -324,7 +286,7 @@ public:
             auto x = *xIt;
             auto y = *yIt;
 #else
-        for (const auto &[x, y] : std::ranges::views::zip(xValues, yValues)) {
+        for (const auto& [x, y] : std::ranges::views::zip(xValues, yValues)) {
 #endif
             if (static_cast<double>(x) < axis_min_x || static_cast<double>(x) >= axis_max_x || static_cast<double>(y) < axis_min_y || static_cast<double>(y) >= axis_max_y) {
                 continue;
@@ -377,7 +339,7 @@ public:
                 }
                 const auto     colourStr     = Color::get(_lastColor);
                 constexpr auto defaultColour = Color::get(Color::Type::Default);
-                auto          &screen        = _screen[bRowIdx / kCellHeight][bColIdx / kCellWidth];
+                auto&          screen        = _screen[bRowIdx / kCellHeight][bColIdx / kCellWidth];
                 switch (style) {
                 case Style::Bars: screen.assign(fmt::format("{}{}{}", colourStr, kBars[dot], defaultColour)); break;
                 case Style::Marker: screen.assign(fmt::format("{}{}{}", colourStr, kMarker[_n_datasets - 1], Color::get(Color::Type::Default))); break;
@@ -389,8 +351,7 @@ public:
         _lastColor = Color::next(_lastColor);
     }
 
-    void
-    draw(std::source_location caller = std::source_location::current()) {
+    void draw(std::source_location caller = std::source_location::current()) {
         _location = caller;
         drawBorder();
         drawAxes();
@@ -400,23 +361,18 @@ public:
         printScreen();
     }
 
-    void
-    clearScreen() noexcept {
-        std::ranges::for_each(_screen, [](auto &line) { std::ranges::fill(line, " "); });
-        std::ranges::for_each(_brailleArray, [](auto &line) { std::ranges::fill(line, 0UZ); });
+    void clearScreen() noexcept {
+        std::ranges::for_each(_screen, [](auto& line) { std::ranges::fill(line, " "); });
+        std::ranges::for_each(_brailleArray, [](auto& line) { std::ranges::fill(line, 0UZ); });
         _lastColor  = kFirstColor;
         _n_datasets = 0UZ;
     }
 
-    void
-    reset() const noexcept {
-        fmt::print("\033[0;0H");
-    }
+    void reset() const noexcept { fmt::print("\033[0;0H"); }
 
-    void
-    printScreen() const noexcept {
-        for (const auto &row : _screen) {
-            for (const auto &cell : row) {
+    void printScreen() const noexcept {
+        for (const auto& row : _screen) {
+            for (const auto& cell : row) {
                 fmt::print("{}", cell);
             }
             fmt::print("\n");
@@ -425,8 +381,7 @@ public:
         fmt::print("{}", Color::get(Color::Type::Default));
     }
 
-    void
-    printSourceLocation() {
+    void printSourceLocation() {
         const std::size_t maxLength = _screen_width / 4UZ;
         std::string       fullPath(_location.file_name());
 
@@ -445,25 +400,20 @@ public:
         }
     }
 
-    [[nodiscard]] constexpr std::size_t
-    getHorizontalAxisPositionY() const noexcept {
+    [[nodiscard]] constexpr std::size_t getHorizontalAxisPositionY() const noexcept {
         const double relative_position = (0.0 - axis_min_y) / (axis_max_y - axis_min_y);
         const auto   position          = static_cast<std::size_t>((1.0 - relative_position) * static_cast<double>(_screen_height));
         return std::clamp(position, 0LU, _screen_height - 3LU);
     }
 
-    [[nodiscard]] constexpr std::size_t
-    getVerticalAxisPositionX() const noexcept {
-        auto y_axis_x = std::is_same_v<horAxisTransform, LogAxisTransform>
-                              ? 0UZ
-                              : static_cast<std::size_t>((std::max(0. - axis_min_x, 0.) / (axis_max_x - axis_min_x)) * static_cast<double>(_screen_width - 1UZ));
+    [[nodiscard]] constexpr std::size_t getVerticalAxisPositionX() const noexcept {
+        auto y_axis_x = std::is_same_v<horAxisTransform, LogAxisTransform> ? 0UZ : static_cast<std::size_t>((std::max(0. - axis_min_x, 0.) / (axis_max_x - axis_min_x)) * static_cast<double>(_screen_width - 1UZ));
         // adjust for axis labels
         std::size_t y_label_width = std::max(fmt::format("{:G}", axis_min_y).size(), fmt::format("{:G}", axis_max_y).size());
         return std::clamp(y_axis_x, y_label_width + 3, _screen_width); // Ensure axis positions are within screen bounds
     }
 
-    void
-    drawAxes() {
+    void drawAxes() {
         const std::size_t horAxisPosY = getHorizontalAxisPositionY();
         const std::size_t verAxisPosX = getVerticalAxisPositionX();
         const std::size_t horOffset   = (axis_min_x == 0.0 || std::is_same_v<horAxisTransform, LogAxisTransform>) ? verAxisPosX : 0UZ;
@@ -479,7 +429,7 @@ public:
 
         // x-axis labels and ticks
         const std::size_t maxHorLabelWidth = std::max(fmt::format("{:+G}", axis_min_x).size(), fmt::format("{:+G}", axis_max_x).size());
-        for (const auto &relTickScreenPos : detail::optimalTickScreenPositions(_screen_width - horOffset, 1UZ)) {
+        for (const auto& relTickScreenPos : detail::optimalTickScreenPositions(_screen_width - horOffset, 1UZ)) {
             const std::size_t tickPos   = horOffset + relTickScreenPos;
             const double      tickValue = horAxisTransform::fromScreen(tickPos, axis_min_x, axis_max_x, horOffset, _screen_width);
             if ((axis_min_x == 0 && relTickScreenPos == 0) || tickPos > _screen_width) {
@@ -500,7 +450,7 @@ public:
         }
 
         // y-axis labels and ticks
-        for (const auto &relTickScreenPos : detail::optimalTickScreenPositions(_screen_height)) {
+        for (const auto& relTickScreenPos : detail::optimalTickScreenPositions(_screen_height)) {
             const std::size_t tickPos   = _screen_height - 1UZ - relTickScreenPos;
             const double      tickValue = verAxisTransform::fromScreen(relTickScreenPos, axis_min_y, axis_max_y, 0UZ, _screen_height);
             if (/*(axis_min_y == 0 && relTickScreenPos == 0) ||*/ tickPos > _screen_height) {
@@ -543,13 +493,12 @@ public:
         }
     }
 
-    void
-    drawLegend() {
+    void drawLegend() {
         const std::size_t cursorY = _screen_height - 1LU; // legend position on last row
         std::size_t       cursorX = getVerticalAxisPositionX() + 2LU;
 
         auto colour = kFirstColor;
-        for (const auto &datasetName : _datasets) {
+        for (const auto& datasetName : _datasets) {
             if (datasetName.empty()) {
                 continue;
             }
@@ -570,8 +519,7 @@ public:
         }
     }
 
-    void
-    drawBorder() {
+    void drawBorder() {
         if (!draw_border) {
             return;
         }

--- a/algorithm/include/gnuradio-4.0/algorithm/fourier/fftw.hpp
+++ b/algorithm/include/gnuradio-4.0/algorithm/fourier/fftw.hpp
@@ -10,63 +10,63 @@
 namespace gr::algorithm {
 
 namespace detail {
-    template<typename TData>
-    struct FFTwImplTypes {
-        using PlanType        = fftwf_plan;
-        using InAlgoDataType  = std::conditional_t<gr::meta::complex_like<TData>, fftwf_complex, float>;
-        using OutAlgoDataType = fftwf_complex;
-    };
+template<typename TData>
+struct FFTwImplTypes {
+    using PlanType        = fftwf_plan;
+    using InAlgoDataType  = std::conditional_t<gr::meta::complex_like<TData>, fftwf_complex, float>;
+    using OutAlgoDataType = fftwf_complex;
+};
 
-    template<typename TData>
-       requires (std::is_same_v<TData, std::complex<double>> || std::is_same_v<TData, double>)
-    struct FFTwImplTypes<TData> {
-        using PlanType        = fftw_plan;
-        using InAlgoDataType  = std::conditional_t<gr::meta::complex_like<TData>, fftw_complex, double>;
-        using OutAlgoDataType = fftw_complex;
-    };
+template<typename TData>
+requires(std::is_same_v<TData, std::complex<double>> || std::is_same_v<TData, double>)
+struct FFTwImplTypes<TData> {
+    using PlanType        = fftw_plan;
+    using InAlgoDataType  = std::conditional_t<gr::meta::complex_like<TData>, fftw_complex, double>;
+    using OutAlgoDataType = fftw_complex;
+};
 
-    template<typename TData>
-    struct FFTwImplFreeIn {
-        using InAlgoDataType = FFTwImplTypes<TData>::InAlgoDataType;
-        void operator()(InAlgoDataType *ptr) { fftwf_free(ptr); }
-    };
+template<typename TData>
+struct FFTwImplFreeIn {
+    using InAlgoDataType = FFTwImplTypes<TData>::InAlgoDataType;
+    void operator()(InAlgoDataType* ptr) { fftwf_free(ptr); }
+};
 
-    template<typename TData>
-       requires (std::is_same_v<TData, std::complex<double>> || std::is_same_v<TData, double>)
-    struct FFTwImplFreeIn<TData> {
-        using InAlgoDataType = FFTwImplTypes<TData>::InAlgoDataType;
-        void operator()(InAlgoDataType *ptr) { fftw_free(ptr); }
-    };
+template<typename TData>
+requires(std::is_same_v<TData, std::complex<double>> || std::is_same_v<TData, double>)
+struct FFTwImplFreeIn<TData> {
+    using InAlgoDataType = FFTwImplTypes<TData>::InAlgoDataType;
+    void operator()(InAlgoDataType* ptr) { fftw_free(ptr); }
+};
 
-    template<typename TData>
-    struct FFTwImplFreeOut {
-        using OutAlgoDataType = FFTwImplTypes<TData>::OutAlgoDataType;
-        void operator()(OutAlgoDataType *ptr) { fftwf_free(ptr); }
-    };
+template<typename TData>
+struct FFTwImplFreeOut {
+    using OutAlgoDataType = FFTwImplTypes<TData>::OutAlgoDataType;
+    void operator()(OutAlgoDataType* ptr) { fftwf_free(ptr); }
+};
 
-    template<typename TData>
-       requires (std::is_same_v<TData, std::complex<double>> || std::is_same_v<TData, double>)
-    struct FFTwImplFreeOut<TData> {
-        using OutAlgoDataType = FFTwImplTypes<TData>::OutAlgoDataType;
-        void operator()(OutAlgoDataType *ptr) { fftw_free(ptr); }
-    };
+template<typename TData>
+requires(std::is_same_v<TData, std::complex<double>> || std::is_same_v<TData, double>)
+struct FFTwImplFreeOut<TData> {
+    using OutAlgoDataType = FFTwImplTypes<TData>::OutAlgoDataType;
+    void operator()(OutAlgoDataType* ptr) { fftw_free(ptr); }
+};
 
-    template<typename TData>
-    struct FFTwImplDestroyPlan {
-        using PlanType = FFTwImplTypes<TData>::PlanType;
-        void operator()(PlanType ptr) { fftwf_destroy_plan(ptr); }
-    };
+template<typename TData>
+struct FFTwImplDestroyPlan {
+    using PlanType = FFTwImplTypes<TData>::PlanType;
+    void operator()(PlanType ptr) { fftwf_destroy_plan(ptr); }
+};
 
-    template<typename TData>
-       requires (std::is_same_v<TData, std::complex<double>> || std::is_same_v<TData, double>)
-    struct FFTwImplDestroyPlan<TData> {
-        using PlanType = FFTwImplTypes<TData>::PlanType;
-        void operator()(PlanType ptr) { fftw_destroy_plan(ptr); }
-    };
-}
+template<typename TData>
+requires(std::is_same_v<TData, std::complex<double>> || std::is_same_v<TData, double>)
+struct FFTwImplDestroyPlan<TData> {
+    using PlanType = FFTwImplTypes<TData>::PlanType;
+    void operator()(PlanType ptr) { fftw_destroy_plan(ptr); }
+};
+} // namespace detail
 
 template<typename TInput, typename TOutput = std::conditional<gr::meta::complex_like<TInput>, TInput, std::complex<typename TInput::value_type>>>
-    requires((gr::meta::complex_like<TInput> || std::floating_point<TInput>) && (gr::meta::complex_like<TOutput>) )
+requires((gr::meta::complex_like<TInput> || std::floating_point<TInput>) && (gr::meta::complex_like<TOutput>))
 struct FFTw {
 private:
     inline static std::mutex fftw_plan_mutex;
@@ -149,28 +149,23 @@ public:
     using OutUniquePtr    = typename FFTwImpl<AlgoDataType>::OutUniquePtr;
     using PlanUniquePtr   = typename FFTwImpl<AlgoDataType>::PlanUniquePtr;
 
-    std::size_t   fftSize{ 0 };
-    std::string   wisdomPath{ ".gr_fftw_wisdom" };
-    int           sign{ FFTW_FORWARD };
-    unsigned int  flags{ FFTW_ESTIMATE }; // FFTW_EXHAUSTIVE, FFTW_MEASURE, FFTW_ESTIMATE
+    std::size_t   fftSize{0};
+    std::string   wisdomPath{".gr_fftw_wisdom"};
+    int           sign{FFTW_FORWARD};
+    unsigned int  flags{FFTW_ESTIMATE}; // FFTW_EXHAUSTIVE, FFTW_MEASURE, FFTW_ESTIMATE
     InUniquePtr   fftwIn{};
     OutUniquePtr  fftwOut{};
     PlanUniquePtr fftwPlan{};
 
-    FFTw()                    = default;
-    FFTw(const FFTw &rhs)     = delete;
-    FFTw(FFTw &&rhs) noexcept = delete;
-    FFTw &
-    operator=(const FFTw &rhs)
-            = delete;
-    FFTw &
-    operator=(FFTw &&rhs) noexcept
-            = delete;
+    FFTw()                               = default;
+    FFTw(const FFTw& rhs)                = delete;
+    FFTw(FFTw&& rhs) noexcept            = delete;
+    FFTw& operator=(const FFTw& rhs)     = delete;
+    FFTw& operator=(FFTw&& rhs) noexcept = delete;
 
     ~FFTw() { clearFftw(); }
 
-    auto
-    compute(const std::ranges::input_range auto &in, std::ranges::output_range<TOutput> auto &&out) {
+    auto compute(const std::ranges::input_range auto& in, std::ranges::output_range<TOutput> auto&& out) {
         if constexpr (requires(std::size_t n) { out.resize(n); }) {
             if (out.size() != in.size()) {
                 out.resize(in.size());
@@ -194,7 +189,7 @@ public:
 
         // precision is defined by output type, if needed cast input
         if constexpr (!std::is_same_v<TInput, AlgoDataType>) {
-            std::span<AlgoDataType> inSpan(reinterpret_cast<AlgoDataType *>(fftwIn.get()), in.size());
+            std::span<AlgoDataType> inSpan(reinterpret_cast<AlgoDataType*>(fftwIn.get()), in.size());
             std::ranges::transform(in.begin(), in.end(), inSpan.begin(), [](const auto c) { return static_cast<AlgoDataType>(c); });
         } else {
             std::memcpy(fftwIn.get(), &(*in.begin()), sizeof(InAlgoDataType) * fftSize);
@@ -220,41 +215,26 @@ public:
         return out;
     }
 
-    auto
-    compute(const std::ranges::input_range auto &in) {
-        return compute(in, std::vector<TOutput>());
-    }
+    auto compute(const std::ranges::input_range auto& in) { return compute(in, std::vector<TOutput>()); }
 
-    [[nodiscard]] inline int
-    importWisdom() const {
+    [[nodiscard]] inline int importWisdom() const {
         // lock file while importing wisdom?
         return FFTwImpl<AlgoDataType>::importWisdomFromFilename(wisdomPath);
     }
 
-    [[nodiscard]] inline int
-    exportWisdom() const {
+    [[nodiscard]] inline int exportWisdom() const {
         // lock file while exporting wisdom?
         return FFTwImpl<AlgoDataType>::exportWisdomToFilename(wisdomPath);
     }
 
-    [[nodiscard]] inline int
-    importWisdomFromString(const std::string &wisdomString) const {
-        return FFTwImpl<AlgoDataType>::importWisdomFromString(wisdomString);
-    }
+    [[nodiscard]] inline int importWisdomFromString(const std::string& wisdomString) const { return FFTwImpl<AlgoDataType>::importWisdomFromString(wisdomString); }
 
-    [[nodiscard]] std::string
-    exportWisdomToString() const {
-        return FFTwImpl<AlgoDataType>::exportWisdomToString();
-    }
+    [[nodiscard]] std::string exportWisdomToString() const { return FFTwImpl<AlgoDataType>::exportWisdomToString(); }
 
-    inline void
-    forgetWisdom() const {
-        return FFTwImpl<AlgoDataType>::forgetWisdom();
-    }
+    inline void forgetWisdom() const { return FFTwImpl<AlgoDataType>::forgetWisdom(); }
 
 private:
-    [[nodiscard]] constexpr std::size_t
-    getOutputSize() const {
+    [[nodiscard]] constexpr std::size_t getOutputSize() const {
         if constexpr (gr::meta::complex_like<TInput>) {
             return fftSize;
         } else {
@@ -262,14 +242,13 @@ private:
         }
     }
 
-    void
-    initAll() {
+    void initAll() {
         clearFftw();
-        fftwIn  = InUniquePtr(static_cast<InAlgoDataType *>(FFTwImpl<AlgoDataType>::malloc(sizeof(InAlgoDataType) * fftSize)));
-        fftwOut = OutUniquePtr(static_cast<OutAlgoDataType *>(FFTwImpl<AlgoDataType>::malloc(sizeof(OutAlgoDataType) * getOutputSize())));
+        fftwIn  = InUniquePtr(static_cast<InAlgoDataType*>(FFTwImpl<AlgoDataType>::malloc(sizeof(InAlgoDataType) * fftSize)));
+        fftwOut = OutUniquePtr(static_cast<OutAlgoDataType*>(FFTwImpl<AlgoDataType>::malloc(sizeof(OutAlgoDataType) * getOutputSize())));
 
         {
-            std::lock_guard lg{ fftw_plan_mutex };
+            std::lock_guard lg{fftw_plan_mutex};
             // what to do if error is returned
             std::ignore = importWisdom();
             fftwPlan    = PlanUniquePtr(FFTwImpl<AlgoDataType>::plan(static_cast<int>(fftSize), fftwIn.get(), fftwOut.get(), sign, flags));
@@ -277,10 +256,9 @@ private:
         }
     }
 
-    void
-    clearFftw() {
+    void clearFftw() {
         {
-            std::lock_guard lg{ fftw_plan_mutex };
+            std::lock_guard lg{fftw_plan_mutex};
             fftwPlan.reset();
         }
         fftwIn.reset();

--- a/algorithm/include/gnuradio-4.0/algorithm/fourier/window.hpp
+++ b/algorithm/include/gnuradio-4.0/algorithm/fourier/window.hpp
@@ -38,9 +38,8 @@ inline static constexpr gr::meta::fixed_string TypeNames = "[None, Rectangular, 
 
 namespace detail {
 template<typename T>
-    requires std::is_floating_point_v<T>
-constexpr T
-bessel_i0(const T x) noexcept {
+requires std::is_floating_point_v<T>
+constexpr T bessel_i0(const T x) noexcept {
     T   sum  = 1;
     T   term = 1;
     int k    = 1;
@@ -68,9 +67,8 @@ bessel_i0(const T x) noexcept {
  * @param Container std::vector containing the values of the window function.
  */
 template<gr::meta::array_or_vector_type ContainerType, typename T = ContainerType::value_type>
-    requires std::is_floating_point_v<T>
-void
-create(ContainerType &container, Type windowFunction, const T beta = static_cast<T>(1.6)) {
+requires std::is_floating_point_v<T>
+void create(ContainerType& container, Type windowFunction, const T beta = static_cast<T>(1.6)) {
     constexpr T       pi2 = 2 * std::numbers::pi_v<T>;
     const std::size_t n   = container.size();
     if (n == 0) {
@@ -118,7 +116,7 @@ create(ContainerType &container, Type windowFunction, const T beta = static_cast
         // Reference: Nuttall, A. (1981). Some Windows with Very Good Sidelobe Behavior. IEEE Transactions on Acoustics, Speech, and Signal Processing, 29(1), 84-91.
         const T a = pi2 / static_cast<T>(n - 1);
         std::ranges::transform(std::views::iota(0UL, n), container.begin(), [a](const auto i) {
-            constexpr std::array<T, 4> coeff = { static_cast<T>(0.355768), static_cast<T>(0.487396), static_cast<T>(0.144232), static_cast<T>(0.012604) };
+            constexpr std::array<T, 4> coeff = {static_cast<T>(0.355768), static_cast<T>(0.487396), static_cast<T>(0.144232), static_cast<T>(0.012604)};
             const T                    ai    = a * static_cast<T>(i);
             return coeff[0] - coeff[1] * std::cos(ai) + coeff[2] * std::cos(2 * ai) - coeff[3] * std::cos(3 * ai);
         });
@@ -129,7 +127,7 @@ create(ContainerType &container, Type windowFunction, const T beta = static_cast
         // reference: Harris, F. J. (1978). On the use of windows for harmonic analysis with the discrete Fourier transform. Proceedings of the IEEE, 66(1), 51-83.
         const T a = pi2 / static_cast<T>(n - 1);
         std::ranges::transform(std::views::iota(0UL, n), container.begin(), [a](const auto i) {
-            constexpr std::array<T, 4> coeff = { static_cast<T>(0.35875), static_cast<T>(0.48829), static_cast<T>(0.14128), static_cast<T>(0.01168) };
+            constexpr std::array<T, 4> coeff = {static_cast<T>(0.35875), static_cast<T>(0.48829), static_cast<T>(0.14128), static_cast<T>(0.01168)};
             const T                    ai    = a * static_cast<T>(i);
             return coeff[0] - coeff[1] * std::cos(ai) + coeff[2] * std::cos(2 * ai) - coeff[3] * std::cos(3 * ai);
         });
@@ -141,8 +139,7 @@ create(ContainerType &container, Type windowFunction, const T beta = static_cast
         const T a = pi2 / static_cast<T>(n - 1);
         std::ranges::transform(std::views::iota(0UL, n), container.begin(), [a](const auto i) {
             const T ai = a * static_cast<T>(i);
-            return static_cast<T>(0.3635819) - static_cast<T>(0.4891775) * std::cos(ai) + static_cast<T>(0.1365995) * std::cos(static_cast<T>(2.) * ai)
-                 - static_cast<T>(0.0106411) * std::cos(static_cast<T>(3.) * ai);
+            return static_cast<T>(0.3635819) - static_cast<T>(0.4891775) * std::cos(ai) + static_cast<T>(0.1365995) * std::cos(static_cast<T>(2.) * ai) - static_cast<T>(0.0106411) * std::cos(static_cast<T>(3.) * ai);
         });
         return;
     }
@@ -151,7 +148,7 @@ create(ContainerType &container, Type windowFunction, const T beta = static_cast
         // reference: D'Antona, G., & Ferrero, A. (2006). Digital Signal Processing for Measurement Systems: Theory and Applications. Springer.
         const T a = pi2 / static_cast<T>(n - 1);
         std::ranges::transform(std::views::iota(0UL, n), container.begin(), [a](const auto i) {
-            constexpr std::array<T, 5> coeff = { static_cast<T>(1.0), static_cast<T>(1.93), static_cast<T>(1.29), static_cast<T>(0.388), static_cast<T>(0.032) };
+            constexpr std::array<T, 5> coeff = {static_cast<T>(1.0), static_cast<T>(1.93), static_cast<T>(1.29), static_cast<T>(0.388), static_cast<T>(0.032)};
             const T                    ai    = a * static_cast<T>(i);
             return coeff[0] - coeff[1] * std::cos(ai) + coeff[2] * std::cos(2 * ai) - coeff[3] * std::cos(3 * ai) + coeff[4] * std::cos(4 * ai);
         });
@@ -167,8 +164,12 @@ create(ContainerType &container, Type windowFunction, const T beta = static_cast
     case Kaiser: {
         // formula: w(n) = I0(beta * sqrt(1 - ((2*n/(N-1)) - 1)^2)) / I0(beta)
         // reference: J. F. Kaiser and R. W. Schafer. On the use of the i0-sinh window for spectrum analysis. IEEE Transactions on Acoustics, Speech, and Signal Processing, 28(1):105–107, 1980.
-        if (beta < 0) throw std::invalid_argument("beta must be non-negative");
-        if (n <= 1) throw std::invalid_argument("n must be larger than one");
+        if (beta < 0) {
+            throw std::invalid_argument("beta must be non-negative");
+        }
+        if (n <= 1) {
+            throw std::invalid_argument("n must be larger than one");
+        }
 
         const T factor = static_cast<T>(1) / static_cast<T>(n - 1);
         const T i0Beta = detail::bessel_i0(static_cast<T>(beta)); // Compute the zeroth order modified Bessel function of the first kind for beta
@@ -193,19 +194,16 @@ create(ContainerType &container, Type windowFunction, const T beta = static_cast
  * @return A std::vector<float> containing the values of the window function.
  */
 template<typename T = float>
-    requires std::is_floating_point_v<T>
-[[nodiscard]] auto
-create(Type windowFunction, const std::size_t n, const T beta = static_cast<T>(1.6)) {
+requires std::is_floating_point_v<T>
+[[nodiscard]] auto create(Type windowFunction, const std::size_t n, const T beta = static_cast<T>(1.6)) {
     std::vector<T> container(n);
     create(container, windowFunction, beta);
     return container;
 }
 
 // this is to speed-up typical instantiations
-template void
-create<std::vector<float>>(std::vector<float> &container, Type windowFunction, float beta);
-template void
-create<std::vector<double>>(std::vector<double> &container, Type windowFunction, double beta);
+template void create<std::vector<float>>(std::vector<float>& container, Type windowFunction, float beta);
+template void create<std::vector<double>>(std::vector<double>& container, Type windowFunction, double beta);
 
 } // namespace gr::algorithm::window
 

--- a/algorithm/test/example_ImChart.cpp
+++ b/algorithm/test/example_ImChart.cpp
@@ -6,8 +6,7 @@
 #include <ranges>
 #include <thread>
 
-int
-main() {
+int main() {
     setlocale(LC_ALL, "");
     constexpr std::size_t sizeX = 121;
     constexpr std::size_t sizeY = 41;
@@ -17,7 +16,7 @@ main() {
     constexpr double      yMax  = +5.0;
 
     using namespace gr::graphs;
-    auto animator = ImChart<sizeX, sizeY>({ { xMin, xMax }, { yMin, yMax } });
+    auto animator = ImChart<sizeX, sizeY>({{xMin, xMax}, {yMin, yMax}});
     // auto animator = ImChart<sizeX, sizeY>();
     double phase = 0.;
 

--- a/algorithm/test/qa_FilterTool.cpp
+++ b/algorithm/test/qa_FilterTool.cpp
@@ -10,29 +10,25 @@
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 
-#include <gnuradio-4.0/algorithm/filter/FilterTool.hpp>
 #include <gnuradio-4.0/algorithm/ImChart.hpp>
+#include <gnuradio-4.0/algorithm/filter/FilterTool.hpp>
 
 template<gr::filter::ResponseType responseType, std::floating_point T>
-[[nodiscard]] std::vector<T>
-calculateFrequencyResponse(const std::vector<T> &frequencies, const gr::filter::iir::PoleZeroLocations &value) {
+[[nodiscard]] std::vector<T> calculateFrequencyResponse(const std::vector<T>& frequencies, const gr::filter::iir::PoleZeroLocations& value) {
     using namespace gr::filter;
     std::vector<double> response(frequencies.size());
-    std::ranges::transform(frequencies, response.begin(), [&](const double &frequency) { return calculateResponse<Frequency::Hertz, responseType>(frequency, value); });
+    std::ranges::transform(frequencies, response.begin(), [&](const double& frequency) { return calculateResponse<Frequency::Hertz, responseType>(frequency, value); });
     return response;
 }
 
 template<gr::filter::ResponseType responseType, std::floating_point T, typename... TFilterCoefficients>
-std::vector<double>
-calculateFrequencyResponse(const std::vector<double> &frequencies, T fs, TFilterCoefficients &&...filterCoefficients) {
-    std::vector<gr::filter::FilterCoefficients<T>> collection{ std::forward<TFilterCoefficients>(filterCoefficients)... };
+std::vector<double> calculateFrequencyResponse(const std::vector<double>& frequencies, T fs, TFilterCoefficients&&... filterCoefficients) {
+    std::vector<gr::filter::FilterCoefficients<T>> collection{std::forward<TFilterCoefficients>(filterCoefficients)...};
 
     std::vector<double> response;
     response.reserve(frequencies.size());
     for (auto freq : frequencies) {
-        auto transform = [normDigitalFrequency = static_cast<T>(freq) / fs](auto &filterSection) {
-            return calculateResponse<gr::filter::Frequency::Normalised, responseType>(normDigitalFrequency, filterSection);
-        };
+        auto transform = [normDigitalFrequency = static_cast<T>(freq) / fs](auto& filterSection) { return calculateResponse<gr::filter::Frequency::Normalised, responseType>(normDigitalFrequency, filterSection); };
 
         if constexpr (responseType == gr::filter::ResponseType::Magnitude) {
             // Magnitude combines multiplicative
@@ -46,15 +42,14 @@ calculateFrequencyResponse(const std::vector<double> &frequencies, T fs, TFilter
 }
 
 template<typename Container>
-void
-printFilter(std::string_view name, const Container &filters) {
+void printFilter(std::string_view name, const Container& filters) {
     if constexpr (gr::filter::iir::HasPoleZeroLocations<Container>) {
         fmt::print("{}-section:{{ zero({}):{}, pole({}):{} }}\n", name, filters.zeros.size(), filters.zeros, filters.poles.size(), filters.poles);
     } else if constexpr (gr::filter::HasFilterCoefficients<Container>) {
         fmt::print("{}(1): a({}):{}, b({}):{}\n", name, filters.a.size(), filters.a, filters.b.size(), filters.b);
     } else if constexpr (std::ranges::range<Container> && gr::filter::HasFilterCoefficients<std::ranges::range_value_t<Container>>) {
         fmt::print("{}({}):", name, std::ranges::size(filters));
-        for (const auto &filter : filters) {
+        for (const auto& filter : filters) {
             fmt::print("-section:{{ a({}):{}, b({}):{} }}\n", filter.a.size(), filter.a, filter.b.size(), filter.b);
         }
         fmt::print("\n");
@@ -64,8 +59,7 @@ printFilter(std::string_view name, const Container &filters) {
 }
 
 template<std::size_t width = 51, std::size_t height = 21>
-void
-poleZeroPlot(const gr::filter::iir::PoleZeroLocations &value, double radius = 2.0) {
+void poleZeroPlot(const gr::filter::iir::PoleZeroLocations& value, double radius = 2.0) {
     constexpr std::size_t samples = 360Z;
     std::vector<double>   xCircle(samples);
     std::vector<double>   yCircle(samples);
@@ -87,7 +81,7 @@ poleZeroPlot(const gr::filter::iir::PoleZeroLocations &value, double radius = 2.
     radius = std::max(radius, std::max(*std::max_element(xPoles.begin(), xPoles.end()), *std::max_element(yPoles.begin(), yPoles.end())));
 
     radius            = std::ceil(15 * radius) / 10.0;
-    auto chart        = gr::graphs::ImChart<width, height>({ { -radius, +radius }, { -radius, +radius } });
+    auto chart        = gr::graphs::ImChart<width, height>({{-radius, +radius}, {-radius, +radius}});
     chart.axis_name_x = "Re";
     chart.axis_name_y = "Im";
     chart.drawAxes();
@@ -115,7 +109,7 @@ const boost::ut::suite<"IIR FilterTool"> iirFilterToolTests = [] {
 
     if (std::getenv("DISABLE_SENSITIVE_TESTS") == nullptr) {
         // conditionally enable visual tests outside the CI
-        boost::ext::ut::cfg<override> = { .tag = { "visual", "benchmarks" } };
+        boost::ext::ut::cfg<override> = {.tag = {"visual", "benchmarks"}};
     }
 
     "IIR filter"_test = [](iir::Design filterDesign) {
@@ -132,16 +126,15 @@ const boost::ut::suite<"IIR FilterTool"> iirFilterToolTests = [] {
                 default: throw std::invalid_argument("unknown filterType");
                 }
 
-                for (const auto &zero : analogPoleZeros.zeros) {
+                for (const auto& zero : analogPoleZeros.zeros) {
                     expect(le(zero.real(), 0.)) << fmt::format("{}::zero{} is not on the left-half plane", enum_name(filterDesign), zero);
                 }
 
-                for (const auto &pole : analogPoleZeros.poles) {
+                for (const auto& pole : analogPoleZeros.poles) {
                     expect(le(pole.real(), 0.)) << fmt::format("{}::pole{} is not on the left-half plane", enum_name(filterDesign), pole);
                 }
 
-                expect(approx(1.0, iir::calculateResponse<Hertz, Magnitude>(0.0, analogPoleZeros), 0.001))
-                        << fmt::format("{} - order {} has non-unity gain at DC: {:.4f}", enum_name(filterDesign), order, 1.0 / iir::calculateResponse<Hertz, Magnitude>(0.0, analogPoleZeros));
+                expect(approx(1.0, iir::calculateResponse<Hertz, Magnitude>(0.0, analogPoleZeros), 0.001)) << fmt::format("{} - order {} has non-unity gain at DC: {:.4f}", enum_name(filterDesign), order, 1.0 / iir::calculateResponse<Hertz, Magnitude>(0.0, analogPoleZeros));
             }
         };
 
@@ -149,7 +142,7 @@ const boost::ut::suite<"IIR FilterTool"> iirFilterToolTests = [] {
             expect(throws([&] { std::ignore = iir::designAnalogFilter(Type::LOWPASS, {}, filterDesign); })) << "undefined fLow should throw";
             expect(throws([&] { std::ignore = iir::designAnalogFilter(Type::HIGHPASS, {}, filterDesign); })) << "undefined fLow should throw";
             expect(throws([&] { std::ignore = iir::designAnalogFilter(Type::BANDPASS, {}, filterDesign); })) << "undefined fLow should throw";
-            expect(throws([&] { std::ignore = iir::designFilter<double>(Type::LOWPASS, { .fLow = 1.0 }, filterDesign); })) << "undefined fs should throw";
+            expect(throws([&] { std::ignore = iir::designFilter<double>(Type::LOWPASS, {.fLow = 1.0}, filterDesign); })) << "undefined fs should throw";
         };
 
         using enum Type;
@@ -162,47 +155,28 @@ const boost::ut::suite<"IIR FilterTool"> iirFilterToolTests = [] {
                 constexpr double kSampling     = 1000.0;
                 constexpr double kNyquist      = kSampling / 2.0;
                 const double     kTolerance    = ((filterDesign == CHEBYSHEV2) ? 10 : 1) * 0.01;
-                const auto       kFilterParams = FilterParameters{ .order = order, .fLow = kFreqLow, .fHigh = kFreqHigh, .attenuationDb = 30, .fs = kSampling };
+                const auto       kFilterParams = FilterParameters{.order = order, .fLow = kFreqLow, .fHigh = kFreqHigh, .attenuationDb = 30, .fs = kSampling};
 
                 // compute analog filter
                 expect(nothrow([&filterDesign, &filterType, &kFilterParams]() { std::ignore = iir::designAnalogFilter(filterType, kFilterParams, filterDesign); })) //
-                        << fmt::format("{}({}) - order {} unexpectedly throws", enum_name(filterDesign), enum_name(filterType), order);
+                    << fmt::format("{}({}) - order {} unexpectedly throws", enum_name(filterDesign), enum_name(filterType), order);
                 PoleZeroLocations analogPoleZeros = iir::designAnalogFilter(filterType, kFilterParams, filterDesign);
 
                 switch (filterType) {
-                case BANDSTOP:
-                    expect(le(iir::calculateResponse<Hertz, Magnitude>(kOmega0, analogPoleZeros), kTolerance))
-                            << fmt::format("{}({}) - order {} insufficient gain in stop-band: {:.4f}", enum_name(filterDesign), enum_name(filterType), order,
-                                           iir::calculateResponse<Hertz, Magnitude>(kOmega0, analogPoleZeros));
-                    [[fallthrough]];
-                case LOWPASS:
-                    expect(approx(1.0, iir::calculateResponse<Hertz, Magnitude>(kDC, analogPoleZeros), kTolerance))
-                            << fmt::format("{}({}) - order {} has non-unity gain at DC: {:.4f}", enum_name(filterDesign), enum_name(filterType), order,
-                                           iir::calculateResponse<Hertz, Magnitude>(kDC, analogPoleZeros));
-
-                    break;
+                case BANDSTOP: expect(le(iir::calculateResponse<Hertz, Magnitude>(kOmega0, analogPoleZeros), kTolerance)) << fmt::format("{}({}) - order {} insufficient gain in stop-band: {:.4f}", enum_name(filterDesign), enum_name(filterType), order, iir::calculateResponse<Hertz, Magnitude>(kOmega0, analogPoleZeros)); [[fallthrough]];
+                case LOWPASS: expect(approx(1.0, iir::calculateResponse<Hertz, Magnitude>(kDC, analogPoleZeros), kTolerance)) << fmt::format("{}({}) - order {} has non-unity gain at DC: {:.4f}", enum_name(filterDesign), enum_name(filterType), order, iir::calculateResponse<Hertz, Magnitude>(kDC, analogPoleZeros)); break;
                 case HIGHPASS:
-                    expect(approx(1.0, iir::calculateResponse<Hertz, Magnitude>(kNyquist, analogPoleZeros), kTolerance))
-                            << fmt::format("({}, {}, {}) has non-unity gain at NQ: {:.4f}", enum_name(filterDesign), enum_name(filterType), order,
-                                           iir::calculateResponse<Hertz, Magnitude>(kNyquist, analogPoleZeros));
-                    expect(le(iir::calculateResponse<Hertz, Magnitude>(kDC, analogPoleZeros), kTolerance))
-                            << fmt::format("({}, {}, {}) insufficient gain in stop-band: {:.4f}", enum_name(filterDesign), enum_name(filterType), order,
-                                           iir::calculateResponse<Hertz, Magnitude>(kOmega0, analogPoleZeros));
+                    expect(approx(1.0, iir::calculateResponse<Hertz, Magnitude>(kNyquist, analogPoleZeros), kTolerance)) << fmt::format("({}, {}, {}) has non-unity gain at NQ: {:.4f}", enum_name(filterDesign), enum_name(filterType), order, iir::calculateResponse<Hertz, Magnitude>(kNyquist, analogPoleZeros));
+                    expect(le(iir::calculateResponse<Hertz, Magnitude>(kDC, analogPoleZeros), kTolerance)) << fmt::format("({}, {}, {}) insufficient gain in stop-band: {:.4f}", enum_name(filterDesign), enum_name(filterType), order, iir::calculateResponse<Hertz, Magnitude>(kOmega0, analogPoleZeros));
                     break;
                 case BANDPASS:
-                    expect(approx(1.0, iir::calculateResponse<Hertz, Magnitude>(kOmega0, analogPoleZeros), kTolerance))
-                            << fmt::format("({}, {}, {}) has non-unity gain at omega0: {:.4f}", enum_name(filterDesign), enum_name(filterType), order,
-                                           iir::calculateResponse<Hertz, Magnitude>(kOmega0, analogPoleZeros));
-                    expect(le(iir::calculateResponse<Hertz, Magnitude>(kDC, analogPoleZeros), kTolerance))
-                            << fmt::format("({}, {}, {}) insufficient gain in stop-band (DC): {:.4f}", enum_name(filterDesign), enum_name(filterType), order,
-                                           iir::calculateResponse<Hertz, Magnitude>(kDC, analogPoleZeros));
-                    expect(le(iir::calculateResponse<Hertz, Magnitude>(kNyquist, analogPoleZeros), kTolerance))
-                            << fmt::format("({}, {}, {}) insufficient gain in stop-band (NQ): {:.4f}", enum_name(filterDesign), enum_name(filterType), order,
-                                           iir::calculateResponse<Hertz, Magnitude>(kNyquist, analogPoleZeros));
+                    expect(approx(1.0, iir::calculateResponse<Hertz, Magnitude>(kOmega0, analogPoleZeros), kTolerance)) << fmt::format("({}, {}, {}) has non-unity gain at omega0: {:.4f}", enum_name(filterDesign), enum_name(filterType), order, iir::calculateResponse<Hertz, Magnitude>(kOmega0, analogPoleZeros));
+                    expect(le(iir::calculateResponse<Hertz, Magnitude>(kDC, analogPoleZeros), kTolerance)) << fmt::format("({}, {}, {}) insufficient gain in stop-band (DC): {:.4f}", enum_name(filterDesign), enum_name(filterType), order, iir::calculateResponse<Hertz, Magnitude>(kDC, analogPoleZeros));
+                    expect(le(iir::calculateResponse<Hertz, Magnitude>(kNyquist, analogPoleZeros), kTolerance)) << fmt::format("({}, {}, {}) insufficient gain in stop-band (NQ): {:.4f}", enum_name(filterDesign), enum_name(filterType), order, iir::calculateResponse<Hertz, Magnitude>(kNyquist, analogPoleZeros));
                     break;
                 }
             }
-        } | std::vector{ LOWPASS, HIGHPASS, BANDSTOP, BANDPASS };
+        } | std::vector{LOWPASS, HIGHPASS, BANDSTOP, BANDPASS};
 
         "IIR digital filter"_test = [&filterDesign](Type filterType) {
             const std::size_t startingOrder = filterDesign == CHEBYSHEV2 ? 3UZ : 1UZ; // Chebyshev with order <=2 has notorious poor performance for band-pass/stop and <=3 for high-pass at NQ
@@ -214,48 +188,29 @@ const boost::ut::suite<"IIR FilterTool"> iirFilterToolTests = [] {
                 constexpr double kSampling     = 1000.0;
                 constexpr double kNyquist      = kSampling / 2.0;
                 constexpr double kTolerance    = 0.01;
-                const auto       kFilterParams = FilterParameters{ .order = order, .fLow = kFreqLow, .fHigh = kFreqHigh, .attenuationDb = 50, .fs = kSampling };
+                const auto       kFilterParams = FilterParameters{.order = order, .fLow = kFreqLow, .fHigh = kFreqHigh, .attenuationDb = 50, .fs = kSampling};
                 // compute analog and digital filters
                 const PoleZeroLocations analogPoleZeros = iir::designAnalogFilter(filterType, kFilterParams, filterDesign);
                 expect(nothrow([&filterDesign, &filterType, &kFilterParams]() { std::ignore = iir::designFilter<double>(filterType, kFilterParams, filterDesign); })) //
-                        << fmt::format("({}, {}, {}) creating digital unbound filter unexpectedly throws", enum_name(filterDesign), order, enum_name(filterType));
+                    << fmt::format("({}, {}, {}) creating digital unbound filter unexpectedly throws", enum_name(filterDesign), order, enum_name(filterType));
                 const auto digitalPoleZerosFull = iir::designFilter<double>(filterType, kFilterParams, filterDesign);
                 expect(nothrow([&filterDesign, &filterType, &kFilterParams]() { std::ignore = iir::designFilter<double, 2UZ>(filterType, kFilterParams, filterDesign); })) //
-                        << fmt::format("({}, {}, {}) creating digital biquad filter unexpectedly throws", enum_name(filterDesign), enum_name(filterType), order);
+                    << fmt::format("({}, {}, {}) creating digital biquad filter unexpectedly throws", enum_name(filterDesign), enum_name(filterType), order);
                 const auto digitalPoleZerosBiquads = iir::designFilter<double, 2UZ>(filterType, kFilterParams, filterDesign);
 
                 // coarse response test
                 switch (filterType) {
-                case BANDSTOP:
-                    expect(le(calculateResponse<Normalised, Magnitude>(kOmega0 / kSampling, digitalPoleZerosBiquads), kTolerance))
-                            << fmt::format("({}, {}, {}) insufficient gain in stop-band: {:.4f}", enum_name(filterDesign), enum_name(filterType), order,
-                                           calculateResponse<Normalised, Magnitude>(kOmega0, digitalPoleZerosBiquads));
-                    [[fallthrough]];
-                case LOWPASS:
-                    expect(approx(1.0, calculateResponse<Normalised, Magnitude>(kDC, digitalPoleZerosBiquads), kTolerance))
-                            << fmt::format("({}, {}, {}) has non-unity gain at DC: {:.4f}", enum_name(filterDesign), enum_name(filterType), order,
-                                           calculateResponse<Normalised, Magnitude>(kDC, digitalPoleZerosBiquads));
-
-                    break;
+                case BANDSTOP: expect(le(calculateResponse<Normalised, Magnitude>(kOmega0 / kSampling, digitalPoleZerosBiquads), kTolerance)) << fmt::format("({}, {}, {}) insufficient gain in stop-band: {:.4f}", enum_name(filterDesign), enum_name(filterType), order, calculateResponse<Normalised, Magnitude>(kOmega0, digitalPoleZerosBiquads)); [[fallthrough]];
+                case LOWPASS: expect(approx(1.0, calculateResponse<Normalised, Magnitude>(kDC, digitalPoleZerosBiquads), kTolerance)) << fmt::format("({}, {}, {}) has non-unity gain at DC: {:.4f}", enum_name(filterDesign), enum_name(filterType), order, calculateResponse<Normalised, Magnitude>(kDC, digitalPoleZerosBiquads)); break;
                 case HIGHPASS:
-                    expect(approx(1.0, calculateResponse<Normalised, Magnitude>(kNyquist / kSampling, digitalPoleZerosBiquads), kTolerance))
-                            << fmt::format("({}, {}, {}) has non-unity gain at NQ: {:.4f}", enum_name(filterDesign), enum_name(filterType), order,
-                                           calculateResponse<Normalised, Magnitude>(kNyquist / kSampling, digitalPoleZerosBiquads));
-                    expect(le(calculateResponse<Normalised, Magnitude>(kDC, digitalPoleZerosBiquads), kTolerance))
-                            << fmt::format("({}, {}, {}) insufficient gain in stop-band: {:.4f}", enum_name(filterDesign), enum_name(filterType), order,
-                                           calculateResponse<Normalised, Magnitude>(kOmega0 / kSampling, digitalPoleZerosBiquads));
+                    expect(approx(1.0, calculateResponse<Normalised, Magnitude>(kNyquist / kSampling, digitalPoleZerosBiquads), kTolerance)) << fmt::format("({}, {}, {}) has non-unity gain at NQ: {:.4f}", enum_name(filterDesign), enum_name(filterType), order, calculateResponse<Normalised, Magnitude>(kNyquist / kSampling, digitalPoleZerosBiquads));
+                    expect(le(calculateResponse<Normalised, Magnitude>(kDC, digitalPoleZerosBiquads), kTolerance)) << fmt::format("({}, {}, {}) insufficient gain in stop-band: {:.4f}", enum_name(filterDesign), enum_name(filterType), order, calculateResponse<Normalised, Magnitude>(kOmega0 / kSampling, digitalPoleZerosBiquads));
                     break;
                 case BANDPASS:
-                    expect(approx(1.0, calculateResponse<Normalised, Magnitude>(kOmega0 / kSampling, digitalPoleZerosBiquads), kTolerance))
-                            << fmt::format("({}, {}, {}) has non-unity gain at omega0: {:.4f}", enum_name(filterDesign), enum_name(filterType), order,
-                                           calculateResponse<Normalised, Magnitude>(kOmega0 / kSampling, digitalPoleZerosBiquads));
-                    expect(le(calculateResponse<Normalised, Magnitude>(kDC, digitalPoleZerosBiquads), kTolerance))
-                            << fmt::format("({}, {}, {}) insufficient gain in stop-band (DC): {:.4f}", enum_name(filterDesign), enum_name(filterType), order,
-                                           calculateResponse<Normalised, Magnitude>(kDC, digitalPoleZerosBiquads));
+                    expect(approx(1.0, calculateResponse<Normalised, Magnitude>(kOmega0 / kSampling, digitalPoleZerosBiquads), kTolerance)) << fmt::format("({}, {}, {}) has non-unity gain at omega0: {:.4f}", enum_name(filterDesign), enum_name(filterType), order, calculateResponse<Normalised, Magnitude>(kOmega0 / kSampling, digitalPoleZerosBiquads));
+                    expect(le(calculateResponse<Normalised, Magnitude>(kDC, digitalPoleZerosBiquads), kTolerance)) << fmt::format("({}, {}, {}) insufficient gain in stop-band (DC): {:.4f}", enum_name(filterDesign), enum_name(filterType), order, calculateResponse<Normalised, Magnitude>(kDC, digitalPoleZerosBiquads));
                     const double relaxFactor = filterDesign == CHEBYSHEV1 ? 20 : (order <= 2 ? 3.0 : 1.0);
-                    expect(le(calculateResponse<Normalised, Magnitude>(kNyquist / kSampling, digitalPoleZerosBiquads), relaxFactor * kTolerance))
-                            << fmt::format("({}, {}, {}) insufficient gain in stop-band (NQ): {:.4f}", enum_name(filterDesign), enum_name(filterType), order,
-                                           calculateResponse<Normalised, Magnitude>(kNyquist / kSampling, digitalPoleZerosBiquads));
+                    expect(le(calculateResponse<Normalised, Magnitude>(kNyquist / kSampling, digitalPoleZerosBiquads), relaxFactor * kTolerance)) << fmt::format("({}, {}, {}) insufficient gain in stop-band (NQ): {:.4f}", enum_name(filterDesign), enum_name(filterType), order, calculateResponse<Normalised, Magnitude>(kNyquist / kSampling, digitalPoleZerosBiquads));
                     break;
                 }
 
@@ -265,7 +220,7 @@ const boost::ut::suite<"IIR FilterTool"> iirFilterToolTests = [] {
                     return iota(1, (end - start) / step + 2) | transform([=](auto i) { return start + step * (i - 1); });
                 };
                 std::vector<double> frequencies;
-                for (auto subrange : { sequence_range(0.1, 0.9, 0.01), sequence_range(1.0, 9.0, 0.1), sequence_range(10.0, 90.0, 1.0), sequence_range(100.0, 490.0, 10.0) }) {
+                for (auto subrange : {sequence_range(0.1, 0.9, 0.01), sequence_range(1.0, 9.0, 0.1), sequence_range(10.0, 90.0, 1.0), sequence_range(100.0, 490.0, 10.0)}) {
                     std::ranges::move(subrange, std::back_inserter(frequencies));
                 }
                 std::vector<double> filterResponse   = calculateFrequencyResponse<Magnitude>(frequencies, analogPoleZeros);                    // provide in absolute values
@@ -278,24 +233,20 @@ const boost::ut::suite<"IIR FilterTool"> iirFilterToolTests = [] {
                     // non-biquad representation is known to be numerically unstable for order > ~4 (N.B. order: 2 -> band-[pass,stop] order: 4
                     if (order <= 2 && reference > 0.01) {
                         expect(le(std::abs(responseDigital1[i] - reference), (filterDesign == BESSEL || filterDesign == CHEBYSHEV2 || order <= 1UZ ? 10 : 1) * kTolerance)) //
-                                << fmt::format("({}, {}, {})@f={}Hz analog-digital mismatch: {:.2f} vs {:.2f}",                                                             //
-                                               enum_name(filterDesign), enum_name(filterType), order, frequencies[i], reference, responseDigital1[i]);
+                            << fmt::format("({}, {}, {})@f={}Hz analog-digital mismatch: {:.2f} vs {:.2f}",                                                                 //
+                                   enum_name(filterDesign), enum_name(filterType), order, frequencies[i], reference, responseDigital1[i]);
                     }
 
                     // biquad style filter
                     if (reference > 0.01) { // BESSEL and CHEBYSHEV1 do not preserve the magnitude response perfectly (visually checked OK)
-                        const double relaxFactor = (filterDesign == BESSEL || order <= 1UZ || (filterDesign == CHEBYSHEV1 && filterType == HIGHPASS)
-                                                    || (filterDesign == CHEBYSHEV2 && filterType == BANDSTOP))
-                                                         ? 10
-                                                         : 1;
-                        expect(le(std::abs(responseDigital2[i] - reference), relaxFactor * kTolerance))
-                                << fmt::format("({}, {}, {})@f={}Hz analog-digital biquad mismatch: {:.2f} vs {:.2f}", //
-                                               enum_name(filterDesign), enum_name(filterType), order, frequencies[i], reference, responseDigital2[i]);
+                        const double relaxFactor = (filterDesign == BESSEL || order <= 1UZ || (filterDesign == CHEBYSHEV1 && filterType == HIGHPASS) || (filterDesign == CHEBYSHEV2 && filterType == BANDSTOP)) ? 10 : 1;
+                        expect(le(std::abs(responseDigital2[i] - reference), relaxFactor * kTolerance)) << fmt::format("({}, {}, {})@f={}Hz analog-digital biquad mismatch: {:.2f} vs {:.2f}", //
+                            enum_name(filterDesign), enum_name(filterType), order, frequencies[i], reference, responseDigital2[i]);
                     }
                 }
             }
-        } | std::vector{ LOWPASS, HIGHPASS, BANDPASS, BANDSTOP };
-    } | std::vector{ BUTTERWORTH, BESSEL, CHEBYSHEV1, CHEBYSHEV2 };
+        } | std::vector{LOWPASS, HIGHPASS, BANDPASS, BANDSTOP};
+    } | std::vector{BUTTERWORTH, BESSEL, CHEBYSHEV1, CHEBYSHEV2};
 
     "IIR low-pass filter"_test = []<typename FilterType>(FilterType) {
         using namespace gr::filter::iir;
@@ -303,9 +254,9 @@ const boost::ut::suite<"IIR FilterTool"> iirFilterToolTests = [] {
         constexpr Design      filterDesign = Design::BUTTERWORTH;
         constexpr std::size_t order        = 4UZ;
 
-        constexpr std::array frequencies{ 3.0, 3.5, 5., 6.5, 7.0 };
-        const auto           digitalBandPass = iir::designFilter<double>(Type::BANDPASS, { .order = order, .fLow = 4., .fHigh = 6., .fs = fs }, filterDesign);
-        for (const auto &frequency : frequencies) {
+        constexpr std::array frequencies{3.0, 3.5, 5., 6.5, 7.0};
+        const auto           digitalBandPass = iir::designFilter<double>(Type::BANDPASS, {.order = order, .fLow = 4., .fHigh = 6., .fs = fs}, filterDesign);
+        for (const auto& frequency : frequencies) {
             auto         filter       = FilterType(digitalBandPass);
             const double expectedGain = calculateResponse<Normalised, Magnitude>(frequency / fs, digitalBandPass);
             double       actualGain   = 0.0;
@@ -319,7 +270,7 @@ const boost::ut::suite<"IIR FilterTool"> iirFilterToolTests = [] {
             expect(approx(expectedGain, actualGain, 0.01)) << fmt::format("frequency: {} Hz, expected {} vs. actual gain {} differs", frequency, expectedGain, actualGain);
 #endif
         }
-    } | std::tuple{ Filter<double, 32UZ, Form::DF_I>(), Filter<double, 32UZ, Form::DF_II>(), Filter<double, 32UZ, Form::DF_I_TRANSPOSED>(), Filter<double, 32UZ, Form::DF_II_TRANSPOSED>() };
+    } | std::tuple{Filter<double, 32UZ, Form::DF_I>(), Filter<double, 32UZ, Form::DF_II>(), Filter<double, 32UZ, Form::DF_I_TRANSPOSED>(), Filter<double, 32UZ, Form::DF_II_TRANSPOSED>()};
     ;
 
     tag("visual") / "basic analog low-/high-/band-pass filter - frequency"_test = []() {
@@ -335,22 +286,22 @@ const boost::ut::suite<"IIR FilterTool"> iirFilterToolTests = [] {
         };
 
         std::vector<double> frequencies;
-        for (auto subrange : { sequence_range(0.1, 0.9, 0.01), sequence_range(1.0, 9.0, 0.1), sequence_range(10.0, 90.0, 1.0), sequence_range(100.0, 1000.0, 10.0) }) {
+        for (auto subrange : {sequence_range(0.1, 0.9, 0.01), sequence_range(1.0, 9.0, 0.1), sequence_range(10.0, 90.0, 1.0), sequence_range(100.0, 1000.0, 10.0)}) {
             std::ranges::move(subrange, std::back_inserter(frequencies));
         }
 
         constexpr iir::Design   filterDesign     = BUTTERWORTH;
         constexpr std::size_t   order            = 5UZ;
-        const PoleZeroLocations filter1          = iir::designAnalogFilter(Type::LOWPASS, { .order = order, .fLow = 1., .attenuationDb = 40 }, filterDesign);
-        const auto              digitalFilter1   = iir::designFilter<T>(Type::LOWPASS, { .order = order, .fLow = 1., .attenuationDb = 40, .fs = fMax }, filterDesign);
+        const PoleZeroLocations filter1          = iir::designAnalogFilter(Type::LOWPASS, {.order = order, .fLow = 1., .attenuationDb = 40}, filterDesign);
+        const auto              digitalFilter1   = iir::designFilter<T>(Type::LOWPASS, {.order = order, .fLow = 1., .attenuationDb = 40, .fs = fMax}, filterDesign);
         std::vector<double>     lowPassResponse  = calculateFrequencyResponse<MagnitudeDB>(frequencies, filter1);
         std::vector<double>     lowPassDigital   = calculateFrequencyResponse<MagnitudeDB>(frequencies, static_cast<T>(fMax), digitalFilter1);
-        const PoleZeroLocations filter2          = iir::designAnalogFilter(Type::HIGHPASS, { .order = order, .fHigh = 10., .attenuationDb = 40 }, filterDesign);
-        const auto              digitalFilter2   = iir::designFilter<T>(Type::HIGHPASS, { .order = order, .fHigh = 10., .attenuationDb = 40, .fs = fMax }, filterDesign);
+        const PoleZeroLocations filter2          = iir::designAnalogFilter(Type::HIGHPASS, {.order = order, .fHigh = 10., .attenuationDb = 40}, filterDesign);
+        const auto              digitalFilter2   = iir::designFilter<T>(Type::HIGHPASS, {.order = order, .fHigh = 10., .attenuationDb = 40, .fs = fMax}, filterDesign);
         std::vector<double>     highPassResponse = calculateFrequencyResponse<MagnitudeDB>(frequencies, filter2);
         std::vector<double>     highPassDigital  = calculateFrequencyResponse<MagnitudeDB>(frequencies, static_cast<T>(fMax), digitalFilter2);
-        const PoleZeroLocations filter3          = iir::designAnalogFilter(Type::BANDPASS, { .order = order, .fLow = 1., .fHigh = 10., .attenuationDb = 40 }, filterDesign);
-        const auto              digitalFilter3   = iir::designFilter<T>(Type::BANDPASS, { .order = order, .fLow = 1., .fHigh = 10., .attenuationDb = 40, .fs = fMax }, filterDesign);
+        const PoleZeroLocations filter3          = iir::designAnalogFilter(Type::BANDPASS, {.order = order, .fLow = 1., .fHigh = 10., .attenuationDb = 40}, filterDesign);
+        const auto              digitalFilter3   = iir::designFilter<T>(Type::BANDPASS, {.order = order, .fLow = 1., .fHigh = 10., .attenuationDb = 40, .fs = fMax}, filterDesign);
         std::vector<double>     bandPassResponse = calculateFrequencyResponse<MagnitudeDB>(frequencies, filter3);
         std::vector<double>     bandPassDigital  = calculateFrequencyResponse<MagnitudeDB>(frequencies, static_cast<T>(fMax), digitalFilter3);
 
@@ -359,10 +310,10 @@ const boost::ut::suite<"IIR FilterTool"> iirFilterToolTests = [] {
         // pole-zero plots:
         poleZeroPlot(iir::calculateFilterButterworth(order), 1.2);
         poleZeroPlot(iir::calculateFilterChebyshevType2(order), 2.2);
-        poleZeroPlot(iir::lowPassProtoToBandPass(iir::calculateFilterChebyshevType2(order, 40.), { .fLow = 10., .fHigh = 20. }), order);
+        poleZeroPlot(iir::lowPassProtoToBandPass(iir::calculateFilterChebyshevType2(order, 40.), {.fLow = 10., .fHigh = 20.}), order);
 
         // plot
-        auto chart        = gr::graphs::ImChart<119, 21, LogAxisTransform>({ { fMin, fMax }, { -45., +5 } });
+        auto chart        = gr::graphs::ImChart<119, 21, LogAxisTransform>({{fMin, fMax}, {-45., +5}});
         chart.axis_name_x = "[Hz]";
         chart.axis_name_y = "[dB]";
         chart.draw(frequencies, lowPassResponse, "low");
@@ -388,17 +339,16 @@ const boost::ut::suite<"IIR FilterTool"> iirFilterToolTests = [] {
             xValues[i] = xMin + static_cast<double>(i) / fs;
         }
 
-        auto chart        = gr::graphs::ImChart<120, 16>({ { xMin, xMax }, { -5.0, +5.0 } });
+        auto chart        = gr::graphs::ImChart<120, 16>({{xMin, xMax}, {-5.0, +5.0}});
         chart.axis_name_x = "time [s]";
         chart.axis_name_y = "IIR filter amplitude [a.u.]";
 
-        const auto digitalBandPass = iir::designFilter<T>(Type::BANDPASS, { .order = 4UZ, .fLow = 4., .fHigh = 6., .fs = fs }, filterDesign);
+        const auto digitalBandPass = iir::designFilter<T>(Type::BANDPASS, {.order = 4UZ, .fLow = 4., .fHigh = 6., .fs = fs}, filterDesign);
 
-        const auto secondOrderLowPass = FilterCoefficients<T>{ { static_cast<T>(1. / 6474.5), static_cast<T>(2. / 6474.5), static_cast<T>(1. / 6474.5) },
-                                                               { 1, static_cast<T>(-1.96454), static_cast<T>(0.96515) } };
+        const auto secondOrderLowPass = FilterCoefficients<T>{{static_cast<T>(1. / 6474.5), static_cast<T>(2. / 6474.5), static_cast<T>(1. / 6474.5)}, {1, static_cast<T>(-1.96454), static_cast<T>(0.96515)}};
         printFilter("secondOrderLowPass", secondOrderLowPass);
 
-        for (const auto &frequency : { 3.0, 3.5, 5., 6.5, 7.0 }) {
+        for (const auto& frequency : {3.0, 3.5, 5., 6.5, 7.0}) {
             auto filter = Filter<T, 32UZ>(digitalBandPass);
             // auto filter = Filter<double>(secondOrderLowPass);
             // auto filter = Filter<double>(simpleLowPass);
@@ -432,22 +382,21 @@ const boost::ut::suite<"IIR FilterTool"> iirFilterToolTests = [] {
 
         fmt::println("");
         using Un = gr::UncertainValue<double>;
-        for (const auto &frequency : { 1.0, 2.0, 4.0 }) {
-            std::vector<FilterCoefficients<double>> digitalLowPass = useFIR ? std::vector{ fir::designFilter<double>(Type::LOWPASS, { .order = 1UZ, .fLow = frequency, .fs = fs }, Hamming) }
-                                                                            : iir::designFilter<double>(Type::LOWPASS, { .order = 2UZ, .fLow = frequency, .fs = fs }, BESSEL);
+        for (const auto& frequency : {1.0, 2.0, 4.0}) {
+            std::vector<FilterCoefficients<double>> digitalLowPass = useFIR ? std::vector{fir::designFilter<double>(Type::LOWPASS, {.order = 1UZ, .fLow = frequency, .fs = fs}, Hamming)} : iir::designFilter<double>(Type::LOWPASS, {.order = 2UZ, .fLow = frequency, .fs = fs}, BESSEL);
             auto                                    filter         = ErrorPropagatingFilter<Un>(digitalLowPass);
-            filter.reset({ 0.0, noiseFigure });
+            filter.reset({0.0, noiseFigure});
 
             std::vector<Un>     yFiltered(xValues.size());
             std::vector<double> yMean(xValues.size());
             std::vector<double> yMin(xValues.size());
             std::vector<double> yMax(xValues.size());
-            std::transform(yValue.cbegin(), yValue.cend(), yFiltered.begin(), [&filter, &noiseFigure](double y) { return filter.processOne({ y, noiseFigure }); });
+            std::transform(yValue.cbegin(), yValue.cend(), yFiltered.begin(), [&filter, &noiseFigure](double y) { return filter.processOne({y, noiseFigure}); });
             std::transform(yFiltered.cbegin(), yFiltered.cend(), yMean.begin(), [](Un val) { return gr::value(val); });
             std::transform(yFiltered.cbegin(), yFiltered.cend(), yMin.begin(), [](Un val) { return gr::value(val) - gr::uncertainty(val); });
             std::transform(yFiltered.cbegin(), yFiltered.cend(), yMax.begin(), [](Un val) { return gr::value(val) + gr::uncertainty(val); });
 
-            auto chart        = gr::graphs::ImChart<120, 18>({ { xMin, xMax }, { -1.0, +4.0 } });
+            auto chart        = gr::graphs::ImChart<120, 18>({{xMin, xMax}, {-1.0, +4.0}});
             chart.axis_name_x = "time [s]";
             chart.axis_name_y = std::string(useFIR ? "FIR" : "IIR") + " filter amplitude [a.u.]";
             chart.draw(xValues, yValue, "reference");
@@ -464,7 +413,7 @@ const boost::ut::suite<"IIR FilterTool"> iirFilterToolTests = [] {
             chart.draw();
             fmt::println("");
         }
-    } | std::vector{ true, false };
+    } | std::vector{true, false};
 
     "quantitative FIR/IIR step-response-pass with UncertainValue Propagation"_test = [](const bool useFIR) {
         using namespace gr::filter::iir;
@@ -487,13 +436,12 @@ const boost::ut::suite<"IIR FilterTool"> iirFilterToolTests = [] {
 
         using Un = gr::UncertainValue<double>;
 
-        std::vector<FilterCoefficients<double>> digitalLowPass = useFIR ? std::vector{ fir::designFilter<double>(Type::LOWPASS, { .order = 1UZ, .fLow = flow, .fs = fs }, Hamming) }
-                                                                        : iir::designFilter<double>(Type::LOWPASS, { .order = 2UZ, .fLow = flow, .fs = fs }, BESSEL);
+        std::vector<FilterCoefficients<double>> digitalLowPass = useFIR ? std::vector{fir::designFilter<double>(Type::LOWPASS, {.order = 1UZ, .fLow = flow, .fs = fs}, Hamming)} : iir::designFilter<double>(Type::LOWPASS, {.order = 2UZ, .fLow = flow, .fs = fs}, BESSEL);
         auto                                    filter         = ErrorPropagatingFilter<Un>(digitalLowPass);
-        filter.reset({ 0.0, noiseFigure });
+        filter.reset({0.0, noiseFigure});
 
         std::vector<Un> yFiltered(xValues.size());
-        std::transform(yValue.cbegin(), yValue.cend(), yFiltered.begin(), [&filter, &noiseFigure](double y) { return filter.processOne({ y, noiseFigure }); });
+        std::transform(yValue.cbegin(), yValue.cend(), yFiltered.begin(), [&filter, &noiseFigure](double y) { return filter.processOne({y, noiseFigure}); });
 
         auto filterType = useFIR ? "FIR" : "IIR";
         expect(approx(0.0, gr::value(yFiltered.front()), 0.001)) << fmt::format("{} - initial value", filterType);
@@ -503,7 +451,7 @@ const boost::ut::suite<"IIR FilterTool"> iirFilterToolTests = [] {
         const double_t expectedNoiseFigure = noiseFigure / std::sqrt(Neff) * (useFIR ? 1.5 : 1.0);
         expect(le(gr::uncertainty(yFiltered[10]), expectedNoiseFigure)) << fmt::format("{} - initial value", filterType);
         expect(le(gr::uncertainty(yFiltered.back()), expectedNoiseFigure)) << fmt::format("{} - last value", filterType);
-    } | std::vector{ true, false };
+    } | std::vector{true, false};
 };
 
 const boost::ut::suite<"FIR FilterTool"> firFilterToolTests = [] {
@@ -515,7 +463,7 @@ const boost::ut::suite<"FIR FilterTool"> firFilterToolTests = [] {
 
     if (std::getenv("DISABLE_SENSITIVE_TESTS") == nullptr) {
         // conditionally enable visual tests outside the CI
-        boost::ext::ut::cfg<override> = { .tag = { "visual", "benchmarks" } };
+        boost::ext::ut::cfg<override> = {.tag = {"visual", "benchmarks"}};
     }
 
     using enum gr::algorithm::window::Type;
@@ -523,12 +471,12 @@ const boost::ut::suite<"FIR FilterTool"> firFilterToolTests = [] {
         using enum gr::filter::Type;
 
         "IIR digital filter"_test = [&filterDesign](Type filterType) {
-            constexpr auto kFilterParams = FilterParameters{ .order = 4UZ, .fLow = 1.0, .fHigh = 10.0, .attenuationDb = 60, .fs = 1000.0 };
+            constexpr auto kFilterParams = FilterParameters{.order = 4UZ, .fLow = 1.0, .fHigh = 10.0, .attenuationDb = 60, .fs = 1000.0};
 
             // compute analog and digital filters
 
             expect(nothrow([&filterDesign, &filterType, &kFilterParams]() { std::ignore = fir::designFilter<double>(filterType, kFilterParams, filterDesign); })) //
-                    << fmt::format("({}, {}, {}) creating digital unbound filter unexpectedly throws", enum_name(filterDesign), kFilterParams.order, enum_name(filterType));
+                << fmt::format("({}, {}, {}) creating digital unbound filter unexpectedly throws", enum_name(filterDesign), kFilterParams.order, enum_name(filterType));
             const FilterCoefficients<double> digitalFilter = fir::designFilter<double>(filterType, kFilterParams, filterDesign);
 
             // coarse response test
@@ -537,45 +485,26 @@ const boost::ut::suite<"FIR FilterTool"> firFilterToolTests = [] {
             constexpr double kNyquist   = 0.48;
             const double     kOmega0    = std::sqrt(kFilterParams.fLow * kFilterParams.fHigh) / kFilterParams.fs;
             switch (filterType) {
-            case BANDSTOP:
-                expect(le(calculateResponse<Normalised, Magnitude>(kOmega0, digitalFilter), 5. * kTolerance))
-                        << fmt::format("({}, {}, {}) insufficient gain in stop-band: {:.4f}", enum_name(filterDesign), enum_name(filterType), kFilterParams.order,
-                                       calculateResponse<Normalised, Magnitude>(kOmega0, digitalFilter));
-                [[fallthrough]];
-            case LOWPASS:
-                expect(approx(1.0, calculateResponse<Normalised, Magnitude>(kDC, digitalFilter), kTolerance))
-                        << fmt::format("({}, {}, {}) has non-unity gain at DC: {:.4f}", enum_name(filterDesign), enum_name(filterType), kFilterParams.order,
-                                       calculateResponse<Normalised, Magnitude>(kDC, digitalFilter));
-
-                break;
+            case BANDSTOP: expect(le(calculateResponse<Normalised, Magnitude>(kOmega0, digitalFilter), 5. * kTolerance)) << fmt::format("({}, {}, {}) insufficient gain in stop-band: {:.4f}", enum_name(filterDesign), enum_name(filterType), kFilterParams.order, calculateResponse<Normalised, Magnitude>(kOmega0, digitalFilter)); [[fallthrough]];
+            case LOWPASS: expect(approx(1.0, calculateResponse<Normalised, Magnitude>(kDC, digitalFilter), kTolerance)) << fmt::format("({}, {}, {}) has non-unity gain at DC: {:.4f}", enum_name(filterDesign), enum_name(filterType), kFilterParams.order, calculateResponse<Normalised, Magnitude>(kDC, digitalFilter)); break;
             case HIGHPASS:
-                expect(approx(1.0, calculateResponse<Normalised, Magnitude>(kNyquist, digitalFilter), kTolerance))
-                        << fmt::format("({}, {}, {}) has non-unity gain at NQ: {:.4f}", enum_name(filterDesign), enum_name(filterType), kFilterParams.order,
-                                       calculateResponse<Normalised, Magnitude>(kNyquist, digitalFilter));
-                expect(le(calculateResponse<Normalised, Magnitude>(kDC, digitalFilter), kTolerance))
-                        << fmt::format("({}, {}, {}) insufficient gain in stop-band: {:.4f}", enum_name(filterDesign), enum_name(filterType), kFilterParams.order,
-                                       calculateResponse<Normalised, Magnitude>(kOmega0, digitalFilter));
+                expect(approx(1.0, calculateResponse<Normalised, Magnitude>(kNyquist, digitalFilter), kTolerance)) << fmt::format("({}, {}, {}) has non-unity gain at NQ: {:.4f}", enum_name(filterDesign), enum_name(filterType), kFilterParams.order, calculateResponse<Normalised, Magnitude>(kNyquist, digitalFilter));
+                expect(le(calculateResponse<Normalised, Magnitude>(kDC, digitalFilter), kTolerance)) << fmt::format("({}, {}, {}) insufficient gain in stop-band: {:.4f}", enum_name(filterDesign), enum_name(filterType), kFilterParams.order, calculateResponse<Normalised, Magnitude>(kOmega0, digitalFilter));
                 break;
             case BANDPASS:
-                expect(approx(1.0, calculateResponse<Normalised, Magnitude>(kOmega0, digitalFilter), kTolerance))
-                        << fmt::format("({}, {}, {}) has non-unity gain at omega0: {:.4f}", enum_name(filterDesign), enum_name(filterType), kFilterParams.order,
-                                       calculateResponse<Normalised, Magnitude>(kOmega0, digitalFilter));
-                expect(le(calculateResponse<Normalised, Magnitude>(kDC, digitalFilter), kTolerance))
-                        << fmt::format("({}, {}, {}) insufficient gain in stop-band (DC): {:.4f}", enum_name(filterDesign), enum_name(filterType), kFilterParams.order,
-                                       calculateResponse<Normalised, Magnitude>(kDC, digitalFilter));
-                expect(le(calculateResponse<Normalised, Magnitude>(kNyquist, digitalFilter), kTolerance))
-                        << fmt::format("({}, {}, {}) insufficient gain in stop-band (NQ): {:.4f}", enum_name(filterDesign), enum_name(filterType), kFilterParams.order,
-                                       calculateResponse<Normalised, Magnitude>(kNyquist, digitalFilter));
+                expect(approx(1.0, calculateResponse<Normalised, Magnitude>(kOmega0, digitalFilter), kTolerance)) << fmt::format("({}, {}, {}) has non-unity gain at omega0: {:.4f}", enum_name(filterDesign), enum_name(filterType), kFilterParams.order, calculateResponse<Normalised, Magnitude>(kOmega0, digitalFilter));
+                expect(le(calculateResponse<Normalised, Magnitude>(kDC, digitalFilter), kTolerance)) << fmt::format("({}, {}, {}) insufficient gain in stop-band (DC): {:.4f}", enum_name(filterDesign), enum_name(filterType), kFilterParams.order, calculateResponse<Normalised, Magnitude>(kDC, digitalFilter));
+                expect(le(calculateResponse<Normalised, Magnitude>(kNyquist, digitalFilter), kTolerance)) << fmt::format("({}, {}, {}) insufficient gain in stop-band (NQ): {:.4f}", enum_name(filterDesign), enum_name(filterType), kFilterParams.order, calculateResponse<Normalised, Magnitude>(kNyquist, digitalFilter));
                 break;
             }
 
             // N.B. cannot test magnitude response shape since there are not analog-vs-digital equivalents to compare
-        } | std::vector{ LOWPASS, HIGHPASS, BANDPASS, BANDSTOP }; //
-    } | std::vector{ Kaiser, Hamming, Hann };
+        } | std::vector{LOWPASS, HIGHPASS, BANDPASS, BANDSTOP}; //
+    } | std::vector{Kaiser, Hamming, Hann};
 
     tag("visual") / "basic fir tests"_test = []() {
         using namespace gr::graphs;
-        constexpr auto kFilterParams = FilterParameters{ .order = 4UZ, .fLow = 1.0, .fHigh = 10.0, .gain = 0.5, .attenuationDb = 50., .fs = 1000.0 };
+        constexpr auto kFilterParams = FilterParameters{.order = 4UZ, .fLow = 1.0, .fHigh = 10.0, .gain = 0.5, .attenuationDb = 50., .fs = 1000.0};
 
         using enum gr::algorithm::window::Type;
         const auto window = Kaiser;
@@ -587,7 +516,7 @@ const boost::ut::suite<"FIR FilterTool"> firFilterToolTests = [] {
             return iota(1, (end - start) / step + 2) | transform([=](auto i) { return start + step * (i - 1); });
         };
         std::vector<double> frequencies;
-        for (auto subrange : { sequence_range(0.1, 0.9, 0.01), sequence_range(1.0, 9.0, 0.01), sequence_range(10.0, 90.0, 0.1), sequence_range(100.0, 490.0, 10.0) }) {
+        for (auto subrange : {sequence_range(0.1, 0.9, 0.01), sequence_range(1.0, 9.0, 0.01), sequence_range(10.0, 90.0, 0.1), sequence_range(100.0, 490.0, 10.0)}) {
             std::ranges::move(subrange, std::back_inserter(frequencies));
         }
         const auto          lowPassFilter    = fir::designFilter<double>(LOWPASS, kFilterParams, window);
@@ -598,7 +527,7 @@ const boost::ut::suite<"FIR FilterTool"> firFilterToolTests = [] {
         std::vector<double> bandPassResponse = calculateFrequencyResponse<MagnitudeDB>(frequencies, kFilterParams.fs, bandPassFilter);
 
         // plots
-        auto chart        = gr::graphs::ImChart<119, 21, LogAxisTransform>({ { 0.1, kFilterParams.fs }, { -45., +5 } });
+        auto chart        = gr::graphs::ImChart<119, 21, LogAxisTransform>({{0.1, kFilterParams.fs}, {-45., +5}});
         chart.axis_name_x = "[Hz]";
         chart.axis_name_y = "[dB]";
         chart.draw(frequencies, lowPassResponse, fmt::format("FIR low(N={})", countFilterCoefficients(lowPassFilter)));
@@ -606,10 +535,10 @@ const boost::ut::suite<"FIR FilterTool"> firFilterToolTests = [] {
         chart.draw(frequencies, bandPassResponse, fmt::format("band-pass({})", countFilterCoefficients(bandPassFilter)));
         chart.draw();
 
-        auto highPassResponses        = gr::graphs::ImChart<119, 21, LogAxisTransform>({ { 0.1, kFilterParams.fs }, { -45., +5 } });
+        auto highPassResponses        = gr::graphs::ImChart<119, 21, LogAxisTransform>({{0.1, kFilterParams.fs}, {-45., +5}});
         highPassResponses.axis_name_x = "[Hz]";
         highPassResponses.axis_name_y = "band-stop response [dB]";
-        for (auto &windowType : { Kaiser, Hamming, Rectangular, Hann, BlackmanNuttall }) {
+        for (auto& windowType : {Kaiser, Hamming, Rectangular, Hann, BlackmanNuttall}) {
             auto                filter   = fir::designFilter<double>(BANDSTOP, kFilterParams, windowType);
             std::vector<double> response = calculateFrequencyResponse<MagnitudeDB>(frequencies, kFilterParams.fs, filter);
             highPassResponses.draw(frequencies, response, fmt::format("{}({})", enum_name(windowType), filter.b.size()));
@@ -618,7 +547,7 @@ const boost::ut::suite<"FIR FilterTool"> firFilterToolTests = [] {
     };
 
     tag("visual") / "basic FIR band-pass filter frequency"_test = []() {
-        constexpr auto   kFilterParams = FilterParameters{ .order = 2UZ, .fLow = 4., .fHigh = 6., .attenuationDb = 50, .fs = 1000.0 };
+        constexpr auto   kFilterParams = FilterParameters{.order = 2UZ, .fLow = 4., .fHigh = 6., .attenuationDb = 50, .fs = 1000.0};
         constexpr double xMin          = 0.0;
         constexpr double xMax          = 2.01;
 
@@ -627,14 +556,14 @@ const boost::ut::suite<"FIR FilterTool"> firFilterToolTests = [] {
             xValues[i] = xMin + static_cast<double>(i) / kFilterParams.fs;
         }
 
-        auto chart        = gr::graphs::ImChart<120, 16>({ { xMin, xMax }, { -5.0, +5.0 } });
+        auto chart        = gr::graphs::ImChart<120, 16>({{xMin, xMax}, {-5.0, +5.0}});
         chart.axis_name_x = "time [s]";
         chart.axis_name_y = "FIR filter amplitude [a.u.]";
 
         const auto window          = gr::algorithm::window::Type::Kaiser;
         const auto digitalBandPass = fir::designFilter<double>(Type::BANDPASS, kFilterParams, window);
         // printFilter("digitalBandPass", digitalBandPass);
-        for (const auto &frequency : { 3.0, 3.5, 5., 6.5, 7.0 }) {
+        for (const auto& frequency : {3.0, 3.5, 5., 6.5, 7.0}) {
             auto                filter = Filter<double>(digitalBandPass);
             std::vector<double> yValue(xValues.size());
             std::vector<double> yFiltered(xValues.size());
@@ -657,20 +586,20 @@ const boost::ut::suite<"IIR & FIR Benchmarks"> filterBenchmarks = [] {
     using magic_enum::enum_name;
 
     "IIR vs. FIR coefficients"_test = [](Type filterType) {
-        constexpr FilterParameters kFilterParameter{ .order = 4UZ, .fLow = 4., .fHigh = 6., .attenuationDb = 50., .fs = 1000. };
+        constexpr FilterParameters kFilterParameter{.order = 4UZ, .fLow = 4., .fHigh = 6., .attenuationDb = 50., .fs = 1000.};
         const auto                 iirFilter = iir::designFilter<double>(filterType, kFilterParameter);
         const auto                 firFilter = fir::designFilter<double>(filterType, kFilterParameter);
         std::size_t                nIIR      = countFilterCoefficients(iirFilter);
         std::size_t                nFIR      = countFilterCoefficients(firFilter);
         expect(le(nIIR, nFIR)) << fmt::format("{} complexity: #IIR {} vs. #FIR {}", enum_name(filterType), nIIR, nFIR);
         tag("visual") / "filter benchmarks"_test = [&] { fmt::print("{} complexity: #IIR {} vs. #FIR {}\n", enum_name(filterType), nIIR, nFIR); };
-    } | std::vector{ LOWPASS, HIGHPASS, BANDPASS, BANDSTOP };
+    } | std::vector{LOWPASS, HIGHPASS, BANDPASS, BANDSTOP};
 
     "IIR vs. FIR magnitude and phase"_test = []() {
         using namespace gr::graphs;
         using enum gr::algorithm::window::Type;
 
-        constexpr FilterParameters kFilterParameter{ .order = 4UZ, .fLow = 10., .gain = 0.5, .fs = 1000. };
+        constexpr FilterParameters kFilterParameter{.order = 4UZ, .fLow = 10., .gain = 0.5, .fs = 1000.};
         const auto                 iirFilter1 = iir::designFilter<double>(LOWPASS, kFilterParameter, BUTTERWORTH);
         const auto                 iirFilter2 = iir::designFilter<double>(LOWPASS, kFilterParameter, BESSEL);
         const auto                 firFilter1 = fir::designFilter<double>(LOWPASS, kFilterParameter, Kaiser);
@@ -682,14 +611,14 @@ const boost::ut::suite<"IIR & FIR Benchmarks"> filterBenchmarks = [] {
             return iota(1, (end - start) / step + 2) | transform([=](auto i) { return start + step * (i - 1); });
         };
         std::vector<double> frequencies;
-        for (auto subrange : { sequence_range(0.1, 0.9, 0.01), sequence_range(1.0, 9.0, 0.01), sequence_range(10.0, 90.0, 0.1), sequence_range(100.0, 490.0, 10.0) }) {
+        for (auto subrange : {sequence_range(0.1, 0.9, 0.01), sequence_range(1.0, 9.0, 0.01), sequence_range(10.0, 90.0, 0.1), sequence_range(100.0, 490.0, 10.0)}) {
             std::ranges::move(subrange, std::back_inserter(frequencies));
         }
 
         //
-        const auto magResponse = [&frequencies, &kFilterParameter](auto &filter) { return calculateFrequencyResponse<MagnitudeDB>(frequencies, kFilterParameter.fs, filter); };
+        const auto magResponse = [&frequencies, &kFilterParameter](auto& filter) { return calculateFrequencyResponse<MagnitudeDB>(frequencies, kFilterParameter.fs, filter); };
 
-        auto magnitudeChart        = gr::graphs::ImChart<119, 21, LogAxisTransform>({ { 0.1, kFilterParameter.fs }, { -45., +5 } });
+        auto magnitudeChart        = gr::graphs::ImChart<119, 21, LogAxisTransform>({{0.1, kFilterParameter.fs}, {-45., +5}});
         magnitudeChart.axis_name_x = "[Hz]";
         magnitudeChart.axis_name_y = "IIR vs. FIR response [dB]";
         magnitudeChart.draw(frequencies, magResponse(iirFilter1), fmt::format("Butterworth(N={})", countFilterCoefficients(iirFilter1)));
@@ -699,16 +628,16 @@ const boost::ut::suite<"IIR & FIR Benchmarks"> filterBenchmarks = [] {
 
         magnitudeChart.draw();
 
-        const auto phaseResponse = [&frequencies, &kFilterParameter](auto &filter, double corr = 0UZ, double offset = 0.) {
+        const auto phaseResponse = [&frequencies, &kFilterParameter](auto& filter, double corr = 0UZ, double offset = 0.) {
             const auto groupDelay = (corr + static_cast<double>(countFilterCoefficients(filter)) - 1.0) / 2.0 / kFilterParameter.fs; // just a coarse estimate
 
             auto normalisedPhase = calculateFrequencyResponse<PhaseDegrees>(frequencies, kFilterParameter.fs, filter);
-            std::transform(normalisedPhase.begin(), normalisedPhase.end(), frequencies.begin(), normalisedPhase.begin(),                                                   //
-                           [groupDelay, offset](auto phase, auto frequency) { return std::fmod(offset + phase + groupDelay * frequency * 360.0 + 180.0, 360.) - 180.0; }); // [-180°, 180°]
+            std::transform(normalisedPhase.begin(), normalisedPhase.end(), frequencies.begin(), normalisedPhase.begin(),                                        //
+                [groupDelay, offset](auto phase, auto frequency) { return std::fmod(offset + phase + groupDelay * frequency * 360.0 + 180.0, 360.) - 180.0; }); // [-180°, 180°]
             return normalisedPhase;
         };
 
-        auto phaseChart        = gr::graphs::ImChart<130, 33, LogAxisTransform>({ { 0.1, kFilterParameter.fs }, { -.5, +.5 } });
+        auto phaseChart        = gr::graphs::ImChart<130, 33, LogAxisTransform>({{0.1, kFilterParameter.fs}, {-.5, +.5}});
         phaseChart.axis_name_x = "[Hz]";
         phaseChart.axis_name_y = "IIR vs. FIR rel. non-linear phase response [°]";
         phaseChart.draw(frequencies, phaseResponse(iirFilter1, 72.5), fmt::format("Butterworth(N={})", countFilterCoefficients(iirFilter1)));
@@ -722,7 +651,7 @@ const boost::ut::suite<"IIR & FIR Benchmarks"> filterBenchmarks = [] {
     tag("benchmarks") / "filter benchmarks"_test = []<typename T>(T) {
         using namespace benchmark;
         using namespace gr::filter::iir;
-        constexpr FilterParameters kFilterParameter{ .order = 4UZ, .fLow = 4., .fHigh = 6., .attenuationDb = 50., .fs = 1000. };
+        constexpr FilterParameters kFilterParameter{.order = 4UZ, .fLow = 4., .fHigh = 6., .attenuationDb = 50., .fs = 1000.};
         constexpr Design           filterDesign = BUTTERWORTH;
 
         constexpr std::size_t nSamples = 100'000;
@@ -732,10 +661,10 @@ const boost::ut::suite<"IIR & FIR Benchmarks"> filterBenchmarks = [] {
             yValues[i] = std::sin(static_cast<T>(2) * std::numbers::pi_v<T> * centreFrequency / static_cast<T>(kFilterParameter.fs) * static_cast<T>(i));
         }
 
-        auto processSignal = [](auto &filter, const std::vector<T> &signalValues) -> T {
+        auto processSignal = [](auto& filter, const std::vector<T>& signalValues) -> T {
             T           actualGain       = 0.0;
             std::size_t processedSamples = 0UZ;
-            for (auto &signalValue : signalValues) {
+            for (auto& signalValue : signalValues) {
                 T filteredValue = filter.processOne(signalValue);
                 processedSamples++;
                 if (processedSamples > signalValues.size() / 2UZ) { // ignore initial transient
@@ -745,10 +674,10 @@ const boost::ut::suite<"IIR & FIR Benchmarks"> filterBenchmarks = [] {
             return actualGain;
         };
 
-        auto processSignalErrors = [](auto &filter, const std::vector<T> &signalValues) -> T {
+        auto processSignalErrors = [](auto& filter, const std::vector<T>& signalValues) -> T {
             T           actualGain       = 0.0;
             std::size_t processedSamples = 0UZ;
-            for (auto &signalValue : signalValues) {
+            for (auto& signalValue : signalValues) {
                 gr::UncertainValue<T> filteredValue = filter.processOne(signalValue);
                 processedSamples++;
                 if (processedSamples > signalValues.size() / 2UZ) { // ignore initial transient
@@ -762,7 +691,7 @@ const boost::ut::suite<"IIR & FIR Benchmarks"> filterBenchmarks = [] {
             T                       actualGain = 0.0;
             gr::HistoryBuffer<T, 8> buffer;
             ::benchmark::benchmark<10>(fmt::format("HistoryBuffer<{}>", gr::meta::type_name<T>()), nSamples) = [&actualGain, &buffer, &yValues] {
-                for (auto &yValue : yValues) {
+                for (auto& yValue : yValues) {
                     buffer.push_back(yValue);
                     actualGain = std::max(actualGain, buffer[0]);
                 }
@@ -829,9 +758,7 @@ const boost::ut::suite<"IIR & FIR Benchmarks"> filterBenchmarks = [] {
             expect(approx(actualGain, static_cast<T>(1), static_cast<T>(0.1))) << fmt::format("IIR approx settling gain threshold for {}", gr::meta::type_name<T>());
         }
         ::benchmark::results::add_separator();
-    } | std::tuple<double, float>{ 1.0, 1.0f };
+    } | std::tuple<double, float>{1.0, 1.0f};
 };
 
-int
-main() { /* not needed for UT */
-}
+int main() { /* not needed for UT */ }

--- a/algorithm/test/qa_ImChart.cpp
+++ b/algorithm/test/qa_ImChart.cpp
@@ -4,8 +4,8 @@
 
 #include <fmt/format.h>
 
-#include <gnuradio-4.0/algorithm/dataset/DataSetUtils.hpp>
 #include <gnuradio-4.0/algorithm/ImChart.hpp>
+#include <gnuradio-4.0/algorithm/dataset/DataSetUtils.hpp>
 
 const boost::ut::suite<"ImChart"> windowTests = [] {
     using namespace boost::ut;
@@ -26,7 +26,7 @@ const boost::ut::suite<"ImChart"> windowTests = [] {
 
         expect(eq(axisOffset, LinearAxisTransform::toScreen(xMin, xMin, xMax, axisOffset, axisWidth))) << "xMin does not correspond to min axis index";
         expect(eq(axisWidth - 1UZ, LinearAxisTransform::toScreen(xMax, xMin, xMax, axisOffset, axisWidth))) << "xMax does not correspond to max axis index";
-    } | std::vector{ 10., 20., 42., 50., 100. };
+    } | std::vector{10., 20., 42., 50., 100.};
 
     "log axis transform"_test = [](const double valueCoordinate) {
         using namespace gr::graphs;
@@ -49,10 +49,10 @@ const boost::ut::suite<"ImChart"> windowTests = [] {
         expect(throws([] { std::ignore = LogAxisTransform::toScreen(1.0, 10., 0., 5UZ, 65UZ); }));
         expect(throws([] { std::ignore = LogAxisTransform::fromScreen(40, 0., 100., 5UZ, 65UZ); }));
         expect(throws([] { std::ignore = LogAxisTransform::fromScreen(40, 10., 0., 5UZ, 65UZ); }));
-    } | std::vector{ 10., 20., 42., 50., 100. };
+    } | std::vector{10., 20., 42., 50., 100.};
 
     "optimal tick position"_test = [](std::size_t axisWidth) {
-        for (std::size_t minGapSize : { 1UZ, 2UZ, 3UZ }) {
+        for (std::size_t minGapSize : {1UZ, 2UZ, 3UZ}) {
             auto tickPositions = gr::graphs::detail::optimalTickScreenPositions(axisWidth, minGapSize);
 
             // first and last tick index fulfill [0, axisWidth - 1].
@@ -72,7 +72,7 @@ const boost::ut::suite<"ImChart"> windowTests = [] {
                 expect(ge(actualGap, minGapSize)) << fmt::format("gap size {} less than minimum required {} at axis width {}", actualGap, minGapSize, axisWidth);
             }
         }
-    } | std::vector{ 10UZ, 20UZ, 42UZ, 50UZ, 100UZ };
+    } | std::vector{10UZ, 20UZ, 42UZ, 50UZ, 100UZ};
 
     constexpr std::size_t sizeX = 120;
     constexpr std::size_t sizeY = 16;
@@ -95,13 +95,13 @@ const boost::ut::suite<"ImChart"> windowTests = [] {
             cosineYValues[i] = 3.0 * std::cos(xValues[i] * 0.2);
         }
 
-        auto chart = defaultConstructor ? gr::graphs::ImChart<sizeX, sizeY>() : gr::graphs::ImChart<sizeX, sizeY>({ { xMin, xMax }, { yMin, yMax } });
+        auto chart = defaultConstructor ? gr::graphs::ImChart<sizeX, sizeY>() : gr::graphs::ImChart<sizeX, sizeY>({{xMin, xMax}, {yMin, yMax}});
 
         expect(nothrow([&] { chart.draw(xValues, sineYValues, "sine-like"); }));
         expect(nothrow([&] { chart.draw(xValues, cosineYValues, "cosine-like"); }));
 
         expect(nothrow([&] { chart.draw(); }));
-    } | std::vector{ true, false };
+    } | std::vector{true, false};
 
     "basic chart - no data"_test = [&]() {
         using namespace gr::graphs;
@@ -127,7 +127,7 @@ const boost::ut::suite<"ImChart"> windowTests = [] {
             gauss2[i]               = 2.0 * std::exp(-std::pow(xValues[i] - mu2, 2.) / (2.0 * std::pow(sigma2, 2.)));
         }
 
-        auto chart        = gr::graphs::ImChart<sizeX, sizeY>({ { xMin, xMax }, { 0.0, 5.0 } });
+        auto chart        = gr::graphs::ImChart<sizeX, sizeY>({{xMin, xMax}, {0.0, 5.0}});
         chart.draw_border = true;
         expect(nothrow([&] { chart.draw<Style::Bars>(xValues, gauss1, "gauss-like1"); }));
         expect(nothrow([&] { chart.draw<Style::Bars>(xValues, gauss2, "gauss-like2"); }));
@@ -147,7 +147,7 @@ const boost::ut::suite<"ImChart"> windowTests = [] {
             sineYValues[i] = 3.0 * std::sin(xValues[i] * 0.2);
         }
 
-        auto chart = gr::graphs::ImChart<sizeX, sizeY>({ { xMin, xMax }, { yMin, yMax } });
+        auto chart = gr::graphs::ImChart<sizeX, sizeY>({{xMin, xMax}, {yMin, yMax}});
         expect(nothrow([&] { chart.draw<Style::Marker>(xValues, sineYValues, "sine-like"); }));
 
         expect(nothrow([&] { chart.draw(); }));
@@ -165,7 +165,7 @@ const boost::ut::suite<"ImChart"> windowTests = [] {
             sineYValues[i] = -5.0 + 3.0 * std::sin(xValues[i] * 0.2);
         }
 
-        auto chart = gr::graphs::ImChart<sizeX, sizeY>({ { xMin, xMax }, { -10, 0 } });
+        auto chart = gr::graphs::ImChart<sizeX, sizeY>({{xMin, xMax}, {-10, 0}});
         expect(nothrow([&] { chart.draw(xValues, sineYValues, "sine-like"); }));
 
         expect(nothrow([&] { chart.draw(); }));
@@ -183,7 +183,7 @@ const boost::ut::suite<"ImChart"> windowTests = [] {
             sineYValues[i] = -5.0 + 3.0 * std::sin(xValues[i] * 0.2);
         }
 
-        auto chart = gr::graphs::ImChart<sizeX, sizeY>({ { -50, +50 }, { -10, 0 } });
+        auto chart = gr::graphs::ImChart<sizeX, sizeY>({{-50, +50}, {-10, 0}});
         expect(nothrow([&] { chart.draw(xValues, sineYValues, "sine-like"); }));
 
         expect(nothrow([&] { chart.draw(); }));
@@ -199,7 +199,7 @@ const boost::ut::suite<"ImChart"> windowTests = [] {
         };
 
         std::vector<double> xValues;
-        for (auto subrange : { sequence_range(0.1, 0.9, 0.1), sequence_range(1.0, 9.0, 1.0), sequence_range(10.0, 90.0, 10.0), sequence_range(100.0, 1000.0, 100.0) }) {
+        for (auto subrange : {sequence_range(0.1, 0.9, 0.1), sequence_range(1.0, 9.0, 1.0), sequence_range(10.0, 90.0, 10.0), sequence_range(100.0, 1000.0, 100.0)}) {
             std::ranges::move(subrange, std::back_inserter(xValues));
         }
         std::vector<double> response1(xValues.size());
@@ -214,7 +214,7 @@ const boost::ut::suite<"ImChart"> windowTests = [] {
             }
         }
 
-        auto chart = gr::graphs::ImChart<width, 16, LogAxisTransform>({ { 0.1, 1'000.0 }, { -100, 0 } });
+        auto chart = gr::graphs::ImChart<width, 16, LogAxisTransform>({{0.1, 1'000.0}, {-100, 0}});
         expect(nothrow([&] { chart.draw(xValues, response1, "low-pass1"); }));
         expect(nothrow([&] { chart.draw(xValues, response2, "low-pass2"); }));
 
@@ -243,5 +243,4 @@ const boost::ut::suite<"ImChart"> windowTests = [] {
     };
 };
 
-int
-main() { /* not needed for UT */ }
+int main() { /* not needed for UT */ }

--- a/algorithm/test/qa_algorithm_fourier.cpp
+++ b/algorithm/test/qa_algorithm_fourier.cpp
@@ -13,12 +13,11 @@
 #include <gnuradio-4.0/algorithm/fourier/fftw.hpp>
 
 template<typename T>
-std::vector<T>
-generateSinSample(std::size_t N, double sample_rate, double frequency, double amplitude) {
+std::vector<T> generateSinSample(std::size_t N, double sample_rate, double frequency, double amplitude) {
     std::vector<T> signal(N);
     for (std::size_t i = 0; i < N; i++) {
         if constexpr (gr::meta::complex_like<T>) {
-            signal[i] = { static_cast<typename T::value_type>(amplitude * std::sin(2. * std::numbers::pi * frequency * static_cast<double>(i) / sample_rate)), 0. };
+            signal[i] = {static_cast<typename T::value_type>(amplitude * std::sin(2. * std::numbers::pi * frequency * static_cast<double>(i) / sample_rate)), 0.};
         } else {
             signal[i] = static_cast<T>(amplitude * std::sin(2. * std::numbers::pi * frequency * static_cast<double>(i) / sample_rate));
         }
@@ -27,23 +26,19 @@ generateSinSample(std::size_t N, double sample_rate, double frequency, double am
 }
 
 template<gr::meta::array_or_vector_type T, gr::meta::array_or_vector_type U = T>
-bool
-equalVectors(const T &v1, const U &v2, double tolerance = std::is_same_v<typename T::value_type, double> ? 1.e-5 : 1e-4) {
+bool equalVectors(const T& v1, const U& v2, double tolerance = std::is_same_v<typename T::value_type, double> ? 1.e-5 : 1e-4) {
     if (v1.size() != v2.size()) {
         return false;
     }
     if constexpr (gr::meta::complex_like<typename T::value_type>) {
-        return std::ranges::equal(v1, v2, [&tolerance](const auto &l, const auto &r) {
-            return std::abs(l.real() - r.real()) < static_cast<typename T::value_type>(tolerance) && std::abs(l.imag() - r.imag()) < static_cast<typename T::value_type>(tolerance);
-        });
+        return std::ranges::equal(v1, v2, [&tolerance](const auto& l, const auto& r) { return std::abs(l.real() - r.real()) < static_cast<typename T::value_type>(tolerance) && std::abs(l.imag() - r.imag()) < static_cast<typename T::value_type>(tolerance); });
     } else {
-        return std::ranges::equal(v1, v2, [&tolerance](const auto &l, const auto &r) { return std::abs(static_cast<double>(l) - static_cast<double>(r)) < tolerance; });
+        return std::ranges::equal(v1, v2, [&tolerance](const auto& l, const auto& r) { return std::abs(static_cast<double>(l) - static_cast<double>(r)) < tolerance; });
     }
 }
 
 template<typename TInput, typename TOutput, typename TExpInput, typename TExpOutput, typename TExpPlan>
-void
-testFFTwTypes() {
+void testFFTwTypes() {
     using namespace boost::ut;
     gr::algorithm::FFTw<TInput, TOutput> fftBlock;
     expect(std::is_same_v<typename std::remove_pointer_t<decltype(fftBlock.fftwIn.get())>, TExpInput>) << "";
@@ -66,46 +61,42 @@ const boost::ut::suite<"FFT algorithms and window functions"> windowTests = [] {
     using gr::algorithm::FFTw;
 
     using ComplexTypesToTest = std::tuple<
-            // complex input, same in-out precision
-            TestTypes<std::complex<float>, std::complex<float>, FFT>, TestTypes<std::complex<float>, std::complex<float>, FFTw>, TestTypes<std::complex<double>, std::complex<double>, FFT>,
-            TestTypes<std::complex<double>, std::complex<double>, FFTw>,
-            // complex input, different in-out precision
-            TestTypes<std::complex<float>, std::complex<double>, FFT>, TestTypes<std::complex<float>, std::complex<double>, FFTw>, TestTypes<std::complex<double>, std::complex<float>, FFT>,
-            TestTypes<std::complex<double>, std::complex<float>, FFTw>>;
+        // complex input, same in-out precision
+        TestTypes<std::complex<float>, std::complex<float>, FFT>, TestTypes<std::complex<float>, std::complex<float>, FFTw>, TestTypes<std::complex<double>, std::complex<double>, FFT>, TestTypes<std::complex<double>, std::complex<double>, FFTw>,
+        // complex input, different in-out precision
+        TestTypes<std::complex<float>, std::complex<double>, FFT>, TestTypes<std::complex<float>, std::complex<double>, FFTw>, TestTypes<std::complex<double>, std::complex<float>, FFT>, TestTypes<std::complex<double>, std::complex<float>, FFTw>>;
 
     using RealTypesToTest = std::tuple<
-            // real input, same in-out precision
-            TestTypes<float, std::complex<float>, FFT>, TestTypes<float, std::complex<float>, FFTw>, TestTypes<double, std::complex<double>, FFT>, TestTypes<double, std::complex<double>, FFTw>,
-            // real input, different in-out precision
-            TestTypes<double, std::complex<float>, FFT>, TestTypes<double, std::complex<float>, FFTw>, TestTypes<double, std::complex<float>, FFT>, TestTypes<double, std::complex<float>, FFTw>>;
+        // real input, same in-out precision
+        TestTypes<float, std::complex<float>, FFT>, TestTypes<float, std::complex<float>, FFTw>, TestTypes<double, std::complex<double>, FFT>, TestTypes<double, std::complex<double>, FFTw>,
+        // real input, different in-out precision
+        TestTypes<double, std::complex<float>, FFT>, TestTypes<double, std::complex<float>, FFTw>, TestTypes<double, std::complex<float>, FFT>, TestTypes<double, std::complex<float>, FFTw>>;
 
     using AllTypesToTest = decltype(std::tuple_cat(std::declval<ComplexTypesToTest>(), std::declval<RealTypesToTest>()));
 
     "FFT algo sin tests"_test = []<typename T>() {
         typename T::AlgoType fftAlgo{};
-        constexpr double     tolerance{ 1.e-5 };
+        constexpr double     tolerance{1.e-5};
         struct TestParams {
-            gr::Size_t N{ 1024 };           // must be power of 2
-            double     sample_rate{ 128. }; // must be power of 2 (only for the unit test for easy comparison with true result)
-            double     frequency{ 1. };
-            double     amplitude{ 1. };
-            bool       outputInDb{ false };
+            gr::Size_t N{1024};           // must be power of 2
+            double     sample_rate{128.}; // must be power of 2 (only for the unit test for easy comparison with true result)
+            double     frequency{1.};
+            double     amplitude{1.};
+            bool       outputInDb{false};
         };
 
-        std::vector<TestParams> testCases = { { 256, 128., 10., 5., false }, { 512, 4., 1., 1., false }, { 512, 32., 1., 0.1, false }, { 256, 128., 10., 5., false } };
-        for (const auto &t : testCases) {
+        std::vector<TestParams> testCases = {{256, 128., 10., 5., false}, {512, 4., 1., 1., false}, {512, 32., 1., 0.1, false}, {256, 128., 10., 5., false}};
+        for (const auto& t : testCases) {
             assert(std::has_single_bit(t.N));
             assert(std::has_single_bit(static_cast<std::size_t>(t.sample_rate)));
 
-            const auto signal{ generateSinSample<typename T::InType>(t.N, t.sample_rate, t.frequency, t.amplitude) };
+            const auto signal{generateSinSample<typename T::InType>(t.N, t.sample_rate, t.frequency, t.amplitude)};
             auto       fftResult         = fftAlgo.compute(signal);
             auto       magnitudeSpectrum = gr::algorithm::fft::computeMagnitudeSpectrum(fftResult);
-            auto       phase             = gr::algorithm::fft::computePhaseSpectrum(fftResult, { .outputInDeg = true, .unwrapPhase = true });
-            const auto peakIndex{ static_cast<std::size_t>(
-                    std::distance(magnitudeSpectrum.begin(),
-                                  std::max_element(magnitudeSpectrum.begin(), std::next(magnitudeSpectrum.begin(), static_cast<std::ptrdiff_t>(t.N / 2u))))) }; // only positive frequencies from FFT
+            auto       phase             = gr::algorithm::fft::computePhaseSpectrum(fftResult, {.outputInDeg = true, .unwrapPhase = true});
+            const auto peakIndex{static_cast<std::size_t>(std::distance(magnitudeSpectrum.begin(), std::max_element(magnitudeSpectrum.begin(), std::next(magnitudeSpectrum.begin(), static_cast<std::ptrdiff_t>(t.N / 2u)))))}; // only positive frequencies from FFT
             const auto peakAmplitude = magnitudeSpectrum[peakIndex];
-            const auto peakFrequency{ static_cast<double>(peakIndex) * t.sample_rate / static_cast<double>(t.N) };
+            const auto peakFrequency{static_cast<double>(peakIndex) * t.sample_rate / static_cast<double>(t.N)};
 
             const auto expectedAmplitude = t.outputInDb ? 20. * log10(std::abs(t.amplitude)) : t.amplitude;
             expect(approx(static_cast<double>(peakAmplitude), expectedAmplitude, tolerance)) << fmt::format("{} equal amplitude", type_name<T>());
@@ -116,43 +107,43 @@ const boost::ut::suite<"FFT algorithms and window functions"> windowTests = [] {
     "FFT algo pattern tests"_test = []<typename T>() {
         using InType = T::InType;
         typename T::AlgoType fftAlgo{};
-        constexpr double     tolerance{ 1.e-5 };
-        constexpr gr::Size_t N{ 16 };
+        constexpr double     tolerance{1.e-5};
+        constexpr gr::Size_t N{16};
         static_assert(N == 16, "expected values are calculated for N == 16");
 
         std::vector<InType> signal(N);
-        std::size_t         expectedPeakIndex{ 0 };
-        InType              expectedFft0{ 0., 0. };
-        double              expectedPeakAmplitude{ 0. };
+        std::size_t         expectedPeakIndex{0};
+        InType              expectedFft0{0., 0.};
+        double              expectedPeakAmplitude{0.};
         for (std::size_t iT = 0; iT < 5; iT++) {
             if (iT == 0) {
                 std::ranges::fill(signal.begin(), signal.end(), InType(0., 0.));
-                expectedFft0          = { 0., 0. };
+                expectedFft0          = {0., 0.};
                 expectedPeakAmplitude = 0.;
             } else if (iT == 1) {
                 std::ranges::fill(signal.begin(), signal.end(), InType(1., 0.));
-                expectedFft0          = { 16., 0. };
+                expectedFft0          = {16., 0.};
                 expectedPeakAmplitude = 2.;
             } else if (iT == 2) {
                 std::ranges::fill(signal.begin(), signal.end(), InType(1., 1.));
-                expectedFft0          = { 16., 16. };
+                expectedFft0          = {16., 16.};
                 expectedPeakAmplitude = std::sqrt(8.);
             } else if (iT == 3) {
                 std::iota(signal.begin(), signal.end(), 1);
-                expectedFft0          = { 136., 0. };
+                expectedFft0          = {136., 0.};
                 expectedPeakAmplitude = 17.;
             } else if (iT == 4) {
                 int i = 0;
                 std::ranges::generate(signal.begin(), signal.end(), [&i] { return InType(static_cast<typename InType::value_type>(i++ % 2), 0.); });
-                expectedFft0          = { 8., 0. };
+                expectedFft0          = {8., 0.};
                 expectedPeakAmplitude = 1.;
             }
 
             auto fftResult         = fftAlgo.compute(signal);
             auto magnitudeSpectrum = gr::algorithm::fft::computeMagnitudeSpectrum(fftResult);
 
-            const auto peakIndex{ static_cast<std::size_t>(std::distance(magnitudeSpectrum.begin(), std::ranges::max_element(magnitudeSpectrum))) };
-            const auto peakAmplitude{ magnitudeSpectrum[peakIndex] };
+            const auto peakIndex{static_cast<std::size_t>(std::distance(magnitudeSpectrum.begin(), std::ranges::max_element(magnitudeSpectrum)))};
+            const auto peakAmplitude{magnitudeSpectrum[peakIndex]};
 
             expect(eq(peakIndex, expectedPeakIndex)) << fmt::format("<{}> equal peak index", type_name<T>());
             expect(approx(static_cast<double>(peakAmplitude), expectedPeakAmplitude, tolerance)) << fmt::format("<{}> equal amplitude", type_name<T>());
@@ -162,10 +153,9 @@ const boost::ut::suite<"FFT algorithms and window functions"> windowTests = [] {
     } | ComplexTypesToTest{};
 
     "Unwrap Phase tests"_test = [] {
-        std::vector<double> phase = { 0.2, -1., 2.5, -3.1, 0.9, -0.5, 1.2, 0.8, 1.5, -1.2, -2.7, 0.9, -0.8, -1.4, 0.6, 1.1, -1.9, 0.4, 1.3, -0.7 };
+        std::vector<double> phase = {0.2, -1., 2.5, -3.1, 0.9, -0.5, 1.2, 0.8, 1.5, -1.2, -2.7, 0.9, -0.8, -1.4, 0.6, 1.1, -1.9, 0.4, 1.3, -0.7};
         // Output generated with python numpy.unwrap(phase)
-        std::vector<double> expOut = { 0.2,         -1.,          -3.78318531,  -3.1,         -5.38318531,  -6.78318531,  -5.08318531,  -5.48318531,  -4.78318531,  -7.48318531,
-                                       -8.98318531, -11.66637061, -13.36637061, -13.96637061, -11.96637061, -11.46637061, -14.46637061, -12.16637061, -11.26637061, -13.26637061 };
+        std::vector<double> expOut = {0.2, -1., -3.78318531, -3.1, -5.38318531, -6.78318531, -5.08318531, -5.48318531, -4.78318531, -7.48318531, -8.98318531, -11.66637061, -13.36637061, -13.96637061, -11.96637061, -11.46637061, -14.46637061, -12.16637061, -11.26637061, -13.26637061};
         gr::algorithm::fft::unwrapPhase(phase);
         expect(equalVectors(phase, expOut)) << "unwrapped phases are equal";
     };
@@ -192,17 +182,17 @@ const boost::ut::suite<"FFT algorithms and window functions"> windowTests = [] {
 
     "window pre-computed array tests"_test = []<typename T>() { // this tests regression w.r.t. changed implementations
         // Expected value for size 8
-        std::array RectangularRef{ 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f };
-        std::array HammingRef{ 0.07672f, 0.25053218f, 0.64108455f, 0.9542833f, 0.95428324f, 0.6410846f, 0.25053206f, 0.07672f };
-        std::array HannRef{ 0.f, 0.1882550991f, 0.611260467f, 0.950484434f, 0.950484434f, 0.611260467f, 0.1882550991f, 0.f };
-        std::array BlackmanRef{ 0.f, 0.09045342435f, 0.4591829575f, 0.9203636181f, 0.9203636181f, 0.4591829575f, 0.09045342435f, 0.f };
-        std::array BlackmanHarrisRef{ 0.00006f, 0.03339172348f, 0.3328335043f, 0.8893697722f, 0.8893697722f, 0.3328335043f, 0.03339172348f, 0.00006f };
-        std::array BlackmanNuttallRef{ 0.0003628f, 0.03777576895f, 0.34272762f, 0.8918518611f, 0.8918518611f, 0.34272762f, 0.03777576895f, 0.0003628f };
-        std::array ExponentialRef{ 1.f, 1.042546905f, 1.08690405f, 1.133148453f, 1.181360413f, 1.231623642f, 1.284025417f, 1.338656724f };
-        std::array FlatTopRef{ 0.004f, -0.1696424054f, 0.04525319348f, 3.622389212f, 3.622389212f, 0.04525319348f, -0.1696424054f, 0.004f };
-        std::array HannExpRef{ 0.f, 0.611260467f, 0.950484434f, 0.1882550991f, 0.1882550991f, 0.950484434f, 0.611260467f, 0.f };
-        std::array NuttallRef{ 0.f, 0.0311427368f, 0.3264168059f, 0.8876284573f, 0.8876284573f, 0.3264168059f, 0.0311427368f, 0.f };
-        std::array KaiserRef{ 0.5714348848f, 0.7650986027f, 0.9113132365f, 0.9899091685f, 0.9899091685f, 0.9113132365f, 0.7650986027f, 0.5714348848f };
+        std::array RectangularRef{1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f};
+        std::array HammingRef{0.07672f, 0.25053218f, 0.64108455f, 0.9542833f, 0.95428324f, 0.6410846f, 0.25053206f, 0.07672f};
+        std::array HannRef{0.f, 0.1882550991f, 0.611260467f, 0.950484434f, 0.950484434f, 0.611260467f, 0.1882550991f, 0.f};
+        std::array BlackmanRef{0.f, 0.09045342435f, 0.4591829575f, 0.9203636181f, 0.9203636181f, 0.4591829575f, 0.09045342435f, 0.f};
+        std::array BlackmanHarrisRef{0.00006f, 0.03339172348f, 0.3328335043f, 0.8893697722f, 0.8893697722f, 0.3328335043f, 0.03339172348f, 0.00006f};
+        std::array BlackmanNuttallRef{0.0003628f, 0.03777576895f, 0.34272762f, 0.8918518611f, 0.8918518611f, 0.34272762f, 0.03777576895f, 0.0003628f};
+        std::array ExponentialRef{1.f, 1.042546905f, 1.08690405f, 1.133148453f, 1.181360413f, 1.231623642f, 1.284025417f, 1.338656724f};
+        std::array FlatTopRef{0.004f, -0.1696424054f, 0.04525319348f, 3.622389212f, 3.622389212f, 0.04525319348f, -0.1696424054f, 0.004f};
+        std::array HannExpRef{0.f, 0.611260467f, 0.950484434f, 0.1882550991f, 0.1882550991f, 0.950484434f, 0.611260467f, 0.f};
+        std::array NuttallRef{0.f, 0.0311427368f, 0.3264168059f, 0.8876284573f, 0.8876284573f, 0.3264168059f, 0.0311427368f, 0.f};
+        std::array KaiserRef{0.5714348848f, 0.7650986027f, 0.9113132365f, 0.9899091685f, 0.9899091685f, 0.9113132365f, 0.7650986027f, 0.5714348848f};
 
         // check all windows for unwanted changes
         using enum gr::algorithm::window::Type;
@@ -211,10 +201,8 @@ const boost::ut::suite<"FFT algorithms and window functions"> windowTests = [] {
         expect(equalVectors(create<T>(Hamming, 8), HammingRef)) << fmt::format("<{}> equal Hamming vector {} vs. ref: {}", type_name<T>(), create<T>(Hamming, 8), HammingRef);
         expect(equalVectors(create<T>(Hann, 8), HannRef)) << fmt::format("<{}> equal Hann vector {} vs. ref: {}", type_name<T>(), create<T>(Hann, 8), HannRef);
         expect(equalVectors(create<T>(Blackman, 8), BlackmanRef)) << fmt::format("<{}> equal Blackman vvector {} vs. ref: {}", type_name<T>(), create<T>(Blackman, 8), BlackmanRef);
-        expect(equalVectors(create<T>(BlackmanHarris, 8), BlackmanHarrisRef))
-                << fmt::format("<{}> equal BlackmanHarris vector {} vs. ref: {}", type_name<T>(), create<T>(BlackmanHarris, 8), BlackmanHarrisRef);
-        expect(equalVectors(create<T>(BlackmanNuttall, 8), BlackmanNuttallRef))
-                << fmt::format("<{}> equal BlackmanNuttall vector {} vs. ref: {}", type_name<T>(), create<T>(BlackmanNuttall, 8), BlackmanNuttallRef);
+        expect(equalVectors(create<T>(BlackmanHarris, 8), BlackmanHarrisRef)) << fmt::format("<{}> equal BlackmanHarris vector {} vs. ref: {}", type_name<T>(), create<T>(BlackmanHarris, 8), BlackmanHarrisRef);
+        expect(equalVectors(create<T>(BlackmanNuttall, 8), BlackmanNuttallRef)) << fmt::format("<{}> equal BlackmanNuttall vector {} vs. ref: {}", type_name<T>(), create<T>(BlackmanNuttall, 8), BlackmanNuttallRef);
         expect(equalVectors(create<T>(Exponential, 8), ExponentialRef)) << fmt::format("<{}> equal Exponential vector {} vs. ref: {}", type_name<T>(), create<T>(Exponential, 8), ExponentialRef);
         expect(equalVectors(create<T>(FlatTop, 8), FlatTopRef)) << fmt::format("<{}> equal FlatTop vector {} vs. ref: {}", type_name<T>(), create<T>(FlatTop, 8), FlatTopRef);
         expect(equalVectors(create<T>(HannExp, 8), HannExpRef)) << fmt::format("<{}> equal HannExp vector {} vs. ref: {}", type_name<T>(), create<T>(HannExp, 8), HannExpRef);
@@ -236,8 +224,8 @@ const boost::ut::suite<"FFT algorithms and window functions"> windowTests = [] {
         expect(eq(create<T>(Kaiser, 0).size(), 0u)) << fmt::format("<{}> zero size Kaiser vectors", type_name<T>());
     } | std::tuple<float, double>();
 
-    "basic window tests"_test = [](auto &val) {
-        const auto &[window, windowName] = val;
+    "basic window tests"_test = [](auto& val) {
+        const auto& [window, windowName] = val;
         using enum gr::algorithm::window::Type;
 
         const auto w = create(window, 1024U);
@@ -258,6 +246,4 @@ const boost::ut::suite<"FFT algorithms and window functions"> windowTests = [] {
     } | std::tuple<float, double>();
 };
 
-int
-main() { /* not needed for UT */
-}
+int main() { /* not needed for UT */ }

--- a/bench/benchmark.hpp
+++ b/bench/benchmark.hpp
@@ -586,7 +586,7 @@ template<Numeric T>
 std::string to_si_prefix(T value_base, std::string_view unit = "s", std::size_t significant_digits = 0) {
     static constexpr std::array  si_prefixes{'q', 'r', 'y', 'z', 'a', 'f', 'p', 'n', 'u', 'm', ' ', 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y', 'R', 'Q'};
     static constexpr long double base  = 1000.0L;
-    auto                  value = static_cast<long double>(value_base);
+    auto                         value = static_cast<long double>(value_base);
 
     std::size_t exponent = 10U;
     if (value == 0.0L) {

--- a/bench/bm_example.cpp
+++ b/bench/bm_example.cpp
@@ -28,8 +28,8 @@ const boost::ut::suite global_benchmarks = [] {
         throw std::invalid_argument("fails here on purpose");
     };
 #if not defined(_LIBCPP_VERSION)
-    "using marker"_benchmark.repeat<10>() = [] (MarkerMap<"source", "sink1", "sink2", "finish">& marker) {
-        std::barrier start(3, [&marker] { marker.at<"source">().now(); }); // 1 source + 2 sinks
+    "using marker"_benchmark.repeat<10>() = [](MarkerMap<"source", "sink1", "sink2", "finish">& marker) {
+        std::barrier start(3, [&marker] { marker.at<"source">().now(); });  // 1 source + 2 sinks
         std::barrier finish(3, [&marker] { marker.at<"finish">().now(); }); // 1 source + 2 sinks
         std::jthread source([&start, &finish] {
             start.arrive_and_wait();

--- a/blocks/basic/include/gnuradio-4.0/basic/DataSink.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/DataSink.hpp
@@ -662,7 +662,7 @@ private:
 
         // polling-only
         std::weak_ptr<StreamingPoller<T>> polling_handler = {};
-        Callback              callback;
+        Callback                          callback;
 
         template<typename CallbackFW>
         explicit ContinuousListener(std::size_t maxChunkSize, CallbackFW&& c, const DataSink<T>& parent) : parent_sink(parent), buffer(maxChunkSize), callback{std::forward<CallbackFW>(c)} {}
@@ -1182,9 +1182,9 @@ private:
 
     template<typename Callback, DataSetMatcher<T> TMatcher>
     struct Listener : public AbstractListener {
-        bool                  block           = false;
-        TMatcher              matcher         = {};
-        gr::property_map      trigger_state;
+        bool                            block   = false;
+        TMatcher                        matcher = {};
+        gr::property_map                trigger_state;
         std::weak_ptr<DataSetPoller<T>> polling_handler = {};
 
         Callback callback;
@@ -1244,7 +1244,7 @@ private:
 
 } // namespace gr::basic
 
-auto registerDataSink = gr::registerBlock<gr::basic::DataSink, float, double>(gr::globalBlockRegistry());
+auto registerDataSink    = gr::registerBlock<gr::basic::DataSink, float, double>(gr::globalBlockRegistry());
 auto registerDataSetSink = gr::registerBlock<gr::basic::DataSetSink, float, double>(gr::globalBlockRegistry());
 
 #endif

--- a/blocks/basic/include/gnuradio-4.0/basic/SignalGenerator.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/SignalGenerator.hpp
@@ -16,8 +16,7 @@ using enum Type;
 constexpr auto                                 TypeList  = magic_enum::enum_values<Type>();
 inline static constexpr gr::meta::fixed_string TypeNames = "[Const, Sin, Cos, Square, Saw, Triangle]";
 
-constexpr Type
-parse(std::string_view name) {
+constexpr Type parse(std::string_view name) {
     auto signalType = magic_enum::enum_cast<Type>(name, magic_enum::case_insensitive);
     if (!signalType.has_value()) {
         throw std::invalid_argument(fmt::format("unknown signal generator type '{}'", name));
@@ -79,14 +78,12 @@ s(t) = A * (4 * abs(t * f - floor(t * f + 0.75) + 0.25) - 1) + O
     signal_generator::Type _signalType = signal_generator::parse(signal_type);
     T                      _timeTick   = T(1.) / T(sample_rate);
 
-    void
-    settingsChanged(const property_map & /*old_settings*/, const property_map & /*new_settings*/) {
+    void settingsChanged(const property_map& /*old_settings*/, const property_map& /*new_settings*/) {
         _signalType = signal_generator::parse(signal_type);
         _timeTick   = T(1.) / T(sample_rate);
     }
 
-    [[nodiscard]] constexpr T
-    processOne(T /*input*/) noexcept {
+    [[nodiscard]] constexpr T processOne(T /*input*/) noexcept {
         using enum signal_generator::Type;
 
         constexpr T pi2 = T(2.) * std::numbers::pi_v<T>;

--- a/blocks/basic/include/gnuradio-4.0/basic/function_generator.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/function_generator.hpp
@@ -14,16 +14,14 @@ namespace gr::basic {
 enum class FunctionMode { Constant, LinearRamp, ParabolicRamp, CubicSpline, ImpulseResponse };
 
 struct FunctionGenerator {
-    double         T_s{ 1 };
-    mutable double time{ 0 };
+    double         T_s{1};
+    mutable double time{0};
 
     explicit FunctionGenerator(double T_s) : T_s(T_s) {}
 
     virtual ~FunctionGenerator() = default;
 
-    virtual double
-    getSample() const
-            = 0;
+    virtual double getSample() const = 0;
 };
 
 struct ConstantFunction : FunctionGenerator {
@@ -31,10 +29,7 @@ struct ConstantFunction : FunctionGenerator {
 
     explicit ConstantFunction(double value, double T_s) : FunctionGenerator(T_s), value(value) {}
 
-    double
-    getSample() const override {
-        return value;
-    }
+    double getSample() const override { return value; }
 };
 
 struct LinearRamp : FunctionGenerator {
@@ -42,8 +37,7 @@ struct LinearRamp : FunctionGenerator {
 
     LinearRamp(double startValue, double finalValue, double duration, double T_s) : FunctionGenerator(T_s), startValue(startValue), finalValue(finalValue), duration(duration) {}
 
-    double
-    getSample() const override {
+    double getSample() const override {
         time += T_s;
         double val = startValue + (finalValue - startValue) * (time / duration);
         return time > duration ? finalValue : val;
@@ -61,25 +55,20 @@ struct ParabolicRamp : FunctionGenerator {
     double transitPoint1;
     double transitPoint2;
 
-    ParabolicRamp(double startValue, double finalValue, double duration, double roundOffTime, double T_s)
-        : FunctionGenerator(T_s), startValue(startValue), finalValue(finalValue), duration(duration), roundOnTime(roundOffTime), roundOffTime(roundOffTime) {
-        init();
-    }
+    ParabolicRamp(double startValue, double finalValue, double duration, double roundOffTime, double T_s) : FunctionGenerator(T_s), startValue(startValue), finalValue(finalValue), duration(duration), roundOnTime(roundOffTime), roundOffTime(roundOffTime) { init(); }
 
-    void
-    init() noexcept {
+    void init() noexcept {
         time                      = 0;
         const double linearLength = duration - (roundOnTime + roundOffTime);
         a                         = (finalValue - startValue) / (2 * roundOnTime * (linearLength + roundOffTime));
 
-        slope                     = (finalValue - startValue - 2 * a * pow(roundOffTime, 2)) / linearLength;
+        slope = (finalValue - startValue - 2 * a * pow(roundOffTime, 2)) / linearLength;
 
-        transitPoint1             = startValue + a * pow(roundOffTime, 2);
-        transitPoint2             = finalValue - a * pow(roundOffTime, 2);
+        transitPoint1 = startValue + a * pow(roundOffTime, 2);
+        transitPoint2 = finalValue - a * pow(roundOffTime, 2);
     }
 
-    double
-    getSample() const override {
+    double getSample() const override {
         time += T_s;
         if (time > duration) {
             return finalValue;
@@ -106,8 +95,7 @@ struct CubicSpline : FunctionGenerator {
 
     CubicSpline(double startValue, double finalValue, double duration, double T_s) : FunctionGenerator(T_s), startValue(startValue), finalValue(finalValue), duration(duration) {}
 
-    double
-    getSample() const override {
+    double getSample() const override {
         time += T_s;
         double normalizedTime = time / duration;
         double val            = (2 * pow(normalizedTime, 3) - 3 * pow(normalizedTime, 2) + 1) * startValue + (-2 * pow(normalizedTime, 3) + 3 * pow(normalizedTime, 2)) * finalValue;
@@ -123,8 +111,7 @@ struct ImpulseResponse : FunctionGenerator {
 
     ImpulseResponse(double startValue, double finalValue, double t0, double t1, double T_s) : FunctionGenerator(T_s), startValue(startValue), finalValue(finalValue), t0(t0), t1(t1) {}
 
-    double
-    getSample() const override {
+    double getSample() const override {
         time += T_s;
         if (time < t0 || time > t0 + t1) {
             return startValue;
@@ -140,8 +127,7 @@ public:
 
     Generator(double f_s) : T_s(1.0 / f_s) {}
 
-    void
-    setMode(FunctionMode mode, double startValue, double finalValue, double duration, double roundOffTime = 0.0, double t0 = 0.0, double t1 = 0.0) {
+    void setMode(FunctionMode mode, double startValue, double finalValue, double duration, double roundOffTime = 0.0, double t0 = 0.0, double t1 = 0.0) {
         switch (mode) {
         case FunctionMode::Constant:
             if (startValue != finalValue) {
@@ -158,11 +144,8 @@ public:
         }
     }
 
-    double
-    getNextSample() {
-        return functionGenerator->getSample();
-    }
+    double getNextSample() { return functionGenerator->getSample(); }
 };
-}
+} // namespace gr::basic
 
 #endif // GNURADIO_DEMO_FUNCTION_GENERATOR_HPP

--- a/blocks/basic/src/function_generator_example.cpp
+++ b/blocks/basic/src/function_generator_example.cpp
@@ -1,7 +1,6 @@
 #include <gnuradio-4.0/basic/function_generator.hpp>
 
-int
-main() {
+int main() {
     using namespace gr::basic;
     const double f_s = 1000.0; // 1 kHz
     Generator    generator(f_s);
@@ -38,4 +37,3 @@ main() {
 
     return 0;
 }
-

--- a/blocks/basic/test/qa_BasicKnownBlocks.cpp
+++ b/blocks/basic/test/qa_BasicKnownBlocks.cpp
@@ -1,11 +1,11 @@
 #include <boost/ut.hpp>
 
-#include <gnuradio-4.0/basic/clock_source.hpp>
-#include <gnuradio-4.0/basic/common_blocks.hpp>
 #include <gnuradio-4.0/basic/DataSink.hpp>
 #include <gnuradio-4.0/basic/FunctionGenerator.hpp>
 #include <gnuradio-4.0/basic/Selector.hpp>
 #include <gnuradio-4.0/basic/SignalGenerator.hpp>
+#include <gnuradio-4.0/basic/clock_source.hpp>
+#include <gnuradio-4.0/basic/common_blocks.hpp>
 
 const boost::ut::suite KnownBlockTests = [] {
     using namespace boost::ut;
@@ -30,7 +30,4 @@ const boost::ut::suite KnownBlockTests = [] {
     };
 };
 
-int
-main() {
-    return boost::ut::cfg<boost::ut::override>.run();
-}
+int main() { return boost::ut::cfg<boost::ut::override>.run(); }

--- a/blocks/basic/test/qa_Converter.cpp
+++ b/blocks/basic/test/qa_Converter.cpp
@@ -61,7 +61,7 @@ const boost::ut::suite<"basic Conversion tests"> basicConversion = [] {
         } | TArithmeticTypes();
 
         "up-convert std::simd<std::uint8_t> to ..."_test = []<typename R>(R /*noop*/) {
-            using T       = uint8_t;
+            using T = uint8_t;
             // careful here: max_fixed_size is 32 *except with AVX-512 and sizeof(T) == 1* where it is 64.
             using V       = std::conditional_t<stdx::native_simd<T>::size() <= stdx::simd_abi::max_fixed_size<R>, stdx::native_simd<T>, stdx::simd<T, stdx::simd_abi::deduce_t<T, stdx::simd_abi::max_fixed_size<R>>>>;
             using RetType = stdx::rebind_simd_t<R, V>;

--- a/blocks/basic/test/qa_DataSink.cpp
+++ b/blocks/basic/test/qa_DataSink.cpp
@@ -528,14 +528,14 @@ const boost::ut::suite DataSinkTests = [] {
         expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(delay).to<"in">(sink)));
 
         auto polling = std::async([] {
-            std::vector<int32_t>                              receivedData;
-            std::vector<Tag>                                  receivedTags;
-            bool                                              seenFinished = false;
-            auto                                              isTrigger    = [](std::string_view /* filterSpec */, const Tag& tag, const property_map& /* filter state */) {
+            std::vector<int32_t> receivedData;
+            std::vector<Tag>     receivedTags;
+            bool                 seenFinished = false;
+            auto                 isTrigger    = [](std::string_view /* filterSpec */, const Tag& tag, const property_map& /* filter state */) {
                 const auto type = tag.get("TYPE");
                 return (type && std::get<std::string>(type->get()) == "TRIGGER") ? trigger::MatchResult::Matching : trigger::MatchResult::Ignore;
             };
-            std::shared_ptr<DataSetPoller<int32_t>>           poller;
+            std::shared_ptr<DataSetPoller<int32_t>> poller;
             expect(spinUntil(4s, [&] {
                 poller = DataSinkRegistry::instance().getTriggerPoller<int32_t>(DataSinkQuery::signalName("test signal"), isTrigger, 0UZ, 2UZ, BlockingMode::Blocking);
                 return poller != nullptr;

--- a/blocks/filter/include/gnuradio-4.0/filter/time_domain_filter.hpp
+++ b/blocks/filter/include/gnuradio-4.0/filter/time_domain_filter.hpp
@@ -11,7 +11,7 @@ namespace gr::filter {
 using namespace gr;
 
 template<typename T>
-    requires std::floating_point<T>
+requires std::floating_point<T>
 struct fir_filter : Block<fir_filter<T>> {
     using Description = Doc<R""(
 @brief Finite Impulse Response (FIR) filter class
@@ -19,23 +19,21 @@ struct fir_filter : Block<fir_filter<T>> {
 The transfer function of an FIR filter is given by:
 H(z) = b[0] + b[1]*z^-1 + b[2]*z^-2 + ... + b[N]*z^-N
 )"">;
-    PortIn<T>        in;
-    PortOut<T>       out;
-    std::vector<T>   b{}; // feedforward coefficients
+    PortIn<T>      in;
+    PortOut<T>     out;
+    std::vector<T> b{}; // feedforward coefficients
 
     GR_MAKE_REFLECTABLE(fir_filter, in, out, b);
 
-    HistoryBuffer<T> inputHistory{ 32 };
+    HistoryBuffer<T> inputHistory{32};
 
-    void
-    settingsChanged(const property_map & /*old_settings*/, const property_map &new_settings) noexcept {
+    void settingsChanged(const property_map& /*old_settings*/, const property_map& new_settings) noexcept {
         if (new_settings.contains("b") && b.size() >= inputHistory.capacity()) {
             inputHistory = HistoryBuffer<T>(std::bit_ceil(b.size()));
         }
     }
 
-    constexpr T
-    processOne(T input) noexcept {
+    constexpr T processOne(T input) noexcept {
         inputHistory.push_back(input);
         return std::inner_product(b.cbegin(), b.cend(), inputHistory.cbegin(), static_cast<T>(0));
     }
@@ -49,7 +47,7 @@ enum class IIRForm {
 };
 
 template<typename T, IIRForm form = std::is_floating_point_v<T> ? IIRForm::DF_II : IIRForm::DF_I>
-    requires std::floating_point<T>
+requires std::floating_point<T>
 struct iir_filter : Block<iir_filter<T, form>> {
     using Description = Doc<R""(
 @brief Infinite Impulse Response (IIR) filter class
@@ -57,18 +55,17 @@ struct iir_filter : Block<iir_filter<T, form>> {
 b are the feed-forward coefficients (N.B. b[0] denoting the newest and b[-1] the previous sample)
 a are the feedback coefficients
 )"">;
-    PortIn<T>        in;
-    PortOut<T>       out;
-    std::vector<T>   b{ 1 }; // feed-forward coefficients
-    std::vector<T>   a{ 1 }; // feedback coefficients
+    PortIn<T>      in;
+    PortOut<T>     out;
+    std::vector<T> b{1}; // feed-forward coefficients
+    std::vector<T> a{1}; // feedback coefficients
 
     GR_MAKE_REFLECTABLE(iir_filter, in, out, b, a);
 
-    HistoryBuffer<T> inputHistory{ 32 };
-    HistoryBuffer<T> outputHistory{ 32 };
+    HistoryBuffer<T> inputHistory{32};
+    HistoryBuffer<T> outputHistory{32};
 
-    void
-    settingsChanged(const property_map & /*old_settings*/, const property_map &new_settings) noexcept {
+    void settingsChanged(const property_map& /*old_settings*/, const property_map& new_settings) noexcept {
         const auto new_size = std::max(a.size(), b.size());
         if ((new_settings.contains("b") || new_settings.contains("a")) && (new_size >= inputHistory.capacity() || new_size >= inputHistory.capacity())) {
             inputHistory  = HistoryBuffer<T>(std::bit_ceil(new_size));
@@ -76,22 +73,21 @@ a are the feedback coefficients
         }
     }
 
-    [[nodiscard]] T
-    processOne(T input) noexcept {
+    [[nodiscard]] T processOne(T input) noexcept {
         if constexpr (form == IIRForm::DF_I) {
             // y[n] = b[0] * x[n]   + b[1] * x[n-1] + ... + b[N] * x[n-N]
             //      - a[1] * y[n-1] - a[2] * y[n-2] - ... - a[M] * y[n-M]
             inputHistory.push_back(input);
-            const T output = std::inner_product(b.cbegin(), b.cend(), inputHistory.cbegin(), static_cast<T>(0))       // feed-forward path
-                           - std::inner_product(a.cbegin() + 1, a.cend(), outputHistory.cbegin(), static_cast<T>(0)); // feedback path
+            const T output = std::inner_product(b.cbegin(), b.cend(), inputHistory.cbegin(), static_cast<T>(0))         // feed-forward path
+                             - std::inner_product(a.cbegin() + 1, a.cend(), outputHistory.cbegin(), static_cast<T>(0)); // feedback path
             outputHistory.push_back(output);
             return output;
         } else if constexpr (form == IIRForm::DF_II) {
             // w[n] = x[n] - a[1] * w[n-1] - a[2] * w[n-2] - ... - a[M] * w[n-M]
             // y[n] =        b[0] * w[n]   + b[1] * w[n-1] + ... + b[N] * w[n-N]
-            const T w = input - std::inner_product(a.cbegin() + 1, a.cend(), inputHistory.cbegin(), T{ 0 });
+            const T w = input - std::inner_product(a.cbegin() + 1, a.cend(), inputHistory.cbegin(), T{0});
             inputHistory.push_back(w);
-            return std::inner_product(b.cbegin(), b.cend(), inputHistory.cbegin(), T{ 0 });
+            return std::inner_product(b.cbegin(), b.cend(), inputHistory.cbegin(), T{0});
         } else if constexpr (form == IIRForm::DF_I_TRANSPOSED) {
             // w_1[n] = x[n] - a[1] * w_2[n-1] - a[2] * w_2[n-2] - ... - a[M] * w_2[n-M]
             // y[n]   = b[0] * w_2[n] + b[1] * w_2[n-1] + ... + b[N] * w_2[n-N]
@@ -100,9 +96,9 @@ a are the feedback coefficients
             return std::inner_product(b.cbegin(), b.cend(), outputHistory.cbegin(), static_cast<T>(0));
         } else if constexpr (form == IIRForm::DF_II_TRANSPOSED) {
             // y[n] = b_0*f[n] + \sum_(k=1)^N(b_k*f[n−k] − a_k*y[n−k])
-            const T output = b[0] * input                                                                           //
-                           + std::inner_product(b.cbegin() + 1, b.cend(), inputHistory.cbegin(), static_cast<T>(0)) //
-                           - std::inner_product(a.cbegin() + 1, a.cend(), outputHistory.cbegin(), static_cast<T>(0));
+            const T output = b[0] * input                                                                             //
+                             + std::inner_product(b.cbegin() + 1, b.cend(), inputHistory.cbegin(), static_cast<T>(0)) //
+                             - std::inner_product(a.cbegin() + 1, a.cend(), outputHistory.cbegin(), static_cast<T>(0));
 
             inputHistory.push_back(input);
             outputHistory.push_back(output);
@@ -114,9 +110,6 @@ a are the feedback coefficients
 } // namespace gr::filter
 
 auto registerFirFilter = gr::registerBlock<gr::filter::fir_filter, double, float>(gr::globalBlockRegistry());
-auto registerIirFilter = gr::registerBlock<gr::filter::iir_filter, gr::filter::IIRForm::DF_I, double, float>(gr::globalBlockRegistry())
-                       | gr::registerBlock<gr::filter::iir_filter, gr::filter::IIRForm::DF_II, double, float>(gr::globalBlockRegistry())
-                       | gr::registerBlock<gr::filter::iir_filter, gr::filter::IIRForm::DF_I_TRANSPOSED, double, float>(gr::globalBlockRegistry())
-                       | gr::registerBlock<gr::filter::iir_filter, gr::filter::IIRForm::DF_II_TRANSPOSED, double, float>(gr::globalBlockRegistry());
+auto registerIirFilter = gr::registerBlock<gr::filter::iir_filter, gr::filter::IIRForm::DF_I, double, float>(gr::globalBlockRegistry()) | gr::registerBlock<gr::filter::iir_filter, gr::filter::IIRForm::DF_II, double, float>(gr::globalBlockRegistry()) | gr::registerBlock<gr::filter::iir_filter, gr::filter::IIRForm::DF_I_TRANSPOSED, double, float>(gr::globalBlockRegistry()) | gr::registerBlock<gr::filter::iir_filter, gr::filter::IIRForm::DF_II_TRANSPOSED, double, float>(gr::globalBlockRegistry());
 
 #endif // GNURADIO_TIME_DOMAIN_FILTER_HPP

--- a/blocks/filter/test/qa_filter.cpp
+++ b/blocks/filter/test/qa_filter.cpp
@@ -7,19 +7,18 @@
 #include <gnuradio-4.0/filter/time_domain_filter.hpp>
 
 template<typename T, typename Range>
-    requires std::floating_point<T>
-constexpr size_t
-estimate_settling_time(const Range &step_response, std::size_t offset = 0, T step_value = 1.0, T threshold = 0.001) {
+requires std::floating_point<T>
+constexpr size_t estimate_settling_time(const Range& step_response, std::size_t offset = 0, T step_value = 1.0, T threshold = 0.001) {
     if (offset >= step_response.size()) {
         throw std::out_of_range("Offset is greater than the size of the step response.");
     }
     const T lower_bound = step_value - threshold;
     const T upper_bound = step_value + threshold;
 
-    auto    begin       = step_response.begin() + static_cast<typename Range::difference_type>(offset);
-    auto    end         = step_response.end();
+    auto begin = step_response.begin() + static_cast<typename Range::difference_type>(offset);
+    auto end   = step_response.end();
 
-    auto    it          = std::find_if(begin, end, [lower_bound, upper_bound](T sample) { return sample >= lower_bound && sample <= upper_bound; });
+    auto it = std::find_if(begin, end, [lower_bound, upper_bound](T sample) { return sample >= lower_bound && sample <= upper_bound; });
 
     // If no such sample is found, return an error
     if (it == end) {
@@ -46,8 +45,8 @@ const boost::ut::suite SequenceTests = [] {
 
     "FIR and IIR general tests"_test = [] {
         std::vector<double> fir_coeffs(10, 0.1); // box car filter
-        std::vector<double> iir_coeffs_b{ 0.55, 0 };
-        std::vector<double> iir_coeffs_a{ 1, -0.45 };
+        std::vector<double> iir_coeffs_b{0.55, 0};
+        std::vector<double> iir_coeffs_a{1, -0.45};
 
         // Create FIR and IIR filter instances
         fir_filter<double> fir_filter;
@@ -89,8 +88,8 @@ const boost::ut::suite SequenceTests = [] {
     "IIR equality tests"_test = [] {
         //        std::vector<double>              iir_coeffs_b{ 0.55, 0 };
         //        std::vector<double>              iir_coeffs_a{ 1, -0.45 };
-        std::vector<double>               iir_coeffs_b{ 0.020083365564211, 0.040166731128423, 0.020083365564211 };
-        std::vector<double>               iir_coeffs_a{ 1.0, -1.561018075800718, 0.641351538057563 };
+        std::vector<double> iir_coeffs_b{0.020083365564211, 0.040166731128423, 0.020083365564211};
+        std::vector<double> iir_coeffs_a{1.0, -1.561018075800718, 0.641351538057563};
 
         iir_filter<double, IIRForm::DF_I> iir_filter_I;
         iir_filter_I.b = iir_coeffs_b;
@@ -102,8 +101,8 @@ const boost::ut::suite SequenceTests = [] {
         iir_filter_IT.b = iir_coeffs_b;
         iir_filter_IT.a = iir_coeffs_a;
         iir_filter<double, IIRForm::DF_II_TRANSPOSED> iir_filter_IIT;
-        iir_filter_IIT.b           = iir_coeffs_b;
-        iir_filter_IIT.a           = iir_coeffs_a;
+        iir_filter_IIT.b = iir_coeffs_b;
+        iir_filter_IIT.a = iir_coeffs_a;
 
         constexpr double tolerance = 0.00001;
         for (std::size_t i = 0UL; i < 20; ++i) {
@@ -118,12 +117,10 @@ const boost::ut::suite SequenceTests = [] {
 
 #if defined(__GNUC__) && !defined(__OPTIMIZE__)
             fmt::print("input[{:2}]={}-> IIR= {:4.2f} (I) {:4.2f} (II) {:4.2f} (I-T) {:4.2f} (II-T)\n", //
-                       i, input, form_I, form_II, form_I_T, form_II_T);
+                i, input, form_I, form_II, form_I_T, form_II_T);
 #endif
         }
     };
 };
 
-int
-main() { /* not needed for UT */
-}
+int main() { /* not needed for UT */ }

--- a/blocks/fourier/include/gnuradio-4.0/fourier/fft.hpp
+++ b/blocks/fourier/include/gnuradio-4.0/fourier/fft.hpp
@@ -93,7 +93,7 @@ On the choice of window (mathematically aka. apodisation) functions
     using InDataType  = std::conditional_t<gr::meta::complex_like<T>, std::complex<value_type>, value_type>;
     using OutDataType = std::complex<value_type>;
 
-    PortIn<T>  in{};
+    PortIn<T>                         in{};
     PortOut<U, RequiredSamples<1, 1>> out{};
 
     FourierAlgorithm<T, std::complex<typename U::value_type>> _fftImpl{};

--- a/core/benchmarks/bm-nosonar_node_api.cpp
+++ b/core/benchmarks/bm-nosonar_node_api.cpp
@@ -23,7 +23,7 @@ template<typename T, char op>
 struct math_bulk_op : public gr::Block<math_bulk_op<T, op>> {
     gr::PortIn<T, gr::RequiredSamples<1, N_MAX>>  in;
     gr::PortOut<T, gr::RequiredSamples<1, N_MAX>> out;
-    T value = static_cast<T>(1.0f);
+    T                                             value = static_cast<T>(1.0f);
 
     GR_MAKE_REFLECTABLE(math_bulk_op, in, out, value);
 
@@ -138,7 +138,7 @@ template<typename T, char op>
 struct gen_operation_SIMD : public gr::Block<gen_operation_SIMD<T, op>> {
     gr::PortIn<T, gr::RequiredSamples<1, N_MAX>>  in;
     gr::PortOut<T, gr::RequiredSamples<1, N_MAX>> out;
-    T value = static_cast<T>(1.0f);
+    T                                             value = static_cast<T>(1.0f);
 
     GR_MAKE_REFLECTABLE(gen_operation_SIMD, in, out, value);
 

--- a/core/benchmarks/bm_Profiler.cpp
+++ b/core/benchmarks/bm_Profiler.cpp
@@ -7,11 +7,10 @@ using namespace gr::profiling;
 inline constexpr std::size_t N_ITER    = 7;
 inline constexpr std::size_t N_SAMPLES = 1;
 
-inline void
-run_without_profiler() {
+inline void run_without_profiler() {
     const auto start = detail::clock::now();
 
-    long long  r     = 0;
+    long long r = 0;
     for (std::size_t i = 0; i < 1000; ++i) {
         for (std::size_t j = 0; j < 1000; ++j) {
             std::vector<int> v(10000);
@@ -25,15 +24,14 @@ run_without_profiler() {
 }
 
 template<ProfilerLike TProfiler>
-inline void
-run_with_profiler(TProfiler &p) {
-    const auto            start                   = detail::clock::now();
-    auto                 &handler                 = p.forThisThread();
+inline void run_with_profiler(TProfiler& p) {
+    const auto start   = detail::clock::now();
+    auto&      handler = p.forThisThread();
 
     [[maybe_unused]] auto whole_calculation_event = handler.startCompleteEvent("whole_calculation");
     long long             r                       = 0;
     for (std::size_t i = 0; i < 1000; ++i) {
-        auto async_event = handler.startAsyncEvent("iteration", {}, { { "arg1", 2 }, { "arg2", "hello" } });
+        auto async_event = handler.startAsyncEvent("iteration", {}, {{"arg1", 2}, {"arg2", "hello"}});
         for (std::size_t j = 0; j < 1000; ++j) {
             std::vector<int> v(10000);
             std::iota(v.begin(), v.end(), 1);
@@ -56,9 +54,7 @@ run_with_profiler(TProfiler &p) {
     null::Profiler null_prof;
     "null profiler"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&p = null_prof] { run_with_profiler(p); };
 
-    "no profiler"_benchmark.repeat<N_ITER>(N_SAMPLES)   = [] { run_without_profiler(); };
+    "no profiler"_benchmark.repeat<N_ITER>(N_SAMPLES) = [] { run_without_profiler(); };
 };
 
-int
-main() { /* not needed by the UT framework */
-}
+int main() { /* not needed by the UT framework */ }

--- a/core/benchmarks/bm_Scheduler.cpp
+++ b/core/benchmarks/bm_Scheduler.cpp
@@ -13,17 +13,16 @@ inline constexpr gr::Size_t  N_SAMPLES = gr::util::round_up(10'000'000, 1024);
 inline constexpr std::size_t N_NODES   = 5;
 
 template<typename T, typename Sink, typename Source>
-void
-create_cascade(gr::Graph &testGraph, Sink &src, Source &sink, std::size_t depth = 1) {
+void create_cascade(gr::Graph& testGraph, Sink& src, Source& sink, std::size_t depth = 1) {
     using namespace boost::ut;
     using namespace benchmark;
     using namespace gr::blocks::math;
 
-    std::vector<MultiplyConst<T> *> mult1;
-    std::vector<DivideConst<T> *>   mult2;
+    std::vector<MultiplyConst<T>*> mult1;
+    std::vector<DivideConst<T>*>   mult2;
     for (std::size_t i = 0; i < depth; i++) {
-        mult1.emplace_back(std::addressof(testGraph.emplaceBlock<MultiplyConst<T>>({ { "value", T(2) }, { "name", fmt::format("mult.{}", i) } })));
-        mult2.emplace_back(std::addressof(testGraph.emplaceBlock<DivideConst<T>>({ { "value", T(2) }, { "name", fmt::format("div.{}", i) } })));
+        mult1.emplace_back(std::addressof(testGraph.emplaceBlock<MultiplyConst<T>>({{"value", T(2)}, {"name", fmt::format("mult.{}", i)}})));
+        mult2.emplace_back(std::addressof(testGraph.emplaceBlock<DivideConst<T>>({{"value", T(2)}, {"name", fmt::format("div.{}", i)}})));
     }
 
     for (std::size_t i = 0; i < mult1.size(); i++) {
@@ -38,12 +37,11 @@ create_cascade(gr::Graph &testGraph, Sink &src, Source &sink, std::size_t depth 
 }
 
 template<typename T>
-gr::Graph
-test_graph_linear(std::size_t depth = 1) {
+gr::Graph test_graph_linear(std::size_t depth = 1) {
     gr::Graph testGraph;
 
-    auto &src  = testGraph.emplaceBlock<gr::testing::ConstantSource<T>>({ { "n_samples_max", N_SAMPLES } });
-    auto &sink = testGraph.emplaceBlock<gr::testing::NullSink<T>>();
+    auto& src  = testGraph.emplaceBlock<gr::testing::ConstantSource<T>>({{"n_samples_max", N_SAMPLES}});
+    auto& sink = testGraph.emplaceBlock<gr::testing::NullSink<T>>();
 
     create_cascade<T>(testGraph, src, sink, depth);
 
@@ -51,15 +49,14 @@ test_graph_linear(std::size_t depth = 1) {
 }
 
 template<typename T>
-gr::Graph
-test_graph_bifurcated(std::size_t depth = 1) {
+gr::Graph test_graph_bifurcated(std::size_t depth = 1) {
     using namespace boost::ut;
     using namespace benchmark;
     gr::Graph testGraph;
 
-    auto &src   = testGraph.emplaceBlock<gr::testing::ConstantSource<T>>({ { "n_samples_max", N_SAMPLES } });
-    auto &sink1 = testGraph.emplaceBlock<gr::testing::NullSink<T>>();
-    auto &sink2 = testGraph.emplaceBlock<gr::testing::NullSink<T>>();
+    auto& src   = testGraph.emplaceBlock<gr::testing::ConstantSource<T>>({{"n_samples_max", N_SAMPLES}});
+    auto& sink1 = testGraph.emplaceBlock<gr::testing::NullSink<T>>();
+    auto& sink2 = testGraph.emplaceBlock<gr::testing::NullSink<T>>();
 
     create_cascade<T>(testGraph, src, sink1, depth);
     create_cascade<T>(testGraph, src, sink2, depth);
@@ -67,8 +64,7 @@ test_graph_bifurcated(std::size_t depth = 1) {
     return testGraph;
 }
 
-void
-exec_bm(auto &scheduler, const std::string &test_case) {
+void exec_bm(auto& scheduler, const std::string& test_case) {
     using namespace boost::ut;
     using namespace benchmark;
     expect(scheduler.runAndWait().has_value()) << fmt::format("scheduler failure for test-case: {}", test_case);
@@ -108,11 +104,7 @@ exec_bm(auto &scheduler, const std::string &test_case) {
     "bifurcated graph - BFS scheduler (multi-threaded)"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched4_mt]() { exec_bm(sched4_mt, "bifurcated-graph BFS-sched (multi-threaded)"); };
 
     gr::scheduler::BreadthFirst<multiThreaded, Profiler> sched4_mt_prof(test_graph_bifurcated<float>(N_NODES), pool);
-    "bifurcated graph - BFS scheduler (multi-threaded) with profiling"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched4_mt_prof]() {
-        exec_bm(sched4_mt_prof, "bifurcated-graph BFS-sched (multi-threaded) with profiling");
-    };
+    "bifurcated graph - BFS scheduler (multi-threaded) with profiling"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched4_mt_prof]() { exec_bm(sched4_mt_prof, "bifurcated-graph BFS-sched (multi-threaded) with profiling"); };
 };
 
-int
-main() { /* not needed by the UT framework */
-}
+int main() { /* not needed by the UT framework */ }

--- a/core/benchmarks/bm_filter.cpp
+++ b/core/benchmarks/bm_filter.cpp
@@ -16,8 +16,7 @@ inline constexpr std::size_t N_ITER = 10;
 // inline constexpr std::size_t N_SAMPLES = gr::util::round_up(1'000'000, 1024);
 inline constexpr std::size_t N_SAMPLES = gr::util::round_up(10'000, 1024);
 
-void
-loop_over_work(auto &node) {
+void loop_over_work(auto& node) {
     using namespace boost::ut;
     using namespace benchmark;
     test::n_samples_produced = 0LU;
@@ -29,8 +28,7 @@ loop_over_work(auto &node) {
     expect(eq(test::n_samples_consumed, N_SAMPLES)) << "consumed too many/few samples";
 }
 
-void
-invoke_work(auto &sched) {
+void invoke_work(auto& sched) {
     using namespace boost::ut;
     using namespace benchmark;
     test::n_samples_produced = 0LU;
@@ -48,8 +46,8 @@ inline const boost::ut::suite _constexpr_bm = [] {
     using namespace gr::blocks::filter;
 
     std::vector<float> fir_coeffs(10.f, 0.1f); // box car filter
-    std::vector<float> iir_coeffs_b{ 0.55f, 0.f };
-    std::vector<float> iir_coeffs_a{ 1.f, -0.45f };
+    std::vector<float> iir_coeffs_b{0.55f, 0.f};
+    std::vector<float> iir_coeffs_a{1.f, -0.45f};
 
     {
         auto mergedBlock = merge<"out", "in">(::test::source<float>(N_SAMPLES), ::test::sink<float>());
@@ -85,59 +83,57 @@ inline const boost::ut::suite _constexpr_bm = [] {
 
     {
         gr::graph testGraph;
-        auto     &src  = testGraph.emplaceBlock<::test::source<float>>(N_SAMPLES);
-        auto     &sink = testGraph.emplaceBlock<::test::sink<float>>();
+        auto&     src  = testGraph.emplaceBlock<::test::source<float>>(N_SAMPLES);
+        auto&     sink = testGraph.emplaceBlock<::test::sink<float>>();
 
         expect(eq(gr::ConnectionResult::SUCCESS, testGraph.connect<"out">(src).to<"in">(sink)));
 
-        gr::scheduler::simple sched{ std::move(testGraph) };
+        gr::scheduler::simple sched{std::move(testGraph)};
 
         "runtime   src->sink overhead"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched]() { invoke_work(sched); };
     }
 
     {
         gr::graph testGraph;
-        auto     &src    = testGraph.emplaceBlock<::test::source<float>>(N_SAMPLES);
-        auto     &sink   = testGraph.emplaceBlock<::test::sink<float>>();
-        auto     &filter = testGraph.emplaceBlock<fir_filter<float>>({ { "b", fir_coeffs } });
+        auto&     src    = testGraph.emplaceBlock<::test::source<float>>(N_SAMPLES);
+        auto&     sink   = testGraph.emplaceBlock<::test::sink<float>>();
+        auto&     filter = testGraph.emplaceBlock<fir_filter<float>>({{"b", fir_coeffs}});
 
         expect(eq(gr::ConnectionResult::SUCCESS, testGraph.connect(src, &::test::source<float>::out).to<"in">(filter)));
         expect(eq(gr::ConnectionResult::SUCCESS, testGraph.connect<"out">(filter).to(sink, &::test::sink<float>::in)));
 
-        gr::scheduler::simple sched{ std::move(testGraph) };
+        gr::scheduler::simple sched{std::move(testGraph)};
 
         "runtime   src->fir_filter->sink"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched]() { invoke_work(sched); };
     }
 
     {
         gr::graph testGraph;
-        auto     &src    = testGraph.emplaceBlock<::test::source<float>>(N_SAMPLES);
-        auto     &sink   = testGraph.emplaceBlock<::test::sink<float>>();
-        auto     &filter = testGraph.emplaceBlock<iir_filter<float, IIRForm::DF_I>>({ { "b", iir_coeffs_b }, { "a", iir_coeffs_a } });
+        auto&     src    = testGraph.emplaceBlock<::test::source<float>>(N_SAMPLES);
+        auto&     sink   = testGraph.emplaceBlock<::test::sink<float>>();
+        auto&     filter = testGraph.emplaceBlock<iir_filter<float, IIRForm::DF_I>>({{"b", iir_coeffs_b}, {"a", iir_coeffs_a}});
 
         expect(eq(gr::ConnectionResult::SUCCESS, testGraph.connect(src, &::test::source<float>::out).to<"in">(filter)));
         expect(eq(gr::ConnectionResult::SUCCESS, testGraph.connect<"out">(filter).to(sink, &::test::sink<float>::in)));
 
-        gr::scheduler::simple sched{ std::move(testGraph) };
+        gr::scheduler::simple sched{std::move(testGraph)};
 
         "runtime   src->iir_filter->sink - direct-form I"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched]() { invoke_work(sched); };
     }
 
     {
         gr::graph testGraph;
-        auto     &src    = testGraph.emplaceBlock<::test::source<float>>(N_SAMPLES);
-        auto     &sink   = testGraph.emplaceBlock<::test::sink<float>>();
-        auto     &filter = testGraph.emplaceBlock<iir_filter<float, IIRForm::DF_II>>({ { "b", iir_coeffs_b }, { "a", iir_coeffs_a } });
+        auto&     src    = testGraph.emplaceBlock<::test::source<float>>(N_SAMPLES);
+        auto&     sink   = testGraph.emplaceBlock<::test::sink<float>>();
+        auto&     filter = testGraph.emplaceBlock<iir_filter<float, IIRForm::DF_II>>({{"b", iir_coeffs_b}, {"a", iir_coeffs_a}});
 
         expect(eq(gr::ConnectionResult::SUCCESS, testGraph.connect(src, &::test::source<float>::out).to<"in">(filter)));
         expect(eq(gr::ConnectionResult::SUCCESS, testGraph.connect<"out">(filter).to(sink, &::test::sink<float>::in)));
 
-        gr::scheduler::simple sched{ std::move(testGraph) };
+        gr::scheduler::simple sched{std::move(testGraph)};
 
         "runtime   src->iir_filter->sink - direct-form II"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched]() { invoke_work(sched); };
     }
 };
 
-int
-main() { /* not needed by the UT framework */
-}
+int main() { /* not needed by the UT framework */ }

--- a/core/include/gnuradio-4.0/ClaimStrategy.hpp
+++ b/core/include/gnuradio-4.0/ClaimStrategy.hpp
@@ -37,7 +37,7 @@ public:
     TWaitStrategy                                           _waitStrategy;
     std::shared_ptr<std::vector<std::shared_ptr<Sequence>>> _readSequences{std::make_shared<std::vector<std::shared_ptr<Sequence>>>()}; // list of dependent reader sequences
 
-    explicit SingleProducerStrategy(const std::size_t bufferSize = SIZE) : _size(bufferSize){};
+    explicit SingleProducerStrategy(const std::size_t bufferSize = SIZE) : _size(bufferSize) {};
     SingleProducerStrategy(const SingleProducerStrategy&)  = delete;
     SingleProducerStrategy(const SingleProducerStrategy&&) = delete;
     void operator=(const SingleProducerStrategy&)          = delete;

--- a/core/include/gnuradio-4.0/DataSet.hpp
+++ b/core/include/gnuradio-4.0/DataSet.hpp
@@ -1,10 +1,10 @@
 #ifndef GNURADIO_DATASET_HPP
 #define GNURADIO_DATASET_HPP
 
-#include <gnuradio-4.0/meta/reflection.hpp>
 #include "Tag.hpp"
 #include <chrono>
 #include <cstdint>
+#include <gnuradio-4.0/meta/reflection.hpp>
 #include <map>
 #include <pmtv/pmt.hpp>
 #include <variant>

--- a/core/include/gnuradio-4.0/HistoryBuffer.hpp
+++ b/core/include/gnuradio-4.0/HistoryBuffer.hpp
@@ -48,14 +48,13 @@ class HistoryBuffer {
 
     buffer_type _buffer{};
     std::size_t _capacity = N;
-    std::size_t _write_position{ 0 };
-    std::size_t _size{ 0UZ };
+    std::size_t _write_position{0};
+    std::size_t _size{0UZ};
 
     /**
      * @brief maps the logical index to the physical index in the buffer.
      */
-    [[nodiscard]] constexpr inline std::size_t
-    map_index(std::size_t index) const noexcept {
+    [[nodiscard]] constexpr inline std::size_t map_index(std::size_t index) const noexcept {
         if constexpr (N == std::dynamic_extent) { // runtime checks
             if (std::has_single_bit(_capacity)) { // _capacity is a power of two
                 return (_write_position + index) & (_capacity - 1UZ);
@@ -86,8 +85,7 @@ public:
     /**
      * @brief Adds an element to the end expiring the oldest element beyond the buffer's capacities.
      */
-    constexpr void
-    push_back(const T &value) noexcept {
+    constexpr void push_back(const T& value) noexcept {
         if (_size < _capacity) [[unlikely]] {
             ++_size;
         }
@@ -103,8 +101,7 @@ public:
      * @brief Adds a range of elements the end expiring the oldest elements beyond the buffer's capacities.
      */
     template<typename Iter>
-    constexpr void
-    push_back_bulk(Iter cbegin, Iter cend) noexcept {
+    constexpr void push_back_bulk(Iter cbegin, Iter cend) noexcept {
         for (auto it = cbegin; it != cend; ++it) {
             push_back(*it);
         }
@@ -114,9 +111,8 @@ public:
      * @brief Adds a range of elements the end expiring the oldest elements beyond the buffer's capacities.
      */
     template<typename Range>
-    constexpr void
-    push_back_bulk(const Range &range) noexcept {
-        for (const auto &item : range) {
+    constexpr void push_back_bulk(const Range& range) noexcept {
+        for (const auto& item : range) {
             push_back(item);
         }
     }
@@ -124,132 +120,71 @@ public:
     /**
      * @brief unchecked accesses of the element at the specified logical index.
      */
-    constexpr T &
-    operator[](std::size_t index) noexcept {
-        return _buffer[map_index(index)];
-    }
+    constexpr T& operator[](std::size_t index) noexcept { return _buffer[map_index(index)]; }
 
-    [[nodiscard]] constexpr const T &
-    operator[](std::size_t index) const noexcept {
-        return _buffer[map_index(index)];
-    }
+    [[nodiscard]] constexpr const T& operator[](std::size_t index) const noexcept { return _buffer[map_index(index)]; }
 
-    [[nodiscard]] constexpr T &
-    at(std::size_t index) noexcept(false) {
+    [[nodiscard]] constexpr T& at(std::size_t index) noexcept(false) {
         if (index >= _size) {
             throw std::out_of_range(fmt::format("index {} out of range [0, {})", index, _size));
         }
         return _buffer[map_index(index)];
     }
 
-    [[nodiscard]] constexpr const T &
-    at(std::size_t index) const noexcept(false) {
+    [[nodiscard]] constexpr const T& at(std::size_t index) const noexcept(false) {
         if (index >= _size) {
             throw std::out_of_range(fmt::format("index {} out of range [0, {})", index, _size));
         }
         return _buffer[map_index(index)];
     }
 
-    [[nodiscard]] constexpr size_t
-    size() const noexcept {
-        return _size;
-    }
+    [[nodiscard]] constexpr size_t size() const noexcept { return _size; }
 
-    [[nodiscard]] constexpr bool
-    empty() const noexcept {
-        return _size == 0;
-    }
+    [[nodiscard]] constexpr bool empty() const noexcept { return _size == 0; }
 
-    [[nodiscard]] constexpr size_t
-    capacity() const noexcept {
-        return _capacity;
-    }
+    [[nodiscard]] constexpr size_t capacity() const noexcept { return _capacity; }
 
-    [[nodiscard]] constexpr T *
-    data() noexcept {
-        return _buffer.data();
-    }
+    [[nodiscard]] constexpr T* data() noexcept { return _buffer.data(); }
 
-    [[nodiscard]] constexpr const T *
-    data() const noexcept {
-        return _buffer.data();
-    }
+    [[nodiscard]] constexpr const T* data() const noexcept { return _buffer.data(); }
 
     /**
      * @brief Returns a span of elements with given (optional) length with the last element being the newest
      */
-    [[nodiscard]] constexpr std::span<const T>
-    get_span(std::size_t index, std::size_t length = std::dynamic_extent) const {
+    [[nodiscard]] constexpr std::span<const T> get_span(std::size_t index, std::size_t length = std::dynamic_extent) const {
         length = std::clamp(length, 0LU, std::min(_size - index, length));
         return std::span<const T>(&_buffer[map_index(index)], length);
     }
 
-    [[nodiscard]] auto
-    begin() noexcept {
-        return std::next(_buffer.begin(), static_cast<signed_index_type>(_write_position));
-    }
+    [[nodiscard]] auto begin() noexcept { return std::next(_buffer.begin(), static_cast<signed_index_type>(_write_position)); }
 
-    constexpr void
-    reset(T defaultValue = T()) {
+    constexpr void reset(T defaultValue = T()) {
         _size           = 0UZ;
         _write_position = 0UZ;
         std::fill(_buffer.begin(), _buffer.end(), defaultValue);
     }
 
-    [[nodiscard]] constexpr auto
-    begin() const noexcept {
-        return std::next(_buffer.begin(), static_cast<signed_index_type>(_write_position));
-    }
+    [[nodiscard]] constexpr auto begin() const noexcept { return std::next(_buffer.begin(), static_cast<signed_index_type>(_write_position)); }
 
-    [[nodiscard]] constexpr auto
-    cbegin() const noexcept {
-        return std::next(_buffer.begin(), static_cast<signed_index_type>(_write_position));
-    }
+    [[nodiscard]] constexpr auto cbegin() const noexcept { return std::next(_buffer.begin(), static_cast<signed_index_type>(_write_position)); }
 
-    [[nodiscard]] auto
-    end() noexcept {
-        return std::next(_buffer.begin(), static_cast<signed_index_type>(_write_position + _size));
-    }
+    [[nodiscard]] auto end() noexcept { return std::next(_buffer.begin(), static_cast<signed_index_type>(_write_position + _size)); }
 
-    [[nodiscard]] constexpr auto
-    end() const noexcept {
-        return std::next(_buffer.begin(), static_cast<signed_index_type>(_write_position + _size));
-    }
+    [[nodiscard]] constexpr auto end() const noexcept { return std::next(_buffer.begin(), static_cast<signed_index_type>(_write_position + _size)); }
 
-    [[nodiscard]] constexpr auto
-    cend() const noexcept {
-        return end();
-    }
+    [[nodiscard]] constexpr auto cend() const noexcept { return end(); }
 
-    [[nodiscard]] auto
-    rbegin() noexcept {
-        return std::make_reverse_iterator(end());
-    }
+    [[nodiscard]] auto rbegin() noexcept { return std::make_reverse_iterator(end()); }
 
-    [[nodiscard]] constexpr auto
-    rbegin() const noexcept {
-        return std::make_reverse_iterator(cend());
-    }
+    [[nodiscard]] constexpr auto rbegin() const noexcept { return std::make_reverse_iterator(cend()); }
 
-    [[nodiscard]] constexpr auto
-    crbegin() const noexcept {
-        return rbegin();
-    }
+    [[nodiscard]] constexpr auto crbegin() const noexcept { return rbegin(); }
 
-    [[nodiscard]] auto
-    rend() noexcept {
-        return std::make_reverse_iterator(begin());
-    }
+    [[nodiscard]] auto rend() noexcept { return std::make_reverse_iterator(begin()); }
 
-    [[nodiscard]] constexpr auto
-    rend() const noexcept {
-        return std::make_reverse_iterator(cbegin());
-    }
+    [[nodiscard]] constexpr auto rend() const noexcept { return std::make_reverse_iterator(cbegin()); }
 
-    [[nodiscard]] constexpr auto
-    crend() const noexcept {
-        return rend();
-    }
+    [[nodiscard]] constexpr auto crend() const noexcept { return rend(); }
 };
 
 } // namespace gr

--- a/core/include/gnuradio-4.0/LifeCycle.hpp
+++ b/core/include/gnuradio-4.0/LifeCycle.hpp
@@ -3,8 +3,8 @@
 
 #include <gnuradio-4.0/Message.hpp>
 #include <gnuradio-4.0/meta/formatter.hpp>
-#include <gnuradio-4.0/meta/utils.hpp>
 #include <gnuradio-4.0/meta/reflection.hpp>
+#include <gnuradio-4.0/meta/utils.hpp>
 
 #include <atomic>
 #include <expected>

--- a/core/include/gnuradio-4.0/Message.hpp
+++ b/core/include/gnuradio-4.0/Message.hpp
@@ -4,8 +4,8 @@
 #include <gnuradio-4.0/Buffer.hpp>
 #include <gnuradio-4.0/CircularBuffer.hpp>
 #include <gnuradio-4.0/meta/formatter.hpp>
-#include <gnuradio-4.0/meta/utils.hpp>
 #include <gnuradio-4.0/meta/reflection.hpp>
+#include <gnuradio-4.0/meta/utils.hpp>
 
 #include <pmtv/pmt.hpp>
 

--- a/core/include/gnuradio-4.0/Tag.hpp
+++ b/core/include/gnuradio-4.0/Tag.hpp
@@ -6,8 +6,8 @@
 #include <pmtv/pmt.hpp>
 
 #include <gnuradio-4.0/meta/formatter.hpp>
-#include <gnuradio-4.0/meta/utils.hpp>
 #include <gnuradio-4.0/meta/reflection.hpp>
+#include <gnuradio-4.0/meta/utils.hpp>
 
 #ifdef __cpp_lib_hardware_interference_size
 using std::hardware_constructive_interference_size;

--- a/core/include/gnuradio-4.0/plugin.hpp
+++ b/core/include/gnuradio-4.0/plugin.hpp
@@ -32,7 +32,7 @@ public:
     virtual std::uint8_t abi_version() const = 0;
 
     virtual std::span<const std::string_view> providedBlocks() const                                                                    = 0;
-    virtual std::unique_ptr<gr::BlockModel> createBlock(std::string_view name, std::string_view type, const gr::property_map& params) = 0;
+    virtual std::unique_ptr<gr::BlockModel>   createBlock(std::string_view name, std::string_view type, const gr::property_map& params) = 0;
     virtual std::vector<std::string_view>     knownBlockParameterizations(std::string_view block) const                                 = 0;
 };
 

--- a/core/include/gnuradio-4.0/thread/thread_affinity.hpp
+++ b/core/include/gnuradio-4.0/thread/thread_affinity.hpp
@@ -35,7 +35,7 @@ class thread_exception : public std::error_category {
     using std::error_category::error_category;
 
 public:
-    constexpr thread_exception() : std::error_category(){};
+    constexpr thread_exception() : std::error_category() {};
 
     const char* name() const noexcept override { return "thread_exception"; };
 

--- a/core/include/gnuradio-4.0/thread/thread_pool.hpp
+++ b/core/include/gnuradio-4.0/thread/thread_pool.hpp
@@ -28,8 +28,7 @@ namespace detail {
 
 // TODO remove all the below and use std when moved to modules // support code from mpunits for basic_fixed_string
 template<class InputIt1, class InputIt2>
-constexpr bool
-equal(InputIt1 first1, InputIt1 last1, InputIt2 first2) {
+constexpr bool equal(InputIt1 first1, InputIt1 last1, InputIt2 first2) {
     for (; first1 != last1; ++first1, ++first2) {
         if (!(*first1 == *first2)) {
             return false;
@@ -39,23 +38,23 @@ equal(InputIt1 first1, InputIt1 last1, InputIt2 first2) {
 }
 
 template<class I1, class I2, class Cmp>
-constexpr auto
-lexicographical_compare_three_way(I1 f1, I1 l1, I2 f2, I2 l2, Cmp comp) -> decltype(comp(*f1, *f2)) {
+constexpr auto lexicographical_compare_three_way(I1 f1, I1 l1, I2 f2, I2 l2, Cmp comp) -> decltype(comp(*f1, *f2)) {
     using ret_t = decltype(comp(*f1, *f2));
-    static_assert(std::disjunction_v<std::is_same<ret_t, std::strong_ordering>, std::is_same<ret_t, std::weak_ordering>, std::is_same<ret_t, std::partial_ordering>>,
-                  "The return type must be a comparison category type.");
+    static_assert(std::disjunction_v<std::is_same<ret_t, std::strong_ordering>, std::is_same<ret_t, std::weak_ordering>, std::is_same<ret_t, std::partial_ordering>>, "The return type must be a comparison category type.");
 
     bool exhaust1 = (f1 == l1);
     bool exhaust2 = (f2 == l2);
-    for (; !exhaust1 && !exhaust2; exhaust1 = (++f1 == l1), exhaust2 = (++f2 == l2))
-        if (auto c = comp(*f1, *f2); c != 0) return c;
+    for (; !exhaust1 && !exhaust2; exhaust1 = (++f1 == l1), exhaust2 = (++f2 == l2)) {
+        if (auto c = comp(*f1, *f2); c != 0) {
+            return c;
+        }
+    }
 
     return !exhaust1 ? std::strong_ordering::greater : !exhaust2 ? std::strong_ordering::less : std::strong_ordering::equal;
 }
 
 template<class I1, class I2>
-constexpr auto
-lexicographical_compare_three_way(I1 f1, I1 l1, I2 f2, I2 l2) {
+constexpr auto lexicographical_compare_three_way(I1 f1, I1 l1, I2 f2, I2 l2) {
     return lexicographical_compare_three_way(f1, l1, f2, l2, std::compare_three_way());
 }
 
@@ -68,94 +67,69 @@ lexicographical_compare_three_way(I1 f1, I1 l1, I2 f2, I2 l2) {
  */
 template<typename CharT, std::size_t N>
 struct basic_fixed_string {
-    CharT data_[N + 1]   = {};
+    CharT data_[N + 1] = {};
 
-    using iterator       = CharT *;
-    using const_iterator = const CharT *;
+    using iterator       = CharT*;
+    using const_iterator = const CharT*;
 
     constexpr explicit(false) basic_fixed_string(CharT ch) noexcept { data_[0] = ch; }
 
     constexpr explicit(false) basic_fixed_string(const CharT (&txt)[N + 1]) noexcept {
-        if constexpr (N != 0)
-            for (std::size_t i = 0; i < N; ++i) data_[i] = txt[i];
+        if constexpr (N != 0) {
+            for (std::size_t i = 0; i < N; ++i) {
+                data_[i] = txt[i];
+            }
+        }
     }
 
-    [[nodiscard]] constexpr bool
-    empty() const noexcept {
-        return N == 0;
-    }
+    [[nodiscard]] constexpr bool empty() const noexcept { return N == 0; }
 
-    [[nodiscard]] constexpr std::size_t
-    size() const noexcept {
-        return N;
-    }
+    [[nodiscard]] constexpr std::size_t size() const noexcept { return N; }
 
-    [[nodiscard]] constexpr const CharT *
-    data() const noexcept {
-        return data_;
-    }
+    [[nodiscard]] constexpr const CharT* data() const noexcept { return data_; }
 
-    [[nodiscard]] constexpr const CharT *
-    c_str() const noexcept {
-        return data();
-    }
+    [[nodiscard]] constexpr const CharT* c_str() const noexcept { return data(); }
 
-    [[nodiscard]] constexpr const CharT &
-    operator[](std::size_t index) const noexcept {
-        return data()[index];
-    }
+    [[nodiscard]] constexpr const CharT& operator[](std::size_t index) const noexcept { return data()[index]; }
 
-    [[nodiscard]] constexpr CharT
-    operator[](std::size_t index) noexcept {
-        return data()[index];
-    }
+    [[nodiscard]] constexpr CharT operator[](std::size_t index) noexcept { return data()[index]; }
 
-    [[nodiscard]] constexpr iterator
-    begin() noexcept {
-        return data();
-    }
+    [[nodiscard]] constexpr iterator begin() noexcept { return data(); }
 
-    [[nodiscard]] constexpr const_iterator
-    begin() const noexcept {
-        return data();
-    }
+    [[nodiscard]] constexpr const_iterator begin() const noexcept { return data(); }
 
-    [[nodiscard]] constexpr iterator
-    end() noexcept {
-        return data() + size();
-    }
+    [[nodiscard]] constexpr iterator end() noexcept { return data() + size(); }
 
-    [[nodiscard]] constexpr const_iterator
-    end() const noexcept {
-        return data() + size();
-    }
+    [[nodiscard]] constexpr const_iterator end() const noexcept { return data() + size(); }
 
     template<std::size_t N2>
-    [[nodiscard]] constexpr friend basic_fixed_string<CharT, N + N2>
-    operator+(const basic_fixed_string &lhs, const basic_fixed_string<CharT, N2> &rhs) noexcept {
+    [[nodiscard]] constexpr friend basic_fixed_string<CharT, N + N2> operator+(const basic_fixed_string& lhs, const basic_fixed_string<CharT, N2>& rhs) noexcept {
         CharT txt[N + N2 + 1] = {};
 
-        for (size_t i = 0; i != N; ++i) txt[i] = lhs[i];
-        for (size_t i = 0; i != N2; ++i) txt[N + i] = rhs[i];
+        for (size_t i = 0; i != N; ++i) {
+            txt[i] = lhs[i];
+        }
+        for (size_t i = 0; i != N2; ++i) {
+            txt[N + i] = rhs[i];
+        }
 
         return basic_fixed_string<CharT, N + N2>(txt);
     }
 
-    [[nodiscard]] constexpr bool
-    operator==(const basic_fixed_string &other) const {
-        if (size() != other.size()) return false;
+    [[nodiscard]] constexpr bool operator==(const basic_fixed_string& other) const {
+        if (size() != other.size()) {
+            return false;
+        }
         return detail::equal(begin(), end(), other.begin()); // TODO std::ranges::equal(*this, other)
     }
 
     template<std::size_t N2>
-    [[nodiscard]] friend constexpr bool
-    operator==(const basic_fixed_string &, const basic_fixed_string<CharT, N2> &) {
+    [[nodiscard]] friend constexpr bool operator==(const basic_fixed_string&, const basic_fixed_string<CharT, N2>&) {
         return false;
     }
 
     template<std::size_t N2>
-    [[nodiscard]] friend constexpr auto
-    operator<=>(const basic_fixed_string &lhs, const basic_fixed_string<CharT, N2> &rhs) {
+    [[nodiscard]] friend constexpr auto operator<=>(const basic_fixed_string& lhs, const basic_fixed_string<CharT, N2>& rhs) {
         // TODO std::lexicographical_compare_three_way(lhs.begin(), lhs.end(), rhs.begin(), rhs.end());
         return detail::lexicographical_compare_three_way(lhs.begin(), lhs.end(), rhs.begin(), rhs.end());
     }
@@ -176,35 +150,32 @@ using fixed_string = basic_fixed_string<char, N>;
  * https://en.cppreference.com/w/cpp/utility/functional/move_only_function/move_only_function
  */
 class move_only_function {
-    using FunPtr            = std::unique_ptr<void, void (*)(void *)>;
-    FunPtr _erased_fun      = { nullptr, [](void *) {} };
-    void   (*_call)(void *) = nullptr;
+    using FunPtr         = std::unique_ptr<void, void (*)(void*)>;
+    FunPtr _erased_fun   = {nullptr, [](void*) {}};
+    void (*_call)(void*) = nullptr;
 
 public:
     constexpr move_only_function() = default;
 
     template<typename F>
-        requires(!std::same_as<move_only_function, std::remove_cvref<F>> && !std::is_reference_v<F>)
-    constexpr move_only_function(F &&fun) : _erased_fun(new F(std::forward<F>(fun)), [](void *ptr) { delete static_cast<F *>(ptr); }), _call([](void *ptr) { (*static_cast<F *>(ptr))(); }) {}
+    requires(!std::same_as<move_only_function, std::remove_cvref<F>> && !std::is_reference_v<F>)
+    constexpr move_only_function(F&& fun) : _erased_fun(new F(std::forward<F>(fun)), [](void* ptr) { delete static_cast<F*>(ptr); }), _call([](void* ptr) { (*static_cast<F*>(ptr))(); }) {}
 
     template<typename F>
-        requires(!std::is_reference_v<F>)
-    constexpr move_only_function &
-    operator=(F &&fun) {
-        _erased_fun = FunPtr(new F(std::forward<F>(fun)), [](void *ptr) { delete static_cast<F *>(ptr); });
-        _call       = [](void *ptr) { (*static_cast<F *>(ptr))(); };
+    requires(!std::is_reference_v<F>)
+    constexpr move_only_function& operator=(F&& fun) {
+        _erased_fun = FunPtr(new F(std::forward<F>(fun)), [](void* ptr) { delete static_cast<F*>(ptr); });
+        _call       = [](void* ptr) { (*static_cast<F*>(ptr))(); };
         return *this;
     }
 
-    constexpr void
-    operator()() {
+    constexpr void operator()() {
         if (_call) {
             _call(_erased_fun.get());
         }
     }
 
-    constexpr void
-    operator()() const {
+    constexpr void operator()() const {
         if (_call) {
             _call(_erased_fun.get());
         }
@@ -218,16 +189,10 @@ struct Task {
     int32_t            priority = 0;
     int32_t            cpuID    = -1;
 
-    std::weak_ordering
-    operator<=>(const Task &other) const noexcept {
-        return priority <=> other.priority;
-    }
+    std::weak_ordering operator<=>(const Task& other) const noexcept { return priority <=> other.priority; }
 
     // We want to reuse objects to avoid reallocations
-    void
-    reset() noexcept {
-        *this = Task();
-    }
+    void reset() noexcept { *this = Task(); }
 };
 
 template<bool lock, typename... Args>
@@ -237,7 +202,7 @@ struct conditional_lock : public std::scoped_lock<Args...> {
 
 template<typename... Args>
 struct conditional_lock<false, Args...> {
-    conditional_lock(const Args &...){};
+    conditional_lock(const Args&...) {};
 };
 
 class TaskQueue {
@@ -247,47 +212,42 @@ public:
 private:
     mutable gr::AtomicMutex<> _mutex;
 
-    TaskContainer             _tasks;
+    TaskContainer _tasks;
 
     template<bool shouldLock>
     using conditional_lock = conditional_lock<shouldLock, gr::AtomicMutex<>>;
 
 public:
-    TaskQueue()                       = default;
-    TaskQueue(const TaskQueue &queue) = delete;
-    TaskQueue &
-    operator=(const TaskQueue &queue)
-            = delete;
+    TaskQueue()                                  = default;
+    TaskQueue(const TaskQueue& queue)            = delete;
+    TaskQueue& operator=(const TaskQueue& queue) = delete;
 
     ~TaskQueue() { clear(); }
 
     template<bool shouldLock = true>
-    void
-    clear() {
+    void clear() {
         conditional_lock<shouldLock> lock(_mutex);
         _tasks.clear();
     }
 
     template<bool shouldLock = true>
-    std::size_t
-    size() const {
+    std::size_t size() const {
         conditional_lock<shouldLock> lock(_mutex);
         return _tasks.size();
     }
 
     template<bool shouldLock = true>
-    void
-    push(TaskContainer jobContainer) {
+    void push(TaskContainer jobContainer) {
         conditional_lock<shouldLock> lock(_mutex);
         assert(!jobContainer.empty());
-        auto      &job                = jobContainer.front();
+        auto&      job                = jobContainer.front();
         const auto currentJobPriority = job.priority;
 
-        const auto insertPosition     = [&] {
+        const auto insertPosition = [&] {
             if (currentJobPriority == 0) {
                 return _tasks.end();
             } else {
-                return std::find_if(_tasks.begin(), _tasks.end(), [currentJobPriority](const auto &task) { return task.priority < currentJobPriority; });
+                return std::find_if(_tasks.begin(), _tasks.end(), [currentJobPriority](const auto& task) { return task.priority < currentJobPriority; });
             }
         }();
 
@@ -295,8 +255,7 @@ public:
     }
 
     template<bool shouldLock = true>
-    TaskContainer
-    pop() {
+    TaskContainer pop() {
         conditional_lock<shouldLock> lock(_mutex);
         TaskContainer                result;
         if (!_tasks.empty()) {
@@ -313,7 +272,7 @@ class TaskQueue;
 enum TaskType { IO_BOUND = 0, CPU_BOUND = 1 };
 
 template<typename T>
-concept ThreadPool = requires(T t, std::function<void()> &&func) {
+concept ThreadPool = requires(T t, std::function<void()>&& func) {
     { t.execute(std::move(func)) } -> std::same_as<void>;
 };
 
@@ -370,13 +329,10 @@ class BasicThreadPool {
     static std::atomic<uint64_t> _globalPoolId;
     static std::atomic<uint64_t> _taskID;
 
-    static std::string
-    generateName() {
-        return fmt::format("BasicThreadPool#{}", _globalPoolId.fetch_add(1));
-    }
+    static std::string generateName() { return fmt::format("BasicThreadPool#{}", _globalPoolId.fetch_add(1)); }
 
-    std::atomic_bool        _initialised = ATOMIC_FLAG_INIT;
-    std::atomic_bool        _shutdown    = false;
+    std::atomic_bool _initialised = ATOMIC_FLAG_INIT;
+    std::atomic_bool _shutdown    = false;
 
     std::condition_variable _condition;
     std::atomic_size_t      _numTaskedQueued = 0U; // cache for _taskQueue.size()
@@ -384,26 +340,24 @@ class BasicThreadPool {
     TaskQueue               _taskQueue;
     TaskQueue               _recycledTasks;
 
-    std::mutex              _threadListMutex;
-    std::atomic_size_t      _numThreads = 0U;
-    std::list<std::thread>  _threads;
+    std::mutex             _threadListMutex;
+    std::atomic_size_t     _numThreads = 0U;
+    std::list<std::thread> _threads;
 
-    std::vector<bool>       _affinityMask;
-    thread::Policy          _schedulingPolicy   = thread::Policy::OTHER;
-    int                     _schedulingPriority = 0;
+    std::vector<bool> _affinityMask;
+    thread::Policy    _schedulingPolicy   = thread::Policy::OTHER;
+    int               _schedulingPriority = 0;
 
-    const std::string       _poolName;
-    const TaskType          _taskType;
-    const uint32_t          _minThreads;
-    const uint32_t          _maxThreads;
+    const std::string _poolName;
+    const TaskType    _taskType;
+    const uint32_t    _minThreads;
+    const uint32_t    _maxThreads;
 
 public:
     std::chrono::microseconds sleepDuration     = std::chrono::milliseconds(1);
     std::chrono::milliseconds keepAliveDuration = std::chrono::seconds(10);
 
-    BasicThreadPool(const std::string_view &name = generateName(), const TaskType taskType = TaskType::CPU_BOUND, uint32_t min = std::thread::hardware_concurrency(),
-                    uint32_t max = std::thread::hardware_concurrency())
-        : _poolName(name), _taskType(taskType), _minThreads(std::min(min, max)), _maxThreads(max) {
+    BasicThreadPool(const std::string_view& name = generateName(), const TaskType taskType = TaskType::CPU_BOUND, uint32_t min = std::thread::hardware_concurrency(), uint32_t max = std::thread::hardware_concurrency()) : _poolName(name), _taskType(taskType), _minThreads(std::min(min, max)), _maxThreads(max) {
         assert(min > 0 && "minimum number of threads must be > 0");
         for (uint32_t i = 0; i < _minThreads; ++i) {
             createWorkerThread();
@@ -413,106 +367,60 @@ public:
     ~BasicThreadPool() {
         _shutdown = true;
         _condition.notify_all();
-        for (auto &t : _threads) {
+        for (auto& t : _threads) {
             t.join();
         }
     }
 
-    BasicThreadPool(const BasicThreadPool &) = delete;
-    BasicThreadPool(BasicThreadPool &&)      = delete;
-    BasicThreadPool &
-    operator=(const BasicThreadPool &)
-            = delete;
-    BasicThreadPool &
-    operator=(BasicThreadPool &&)
-            = delete;
+    BasicThreadPool(const BasicThreadPool&)            = delete;
+    BasicThreadPool(BasicThreadPool&&)                 = delete;
+    BasicThreadPool& operator=(const BasicThreadPool&) = delete;
+    BasicThreadPool& operator=(BasicThreadPool&&)      = delete;
 
-    [[nodiscard]] std::string
-    poolName() const noexcept {
-        return _poolName;
-    }
+    [[nodiscard]] std::string poolName() const noexcept { return _poolName; }
 
-    [[nodiscard]] uint32_t
-    minThreads() const noexcept {
-        return _minThreads;
-    };
+    [[nodiscard]] uint32_t minThreads() const noexcept { return _minThreads; };
 
-    [[nodiscard]] uint32_t
-    maxThreads() const noexcept {
-        return _maxThreads;
-    };
+    [[nodiscard]] uint32_t maxThreads() const noexcept { return _maxThreads; };
 
-    [[nodiscard]] std::size_t
-    numThreads() const noexcept {
-        return std::atomic_load_explicit(&_numThreads, std::memory_order_acquire);
-    }
+    [[nodiscard]] std::size_t numThreads() const noexcept { return std::atomic_load_explicit(&_numThreads, std::memory_order_acquire); }
 
-    [[nodiscard]] std::size_t
-    numTasksRunning() const noexcept {
-        return std::atomic_load_explicit(&_numTasksRunning, std::memory_order_acquire);
-    }
+    [[nodiscard]] std::size_t numTasksRunning() const noexcept { return std::atomic_load_explicit(&_numTasksRunning, std::memory_order_acquire); }
 
-    [[nodiscard]] std::size_t
-    numTasksQueued() const {
-        return std::atomic_load_explicit(&_numTaskedQueued, std::memory_order_acquire);
-    }
+    [[nodiscard]] std::size_t numTasksQueued() const { return std::atomic_load_explicit(&_numTaskedQueued, std::memory_order_acquire); }
 
-    [[nodiscard]] std::size_t
-    numTasksRecycled() const {
-        return _recycledTasks.size();
-    }
+    [[nodiscard]] std::size_t numTasksRecycled() const { return _recycledTasks.size(); }
 
-    [[nodiscard]] bool
-    isInitialised() const {
-        return _initialised.load(std::memory_order::acquire);
-    }
+    [[nodiscard]] bool isInitialised() const { return _initialised.load(std::memory_order::acquire); }
 
-    void
-    waitUntilInitialised() const {
-        _initialised.wait(false);
-    }
+    void waitUntilInitialised() const { _initialised.wait(false); }
 
-    void
-    requestShutdown() {
+    void requestShutdown() {
         _shutdown = true;
         _condition.notify_all();
-        for (auto &t : _threads) {
+        for (auto& t : _threads) {
             t.join();
         }
     }
 
-    [[nodiscard]] bool
-    isShutdown() const {
-        return _shutdown;
-    }
+    [[nodiscard]] bool isShutdown() const { return _shutdown; }
 
     //
 
-    [[nodiscard]] std::vector<bool>
-    getAffinityMask() const {
-        return _affinityMask;
-    }
+    [[nodiscard]] std::vector<bool> getAffinityMask() const { return _affinityMask; }
 
-    void
-    setAffinityMask(const std::vector<bool> &threadAffinityMask) {
+    void setAffinityMask(const std::vector<bool>& threadAffinityMask) {
         _affinityMask.clear();
         std::copy(threadAffinityMask.begin(), threadAffinityMask.end(), std::back_inserter(_affinityMask));
         cleanupFinishedThreads();
         updateThreadConstraints();
     }
 
-    [[nodiscard]] auto
-    getSchedulingPolicy() const {
-        return _schedulingPolicy;
-    }
+    [[nodiscard]] auto getSchedulingPolicy() const { return _schedulingPolicy; }
 
-    [[nodiscard]] auto
-    getSchedulingPriority() const {
-        return _schedulingPriority;
-    }
+    [[nodiscard]] auto getSchedulingPriority() const { return _schedulingPriority; }
 
-    void
-    setThreadSchedulingPolicy(const thread::Policy schedulingPolicy = thread::Policy::OTHER, const int schedulingPriority = 0) {
+    void setThreadSchedulingPolicy(const thread::Policy schedulingPolicy = thread::Policy::OTHER, const int schedulingPriority = 0) {
         _schedulingPolicy   = schedulingPolicy;
         _schedulingPriority = schedulingPriority;
         cleanupFinishedThreads();
@@ -521,14 +429,12 @@ public:
 
     // TODO: Do we need support for cancellation?
     template<const detail::basic_fixed_string taskName = "", uint32_t priority = 0, int32_t cpuID = -1, std::invocable Callable, typename... Args, typename R = std::invoke_result_t<Callable, Args...>>
-        requires(std::is_same_v<R, void>)
-    void
-    execute(Callable &&func, Args &&...args) {
+    requires(std::is_same_v<R, void>)
+    void execute(Callable&& func, Args&&... args) {
         static thread_local gr::SpinWait spinWait;
         if constexpr (cpuID >= 0) {
             if (cpuID >= _affinityMask.size() || (cpuID >= 0 && !_affinityMask[cpuID])) {
-                throw std::invalid_argument(
-                        fmt::format("requested cpuID {} incompatible with set affinity mask({}): [{}]", cpuID, _affinityMask.size(), fmt::join(_affinityMask.begin(), _affinityMask.end(), ", ")));
+                throw std::invalid_argument(fmt::format("requested cpuID {} incompatible with set affinity mask({}): [{}]", cpuID, _affinityMask.size(), fmt::join(_affinityMask.begin(), _affinityMask.end(), ", ")));
             }
         }
         _numTaskedQueued.fetch_add(1U);
@@ -551,9 +457,8 @@ public:
     }
 
     template<const detail::basic_fixed_string taskName = "", uint32_t priority = 0, int32_t cpuID = -1, std::invocable Callable, typename... Args, typename R = std::invoke_result_t<Callable, Args...>>
-        requires(!std::is_same_v<R, void>)
-    [[nodiscard]] std::future<R>
-    execute(Callable &&func, Args &&...funcArgs) {
+    requires(!std::is_same_v<R, void>)
+    [[nodiscard]] std::future<R> execute(Callable&& func, Args&&... funcArgs) {
         if constexpr (cpuID >= 0) {
             if (cpuID >= _affinityMask.size() || (cpuID >= 0 && !_affinityMask[cpuID])) {
 #ifdef _LIBCPP_VERSION
@@ -577,8 +482,7 @@ public:
     }
 
 private:
-    void
-    cleanupFinishedThreads() {
+    void cleanupFinishedThreads() {
         std::scoped_lock lock(_threadListMutex);
         // TODO:
         // (C++Ref) A thread that has finished executing code, but has not yet been
@@ -587,16 +491,14 @@ private:
         // std::erase_if(_threads, [](auto &thread) { return !thread.joinable(); });
     }
 
-    void
-    updateThreadConstraints() {
+    void updateThreadConstraints() {
         std::scoped_lock lock(_threadListMutex);
         // std::erase_if(_threads, [](auto &thread) { return !thread.joinable(); });
 
-        std::for_each(_threads.begin(), _threads.end(), [this, threadID = std::size_t{ 0 }](auto &thread) mutable { this->updateThreadConstraints(threadID++, thread); });
+        std::for_each(_threads.begin(), _threads.end(), [this, threadID = std::size_t{0}](auto& thread) mutable { this->updateThreadConstraints(threadID++, thread); });
     }
 
-    void
-    updateThreadConstraints(const std::size_t threadID, std::thread &thread) const {
+    void updateThreadConstraints(const std::size_t threadID, std::thread& thread) const {
         thread::setThreadName(fmt::format("{}#{}", _poolName, threadID), thread);
         thread::setThreadSchedulingParameter(_schedulingPolicy, _schedulingPriority, thread);
         if (!_affinityMask.empty()) {
@@ -610,8 +512,7 @@ private:
         }
     }
 
-    std::vector<bool>
-    distributeThreadAffinityAcrossCores(const std::vector<bool> &globalAffinityMask, const std::size_t threadID) const {
+    std::vector<bool> distributeThreadAffinityAcrossCores(const std::vector<bool>& globalAffinityMask, const std::size_t threadID) const {
         if (globalAffinityMask.empty()) {
             return {};
         }
@@ -627,27 +528,25 @@ private:
         return affinityMask;
     }
 
-    void
-    createWorkerThread() {
+    void createWorkerThread() {
         std::scoped_lock  lock(_threadListMutex);
         const std::size_t nThreads = numThreads();
-        std::thread      &thread   = _threads.emplace_back(&BasicThreadPool::worker, this);
+        std::thread&      thread   = _threads.emplace_back(&BasicThreadPool::worker, this);
         updateThreadConstraints(nThreads + 1, thread);
     }
 
     template<const detail::basic_fixed_string taskName = "", uint32_t priority = 0, int32_t cpuID = -1, std::invocable Callable, typename... Args>
-    auto
-    createTask(Callable &&func, Args &&...funcArgs) {
-        const auto getTask = [&recycledTasks = _recycledTasks](Callable &&f, Args &&...args) {
+    auto createTask(Callable&& func, Args&&... funcArgs) {
+        const auto getTask = [&recycledTasks = _recycledTasks](Callable&& f, Args&&... args) {
             auto extracted = recycledTasks.pop();
             if (extracted.empty()) {
                 if constexpr (sizeof...(Args) == 0) {
-                    extracted.push_front(Task{ .id = _taskID.fetch_add(1U) + 1U, .func = std::move(f) });
+                    extracted.push_front(Task{.id = _taskID.fetch_add(1U) + 1U, .func = std::move(f)});
                 } else {
-                    extracted.push_front(Task{ .id = _taskID.fetch_add(1U) + 1U, .func = std::move(std::bind_front(std::forward<decltype(func)>(f), std::forward<decltype(func)>(args)...)) });
+                    extracted.push_front(Task{.id = _taskID.fetch_add(1U) + 1U, .func = std::move(std::bind_front(std::forward<decltype(func)>(f), std::forward<decltype(func)>(args)...))});
                 }
             } else {
-                auto &task = extracted.front();
+                auto& task = extracted.front();
                 task.id    = _taskID.fetch_add(1U) + 1U;
                 if constexpr (sizeof...(Args) == 0) {
                     task.func = std::move(f);
@@ -659,7 +558,7 @@ private:
         };
 
         auto  taskContainer = getTask(std::forward<decltype(func)>(func), std::forward<decltype(func)>(funcArgs)...);
-        auto &task          = taskContainer.front();
+        auto& task          = taskContainer.front();
 
         if constexpr (!taskName.empty()) {
             task.name = taskName.c_str();
@@ -670,8 +569,7 @@ private:
         return taskContainer;
     }
 
-    TaskQueue::TaskContainer
-    popTask() {
+    TaskQueue::TaskContainer popTask() {
         auto result = _taskQueue.pop();
         if (!result.empty()) {
             _numTaskedQueued.fetch_sub(1U);
@@ -679,8 +577,7 @@ private:
         return result;
     }
 
-    void
-    worker() {
+    void worker() {
         constexpr uint32_t N_SPIN       = 1 << 8;
         uint32_t           noop_counter = 0;
         const auto         threadID     = _numThreads.fetch_add(1);
@@ -697,7 +594,7 @@ private:
         do {
             if (TaskQueue::TaskContainer currentTaskContainer = popTask(); !currentTaskContainer.empty()) {
                 assert(!currentTaskContainer.empty());
-                auto &currentTask = currentTaskContainer.front();
+                auto& currentTask = currentTaskContainer.front();
                 _numTasksRunning.fetch_add(1);
                 bool nameSet = !(currentTask.name.empty());
                 if (nameSet) {

--- a/core/test/plugins/bad_plugin.cpp
+++ b/core/test/plugins/bad_plugin.cpp
@@ -3,22 +3,16 @@
 #include <gnuradio-4.0/plugin.hpp>
 
 namespace {
-gr_plugin_metadata plugin_metadata [[maybe_unused]]{ "Bad Plugin", "Unknown", "Public Domain", "v0" };
+gr_plugin_metadata plugin_metadata [[maybe_unused]]{"Bad Plugin", "Unknown", "Public Domain", "v0"};
 
 class bad_plugin : public gr_plugin_base {
 private:
     std::vector<std::string_view> block_types;
 
 public:
-    std::unique_ptr<gr::BlockModel>
-    createBlock(std::string_view /*name*/, std::string_view /*type*/, const gr::property_map &) override {
-        return {};
-    }
+    std::unique_ptr<gr::BlockModel> createBlock(std::string_view /*name*/, std::string_view /*type*/, const gr::property_map&) override { return {}; }
 
-    [[nodiscard]] std::uint8_t
-    abi_version() const override {
-        return 0;
-    }
+    [[nodiscard]] std::uint8_t abi_version() const override { return 0; }
 
     [[nodiscard]] std::span<const std::string_view> providedBlocks() const override { return block_types; }
 };
@@ -26,13 +20,7 @@ public:
 } // namespace
 
 extern "C" {
-void GNURADIO_PLUGIN_EXPORT
-gr_plugin_make(gr_plugin_base **plugin) {
-    *plugin = nullptr;
-}
+void GNURADIO_PLUGIN_EXPORT gr_plugin_make(gr_plugin_base** plugin) { *plugin = nullptr; }
 
-void GNURADIO_PLUGIN_EXPORT
-gr_plugin_free(gr_plugin_base *plugin) {
-    delete plugin;
-}
+void GNURADIO_PLUGIN_EXPORT gr_plugin_free(gr_plugin_base* plugin) { delete plugin; }
 }

--- a/core/test/plugins/good_conversion_plugin.cpp
+++ b/core/test/plugins/good_conversion_plugin.cpp
@@ -15,10 +15,7 @@ public:
 
     GR_MAKE_REFLECTABLE(convert, in, out);
 
-    [[nodiscard]] constexpr auto
-    processOne(From value) const noexcept {
-        return static_cast<To>(value);
-    }
+    [[nodiscard]] constexpr auto processOne(From value) const noexcept { return static_cast<To>(value); }
 };
 
 } // namespace good

--- a/core/test/plugins/good_math_plugin.cpp
+++ b/core/test/plugins/good_math_plugin.cpp
@@ -8,12 +8,11 @@ GR_PLUGIN("Good Math Plugin", "Unknown", "LGPL3", "v1")
 namespace good {
 
 template<typename T>
-auto
-factor(const gr::property_map &params) {
+auto factor(const gr::property_map& params) {
     T factor = 1;
     if (auto it = params.find("factor"s); it != params.end()) {
-        auto &variant = it->second;
-        auto *ptr     = std::get_if<T>(&variant);
+        auto& variant = it->second;
+        auto* ptr     = std::get_if<T>(&variant);
         if (ptr) {
             factor = *ptr;
         }
@@ -32,7 +31,7 @@ public:
 
     math_base() = delete;
 
-    explicit math_base(const gr::property_map &params) : _factor(factor<T>(params)) {}
+    explicit math_base(const gr::property_map& params) : _factor(factor<T>(params)) {}
 };
 
 template<typename T>
@@ -45,8 +44,7 @@ public:
     GR_MAKE_REFLECTABLE(multiply, in, out);
 
     template<gr::meta::t_or_simd<T> V>
-    [[nodiscard]] constexpr auto
-    processOne(const V &a) const noexcept {
+    [[nodiscard]] constexpr auto processOne(const V& a) const noexcept {
         return a * math_base<T>::_factor;
     }
 };
@@ -61,8 +59,7 @@ public:
     GR_MAKE_REFLECTABLE(divide, in, out);
 
     template<gr::meta::t_or_simd<T> V>
-    [[nodiscard]] constexpr auto
-    processOne(const V &a) const noexcept {
+    [[nodiscard]] constexpr auto processOne(const V& a) const noexcept {
         return a / math_base<T>::_factor;
     }
 };

--- a/core/test/qa_LifeCycle.cpp
+++ b/core/test/qa_LifeCycle.cpp
@@ -33,36 +33,25 @@ struct MockStateMachine : public lifecycle::StateMachine<MockStateMachine<storag
     int         resumeCalled{};
     int         resetCalled{};
 
-    void
-    start() {
+    void start() {
         startCalled++;
         if constexpr (throwException) { // throw voluntary exception
             throw std::domain_error("start() throws specific exception");
         }
     }
 
-    void
-    stop() {
+    void stop() {
         stopCalled++;
         if constexpr (throwException) { // throw voluntary unknown exception
             throw "unknown/unnamed exception";
         }
     }
 
-    void
-    pause() {
-        pauseCalled++;
-    }
+    void pause() { pauseCalled++; }
 
-    void
-    resume() {
-        resumeCalled++;
-    }
+    void resume() { resumeCalled++; }
 
-    void
-    reset() {
-        resetCalled++;
-    }
+    void reset() { resetCalled++; }
 };
 
 } // namespace gr::test
@@ -139,14 +128,14 @@ const boost::ut::suite StateMachineTest = [] {
 
     "StateMachine all State transitions"_test = [] {
         std::map<State, std::vector<State>> allowedTransitions = {
-            { State::IDLE, { State::INITIALISED, State::REQUESTED_STOP, State::STOPPED } },
-            { State::INITIALISED, { State::RUNNING, State::REQUESTED_STOP, State::STOPPED } },
-            { State::RUNNING, { State::REQUESTED_PAUSE, State::REQUESTED_STOP } },
-            { State::REQUESTED_PAUSE, { State::PAUSED } },
-            { State::PAUSED, { State::RUNNING, State::REQUESTED_STOP } },
-            { State::REQUESTED_STOP, { State::STOPPED } },
-            { State::STOPPED, { State::INITIALISED } },
-            { State::ERROR, { State::INITIALISED } },
+            {State::IDLE, {State::INITIALISED, State::REQUESTED_STOP, State::STOPPED}},
+            {State::INITIALISED, {State::RUNNING, State::REQUESTED_STOP, State::STOPPED}},
+            {State::RUNNING, {State::REQUESTED_PAUSE, State::REQUESTED_STOP}},
+            {State::REQUESTED_PAUSE, {State::PAUSED}},
+            {State::PAUSED, {State::RUNNING, State::REQUESTED_STOP}},
+            {State::REQUESTED_STOP, {State::STOPPED}},
+            {State::STOPPED, {State::INITIALISED}},
+            {State::ERROR, {State::INITIALISED}},
         };
 
         magic_enum::enum_for_each<State>([&allowedTransitions](State fromState) {
@@ -161,8 +150,7 @@ const boost::ut::suite StateMachineTest = [] {
                 bool isValid = isValidTransition(fromState, toState);
 
                 // Assert that the function's validity matches the expected validity
-                expect(isValid == isAllowed) << fmt::format("Transition from {} to {} should be {}", magic_enum::enum_name(fromState), magic_enum::enum_name(toState),
-                                                            isAllowed ? "allowed" : "disallowed");
+                expect(isValid == isAllowed) << fmt::format("Transition from {} to {} should be {}", magic_enum::enum_name(fromState), magic_enum::enum_name(toState), isAllowed ? "allowed" : "disallowed");
             });
         });
     };
@@ -195,7 +183,7 @@ const boost::ut::suite StateMachineTest = [] {
 
     "StateMachine misc"_test = [] {
         magic_enum::enum_for_each<State>([&](State state) {
-            std::vector<State> allowedState{ RUNNING, REQUESTED_PAUSE, PAUSED };
+            std::vector<State> allowedState{RUNNING, REQUESTED_PAUSE, PAUSED};
 
             if (std::ranges::find(allowedState, state) != allowedState.end()) {
                 expect(isActive(state));
@@ -205,7 +193,7 @@ const boost::ut::suite StateMachineTest = [] {
         });
 
         magic_enum::enum_for_each<State>([&](State state) {
-            std::vector<State> allowedState{ REQUESTED_STOP, STOPPED };
+            std::vector<State> allowedState{REQUESTED_STOP, STOPPED};
 
             if (std::ranges::find(allowedState, state) != allowedState.end()) {
                 expect(isShuttingDown(state));
@@ -236,10 +224,7 @@ const boost::ut::suite StateMachineTest = [] {
         struct MockStateMachine : public gr::lifecycle::StateMachine<void> {
             int startCalled{};
 
-            void
-            start() {
-                startCalled++;
-            }
+            void start() { startCalled++; }
         } machine;
 
         expect(machine.state() == State::IDLE);
@@ -280,6 +265,4 @@ const boost::ut::suite StateMachineTest = [] {
     };
 };
 
-int
-main() { /* tests are statically executed */
-}
+int main() { /* tests are statically executed */ }

--- a/core/test/qa_Port.cpp
+++ b/core/test/qa_Port.cpp
@@ -69,13 +69,7 @@ const boost::ut::suite PortTests = [] {
         { // partial consume
             auto data = in.get<SpanReleasePolicy::ProcessAll>(6);
             expect(std::ranges::equal(data.rawTags, std::vector<gr::Tag>{{-1, {{"id", "tag@-1"}, {"id0", true}}}, {1, {{"id", "tag@101"}, {"id1", true}}}, {3, {{"id", "tag@103"}, {"id3", true}}}, {4, {{"id", "tag@104"}, {"id4", true}}}, {5, {{"id", "tag@105"}, {"id5", true}}}}));
-            expect(equalTags(data.tags(), std::vector{
-                std::make_pair(0L, gr::property_map{{"id", "tag@-1"}, {"id0", true}}),
-                std::make_pair(1L, gr::property_map{{"id", "tag@101"}, {"id1", true}}),
-                std::make_pair(3L, gr::property_map{{"id", "tag@103"}, {"id3", true}}),
-                std::make_pair(4L, gr::property_map{{"id", "tag@104"}, {"id4", true}}),
-                std::make_pair(5L, gr::property_map{{"id", "tag@105"}, {"id5", true}})
-            }));
+            expect(equalTags(data.tags(), std::vector{std::make_pair(0L, gr::property_map{{"id", "tag@-1"}, {"id0", true}}), std::make_pair(1L, gr::property_map{{"id", "tag@101"}, {"id1", true}}), std::make_pair(3L, gr::property_map{{"id", "tag@103"}, {"id3", true}}), std::make_pair(4L, gr::property_map{{"id", "tag@104"}, {"id4", true}}), std::make_pair(5L, gr::property_map{{"id", "tag@105"}, {"id5", true}})}));
             expect(std::ranges::equal(data, std::views::iota(100) | std::views::take(6)));
             expect(data.getMergedTag() == gr::Tag{-1, {{"id", "tag@-1"}, {"id0", true}}});
             expect(data.consume(3));
@@ -97,7 +91,7 @@ const boost::ut::suite PortTests = [] {
         { // get last sample
             auto data = in.get<SpanReleasePolicy::ProcessAll>(1);
             expect(std::ranges::equal(data.rawTags, std::vector<gr::Tag>{{4, {{"id", "tag@104"}, {"id4", true}}}, {5, {{"id", "tag@105"}, {"id5", true}}}}));
-            expect(equalTags(data.tags(), std::vector{std::make_pair(-1L, gr::property_map{{"id", "tag@104"}, {"id4", true}}), std::make_pair(0L, property_map {{"id", "tag@105"}, {"id5", true}})}));
+            expect(equalTags(data.tags(), std::vector{std::make_pair(-1L, gr::property_map{{"id", "tag@104"}, {"id4", true}}), std::make_pair(0L, property_map{{"id", "tag@105"}, {"id5", true}})}));
             expect(std::ranges::equal(data, std::views::iota(100) | std::views::drop(5) | std::views::take(1)));
             expect(data.getMergedTag() == gr::Tag{-1, {{"id", "tag@105"}, {"id4", true}, {"id5", true}}});
         }

--- a/core/test/qa_Scheduler.cpp
+++ b/core/test/qa_Scheduler.cpp
@@ -28,8 +28,8 @@ public:
 // define some example graph nodes
 template<typename T>
 struct CountSource : public gr::Block<CountSource<T>> {
-    gr::PortOut<T>          out;
-    gr::Size_t              n_samples_max = 0;
+    gr::PortOut<T> out;
+    gr::Size_t     n_samples_max = 0;
 
     GR_MAKE_REFLECTABLE(CountSource, out, n_samples_max);
 
@@ -56,8 +56,8 @@ static_assert(gr::BlockLike<CountSource<float>>);
 
 template<typename T>
 struct ExpectSink : public gr::Block<ExpectSink<T>> {
-    gr::PortIn<T>                                   in;
-    gr::Size_t                                      n_samples_max = 0;
+    gr::PortIn<T> in;
+    gr::Size_t    n_samples_max = 0;
 
     GR_MAKE_REFLECTABLE(ExpectSink, in, n_samples_max);
 
@@ -106,9 +106,9 @@ struct Scale : public gr::Block<Scale<T>> {
 template<typename T>
 struct Adder : public gr::Block<Adder<T>> {
     using R = decltype(std::declval<T>() + std::declval<T>());
-    gr::PortIn<T>           addend0;
-    gr::PortIn<T>           addend1;
-    gr::PortOut<R>          sum;
+    gr::PortIn<T>  addend0;
+    gr::PortIn<T>  addend1;
+    gr::PortOut<R> sum;
 
     GR_MAKE_REFLECTABLE(Adder, addend0, addend1, sum);
 
@@ -245,8 +245,8 @@ struct LifecycleSource : public gr::Block<LifecycleSource<T>> {
 
     GR_MAKE_REFLECTABLE(LifecycleSource, out);
 
-    std::int32_t   n_samples_produced = 0;
-    std::int32_t   n_samples_max      = 10;
+    std::int32_t n_samples_produced = 0;
+    std::int32_t n_samples_max      = 10;
 
     [[nodiscard]] constexpr T processOne() noexcept {
         n_samples_produced++;
@@ -296,8 +296,8 @@ struct BusyLoopBlock : public gr::Block<BusyLoopBlock<T>> {
 
     GR_MAKE_REFLECTABLE(BusyLoopBlock, in, out);
 
-    gr::Sequence   _produceCount{0};
-    gr::Sequence   _invokeCount{0};
+    gr::Sequence _produceCount{0};
+    gr::Sequence _invokeCount{0};
 
     [[nodiscard]] constexpr gr::work::Status processBulk(gr::InputSpanLike auto& input, gr::OutputSpanLike auto& output) noexcept {
         auto produceCount = _produceCount.value();

--- a/core/test/qa_Tags.cpp
+++ b/core/test/qa_Tags.cpp
@@ -31,7 +31,7 @@ or next chunk, whichever is closer. Also adds an "offset" key to the tag map sig
     // gr::PortIn<T, Doc<"In">, RequiredSamples<1024, 1024, true>> inPort;
     gr::PortIn<T, gr::Doc<"In">, gr::RequiredSamples<24, 24, false>> inPort;
     // gr::PortIn<T, Doc<"In">> inPort;
-    gr::PortOut<T>                            outPort;
+    gr::PortOut<T> outPort;
 
     GR_MAKE_REFLECTABLE(RealignTagsToChunks, inPort, outPort);
 

--- a/core/test/qa_reader_writer_lock.cpp
+++ b/core/test/qa_reader_writer_lock.cpp
@@ -52,8 +52,6 @@ const boost::ut::suite basicTests = [] {
         expect(!rwlock.tryLock<READ>());
     };
 };
-}
+} // namespace gr::reader_writer_lock_test
 
-int
-main() { /* tests are statically executed */
-}
+int main() { /* tests are statically executed */ }

--- a/core/test/qa_thread_pool.cpp
+++ b/core/test/qa_thread_pool.cpp
@@ -9,8 +9,8 @@ const boost::ut::suite ThreadPoolTests = [] {
         expect(nothrow([] { gr::thread_pool::BasicThreadPool("test", gr::thread_pool::IO_BOUND, 4UL); }));
         expect(nothrow([] { gr::thread_pool::BasicThreadPool("test2", gr::thread_pool::CPU_BOUND, 4UL); }));
 
-        std::atomic<int>                   enqueueCount{ 0 };
-        std::atomic<int>                   executeCount{ 0 };
+        std::atomic<int>                 enqueueCount{0};
+        std::atomic<int>                 executeCount{0};
         gr::thread_pool::BasicThreadPool pool("TestPool", gr::thread_pool::IO_BOUND, 1, 2);
         expect(nothrow([&] { pool.sleepDuration = std::chrono::milliseconds(1); }));
         expect(nothrow([&] { pool.keepAliveDuration = std::chrono::seconds(10); }));
@@ -53,7 +53,7 @@ const boost::ut::suite ThreadPoolTests = [] {
         expect(nothrow([&] { pool.setThreadSchedulingPolicy(pool.getSchedulingPolicy(), pool.getSchedulingPriority()); }));
     };
     "contention tests"_test = [] {
-        std::atomic<int>                   counter{ 0 };
+        std::atomic<int>                 counter{0};
         gr::thread_pool::BasicThreadPool pool("contention", gr::thread_pool::IO_BOUND, 1, 4);
         pool.waitUntilInitialised();
         expect(that % pool.isInitialised());
@@ -79,12 +79,12 @@ const boost::ut::suite ThreadPoolTests = [] {
         struct bounds_def {
             std::uint32_t min, max;
         };
-        std::array<bounds_def, 5> bounds{ bounds_def{ 1, 1 }, bounds_def{ 1, 4 }, bounds_def{ 2, 2 }, bounds_def{ 2, 8 }, bounds_def{ 4, 8 } };
+        std::array<bounds_def, 5> bounds{bounds_def{1, 1}, bounds_def{1, 4}, bounds_def{2, 2}, bounds_def{2, 8}, bounds_def{4, 8}};
 
         for (const auto [minThreads, maxThreads] : bounds) {
-            for (const auto taskCount : { 2, 8, 32 }) {
+            for (const auto taskCount : {2, 8, 32}) {
                 fmt::print("## Test with min={} and max={} and taskCount={}\n", minThreads, maxThreads, taskCount);
-                std::atomic<int> counter{ 0 };
+                std::atomic<int> counter{0};
 
                 // Pool with min and max thread count
                 gr::thread_pool::BasicThreadPool pool("count_test", gr::thread_pool::IO_BOUND, minThreads, maxThreads);
@@ -117,6 +117,4 @@ const boost::ut::suite ThreadPoolTests = [] {
     };
 };
 
-int
-main() { /* tests are statically executed */
-}
+int main() { /* tests are statically executed */ }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -13,8 +13,10 @@ sonar.cfamily.cpp23.enabled=true
 #sonar.sourceEncoding=UTF-8
 
 sonar.coverageReportPaths=../build/coverage.xml
-sonar.test=.
+sonar.sources=.
+sonar.tests=.
 # note: only add benchmarks starting with bm_ to be able to exclude bm-nosonar_ files
-sonar.exclusions=**/third_party/**/*,**/test/**/*,**/benchmarks/*
-sonar.test.inclusions=**/test/**/*,**/benchmarks/bm_*
+sonar.exclusions=**/third_party/**/*,**/test/**/*
+sonar.coverage.exclusions=devtools/**/*,docs/**/*,cmake/**,docker/**/*,patches/**/*,core/src/main.cpp,**/**_example.cpp,**/bm_test_helper.hpp
+sonar.test.inclusions=**/test/**/*,**/benchmarks/bm_*,bench/bm_*,
 sonar.cfamily.compile-commands=../build/compile_commands.json


### PR DESCRIPTION
Fix sonarcube configuration to correctly exclude everything that is not run by the CI and therefore cannot have any coverage data. Also exclude a bunch of auxiliary files that are part of the build system or generic helper tools.