### PR TITLE
Call publishPendingTags on all blocks rather than this scheduler

### DIFF
--- a/core/include/gnuradio-4.0/Scheduler.hpp
+++ b/core/include/gnuradio-4.0/Scheduler.hpp
@@ -234,7 +234,6 @@ protected:
         std::lock_guard lock(_jobListsMutex);
         _graph.forEachBlockMutable([this](auto& block) {
             this->emitErrorMessageIfAny("LifecycleState -> RUNNING", block.changeState(lifecycle::RUNNING));
-            for_each_port([](auto& port) { port.publishPendingTags(); }, outputPorts<PortType::STREAM>(this));
         });
         if constexpr (executionPolicy() == ExecutionPolicy::singleThreaded || executionPolicy() == ExecutionPolicy::singleThreadedBlocking) {
             assert(_nRunningJobs.load(std::memory_order_acquire) == 0UZ);


### PR DESCRIPTION
The call was originally introduced with 49adc04b47cd9bfb8caa02aebddba9e3bde81363.

I'm not sure that my change reflects the intention. If it isn't, this needs a comment IMHO.