### PR TITLE
ConsumableInputPortRange Tag API

### DIFF
--- a/core/include/gnuradio-4.0/Block.hpp
+++ b/core/include/gnuradio-4.0/Block.hpp
@@ -744,10 +744,10 @@ public:
                         destinationMap.insert_or_assign(key, value);
                     }
                 };
-                if constexpr (ConsumablePortSpan<std::remove_cvref_t<decltype(inputSpanOrVector)>>) {
-                    mergeSrcMapInto(inputSpanOrVector.getMergedTag().map, _mergedInputTag.map);
+                if constexpr (InputSpan<std::remove_cvref_t<decltype(inputSpanOrVector)>>) {
+                    mergeSrcMapInto(inputSpanOrVector.getMergedTag(0).map, _mergedInputTag.map);
                 } else {
-                    std::ranges::for_each(inputSpanOrVector, [this, &mergeSrcMapInto](auto& inputSpan) { mergeSrcMapInto(inputSpan.getMergedTag().map, _mergedInputTag.map); });
+                    std::ranges::for_each(inputSpanOrVector, [this, &mergeSrcMapInto](auto& inputSpan) { mergeSrcMapInto(inputSpan.getMergedTag(0).map, _mergedInputTag.map); });
                 }
             },
             inputSpans);

--- a/core/include/gnuradio-4.0/Block.hpp
+++ b/core/include/gnuradio-4.0/Block.hpp
@@ -735,19 +735,22 @@ public:
      * @param untilOffset defaults to 0, if bigger merges all tags from samples 0...untilOffset for each port before merging
      *                    them
      */
-    constexpr void updateInputAndOutputTags(std::size_t /*untilOffset*/ = 0UZ) noexcept {
-        for_each_port(
-            [this]<PortLike TPort>(TPort& input_port) noexcept {
+    constexpr void updateInputAndOutputTags(auto& inputSpans, std::size_t /*untilOffset*/ = 0UZ) noexcept {
+        gr::meta::tuple_for_each(
+            [this](const auto& inputSpanOrVector) noexcept {
                 auto mergeSrcMapInto = [](const property_map& sourceMap, property_map& destinationMap) {
                     assert(&sourceMap != &destinationMap);
                     for (const auto& [key, value] : sourceMap) {
                         destinationMap.insert_or_assign(key, value);
                     }
                 };
-
-                mergeSrcMapInto(input_port.getMergedTag().map, _mergedInputTag.map);
+                if constexpr (ConsumablePortSpan<std::remove_cvref_t<decltype(inputSpanOrVector)>>) {
+                    mergeSrcMapInto(inputSpanOrVector.getMergedTag().map, _mergedInputTag.map);
+                } else {
+                    std::ranges::for_each(inputSpanOrVector, [this, &mergeSrcMapInto](auto& inputSpan) { mergeSrcMapInto(inputSpan.getMergedTag().map, _mergedInputTag.map); });
+                }
             },
-            inputPorts<PortType::STREAM>(&self()));
+            inputSpans);
 
         if (!mergedInputTag().map.empty()) {
             settings().autoUpdate(mergedInputTag()); // apply tags as new settings if matching
@@ -1464,8 +1467,8 @@ protected:
         const bool isEosTagPresent                                            = nextEosTag <= 0 || nextEosTagSkipBefore < minSyncIn || nextEosTagSkipBefore < input_chunk_size || output_chunk_size * (nextEosTagSkipBefore / input_chunk_size) < minSyncOut;
 
         if (inputSkipBefore > 0) {                                                                          // consume samples on sync ports that need to be consumed due to the stride
-            updateInputAndOutputTags(inputSkipBefore);                                                      // apply all tags in the skipped data range
             const auto inputSpans = prepareStreams(inputPorts<PortType::STREAM>(&self()), inputSkipBefore); // only way to consume is via the ConsumableSpan now
+            updateInputAndOutputTags(inputSpans, inputSkipBefore);                                          // apply all tags in the skipped data range
             consumeReaders(inputSkipBefore, inputSpans);
         }
         // return if there is no work to be performed // todo: add eos policy
@@ -1495,7 +1498,7 @@ protected:
             return {requestedWork, 0UZ, INSUFFICIENT_OUTPUT_ITEMS};
         }
 
-        updateInputAndOutputTags();
+        updateInputAndOutputTags(inputSpans);
         applyChangedSettings();
 
         copyCachedOutputTags(outputSpans);

--- a/core/include/gnuradio-4.0/BlockTraits.hpp
+++ b/core/include/gnuradio-4.0/BlockTraits.hpp
@@ -297,10 +297,14 @@ public:
 static_assert(ConsumableSpan<DummyConsumableSpan<int>>);
 
 template<typename T>
-struct DummyConsumablePortSpan: public DummyConsumableSpan<T> {
-    DummyConsumableSpan<gr::Tag> tags{};
+struct DummyInputSpan: public DummyConsumableSpan<T> {
+    DummyConsumableSpan<gr::Tag> rawTags{};
+    auto tags() { return std::views::empty<std::pair<Tag::signed_index_type, const property_map&>>; }
+    [[nodiscard]] inline Tag getMergedTag(gr::Tag::signed_index_type /*untilLocalIndex*/) const { return {}; }
+    void consumeTags(gr::Tag::signed_index_type /*untilLocalIndex*/) { }
 };
-static_assert(ConsumablePortSpan<DummyConsumablePortSpan<int>>);
+static_assert(ConsumableSpan<DummyInputSpan<int>>);
+static_assert(InputSpan<DummyInputSpan<int>>);
 
 template<typename T>
 struct DummyPublishableSpan {
@@ -377,7 +381,7 @@ constexpr auto* port_to_processBulk_argument_helper() {
             if constexpr (isVectorOfSpansReturned) {
                 return static_cast<std::span<std::span<const typename Port::value_type::value_type>>*>(nullptr);
             } else {
-                return static_cast<std::span<DummyConsumablePortSpan<typename Port::value_type::value_type>>*>(nullptr);
+                return static_cast<std::span<DummyInputSpan<typename Port::value_type::value_type>>*>(nullptr);
             }
         } else if constexpr (Port::value_type::kIsOutput) {
             if constexpr (isVectorOfSpansReturned) {
@@ -389,7 +393,7 @@ constexpr auto* port_to_processBulk_argument_helper() {
 
     } else { // single port
         if constexpr (Port::kIsInput) {
-            return static_cast<DummyConsumablePortSpan<typename Port::value_type>*>(nullptr);
+            return static_cast<DummyInputSpan<typename Port::value_type>*>(nullptr);
         } else if constexpr (Port::kIsOutput) {
             return static_cast<DummyPublishablePortSpan<typename Port::value_type>*>(nullptr);
         }
@@ -431,7 +435,7 @@ concept can_processBulk = can_processBulk_helper<TBlock, detail::port_to_process
  * must be std::span<T> and *not* a type satisfying PublishableSpan<T>.
  */
 template<typename TDerived, std::size_t I>
-concept processBulk_requires_ith_output_as_span = can_processBulk<TDerived> && (I < traits::block::stream_output_port_types<TDerived>::size) && (I >= 0) && requires(TDerived& d, typename meta::transform_types<detail::DummyConsumablePortSpan, traits::block::stream_input_port_types<TDerived>>::template apply<std::tuple> inputs, typename meta::transform_conditional<decltype([](auto j) { return j == I; }), detail::dynamic_span, detail::DummyPublishablePortSpan, traits::block::stream_output_port_types<TDerived>>::template apply<std::tuple> outputs, typename meta::transform_conditional<decltype([](auto j) { return j == I; }), detail::nothing_you_ever_wanted, detail::DummyPublishablePortSpan, traits::block::stream_output_port_types<TDerived>>::template apply<std::tuple> bad_outputs) {
+concept processBulk_requires_ith_output_as_span = can_processBulk<TDerived> && (I < traits::block::stream_output_port_types<TDerived>::size) && (I >= 0) && requires(TDerived& d, typename meta::transform_types<detail::DummyInputSpan, traits::block::stream_input_port_types < TDerived>>::template apply<std::tuple> inputs, typename meta::transform_conditional<decltype([](auto j) { return j == I; }), detail::dynamic_span, detail::DummyPublishablePortSpan, traits::block::stream_output_port_types < TDerived>>::template apply<std::tuple> outputs, typename meta::transform_conditional<decltype([](auto j) { return j == I; }), detail::nothing_you_ever_wanted, detail::DummyPublishablePortSpan, traits::block::stream_output_port_types < TDerived>>::template apply<std::tuple> bad_outputs) {
     { detail::can_processBulk_invoke_test(d, inputs, outputs, std::make_index_sequence<stream_input_port_types<TDerived>::size>(), std::make_index_sequence<stream_output_port_types<TDerived>::size>()) } -> std::same_as<work::Status>;
     // TODO: Is this check redundant?
     not requires { []<std::size_t... InIdx, std::size_t... OutIdx>(std::index_sequence<InIdx...>, std::index_sequence<OutIdx...>) -> decltype(d.processBulk(std::get<InIdx>(inputs)..., std::get<OutIdx>(bad_outputs)...)) { return {}; }(std::make_index_sequence<traits::block::stream_input_port_types<TDerived>::size>(), std::make_index_sequence<traits::block::stream_output_port_types<TDerived>::size>()); };

--- a/core/include/gnuradio-4.0/BlockTraits.hpp
+++ b/core/include/gnuradio-4.0/BlockTraits.hpp
@@ -381,7 +381,7 @@ constexpr auto* port_to_processBulk_argument_helper() {
             if constexpr (isVectorOfSpansReturned) {
                 return static_cast<std::span<std::span<const typename Port::value_type::value_type>>*>(nullptr);
             } else {
-                return static_cast<std::span<DummyInputSpan<typename Port::value_type::value_type>>*>(nullptr);
+                return static_cast<std::span<DummyInputSpan<const typename Port::value_type::value_type>>*>(nullptr);
             }
         } else if constexpr (Port::value_type::kIsOutput) {
             if constexpr (isVectorOfSpansReturned) {
@@ -393,7 +393,7 @@ constexpr auto* port_to_processBulk_argument_helper() {
 
     } else { // single port
         if constexpr (Port::kIsInput) {
-            return static_cast<DummyInputSpan<typename Port::value_type>*>(nullptr);
+            return static_cast<DummyInputSpan<const typename Port::value_type>*>(nullptr);
         } else if constexpr (Port::kIsOutput) {
             return static_cast<DummyPublishablePortSpan<typename Port::value_type>*>(nullptr);
         }

--- a/core/test/qa_Block.cpp
+++ b/core/test/qa_Block.cpp
@@ -859,12 +859,12 @@ const boost::ut::suite<"Requested Work Tests"> _requestedWorkTests = [] {
         expect(eq(ConnectionResult::SUCCESS, graph.connect<"out">(testBlock).template to<"in">(sink)));
 
         graph.reconnectAllEdges();
-        auto blockInit = [](auto& block) {
-            if (block.state() == lifecycle::State::IDLE) {
-                std::ignore = block.changeStateTo(lifecycle::State::INITIALISED);
+        auto blockInit = [](auto& blockToInit) {
+            if (blockToInit.state() == lifecycle::State::IDLE) {
+                std::ignore = blockToInit.changeStateTo(lifecycle::State::INITIALISED);
             }
-            std::ignore = block.changeStateTo(lifecycle::State::RUNNING);
-            expect(block.state() == lifecycle::State::RUNNING);
+            std::ignore = blockToInit.changeStateTo(lifecycle::State::RUNNING);
+            expect(blockToInit.state() == lifecycle::State::RUNNING);
         };
         blockInit(src);
         blockInit(testBlock);

--- a/core/test/qa_Block.cpp
+++ b/core/test/qa_Block.cpp
@@ -163,13 +163,13 @@ struct BlockSignaturesProcessBulkSpan : public gr::Block<BlockSignaturesProcessB
         return gr::work::Status::OK;
     }
 
-    gr::work::Status processBulk(gr::ConsumablePortSpan auto&, gr::PublishablePortSpan auto&)
+    gr::work::Status processBulk(const gr::InputSpan auto&, gr::PublishablePortSpan auto&)
     requires(processVariant == ProcessBulkVariant::CONSUMABLE_PUBLISHABLE_PORT)
     {
         return gr::work::Status::OK;
     }
 
-    gr::work::Status processBulk(gr::ConsumablePortSpan auto, gr::PublishablePortSpan auto)
+    gr::work::Status processBulk(const gr::InputSpan auto, gr::PublishablePortSpan auto)
     requires(processVariant == ProcessBulkVariant::CONSUMABLE_PUBLISHABLE_PORT2)
     {
         return gr::work::Status::OK;

--- a/core/test/qa_Port.cpp
+++ b/core/test/qa_Port.cpp
@@ -53,26 +53,26 @@ const boost::ut::suite PortTests = [] {
             // fmt::print("idx: {}: data: {}\ntags: {}\nmergedTag: {}\n", data.streamIndex, std::span(data), in.tags, in.getMergedTag());
             expect(std::ranges::equal(data.tags, std::vector<gr::Tag>{{-1, {{"id", "tag@-1"}, {"id0", true}}}, {1, {{"id", "tag@101"}, {"id1", true}}}, {2, {{"id", "tag@102"}, {"id2", true}}}, {3, {{"id", "tag@103"}, {"id3", true}}}, {4, {{"id", "tag@104"}, {"id4", true}}}}));
             expect(std::ranges::equal(data, std::views::iota(100) | std::views::take(5)));
-            expect(in.getMergedTag() == gr::Tag{-1, {{"id", "tag@-1"}, {"id0", true}}});
+            expect(data.getMergedTag() == gr::Tag{-1, {{"id", "tag@-1"}, {"id0", true}}});
             expect(data.consume(2));
         }
         { // full consume
             auto data = in.get<SpanReleasePolicy::ProcessAll>(2);
             expect(std::ranges::equal(data.tags, std::vector<gr::Tag>{{1, {{"id", "tag@101"}, {"id1", true}}}, {2, {{"id", "tag@102"}, {"id2", true}}}, {3, {{"id", "tag@103"}, {"id3", true}}}}));
             expect(std::ranges::equal(data, std::views::iota(100) | std::views::drop(2) | std::views::take(2)));
-            expect(in.getMergedTag() == gr::Tag{-1, {{"id", "tag@102"}, {"id1", true}, {"id2", true}}});
+            expect(data.getMergedTag() == gr::Tag{-1, {{"id", "tag@102"}, {"id1", true}, {"id2", true}}});
         }
         { // get empty range
             auto data = in.get<SpanReleasePolicy::ProcessAll>(0);
             expect(std::ranges::equal(data.tags, std::vector<gr::Tag>{{3, {{"id", "tag@103"}, {"id3", true}}}}));
             expect(std::ranges::equal(data, std::vector<int>()));
-            expect(in.getMergedTag() == gr::Tag{-1, {{"id", "tag@103"}, {"id3", true}}});
+            expect(data.getMergedTag() == gr::Tag{-1, {{"id", "tag@103"}, {"id3", true}}});
         }
         { // get last sample
             auto data = in.get<SpanReleasePolicy::ProcessAll>(1);
             expect(std::ranges::equal(data.tags, std::vector<gr::Tag>{{3, {{"id", "tag@103"}, {"id3", true}}}, {4, {{"id", "tag@104"}, {"id4", true}}}}));
             expect(std::ranges::equal(data, std::views::iota(100) | std::views::drop(4) | std::views::take(1)));
-            expect(in.getMergedTag() == gr::Tag{-1, {{"id", "tag@104"}, {"id3", true}, {"id4", true}}});
+            expect(data.getMergedTag() == gr::Tag{-1, {{"id", "tag@104"}, {"id3", true}, {"id4", true}}});
         }
     };
 

--- a/core/test/qa_Tags.cpp
+++ b/core/test/qa_Tags.cpp
@@ -39,8 +39,8 @@ or next chunk, whichever is closer. Also adds an "offset" key to the tag map sig
         std::copy(inSamples.begin(), inSamples.end(), outSamples.begin());
         std::size_t tagsForwarded = 0;
         for (gr::Tag tag : inSamples.tags) {
-            if (tag.index < (inPort.streamIndex + (static_cast<gr::Tag::signed_index_type>(inSamples.size()) + 1) / 2)) {
-                tag.insert_or_assign("offset", sampling_rate * static_cast<double>(tag.index - inPort.streamIndex));
+            if (tag.index < (inSamples.streamIndex + (static_cast<gr::Tag::signed_index_type>(inSamples.size()) + 1) / 2)) {
+                tag.insert_or_assign("offset", sampling_rate * static_cast<double>(tag.index - inSamples.streamIndex));
                 outSamples.publishTag(tag.map, 0);
                 tagsForwarded++;
             } else {

--- a/core/test/qa_Tags.cpp
+++ b/core/test/qa_Tags.cpp
@@ -35,10 +35,10 @@ or next chunk, whichever is closer. Also adds an "offset" key to the tag map sig
     double                                    sampling_rate = 1.0;
     constexpr static gr::TagPropagationPolicy tag_policy    = gr::TagPropagationPolicy::TPP_DONT;
 
-    gr::work::Status processBulk(const gr::ConsumablePortSpan auto inSamples, gr::PublishablePortSpan auto& outSamples) {
+    gr::work::Status processBulk(const gr::InputSpan auto inSamples, gr::PublishablePortSpan auto& outSamples) {
         std::copy(inSamples.begin(), inSamples.end(), outSamples.begin());
         std::size_t tagsForwarded = 0;
-        for (gr::Tag tag : inSamples.tags) {
+        for (gr::Tag tag : inSamples.rawTags) {
             if (tag.index < (inSamples.streamIndex + (static_cast<gr::Tag::signed_index_type>(inSamples.size()) + 1) / 2)) {
                 tag.insert_or_assign("offset", sampling_rate * static_cast<double>(tag.index - inSamples.streamIndex));
                 outSamples.publishTag(tag.map, 0);
@@ -47,7 +47,7 @@ or next chunk, whichever is closer. Also adds an "offset" key to the tag map sig
                 break;
             }
         }
-        if (inSamples.tags.consume(tagsForwarded)) {
+        if (inSamples.rawTags.consume(tagsForwarded)) {
             return gr::work::Status::OK;
         } else {
             return gr::work::Status::ERROR;


### PR DESCRIPTION
As outlined in #407 I.) this PR introduces a way to directly access and consume tags on the current ConsumableSpan by introducing a `tags()` function which will return a view of all tags with the indices shifted to correspond to the local span indices and a `consumeTags(untilLocalIndex = 1)` which will consume all tags up to the local sample index in the span. The original Tags with the global index can still be accessed via the `rawTags` member.

This is mostly done, there is still a small issue with the concept for the `tags()` function, which is for now commented out and has to be either fixed or removed.