### PR TITLE
Adding the assembly yeild command to support noop for ARM

### DIFF
--- a/core/include/gnuradio-4.0/WaitStrategy.hpp
+++ b/core/include/gnuradio-4.0/WaitStrategy.hpp
@@ -245,10 +245,12 @@ class SpinWait {
             yieldProcessor();
         }
     }
-#if not defined(__EMSCRIPTEN__) && not defined(__APPLE__)
-    static void yieldProcessor() noexcept { asm volatile("rep\nnop"); }
-#else
+#if defined( __EMSCRIPTEN__)
     static void yieldProcessor() noexcept { std::this_thread::sleep_for(std::chrono::milliseconds(1)); }
+#elif defined(DISRUPTOR_CPU_ARM)
+    static void yieldProcessor() noexcept {  asm volatile("yield"); }
+#else
+    static void yieldProcessor() noexcept { asm volatile("rep\nnop"); }
 #endif
 
 public:


### PR DESCRIPTION
This fixes and error when cross-compiling for ARM processors.  The ARM asm equivalent to rep/nnop is yield.