### PR TITLE
Minor soapy cleanups

### DIFF
--- a/blocks/soapy/include/gnuradio-4.0/soapy/Soapy.hpp
+++ b/blocks/soapy/include/gnuradio-4.0/soapy/Soapy.hpp
@@ -33,7 +33,7 @@ This block supports multiple output ports and was tested against the 'rtlsdr' an
     using A = Annotated<U, description, Arguments...>; // optional shortening
 
     using TimePoint    = std::chrono::time_point<std::chrono::system_clock>;
-    using TSizeChecker = Limits<0U, std::numeric_limits<std::uint32_t>::max(), std::has_single_bit<std::uint32_t>>;
+    using TSizeChecker = Limits<0U, std::numeric_limits<std::uint32_t>::max(), [](std::uint32_t x) { return std::has_single_bit(x); }>;
     using TBasePort    = PortOut<T>;
     using TPortType    = std::conditional_t<nPorts == 1U, TBasePort, std::conditional_t<nPorts == std::dynamic_extent, std::vector<TBasePort>, std::array<TBasePort, nPorts>>>;
 

--- a/blocks/soapy/include/gnuradio-4.0/soapy/SoapyRaiiWrapper.hpp
+++ b/blocks/soapy/include/gnuradio-4.0/soapy/SoapyRaiiWrapper.hpp
@@ -585,12 +585,12 @@ public:
                 return SOAPY_SDR_TIMEOUT;
             }
             if constexpr (sizeof...(TBuffers) == 1UZ) {
-                auto&& buffer          = std::get<0>(std::forward_as_tuple(ioBuffers...));
+                auto&& buffer          = std::get<0>(std::tie(ioBuffers...));
                 void*  ioBufferPointer = static_cast<void*>(buffer.data());
                 return SoapySDRDevice_readStream(_device.get(), _stream.get(), &ioBufferPointer, buffer.size(), &flags, &timeNs, static_cast<long>(timeOutUs));
             } else {
                 std::array<void*, sizeof...(ioBuffers)> ioBufferPointers = {static_cast<void*>(ioBuffers.data())...};
-                return SoapySDRDevice_readStream(_device.get(), _stream.get(), ioBufferPointers.data(), std::get<0>(std::forward_as_tuple(ioBuffers...)).size(), &flags, &timeNs, timeOutUs);
+                return SoapySDRDevice_readStream(_device.get(), _stream.get(), ioBufferPointers.data(), std::get<0>(std::tie(ioBuffers...)).size(), &flags, &timeNs, timeOutUs);
             }
         }
 


### PR DESCRIPTION
Avoid reference to stdlib function which is unspecified (possibly ill-formed):
https://eel.is/c++draft/library#namespace.std-6

Use std::tie instead of std::forward_as_tuple.
The former creates a tuple of lvalue references, the latter can additionally hold rvalue references, which is not the intent here.