### PR TITLE
Block: add std::complex as a special case in reflFirstTypeName

### DIFF
--- a/core/include/gnuradio-4.0/Block.hpp
+++ b/core/include/gnuradio-4.0/Block.hpp
@@ -2024,6 +2024,8 @@ std::string reflFirstTypeName() {
         return fmt::format("gr::DataSet<{}>", reflFirstTypeName<typename Type::value_type>());
     } else if constexpr (UncertainValueLike<Type>) {
         return fmt::format("gr::UncertainValue<{}>", reflFirstTypeName<typename Type::value_type>());
+    } else if constexpr (pmtv::Complex<Type>) {
+        return fmt::format("std::complex<{}>", reflFirstTypeName<typename Type::value_type>());
     } else if constexpr (refl::is_reflectable<Type>()) {
         return refl::reflect<Type>().name.str();
 

--- a/core/test/qa_Block.cpp
+++ b/core/test/qa_Block.cpp
@@ -890,4 +890,18 @@ const boost::ut::suite<"Requested Work Tests"> _requestedWorkTests = [] {
         expect(eq(resultSink.performed_work, 100UZ));
     };
 };
+
+const boost::ut::suite<"reflFirstTypeName Tests"> _reflFirstTypeNameTests = [] {
+    using namespace boost::ut;
+    using namespace gr::detail;
+    using namespace std::literals::string_literals;
+
+    "std::complex"_test = []() {
+        expect(eq(reflFirstTypeName<std::complex<double>>(),
+                  "std::complex<double>"s));
+        expect(eq(reflFirstTypeName<std::complex<float>>(),
+                  "std::complex<float>"s));
+    };
+};
+
 int main() { /* not needed for UT */ }


### PR DESCRIPTION
This makes `reflFirstTypeName<std::complex<float>>()` return `"std::complex<float>"s` instead of `"std::complex<T>"s`, and likewise for `std::complex<double>`.