### PR TITLE
Update of StreamToDataSet block

### DIFF
--- a/blocks/basic/test/qa_StreamToDataSet.cpp
+++ b/blocks/basic/test/qa_StreamToDataSet.cpp
@@ -111,81 +111,52 @@ const boost::ut::suite<"StreamToDataSet Block"> selectorTest = [] {
     tag("visual") / "default ^matcher"_test            = [&runUIExample] { runUIExample(5, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/^FAIR.SELECTOR.C=1:S=1:P=3]", 0, 0); };
     tag("visual") / "default ^matcher + pre/post"_test = [&runUIExample] { runUIExample(5, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/^FAIR.SELECTOR.C=1:S=1:P=3]", 30, 30); };
     tag("visual") / "single trigger"_test              = [&runUIExample] { runUIExample(10, "CMD_DIAG_TRIGGER1", 30, 30); };
+};
 
-    auto runTest = [](std::string filter, gr::Size_t preSamples, gr::Size_t postSamples, std::array<float, 2> expectedValues, std::size_t nTags, gr::Size_t maxSamples = 10000U) {
-        using namespace gr;
-        using namespace gr::basic;
-        using namespace gr::testing;
-        using gr::tag::TRIGGER_NAME;
-        using gr::tag::CONTEXT;
+gr::Tag genTrigger(gr::Tag::signed_index_type index, std::string triggerName, std::string triggerCtx = {}) {
+    return {index, {{gr::tag::TRIGGER_NAME.shortKey(), triggerName}, {gr::tag::TRIGGER_TIME.shortKey(), std::uint64_t(0)}, {gr::tag::TRIGGER_OFFSET.shortKey(), 0.f}, //
+                       {gr::tag::TRIGGER_META_INFO.shortKey(), gr::property_map{{gr::tag::CONTEXT.shortKey(), triggerCtx}}}}};
+};
 
-        using namespace function_generator;
-        constexpr gr::Size_t N_SAMPLES   = 402U;
-        constexpr float      sample_rate = 1'000.f;
+const boost::ut::suite<"StreamToStream test"> streamToStreamTest = [] {
+    using namespace boost::ut;
+    using namespace gr;
+    using namespace gr::basic;
+    using namespace gr::testing;
 
-        Graph graph;
+    auto runTestStream = [](gr::Size_t nSamples, std::string filter, gr::Size_t preSamples, gr::Size_t postSamples, const std::vector<float>& expectedValues, std::size_t nTags, gr::Size_t maxSamples = 100000U) {
+        constexpr float sample_rate = 1'000.f;
+        Graph           graph;
 
-        // all times are in nanoseconds
-        auto& clockSrc = graph.emplaceBlock<TagSource<float, ProcessFunction::USE_PROCESS_BULK>>({{"sample_rate", sample_rate}, //
-            {"n_samples_max", N_SAMPLES},                                                                                       //
-            {"name", "TagSource"},                                                                                              //
-            {"verbose_console", false},                                                                                         //
-            {"repeat_tags", true}});
-
-        auto genTrigger = [](Tag::signed_index_type index, std::string triggerName, std::string triggerCtx = {}) -> Tag {
-            return {index, {{tag::TRIGGER_NAME.shortKey(), triggerName},         //
-                               {tag::TRIGGER_TIME.shortKey(), std::uint64_t(0)}, //
-                               {tag::TRIGGER_OFFSET.shortKey(), 0.f},            //
-                               {tag::TRIGGER_META_INFO.shortKey(), property_map{{tag::CONTEXT.shortKey(), triggerCtx}}}}};
+        auto& tagSrc = graph.emplaceBlock<TagSource<float, ProcessFunction::USE_PROCESS_BULK>>({{"sample_rate", sample_rate}, //
+            {"n_samples_max", nSamples}, {"name", "TagSource"}, {"verbose_console", false}, {"repeat_tags", false}, {"mark_tag", false}});
+        tagSrc._tags = {
+            genTrigger(5, "CMD_BP_START", "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1"),  // start
+            genTrigger(8, "CMD_DIAG_TRIGGER1", "CMD_DIAG_TRIGGER1"),                  // it is also used to split samples processing into 2 iterations
+            genTrigger(10, "CMD_BP_START", "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2"), // stop
+            genTrigger(12, "CMD_DIAG_TRIGGER1", "CMD_DIAG_TRIGGER1"),                 // it is also used as end trigger for "including" mode
+            genTrigger(15, "CMD_BP_START", "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1"), // start
+            genTrigger(20, "CMD_BP_START", "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2"), // stop
+            genTrigger(22, "CMD_DIAG_TRIGGER1", "CMD_DIAG_TRIGGER1")                  // it is also used as end trigger for "including" mode
         };
 
-        clockSrc._tags = { //
-            // TODO: refactor triggerCtx do only contain the 'FAIR.SELECTOR...' info (-> needs changes in FunctionGenerator)
-            genTrigger(10, "CMD_BP_START", "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1"),  //
-            genTrigger(50, "CMD_DIAG_TRIGGER1", "CMD_DIAG_TRIGGER1"),                  //
-            genTrigger(100, "CMD_BP_START", "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2"), //
-            genTrigger(200, "CMD_BP_START", "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=3"), //
-            genTrigger(300, "CMD_BP_START", "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=4"), //
-            genTrigger(400, "CMD_BP_START", "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=5")};
-
-        auto&      funcGen = graph.emplaceBlock<FunctionGenerator<float>>({{"sample_rate", sample_rate}, {"name", "FunctionGenerator"}});
-        const auto now     = settings::convertTimePointToUint64Ns(std::chrono::system_clock::now());
-
-        // TODO: add graphic
-        expect(funcGen.settings().set(createConstPropertyMap(1.f), SettingsCtx{now, "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1"}).empty());
-        expect(funcGen.settings().set(createConstPropertyMap(2.f), SettingsCtx{now, "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2"}).empty());
-        expect(funcGen.settings().set(createConstPropertyMap(3.f), SettingsCtx{now, "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=3"}).empty());
-        expect(funcGen.settings().set(createConstPropertyMap(4.f), SettingsCtx{now, "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=4"}).empty());
-        expect(funcGen.settings().set(createConstPropertyMap(5.f), SettingsCtx{now, "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=5"}).empty());
-        expect(eq(ConnectionResult::SUCCESS, graph.connect<"out">(clockSrc).to<"in">(funcGen))) << "connect clockSrc->funcGen";
-
-        const property_map blockSettings = {{"filter", filter}, {"n_pre", preSamples}, {"n_post", postSamples}, {"n_max", maxSamples}};
-        // producing stream (filtered)
-        auto& filterStreamToStream = graph.emplaceBlock<StreamFilter<float>>(blockSettings);
-        auto& streamSink           = graph.emplaceBlock<TagSink<float, ProcessFunction::USE_PROCESS_ONE>>({{"name", "streamSink"}, {"log_tags", true}, {"log_samples", true}, {"n_samples_expected", N_SAMPLES}, {"verbose_console", false}});
-        expect(eq(gr::ConnectionResult::SUCCESS, graph.connect<"out">(funcGen).template to<"in">(filterStreamToStream))) << "connect funcGen->filterStreamToStream";
-        expect(eq(gr::ConnectionResult::SUCCESS, graph.connect<"out">(filterStreamToStream).template to<"in">(streamSink))) << "connect filterStreamToStream->streamSink";
-        // producing DataSet (filtered)
-        auto& filterStreamToDataSet = graph.emplaceBlock<StreamToDataSet<float>>(blockSettings);
-        auto& dataSetSink           = graph.emplaceBlock<TagSink<DataSet<float>, ProcessFunction::USE_PROCESS_BULK>>({{"name", "dataSetSink"}, {"log_tags", true}, {"log_samples", true}, {"n_samples_expected", gr::Size_t(1)}, {"verbose_console", false}});
-        expect(eq(gr::ConnectionResult::SUCCESS, graph.connect<"out">(funcGen).template to<"in">(filterStreamToDataSet))) << "connect funcGen->filterStreamToDataSet";
-        expect(eq(gr::ConnectionResult::SUCCESS, graph.connect<"out">(filterStreamToDataSet).template to<"in">(dataSetSink))) << "connect filterStreamToDataSet->dataSetSink";
+        const property_map blockSettings        = {{"filter", filter}, {"n_pre", preSamples}, {"n_post", postSamples}, {"n_max", maxSamples}};
+        auto&              filterStreamToStream = graph.emplaceBlock<StreamFilter<float>>(blockSettings);
+        auto&              streamSink           = graph.emplaceBlock<TagSink<float, ProcessFunction::USE_PROCESS_ONE>>({{"name", "streamSink"}, {"log_tags", true}, {"log_samples", true}, {"verbose_console", false}});
+        expect(eq(gr::ConnectionResult::SUCCESS, graph.connect<"out">(tagSrc).template to<"in">(filterStreamToStream)));
+        expect(eq(gr::ConnectionResult::SUCCESS, graph.connect<"out">(filterStreamToStream).template to<"in">(streamSink)));
 
         gr::scheduler::Simple sched{std::move(graph)};
-        fmt::println("start test with filter: {}", filter);
+        fmt::println("start -> Stream-to-Stream with filter: {} n_pre:{} n_post:{}", filter, preSamples, postSamples);
         expect(sched.runAndWait().has_value()) << fmt::format("runAndWait - filter {}", filter);
-        fmt::println("start test with filter: {} -- DONE", filter);
+        fmt::println("done -> Stream-to-Stream with filter: {} n_pre:{} n_post:{}", filter, preSamples, postSamples);
 
-        expect(eq(clockSrc.sample_rate, sample_rate)) << "clockSrc.sample_rate";
-        expect(eq(funcGen.sample_rate, sample_rate)) << "funcGen.sample_rate";
-        expect(eq(filterStreamToStream.sample_rate, sample_rate)) << "filterStreamToStream.sample_rate";
-        expect(eq(filterStreamToDataSet.sample_rate, sample_rate)) << "filterStreamToDataSet.sample_rate";
-        expect(eq(streamSink.sample_rate, sample_rate)) << "streamSink.sample_rate";
-        expect(eq(dataSetSink.sample_rate, sample_rate)) << "dataSetSink.sample_rate";
+        expect(eq(tagSrc.sample_rate, sample_rate));
+        expect(eq(filterStreamToStream.sample_rate, sample_rate));
+        expect(eq(streamSink.sample_rate, sample_rate));
 
-        expect(!streamSink._samples.empty()) << "streamSink._samples.empty()";
-        expect(eq(streamSink._samples.front(), expectedValues.front())) << fmt::format("streamSink._samples - first sample does not match({}): {}", streamSink._samples.size(), fmt::join(streamSink._samples, ", "));
-        expect(eq(streamSink._samples.back(), expectedValues.back())) << fmt::format("streamSink._samples - last sample does not match({}): {}", streamSink._samples.size(), fmt::join(streamSink._samples, ", "));
+        expect(eq(streamSink._samples.size(), expectedValues.size()));
+        expect(std::ranges::equal(streamSink._samples, expectedValues));
 
         expect(eq(streamSink._tags.size(), nTags)) << [&]() {
             std::string ret = fmt::format("Stream nTags: {}\n", streamSink._tags.size());
@@ -194,33 +165,107 @@ const boost::ut::suite<"StreamToDataSet Block"> selectorTest = [] {
             }
             return ret;
         }();
+    };
+    // We always test scenarios where no overlaps occur. If accumulation is currently active in the block, no new "Start" should happen.
+    // Any new Start events are ignored, and this behavior is considered undefined for stream-to-stream mode
+    std::vector<float> expectedValues                = {5, 6, 7, 8, 9, 15, 16, 17, 18, 19};
+    "start->stop matcher (excluding)"_test           = [&runTestStream, &expectedValues] { runTestStream(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2]", 0, 0, expectedValues, 3UZ /* 2 BPs (2 starts) + custom diag trigger */); };
+    expectedValues                                   = {3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 14, 15, 16, 17, 18, 19, 20, 21};
+    "start->stop matcher (excluding +pre/post)"_test = [&runTestStream, &expectedValues] { runTestStream(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2]", 2, 2, expectedValues, 5UZ /* 4 BPs (2 starts + 2 stops) + custom diag trigger */); };
 
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
-        expect(!dataSetSink._samples.empty()) << "dataSetSink did not receive the required minimum data";
-        if (dataSetSink._samples.empty()) {
-            return;
+    expectedValues                                     = {5, 6, 7, 8, 9, 10, 11, 15, 16, 17, 18, 19, 20, 21};
+    "start->^stop matcher (including)"_test            = [&runTestStream, &expectedValues] { runTestStream(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/^FAIR.SELECTOR.C=1:S=1:P=2]", 0, 0, expectedValues, 5UZ /* 4 BPs (2 starts + 2 stops) + custom diag trigger */); };
+    expectedValues                                     = {3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23};
+    "start->^stop matcher (including. +pre/post)"_test = [&runTestStream, &expectedValues] { runTestStream(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/^FAIR.SELECTOR.C=1:S=1:P=2]", 2, 2, expectedValues, 7UZ /* 4 BPs (2 starts + 2 stops) + 3 custom diag event */); };
+
+    expectedValues                    = {6, 7, 8, 9, 10, 11, 12, 13, 20, 21, 22, 23};
+    "single trigger (+pre/post)"_test = [&runTestStream, &expectedValues] { runTestStream(50U, "CMD_DIAG_TRIGGER1", 2, 2, expectedValues, 3UZ); };
+};
+
+const boost::ut::suite<"StreamToDataSet test"> streamToDataSetTest = [] {
+    using namespace boost::ut;
+    using namespace gr;
+    using namespace gr::basic;
+    using namespace gr::testing;
+
+    auto runTestDataSet = [](gr::Size_t nSamples, std::string filter, gr::Size_t preSamples, gr::Size_t postSamples, const std::vector<std::vector<float>>& expectedValues, const std::vector<std::size_t>& nTags, gr::Size_t maxSamples = 100000U) {
+        using namespace gr;
+        using namespace gr::basic;
+        using namespace gr::testing;
+
+        constexpr float sample_rate = 1'000.f;
+        Graph           graph;
+
+        auto& tagSrc = graph.emplaceBlock<TagSource<float, ProcessFunction::USE_PROCESS_BULK>>({{"sample_rate", sample_rate}, //
+            {"n_samples_max", nSamples}, {"name", "TagSource"}, {"verbose_console", false}, {"repeat_tags", false}, {"mark_tag", false}});
+        tagSrc._tags = {
+            genTrigger(5, "CMD_BP_START", "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1"),  // start
+            genTrigger(8, "CMD_DIAG_TRIGGER1", "CMD_DIAG_TRIGGER1"),                  // it is also used to split samples processing into 2 iterations
+            genTrigger(10, "CMD_BP_START", "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2"), // stop
+            genTrigger(12, "CMD_DIAG_TRIGGER1", "CMD_DIAG_TRIGGER1"),                 // it is also used as end trigger for "including" mode
+            genTrigger(15, "CMD_BP_START", "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1"), // start
+            genTrigger(20, "CMD_BP_START", "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1"), // start
+            genTrigger(25, "CMD_BP_START", "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2"), // stop
+            genTrigger(27, "CMD_DIAG_TRIGGER1", "CMD_DIAG_TRIGGER1"),                 // it is also used as end trigger for "including" mode
+            genTrigger(30, "CMD_BP_START", "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2"), // stop
+            genTrigger(32, "CMD_DIAG_TRIGGER1", "CMD_DIAG_TRIGGER1")                  // it is also used as end trigger for "including" mode
+        };
+
+        const property_map blockSettings         = {{"filter", filter}, {"n_pre", preSamples}, {"n_post", postSamples}, {"n_max", maxSamples}};
+        auto&              filterStreamToDataSet = graph.emplaceBlock<StreamToDataSet<float>>(blockSettings);
+        auto&              dataSetSink           = graph.emplaceBlock<TagSink<DataSet<float>, ProcessFunction::USE_PROCESS_BULK>>({{"name", "dataSetSink"}, {"log_tags", true}, {"log_samples", true}, {"verbose_console", false}});
+        expect(eq(gr::ConnectionResult::SUCCESS, graph.connect<"out">(tagSrc).template to<"in">(filterStreamToDataSet)));
+        expect(eq(gr::ConnectionResult::SUCCESS, graph.connect<"out">(filterStreamToDataSet).template to<"in">(dataSetSink)));
+
+        gr::scheduler::Simple sched{std::move(graph)};
+        fmt::println("start -> Stream-to-DataSet with filter: {} n_pre:{} n_post:{}", filter, preSamples, postSamples);
+        expect(sched.runAndWait().has_value()) << fmt::format("runAndWait - filter {}", filter);
+        fmt::println("done -> Stream-to-DataSet with filter: {} n_pre:{} n_post:{}", filter, preSamples, postSamples);
+
+        expect(eq(tagSrc.sample_rate, sample_rate));
+        expect(eq(filterStreamToDataSet.sample_rate, sample_rate));
+        expect(eq(dataSetSink.sample_rate, sample_rate));
+
+        expect(eq(dataSetSink._samples.size(), expectedValues.size()));
+        for (std::size_t i = 0; i < dataSetSink._samples.size(); i++) {
+            const DataSet<float>& ds = dataSetSink._samples.at(i);
+            expect(std::ranges::equal(ds.signal_values, expectedValues[i]));
+
+            expect(fatal(eq(ds.timing_events.size(), 1UZ)));
+            const std::vector<Tag>& timingEvt0 = ds.timing_events[0];
+            expect(eq(timingEvt0.size(), nTags[i])) << [&]() {
+                std::string ret = fmt::format("DataSet nTags: {}\n", timingEvt0.size());
+                for (const auto& tag : timingEvt0) {
+                    ret += fmt::format("tag.index: {} .map: {}\n", tag.index, tag.map);
+                }
+                return ret;
+            }();
         }
-        const DataSet<float>& dataSet = dataSetSink._samples.at(0UZ);
-        expect(ge(streamSink._samples.size(), dataSet.signal_values.size())) << "streamSink needs to receive correct amount of samples";
-
-        expect(fatal(!dataSet.signal_values.empty())) << "no samples in DataSet";
-        expect(eq(dataSet.signal_values.front(), expectedValues.front())) << fmt::format("dataSet.signal_values - first sample does not match ({}): {}", dataSet.signal_values.size(), fmt::join(dataSet.signal_values, ", "));
-        expect(eq(dataSet.signal_values.back(), expectedValues.back())) << fmt::format("dataSet.signal_values - last sample does not match({}): {}", dataSet.signal_values.size(), fmt::join(dataSet.signal_values, ", "));
-        expect(fatal(eq(dataSet.timing_events.size(), 1UZ))) << "dataSetSink._samples[0] -> DataSet - timing_events match";
-        const std::vector<Tag>& timingEvt0 = dataSet.timing_events[0];
-        expect(eq(timingEvt0.size(), nTags)) << [&]() {
-            std::string ret = fmt::format("DataSet nTags: {}\n", timingEvt0.size());
-            for (const auto& tag : timingEvt0) {
-                ret += fmt::format("tag.index: {} .map: {}\n", tag.index, tag.map);
-            }
-            return ret;
-        }();
     };
 
-    "start->stop matcher (excluding)"_test             = [&runTest] { runTest("[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=4]", 0, 0, {1.f, 3.f}, 4UZ /* 3 BPs + custom diag event */); };
-    "start->^stop matcher (including)"_test            = [&runTest] { runTest("[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/^FAIR.SELECTOR.C=1:S=1:P=3]", 0, 0, {1.f, 3.f}, 4UZ /* 3 BPs + custom diag event */); };
-    "start->^stop matcher (including. +pre/post)"_test = [&runTest] { runTest("[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/^FAIR.SELECTOR.C=1:S=1:P=3]", 30, 30, {0.f, 4.f}, 5UZ /* 3+1 BPs (because of +30 post samples ranging into P=4) + custom diag event */); };
-    "single trigger (+pre/post)"_test                  = [&runTest] { runTest("CMD_DIAG_TRIGGER1", 30, 30, {1.f, 1.f}, 1UZ); };
+    std::vector<std::vector<float>> expectedValues = {{5, 6, 7, 8, 9}, {15, 16, 17, 18, 19, 20, 21, 22, 23, 24}, {20, 21, 22, 23, 24, 25, 26, 27, 28, 29}};
+    "start->stop matcher (excluding)"_test         = [&runTestDataSet, &expectedValues] { runTestDataSet(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2]", 0, 0, expectedValues, {3UZ, 3UZ, 4UZ}); };
+
+    expectedValues                                   = {{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},                       //
+                                          {8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31}, //
+                                          {13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36}};
+    "start->stop matcher (excluding +pre/post)"_test = [&runTestDataSet, &expectedValues] { runTestDataSet(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2]", 7, 7, expectedValues, {5UZ, 5UZ, 5UZ}); };
+
+    expectedValues                          = {{5, 6, 7, 8, 9, 10, 11},            //
+                                 {15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26}, //
+                                 {20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31}};
+    "start->^stop matcher (including)"_test = [&runTestDataSet, &expectedValues] { runTestDataSet(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/^FAIR.SELECTOR.C=1:S=1:P=2]", 0, 0, expectedValues, {4UZ, 4UZ, 5UZ}); };
+
+    expectedValues                                     = {{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18},                       //
+                                            {8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33}, //
+                                            {13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38}};
+    "start->^stop matcher (including. +pre/post)"_test = [&runTestDataSet, &expectedValues] { runTestDataSet(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/^FAIR.SELECTOR.C=1:S=1:P=2]", 7, 7, expectedValues, {5UZ, 6UZ, 5UZ}); };
+
+    expectedValues                    = {{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14}, //
+                           {5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18},           //
+                           {20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33},      //
+                           {25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38}};
+    "single trigger (+pre/post)"_test = [&runTestDataSet, &expectedValues] { runTestDataSet(50U, "CMD_DIAG_TRIGGER1", 7, 7, expectedValues, {3UZ, 2UZ, 3UZ, 1UZ}); };
 };
 
 int main() { /* not needed for UT */ }


### PR DESCRIPTION
* Support several parallel DataSet accumulation
* Support sample accumulation between work() iterations
* Update unit tests

Notes:
- `n_pre` must be less than the size of the output port's `CircularBuffer`. The blok waits until all `n_pre` samples can be written to the output in a single iteration.
- In stream-to-stream mode, the "stop" Tag is not included in the output.
- Stream-to-stream mode has limited support for overlapping triggers. Configurations such as Start-Stop-Start-Stop work as expected, but configurations like Start-Start-Stop-Stop result in undefined behavior. If data accumulation is active, the second "start" is ignored, and the output may vary depending on subsequent tags.
- In stream-to-dataset modes, the "stop" Tag is included in the DataSet output.
- Tags for pre-samples are not stored and are not included in the output.
- It is expected that "start" and "stop" Tags will come from different iterations. If multiple "start" Tags arrive in a single merged tag, only one DataSet is created. The same applies for "stop" Tags. This may lead to incorrect or unexpected output.
- Currently used Matcher doesn't really support overlapping DataSets

Example of Stream-to-Dataset with overlapping datasets and pre/post samples:
![IMG_6168](https://github.com/user-attachments/assets/a87a9a99-4201-495c-899e-e3cdb2b68cde)
