### PR TITLE
InputSpan and OutputSpan

### DIFF
--- a/blocks/basic/include/gnuradio-4.0/basic/DataSink.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/DataSink.hpp
@@ -350,9 +350,9 @@ public:
                 return false;
             }
 
-            const auto readData = reader.get(nProcess);
+            auto readData = reader.get(nProcess);
             if constexpr (requires { fnc(std::span<const T>(), std::span<const Tag>()); }) {
-                const auto tags         = tag_reader.get();
+                auto       tags         = tag_reader.get();
                 const auto it           = std::find_if_not(tags.begin(), tags.end(), [until = static_cast<int64_t>(samples_read + nProcess)](const auto& tag) { return tag.index < until; });
                 auto       relevantTags = std::vector<Tag>(tags.begin(), it);
                 for (auto& t : relevantTags) {
@@ -361,8 +361,8 @@ public:
                 fnc(readData, std::span<const Tag>(relevantTags));
                 std::ignore = tags.consume(relevantTags.size());
             } else {
-                const auto tags = tag_reader.get();
-                std::ignore     = tags.consume(tags.size());
+                auto tags   = tag_reader.get();
+                std::ignore = tags.consume(tags.size());
                 fnc(readData);
             }
 
@@ -386,7 +386,7 @@ public:
                 return false;
             }
 
-            const auto readData = reader.get(nProcess);
+            auto readData = reader.get(nProcess);
             fnc(readData);
             std::ignore = readData.consume(nProcess);
             return true;
@@ -480,7 +480,7 @@ public:
         _listeners_finished = true;
     }
 
-    [[nodiscard]] work::Status processBulk(std::span<const T> inData) noexcept {
+    [[nodiscard]] work::Status processBulk(std::span<const T>& inData) noexcept {
         std::optional<property_map> tagData;
         if (this->inputTagsPresent()) {
             assert(this->mergedInputTag().index == 0);

--- a/blocks/basic/include/gnuradio-4.0/basic/clock_source.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/clock_source.hpp
@@ -93,7 +93,7 @@ The 'tag_times[ns]:tag_value(string)' vectors control the emission of tags with 
         }
     }
 
-    work::Status processBulk(PublishablePortSpan auto& outSpan) noexcept {
+    work::Status processBulk(OutputSpanLike auto& outSpan) noexcept {
         if (n_samples_max > 0 && n_samples_produced >= n_samples_max) {
             outSpan.publish(0UZ);
             return work::Status::DONE;

--- a/blocks/fileio/include/gnuradio-4.0/fileio/BasicFileIo.hpp
+++ b/blocks/fileio/include/gnuradio-4.0/fileio/BasicFileIo.hpp
@@ -98,7 +98,7 @@ Important: this implementation assumes a host-order, CPU architecture specific b
 
     void stop() { closeFile(); }
 
-    [[nodiscard]] constexpr work::Status processBulk(ConsumableSpan auto& dataIn) {
+    [[nodiscard]] constexpr work::Status processBulk(InputSpanLike auto& dataIn) {
         if (max_bytes_per_file.value != 0U && _totalBytesWrittenFile >= max_bytes_per_file.value) {
             closeFile();
             openNextFile();
@@ -223,7 +223,7 @@ Important: this implementation assumes a host-order, CPU architecture specific b
 
     void stop() { closeFile(); }
 
-    [[nodiscard]] constexpr work::Status processBulk(PublishablePortSpan auto& dataOut) noexcept {
+    [[nodiscard]] constexpr work::Status processBulk(OutputSpanLike auto& dataOut) noexcept {
         if (!_file.is_open()) {
             return work::Status::DONE;
         }

--- a/blocks/soapy/include/gnuradio-4.0/soapy/Soapy.hpp
+++ b/blocks/soapy/include/gnuradio-4.0/soapy/Soapy.hpp
@@ -88,7 +88,7 @@ This block supports multiple output ports and was tested against the 'rtlsdr' an
     void resume() { _rxStream.activate(); }
     void stop() { _device.reset(); }
 
-    constexpr work::Status processBulk(PublishableSpan auto& output)
+    constexpr work::Status processBulk(OutputSpanLike auto& output)
     requires(nPorts == 1U)
     {
         // special case single ouput -> simplifies connect API because this doesn't require sub-indices
@@ -113,7 +113,7 @@ This block supports multiple output ports and was tested against the 'rtlsdr' an
         return status;
     }
 
-    template<PublishableSpan TOutputBuffer>
+    template<OutputSpanLike TOutputBuffer>
     constexpr work::Status processBulk(std::span<TOutputBuffer>& outputs)
     requires(nPorts > 1U)
     {

--- a/blocks/testing/include/gnuradio-4.0/testing/Delay.hpp
+++ b/blocks/testing/include/gnuradio-4.0/testing/Delay.hpp
@@ -19,8 +19,7 @@ struct Delay : public gr::Block<Delay<T>> {
     bool              _waiting = true;
     clock::time_point _start_time;
 
-    gr::work::Status
-    processBulk(ConsumableSpan auto &input, PublishableSpan auto &output) {
+    gr::work::Status processBulk(InputSpanLike auto& input, OutputSpanLike auto& output) {
         if (_waiting) {
             if (clock::now() - _start_time < std::chrono::milliseconds(delay_ms)) {
                 std::ignore = input.consume(0);
@@ -37,8 +36,7 @@ struct Delay : public gr::Block<Delay<T>> {
         return work::Status::OK;
     }
 
-    void
-    start() noexcept {
+    void start() noexcept {
         _waiting    = true;
         _start_time = clock::now();
     }

--- a/blocks/testing/include/gnuradio-4.0/testing/NullSources.hpp
+++ b/blocks/testing/include/gnuradio-4.0/testing/NullSources.hpp
@@ -56,7 +56,7 @@ struct SlowSource : public gr::Block<SlowSource<T>> {
 
     std::optional<std::chrono::time_point<std::chrono::system_clock>> lastEventAt;
 
-    [[nodiscard]] gr::work::Status processBulk(PublishableSpan auto& output) {
+    [[nodiscard]] gr::work::Status processBulk(OutputSpanLike auto& output) {
         if (!lastEventAt || std::chrono::system_clock::now() - *lastEventAt > std::chrono::milliseconds(n_delay)) {
             lastEventAt = std::chrono::system_clock::now();
 

--- a/blocks/testing/include/gnuradio-4.0/testing/PerformanceMonitor.hpp
+++ b/blocks/testing/include/gnuradio-4.0/testing/PerformanceMonitor.hpp
@@ -98,7 +98,7 @@ Additionally, the block provides three optional output ports for real-time strea
 
     void stop() { closeFile(); }
 
-    gr::work::Status processBulk(gr::ConsumableSpan auto& inSpan, gr::PublishableSpan auto& outResSpan, gr::PublishableSpan auto& outRateSpan) {
+    gr::work::Status processBulk(gr::InputSpanLike auto& inSpan, gr::OutputSpanLike auto& outResSpan, gr::OutputSpanLike auto& outRateSpan) {
         const std::size_t nSamples = std::min(inSpan.size(), static_cast<std::size_t>(evaluate_perf_rate - _nSamplesCounter));
         std::ignore                = inSpan.consume(nSamples);
         _nSamplesCounter += static_cast<gr::Size_t>(nSamples);
@@ -134,7 +134,7 @@ private:
         }
     }
 
-    void addNewMetrics(gr::PublishableSpan auto& outResSpan, gr::PublishableSpan auto& outRateSpan) {
+    void addNewMetrics(gr::OutputSpanLike auto& outResSpan, gr::OutputSpanLike auto& outRateSpan) {
         const std::chrono::time_point<ClockSourceType> timeNow = ClockSourceType::now();
         const auto                                     dTime   = std::chrono::duration_cast<std::chrono::microseconds>(timeNow - _lastTimePoint).count();
         const double                                   rate    = (dTime == 0) ? 0. : static_cast<double>(_nSamplesCounter) * 1.e6 / static_cast<double>(dTime);

--- a/blocks/testing/include/gnuradio-4.0/testing/TagMonitors.hpp
+++ b/blocks/testing/include/gnuradio-4.0/testing/TagMonitors.hpp
@@ -145,7 +145,7 @@ struct TagSource : public Block<TagSource<T, UseProcessVariant>> {
         return mark_tag ? (tagGenerated ? static_cast<T>(1) : static_cast<T>(0)) : static_cast<T>(_nSamplesProduced);
     }
 
-    work::Status processBulk(PublishablePortSpan auto& outSpan) noexcept
+    work::Status processBulk(OutputSpanLike auto& outSpan) noexcept
     requires(UseProcessVariant == ProcessFunction::USE_PROCESS_BULK)
     {
         const auto [tagGenerated, tagRepeatStarted] = generateTag(                                           //

--- a/core/README.md
+++ b/core/README.md
@@ -392,7 +392,7 @@ with properties:
 sendMessage<Set>(toBlock /* MsgOut port */, "" /* serviceName */, block::property::kStagedSetting /* endpoint */, { { "factor", 42 } } /* data  */);
 // and to read one message:
 auto returnReplyMsg = [](gr::MsgPortIn &fromBlock) {
-    ConsumableSpan auto span = fromBlock.streamReader().get<SpanReleasePolicy::ProcessAll>(1UZ);
+    ReaderSpanLike auto span = fromBlock.streamReader().get<SpanReleasePolicy::ProcessAll>(1UZ);
     Message             msg  = span[0];
     expect(span.consume(span.size()));
     return msg;

--- a/core/benchmarks/bm-nosonar_node_api.cpp
+++ b/core/benchmarks/bm-nosonar_node_api.cpp
@@ -150,10 +150,10 @@ struct gen_operation_SIMD : public gr::Block<gen_operation_SIMD<T, op>, gr::Port
             return {requested_work, 0UL, gr::work::Status::INSUFFICIENT_OUTPUT_ITEMS};
         }
         const std::size_t n_to_publish = std::min(n_readable, n_writable);
-        const auto        input        = reader.get();
+        auto              input        = reader.get();
 
         {
-            gr::PublishableSpan auto pSpan = writer.template reserve<gr::SpanReleasePolicy::ProcessAll>(n_to_publish);
+            gr::WriterSpanLike auto pSpan = writer.template reserve<gr::SpanReleasePolicy::ProcessAll>(n_to_publish);
             using namespace vir::stdx;
             using V            = native_simd<T>;
             std::size_t i      = 0;
@@ -237,13 +237,13 @@ public:
             return {requested_work, 0UL, gr::work::Status::INSUFFICIENT_OUTPUT_ITEMS};
         }
         const std::size_t n_to_publish = std::min(n_readable, n_writable);
-        const auto        input        = reader.get();
+        auto              input        = reader.get();
 
         if constexpr (use_memcopy) {
-            gr::PublishableSpan auto pSpan = writer.template reserve<gr::SpanReleasePolicy::ProcessAll>(n_to_publish);
+            gr::WriterSpanLike auto pSpan = writer.template reserve<gr::SpanReleasePolicy::ProcessAll>(n_to_publish);
             std::memcpy(pSpan.data(), reader.get().data(), n_to_publish * sizeof(T));
         } else {
-            gr::PublishableSpan auto pSpan = writer.template reserve<gr::SpanReleasePolicy::ProcessAll>(n_to_publish);
+            gr::WriterSpanLike auto pSpan = writer.template reserve<gr::SpanReleasePolicy::ProcessAll>(n_to_publish);
             for (std::size_t i = 0; i < n_to_publish; i++) {
                 pSpan[i] = input[i];
             }

--- a/core/benchmarks/bm_Buffer.cpp
+++ b/core/benchmarks/bm_Buffer.cpp
@@ -65,7 +65,7 @@ void runTest(BufferLike auto& buffer, const std::size_t vectorLength, const std:
                 std::size_t           nSamplesProduced = 0;
                 barrier.arrive_and_wait();
                 while (nSamplesProduced <= (minSamples + nProducer - 1) / nProducer) {
-                    PublishableSpan auto data = writer.reserve(vectorLength);
+                    WriterSpanLike auto data = writer.reserve(vectorLength);
                     if (!data.empty()) {
                         data.publish(vectorLength);
                         nSamplesProduced += vectorLength;
@@ -93,7 +93,7 @@ void runTest(BufferLike auto& buffer, const std::size_t vectorLength, const std:
                     if (reader.available() < vectorLength) {
                         continue;
                     }
-                    const ConsumableSpan auto& input = reader.get(vectorLength);
+                    ReaderSpanLike auto input = reader.get(vectorLength);
                     nSamplesConsumed += input.size();
 
                     if (!input.consume(input.size())) {

--- a/core/benchmarks/bm_HistoryBuffer.cpp
+++ b/core/benchmarks/bm_HistoryBuffer.cpp
@@ -25,12 +25,12 @@ inline const boost::ut::suite _buffer_tests = [] {
             static int counter = 0;
             for (std::size_t i = 0; i < samples; i++) {
                 {
-                    PublishableSpan auto pSpan = writer.tryReserve(1);
+                    WriterSpanLike auto pSpan = writer.tryReserve(1);
                     boost::ut::expect(!pSpan.empty());
                     pSpan[0] = counter;
                     pSpan.publish(1);
                 }
-                ConsumableSpan auto data = reader.get(1);
+                ReaderSpanLike auto data = reader.get(1);
                 if (data[0] != counter) {
                     throw std::runtime_error(fmt::format("write {} read {} mismatch", counter, data[0]));
                 }
@@ -48,12 +48,12 @@ inline const boost::ut::suite _buffer_tests = [] {
             static int counter = 0;
             for (std::size_t i = 0; i < samples; i++) {
                 {
-                    PublishableSpan auto pSpan = writer.tryReserve(1);
+                    WriterSpanLike auto pSpan = writer.tryReserve(1);
                     boost::ut::expect(!pSpan.empty());
                     pSpan[0] = counter;
                     pSpan.publish(1);
                 }
-                ConsumableSpan auto data = reader.get(1);
+                ReaderSpanLike auto data = reader.get(1);
                 if (data[0] != counter) {
                     throw std::runtime_error(fmt::format("write {} read {} mismatch", counter, data[0]));
                 }
@@ -71,12 +71,12 @@ inline const boost::ut::suite _buffer_tests = [] {
             static int counter = 0;
             for (std::size_t i = 0; i < samples; i++) {
                 {
-                    PublishableSpan auto pSpan = writer.tryReserve(1LU);
+                    WriterSpanLike auto pSpan = writer.tryReserve(1LU);
                     boost::ut::expect(!pSpan.empty());
                     pSpan[0] = counter;
                     pSpan.publish(1);
                 }
-                ConsumableSpan auto data = reader.get(1);
+                ReaderSpanLike auto data = reader.get(1);
                 if (data[0] != counter) {
                     throw std::runtime_error(fmt::format("write {} read {} mismatch", counter, data[0]));
                 }
@@ -126,11 +126,11 @@ inline const boost::ut::suite _buffer_tests = [] {
             static int counter = 0;
             for (std::size_t i = 0; i < samples; i++) {
                 {
-                    PublishableSpan auto pSpan = writer.tryReserve<SpanReleasePolicy::ProcessAll>(1LU);
+                    WriterSpanLike auto pSpan = writer.tryReserve<SpanReleasePolicy::ProcessAll>(1LU);
                     boost::ut::expect(!pSpan.empty());
                     pSpan[0] = counter;
                 }
-                gr::ConsumableSpan auto     range = reader.get(1);
+                ReaderSpanLike auto         range = reader.get(1);
                 [[maybe_unused]] const auto data  = range[0];
                 [[maybe_unused]] const auto ret   = range.consume(1);
                 counter++;

--- a/core/benchmarks/bm_fft.cpp
+++ b/core/benchmarks/bm_fft.cpp
@@ -17,12 +17,13 @@
  * reference: https://en.wikipedia.org/wiki/Cooley%E2%80%93Tukey_FFT_algorithm#Pseudocode
  */
 template<typename T>
-    requires gr::meta::complex_like<T>
-void
-computeFFTCooleyTukey(std::vector<T> &signal) {
-    const std::size_t N{ signal.size() };
+requires gr::meta::complex_like<T>
+void computeFFTCooleyTukey(std::vector<T>& signal) {
+    const std::size_t N{signal.size()};
 
-    if (N == 1) return;
+    if (N == 1) {
+        return;
+    }
 
     std::vector<T> even(N / 2);
     std::vector<T> odd(N / 2);
@@ -34,7 +35,7 @@ computeFFTCooleyTukey(std::vector<T> &signal) {
     computeFFTCooleyTukey(even);
     computeFFTCooleyTukey(odd);
 
-    const typename T::value_type wn{ static_cast<typename T::value_type>(2. * std::numbers::pi_v<double>) / static_cast<typename T::value_type>(N) };
+    const typename T::value_type wn{static_cast<typename T::value_type>(2. * std::numbers::pi_v<double>) / static_cast<typename T::value_type>(N)};
     for (std::size_t i = 0; i < N / 2; i++) {
         const T wkn(std::cos(wn * static_cast<typename T::value_type>(i)), std::sin(wn * static_cast<typename T::value_type>(i)));
         signal[i]         = even[i] + wkn * odd[i];
@@ -43,12 +44,11 @@ computeFFTCooleyTukey(std::vector<T> &signal) {
 }
 
 template<typename T>
-std::vector<T>
-generateSinSample(std::size_t N, double sampleRate, double frequency, double amplitude) {
+std::vector<T> generateSinSample(std::size_t N, double sampleRate, double frequency, double amplitude) {
     std::vector<T> signal(N);
     for (std::size_t i = 0; i < N; i++) {
         if constexpr (gr::meta::complex_like<T>) {
-            signal[i] = { static_cast<typename T::value_type>(amplitude * std::sin(2. * std::numbers::pi * frequency * static_cast<double>(i) / sampleRate)), 0. };
+            signal[i] = {static_cast<typename T::value_type>(amplitude * std::sin(2. * std::numbers::pi * frequency * static_cast<double>(i) / sampleRate)), 0.};
         } else {
             signal[i] = static_cast<T>(amplitude * std::sin(2. * std::numbers::pi * frequency * static_cast<double>(i) / sampleRate));
         }
@@ -67,19 +67,18 @@ struct FFTAlgoPrecision<T> {
 };
 
 template<typename T>
-void
-testFFT() {
+void testFFT() {
     using namespace benchmark;
     using namespace boost::ut;
     using namespace boost::ut::reflection;
     using namespace gr;
     using namespace gr::algorithm;
 
-    constexpr gr::Size_t N{ 1024U }; // must be power of 2
-    constexpr double     sampleRate{ 256. };
-    constexpr double     frequency{ 100. };
-    constexpr double     amplitude{ 1. };
-    constexpr int        nRepetitions{ 100 };
+    constexpr gr::Size_t N{1024U}; // must be power of 2
+    constexpr double     sampleRate{256.};
+    constexpr double     frequency{100.};
+    constexpr double     amplitude{1.};
+    constexpr int        nRepetitions{100};
 
     using PrecisionType = FFTAlgoPrecision<T>::type;
 
@@ -88,22 +87,18 @@ testFFT() {
     std::vector<T> signal = generateSinSample<T>(N, sampleRate, frequency, amplitude);
 
     {
-        gr::blocks::fft::FFT<T, DataSet<PrecisionType>, FFTw> fft1({ { "fftSize", N } });
+        gr::blocks::fft::FFT<T, DataSet<PrecisionType>, FFTw> fft1({{"fftSize", N}});
         std::ignore = fft1.settings().applyStagedParameters();
 
         std::vector<DataSet<PrecisionType>> resultingDataSets(1);
-        ::benchmark::benchmark<nRepetitions>(fmt::format("{} - fftw", type_name<T>())) = [&fft1, &signal, &resultingDataSets] {
-            expect(gr::work::Status::OK == fft1.processBulk(signal, resultingDataSets));
-        };
+        ::benchmark::benchmark<nRepetitions>(fmt::format("{} - fftw", type_name<T>())) = [&fft1, &signal, &resultingDataSets] { expect(gr::work::Status::OK == fft1.processBulk(signal, resultingDataSets)); };
     }
     {
-        gr::blocks::fft::FFT<T, DataSet<PrecisionType>, FFT> fft1({ { "fftSize", N } });
+        gr::blocks::fft::FFT<T, DataSet<PrecisionType>, FFT> fft1({{"fftSize", N}});
         std::ignore = fft1.settings().applyStagedParameters();
 
         std::vector<DataSet<PrecisionType>> resultingDataSets(1);
-        ::benchmark::benchmark<nRepetitions>(fmt::format("{} - fft", type_name<T>())) = [&fft1, &signal, &resultingDataSets] {
-            expect(gr::work::Status::OK == fft1.processBulk(signal, resultingDataSets));
-        };
+        ::benchmark::benchmark<nRepetitions>(fmt::format("{} - fft", type_name<T>())) = [&fft1, &signal, &resultingDataSets] { expect(gr::work::Status::OK == fft1.processBulk(signal, resultingDataSets)); };
     }
 
     if constexpr (gr::meta::complex_like<T>) {
@@ -124,6 +119,4 @@ inline const boost::ut::suite _fft_bm_tests = [] {
     std::apply([]<class... TArgs>(TArgs... /*args*/) { (testFFT<TArgs>(), ...); }, realTypesToTest);
 };
 
-int
-main() { /* not needed by the UT framework */
-}
+int main() { /* not needed by the UT framework */ }

--- a/core/include/gnuradio-4.0/Message.hpp
+++ b/core/include/gnuradio-4.0/Message.hpp
@@ -132,8 +132,8 @@ void sendMessage(auto& port, std::string_view serviceName, std::string_view endp
     } else {
         message.data = std::unexpected(userMessage);
     }
-    PublishableSpan auto msgSpan = port.streamWriter().template reserve<SpanReleasePolicy::ProcessAll>(1UZ);
-    msgSpan[0]                   = std::move(message);
+    WriterSpanLike auto msgSpan = port.streamWriter().template reserve<SpanReleasePolicy::ProcessAll>(1UZ);
+    msgSpan[0]                  = std::move(message);
 }
 } // namespace detail
 

--- a/core/include/gnuradio-4.0/Profiler.hpp
+++ b/core/include/gnuradio-4.0/Profiler.hpp
@@ -314,8 +314,8 @@ public:
             while (!seen_finished) {
                 seen_finished = finished;
                 while (reader.available() > 0) {
-                    gr::ConsumableSpan auto event = reader.get(1);
-                    auto                    it    = mapped_threads.find(event[0].thread_id);
+                    ReaderSpanLike auto event = reader.get(1);
+                    auto                it    = mapped_threads.find(event[0].thread_id);
                     if (it == mapped_threads.end()) {
                         it = mapped_threads.emplace(event[0].thread_id, static_cast<int>(mapped_threads.size())).first;
                     }

--- a/core/test/qa_Block.cpp
+++ b/core/test/qa_Block.cpp
@@ -114,7 +114,7 @@ static_assert(gr::HasProcessOneFunction<BlockSignaturesTemplatedProcessOneConst<
 static_assert(gr::HasConstProcessOneFunction<BlockSignaturesTemplatedProcessOneConst<float>>);
 static_assert(!gr::HasProcessBulkFunction<BlockSignaturesTemplatedProcessOneConst<float>>);
 
-enum class ProcessBulkVariant { SPAN_SPAN, SPAN_PUBLISHABLE, SPAN_PUBLISHABLE2, CONSUMABLE_SPAN, CONSUMABLE_SPAN2, CONSUMABLE_PUBLISHABLE, CONSUMABLE_PUBLISHABLE2, CONSUMABLE_PUBLISHABLE_PORT, CONSUMABLE_PUBLISHABLE_PORT2 };
+enum class ProcessBulkVariant { STD_STD, STD_STD_REF, STD_OUTPUT, STD_OUTPUT_REF, INPUT_STD, INPUT_STD_REF, INPUT_OUTPUT, INPUT_OUTPUT_REF };
 
 template<typename T, ProcessBulkVariant processVariant>
 struct BlockSignaturesProcessBulkSpan : public gr::Block<BlockSignaturesProcessBulkSpan<T, processVariant>> {
@@ -122,79 +122,72 @@ struct BlockSignaturesProcessBulkSpan : public gr::Block<BlockSignaturesProcessB
     gr::PortOut<T> out{};
 
     gr::work::Status processBulk(std::span<const T>, std::span<T>)
-    requires(processVariant == ProcessBulkVariant::SPAN_SPAN)
+    requires(processVariant == ProcessBulkVariant::STD_STD)
     {
         return gr::work::Status::OK;
     }
 
-    gr::work::Status processBulk(std::span<const T>, gr::PublishableSpan auto&)
-    requires(processVariant == ProcessBulkVariant::SPAN_PUBLISHABLE)
+    gr::work::Status processBulk(std::span<const T>&, std::span<T>&)
+    requires(processVariant == ProcessBulkVariant::STD_STD_REF)
     {
         return gr::work::Status::OK;
     }
 
-    gr::work::Status processBulk(std::span<const T>, gr::PublishableSpan auto)
-    requires(processVariant == ProcessBulkVariant::SPAN_PUBLISHABLE2)
+    gr::work::Status processBulk(std::span<const T>, gr::OutputSpanLike auto)
+    requires(processVariant == ProcessBulkVariant::STD_OUTPUT)
     {
         return gr::work::Status::OK;
     }
 
-    gr::work::Status processBulk(gr::ConsumableSpan auto, std::span<T>)
-    requires(processVariant == ProcessBulkVariant::CONSUMABLE_SPAN)
+    gr::work::Status processBulk(std::span<const T>&, gr::OutputSpanLike auto&)
+    requires(processVariant == ProcessBulkVariant::STD_OUTPUT_REF)
     {
         return gr::work::Status::OK;
     }
 
-    gr::work::Status processBulk(gr::ConsumableSpan auto&, std::span<T>)
-    requires(processVariant == ProcessBulkVariant::CONSUMABLE_SPAN2)
+    gr::work::Status processBulk(gr::InputSpanLike auto, std::span<T>)
+    requires(processVariant == ProcessBulkVariant::INPUT_STD)
     {
         return gr::work::Status::OK;
     }
 
-    gr::work::Status processBulk(gr::ConsumableSpan auto&, gr::PublishableSpan auto&)
-    requires(processVariant == ProcessBulkVariant::CONSUMABLE_PUBLISHABLE)
+    gr::work::Status processBulk(gr::InputSpanLike auto&, std::span<T>&)
+    requires(processVariant == ProcessBulkVariant::INPUT_STD_REF)
     {
         return gr::work::Status::OK;
     }
 
-    gr::work::Status processBulk(gr::ConsumableSpan auto, gr::PublishableSpan auto)
-    requires(processVariant == ProcessBulkVariant::CONSUMABLE_PUBLISHABLE2)
+    gr::work::Status processBulk(gr::InputSpanLike auto, gr::OutputSpanLike auto)
+    requires(processVariant == ProcessBulkVariant::INPUT_OUTPUT)
     {
         return gr::work::Status::OK;
     }
 
-    gr::work::Status processBulk(const gr::InputSpan auto&, gr::PublishablePortSpan auto&)
-    requires(processVariant == ProcessBulkVariant::CONSUMABLE_PUBLISHABLE_PORT)
-    {
-        return gr::work::Status::OK;
-    }
-
-    gr::work::Status processBulk(const gr::InputSpan auto, gr::PublishablePortSpan auto)
-    requires(processVariant == ProcessBulkVariant::CONSUMABLE_PUBLISHABLE_PORT2)
+    gr::work::Status processBulk(gr::InputSpanLike auto&, gr::OutputSpanLike auto&)
+    requires(processVariant == ProcessBulkVariant::INPUT_OUTPUT_REF)
     {
         return gr::work::Status::OK;
     }
 };
 
 ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T, ProcessBulkVariant processVariant), (BlockSignaturesProcessBulkSpan<T, processVariant>), in, out);
+static_assert(gr::HasRequiredProcessFunction<BlockSignaturesProcessBulkSpan<float, ProcessBulkVariant::STD_STD>>);
+static_assert(!gr::HasProcessOneFunction<BlockSignaturesProcessBulkSpan<float, ProcessBulkVariant::STD_STD>>);
+static_assert(!gr::HasConstProcessOneFunction<BlockSignaturesProcessBulkSpan<float, ProcessBulkVariant::STD_STD>>);
+static_assert(gr::HasProcessBulkFunction<BlockSignaturesProcessBulkSpan<float, ProcessBulkVariant::STD_STD>>);
 
-static_assert(gr::HasRequiredProcessFunction<BlockSignaturesProcessBulkSpan<float, ProcessBulkVariant::SPAN_SPAN>>);
-static_assert(!gr::HasProcessOneFunction<BlockSignaturesProcessBulkSpan<float, ProcessBulkVariant::SPAN_SPAN>>);
-static_assert(!gr::HasConstProcessOneFunction<BlockSignaturesProcessBulkSpan<float, ProcessBulkVariant::SPAN_SPAN>>);
-static_assert(gr::HasProcessBulkFunction<BlockSignaturesProcessBulkSpan<float, ProcessBulkVariant::SPAN_SPAN>>);
-static_assert(gr::HasProcessBulkFunction<BlockSignaturesProcessBulkSpan<float, ProcessBulkVariant::SPAN_PUBLISHABLE>>);
-static_assert(!gr::HasProcessBulkFunction<BlockSignaturesProcessBulkSpan<float, ProcessBulkVariant::SPAN_PUBLISHABLE2>>); // TODO: fix the signature is required to work
-static_assert(gr::HasProcessBulkFunction<BlockSignaturesProcessBulkSpan<float, ProcessBulkVariant::CONSUMABLE_SPAN>>);
-static_assert(gr::HasProcessBulkFunction<BlockSignaturesProcessBulkSpan<float, ProcessBulkVariant::CONSUMABLE_SPAN2>>);
-static_assert(gr::HasProcessBulkFunction<BlockSignaturesProcessBulkSpan<float, ProcessBulkVariant::CONSUMABLE_PUBLISHABLE>>);
-static_assert(!gr::HasProcessBulkFunction<BlockSignaturesProcessBulkSpan<float, ProcessBulkVariant::CONSUMABLE_PUBLISHABLE2>>); // TODO: fix the signature is required to work
-static_assert(gr::HasProcessBulkFunction<BlockSignaturesProcessBulkSpan<float, ProcessBulkVariant::CONSUMABLE_PUBLISHABLE_PORT>>);
-static_assert(!gr::HasProcessBulkFunction<BlockSignaturesProcessBulkSpan<float, ProcessBulkVariant::CONSUMABLE_PUBLISHABLE_PORT2>>); // TODO: fix the signature is required to work
+static_assert(gr::HasProcessBulkFunction<BlockSignaturesProcessBulkSpan<float, ProcessBulkVariant::STD_STD_REF>>);
+static_assert(gr::HasProcessBulkFunction<BlockSignaturesProcessBulkSpan<float, ProcessBulkVariant::STD_OUTPUT>>);
+static_assert(gr::HasProcessBulkFunction<BlockSignaturesProcessBulkSpan<float, ProcessBulkVariant::STD_OUTPUT_REF>>);
+static_assert(gr::HasProcessBulkFunction<BlockSignaturesProcessBulkSpan<float, ProcessBulkVariant::INPUT_STD>>);
+static_assert(gr::HasProcessBulkFunction<BlockSignaturesProcessBulkSpan<float, ProcessBulkVariant::INPUT_STD_REF>>);
+static_assert(gr::HasProcessBulkFunction<BlockSignaturesProcessBulkSpan<float, ProcessBulkVariant::INPUT_OUTPUT>>);
+static_assert(gr::HasProcessBulkFunction<BlockSignaturesProcessBulkSpan<float, ProcessBulkVariant::INPUT_OUTPUT_REF>>);
 
-static_assert(gr::traits::block::processBulk_requires_ith_output_as_span<BlockSignaturesProcessBulkSpan<float, ProcessBulkVariant::SPAN_SPAN>, 0>);
-static_assert(!gr::traits::block::processBulk_requires_ith_output_as_span<BlockSignaturesProcessBulkSpan<float, ProcessBulkVariant::SPAN_PUBLISHABLE>, 0>);
+// static_assert(gr::traits::block::processBulk_requires_ith_output_as_span<BlockSignaturesProcessBulkSpan<float, ProcessBulkVariant::STD_STD>, 0>);
+static_assert(!gr::traits::block::processBulk_requires_ith_output_as_span<BlockSignaturesProcessBulkSpan<float, ProcessBulkVariant::STD_OUTPUT>, 0>);
 
-enum class ProcessBulkTwoOutsVariant { SPAN_SPAN, PUBLISHABLE_SPAN, PUBLISHABLE_PUBLISHABLE, SPAN_PUBLISHABLE };
+enum class ProcessBulkTwoOutsVariant { STD_STD, OUTPUT_STD, OUTPUT_OUTPUT, STD_OUTPUT };
 
 template<typename T, ProcessBulkTwoOutsVariant processVariant>
 struct BlockSignaturesProcessBulkTwoOuts : public gr::Block<BlockSignaturesProcessBulkTwoOuts<T, processVariant>> {
@@ -203,25 +196,25 @@ struct BlockSignaturesProcessBulkTwoOuts : public gr::Block<BlockSignaturesProce
     gr::PortOut<T> out2{};
 
     gr::work::Status processBulk(std::span<const T>, std::span<T>, std::span<T>)
-    requires(processVariant == ProcessBulkTwoOutsVariant::SPAN_SPAN)
+    requires(processVariant == ProcessBulkTwoOutsVariant::STD_STD)
     {
         return gr::work::Status::OK;
     }
 
-    gr::work::Status processBulk(std::span<const T>, gr::PublishableSpan auto&, std::span<T>)
-    requires(processVariant == ProcessBulkTwoOutsVariant::PUBLISHABLE_SPAN)
+    gr::work::Status processBulk(std::span<const T>, gr::OutputSpanLike auto, std::span<T>)
+    requires(processVariant == ProcessBulkTwoOutsVariant::OUTPUT_STD)
     {
         return gr::work::Status::OK;
     }
 
-    gr::work::Status processBulk(std::span<const T>, gr::PublishableSpan auto&, gr::PublishableSpan auto&)
-    requires(processVariant == ProcessBulkTwoOutsVariant::PUBLISHABLE_PUBLISHABLE)
+    gr::work::Status processBulk(std::span<const T>, gr::OutputSpanLike auto, gr::OutputSpanLike auto)
+    requires(processVariant == ProcessBulkTwoOutsVariant::OUTPUT_OUTPUT)
     {
         return gr::work::Status::OK;
     }
 
-    gr::work::Status processBulk(std::span<const T>, std::span<T>, gr::PublishableSpan auto&)
-    requires(processVariant == ProcessBulkTwoOutsVariant::SPAN_PUBLISHABLE)
+    gr::work::Status processBulk(std::span<const T>, std::span<T>, gr::OutputSpanLike auto)
+    requires(processVariant == ProcessBulkTwoOutsVariant::STD_OUTPUT)
     {
         return gr::work::Status::OK;
     }
@@ -229,59 +222,59 @@ struct BlockSignaturesProcessBulkTwoOuts : public gr::Block<BlockSignaturesProce
 
 ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T, ProcessBulkTwoOutsVariant processVariant), (BlockSignaturesProcessBulkTwoOuts<T, processVariant>), in, out1, out2);
 
-static_assert(gr::traits::block::processBulk_requires_ith_output_as_span<BlockSignaturesProcessBulkTwoOuts<float, ProcessBulkTwoOutsVariant::SPAN_SPAN>, 0>);
-static_assert(gr::traits::block::processBulk_requires_ith_output_as_span<BlockSignaturesProcessBulkTwoOuts<float, ProcessBulkTwoOutsVariant::SPAN_SPAN>, 1>);
-static_assert(!gr::traits::block::processBulk_requires_ith_output_as_span<BlockSignaturesProcessBulkTwoOuts<float, ProcessBulkTwoOutsVariant::PUBLISHABLE_SPAN>, 0>);
-static_assert(gr::traits::block::processBulk_requires_ith_output_as_span<BlockSignaturesProcessBulkTwoOuts<float, ProcessBulkTwoOutsVariant::PUBLISHABLE_SPAN>, 1>);
-static_assert(gr::traits::block::processBulk_requires_ith_output_as_span<BlockSignaturesProcessBulkTwoOuts<float, ProcessBulkTwoOutsVariant::SPAN_PUBLISHABLE>, 0>);
-static_assert(!gr::traits::block::processBulk_requires_ith_output_as_span<BlockSignaturesProcessBulkTwoOuts<float, ProcessBulkTwoOutsVariant::SPAN_PUBLISHABLE>, 1>);
-static_assert(!gr::traits::block::processBulk_requires_ith_output_as_span<BlockSignaturesProcessBulkTwoOuts<float, ProcessBulkTwoOutsVariant::PUBLISHABLE_PUBLISHABLE>, 0>);
-static_assert(!gr::traits::block::processBulk_requires_ith_output_as_span<BlockSignaturesProcessBulkTwoOuts<float, ProcessBulkTwoOutsVariant::PUBLISHABLE_PUBLISHABLE>, 1>);
-static_assert(!gr::traits::block::processBulk_requires_ith_output_as_span<BlockSignaturesProcessBulkTwoOuts<float, ProcessBulkTwoOutsVariant::SPAN_SPAN>, 2>); // out-of-range check
+static_assert(gr::traits::block::processBulk_requires_ith_output_as_span<BlockSignaturesProcessBulkTwoOuts<float, ProcessBulkTwoOutsVariant::STD_STD>, 0>);
+static_assert(gr::traits::block::processBulk_requires_ith_output_as_span<BlockSignaturesProcessBulkTwoOuts<float, ProcessBulkTwoOutsVariant::STD_STD>, 1>);
+static_assert(!gr::traits::block::processBulk_requires_ith_output_as_span<BlockSignaturesProcessBulkTwoOuts<float, ProcessBulkTwoOutsVariant::OUTPUT_STD>, 0>);
+static_assert(gr::traits::block::processBulk_requires_ith_output_as_span<BlockSignaturesProcessBulkTwoOuts<float, ProcessBulkTwoOutsVariant::OUTPUT_STD>, 1>);
+static_assert(gr::traits::block::processBulk_requires_ith_output_as_span<BlockSignaturesProcessBulkTwoOuts<float, ProcessBulkTwoOutsVariant::STD_OUTPUT>, 0>);
+static_assert(!gr::traits::block::processBulk_requires_ith_output_as_span<BlockSignaturesProcessBulkTwoOuts<float, ProcessBulkTwoOutsVariant::STD_OUTPUT>, 1>);
+static_assert(!gr::traits::block::processBulk_requires_ith_output_as_span<BlockSignaturesProcessBulkTwoOuts<float, ProcessBulkTwoOutsVariant::OUTPUT_OUTPUT>, 0>);
+static_assert(!gr::traits::block::processBulk_requires_ith_output_as_span<BlockSignaturesProcessBulkTwoOuts<float, ProcessBulkTwoOutsVariant::OUTPUT_OUTPUT>, 1>);
+static_assert(!gr::traits::block::processBulk_requires_ith_output_as_span<BlockSignaturesProcessBulkTwoOuts<float, ProcessBulkTwoOutsVariant::STD_STD>, 2>); // out-of-range check
 
-enum class ProcessBulkVectorVariant { SPAN_SPAN, SPAN_SPAN2, CONSUMABLE_SPAN, CONSUMABLE_PUBLISHABLE, CONSUMABLE_PUBLISHABLE2, SPAN_PUBLISHABLE };
+enum class ProcessBulkVectorVariant { STD_STD, STD_STD_REF, INPUT_STD, STD_OUTPUT, INPUT_OUTPUT, INPUT_OUTPUT_REF };
 
 template<typename T, ProcessBulkVectorVariant processVariant>
 struct BlockSignaturesProcessBulkVector : public gr::Block<BlockSignaturesProcessBulkVector<T, processVariant>> {
     std::array<gr::PortIn<T>, 3>  inputs{};
     std::array<gr::PortOut<T>, 6> outputs{};
 
-    gr::work::Status processBulk(const std::span<std::span<const T>>&, std::span<std::span<T>>&)
-    requires(processVariant == ProcessBulkVectorVariant::SPAN_SPAN)
-    {
-        return gr::work::Status::OK;
-    }
-
     gr::work::Status processBulk(std::span<std::span<const T>>, std::span<std::span<T>>)
-    requires(processVariant == ProcessBulkVectorVariant::SPAN_SPAN2)
+    requires(processVariant == ProcessBulkVectorVariant::STD_STD)
     {
         return gr::work::Status::OK;
     }
 
-    template<gr::ConsumableSpan TInput>
-    gr::work::Status processBulk(const std::span<TInput>&, std::span<std::span<T>>&)
-    requires(processVariant == ProcessBulkVectorVariant::CONSUMABLE_SPAN)
+    gr::work::Status processBulk(std::span<std::span<const T>>&, std::span<std::span<T>>&)
+    requires(processVariant == ProcessBulkVectorVariant::STD_STD_REF)
     {
         return gr::work::Status::OK;
     }
 
-    template<gr::ConsumableSpan TInput, gr::PublishableSpan TOutput>
-    gr::work::Status processBulk(const std::span<TInput>&, std::span<TOutput>&)
-    requires(processVariant == ProcessBulkVectorVariant::CONSUMABLE_PUBLISHABLE)
+    template<gr::InputSpanLike TInput>
+    gr::work::Status processBulk(std::span<TInput>&, std::span<std::span<T>>&)
+    requires(processVariant == ProcessBulkVectorVariant::INPUT_STD)
     {
         return gr::work::Status::OK;
     }
 
-    template<gr::ConsumableSpan TInput, gr::PublishableSpan TOutput>
+    template<gr::OutputSpanLike TOutput>
+    gr::work::Status processBulk(std::span<std::span<const T>>&, std::span<TOutput>&)
+    requires(processVariant == ProcessBulkVectorVariant::STD_OUTPUT)
+    {
+        return gr::work::Status::OK;
+    }
+
+    template<gr::InputSpanLike TInput, gr::OutputSpanLike TOutput>
     gr::work::Status processBulk(std::span<TInput>, std::span<TOutput>)
-    requires(processVariant == ProcessBulkVectorVariant::CONSUMABLE_PUBLISHABLE2)
+    requires(processVariant == ProcessBulkVectorVariant::INPUT_OUTPUT)
     {
         return gr::work::Status::OK;
     }
 
-    template<gr::PublishableSpan TOutput>
-    gr::work::Status processBulk(const std::span<std::span<const T>>&, std::span<TOutput>&)
-    requires(processVariant == ProcessBulkVectorVariant::SPAN_PUBLISHABLE)
+    template<gr::InputSpanLike TInput, gr::OutputSpanLike TOutput>
+    gr::work::Status processBulk(std::span<TInput>&, std::span<TOutput>&)
+    requires(processVariant == ProcessBulkVectorVariant::INPUT_OUTPUT_REF)
     {
         return gr::work::Status::OK;
     }
@@ -289,12 +282,12 @@ struct BlockSignaturesProcessBulkVector : public gr::Block<BlockSignaturesProces
 
 ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T, ProcessBulkVectorVariant processVariant), (BlockSignaturesProcessBulkVector<T, processVariant>), inputs, outputs);
 
-static_assert(gr::HasProcessBulkFunction<BlockSignaturesProcessBulkVector<float, ProcessBulkVectorVariant::SPAN_SPAN>>);
-static_assert(gr::HasProcessBulkFunction<BlockSignaturesProcessBulkVector<float, ProcessBulkVectorVariant::SPAN_SPAN2>>);
-static_assert(!gr::HasProcessBulkFunction<BlockSignaturesProcessBulkVector<float, ProcessBulkVectorVariant::CONSUMABLE_SPAN>>); // combinations are not supported yet
-static_assert(gr::HasProcessBulkFunction<BlockSignaturesProcessBulkVector<float, ProcessBulkVectorVariant::CONSUMABLE_PUBLISHABLE>>);
-static_assert(gr::HasProcessBulkFunction<BlockSignaturesProcessBulkVector<float, ProcessBulkVectorVariant::CONSUMABLE_PUBLISHABLE2>>);
-static_assert(!gr::HasProcessBulkFunction<BlockSignaturesProcessBulkVector<float, ProcessBulkVectorVariant::SPAN_PUBLISHABLE>>); // combinations are not supported yet
+static_assert(gr::HasProcessBulkFunction<BlockSignaturesProcessBulkVector<float, ProcessBulkVectorVariant::STD_STD>>);
+static_assert(gr::HasProcessBulkFunction<BlockSignaturesProcessBulkVector<float, ProcessBulkVectorVariant::STD_STD_REF>>);
+static_assert(gr::HasProcessBulkFunction<BlockSignaturesProcessBulkVector<float, ProcessBulkVectorVariant::INPUT_STD>>);
+static_assert(gr::HasProcessBulkFunction<BlockSignaturesProcessBulkVector<float, ProcessBulkVectorVariant::STD_OUTPUT>>);
+static_assert(gr::HasProcessBulkFunction<BlockSignaturesProcessBulkVector<float, ProcessBulkVectorVariant::INPUT_OUTPUT>>);
+static_assert(gr::HasProcessBulkFunction<BlockSignaturesProcessBulkVector<float, ProcessBulkVectorVariant::INPUT_OUTPUT_REF>>);
 
 struct InvalidSettingBlock : gr::Block<InvalidSettingBlock> {
     std::tuple<int> tuple; // this type is not supported and should cause the checkBlockContracts<T>() to throw
@@ -323,8 +316,8 @@ struct MissingProcessSignature3 : gr::Block<MissingProcessSignature3> {
     std::vector<gr::PortOut<float>>   outA;
     std::array<gr::PortOut<float>, 2> outB;
 
-    template<typename PublishableSpan2>
-    gr::work::Status processBulk(std::span<std::vector<float>>&, PublishableSpan2&) { // TODO: needs proper explicit signature
+    template<gr::OutputSpanLike TOutputSpan2>
+    gr::work::Status processBulk(std::span<std::vector<float>>&, std::span<TOutputSpan2>&) {
         return gr::work::Status::OK;
     }
 };
@@ -378,7 +371,7 @@ struct IntDecBlock : public gr::Block<IntDecBlock<T>, gr::Resampling<>, gr::Stri
     ProcessStatus status{};
     bool          write_to_vector{false};
 
-    gr::work::Status processBulk(std::span<const T> input, std::span<T> output) noexcept {
+    gr::work::Status processBulk(std::span<const T>& input, std::span<T>& output) noexcept {
         status.n_inputs  = input.size();
         status.n_outputs = output.size();
         status.process_counter++;
@@ -401,7 +394,7 @@ struct SyncOrAsyncBlock : gr::Block<SyncOrAsyncBlock<T, isInputAsync, isOutputAs
     InputPortType  in{};
     OutputPortType out{};
 
-    gr::work::Status processBulk(const gr::ConsumableSpan auto& inSpan, gr::PublishableSpan auto& outSpan) {
+    gr::work::Status processBulk(gr::InputSpanLike auto& inSpan, gr::OutputSpanLike auto& outSpan) {
         const auto available = std::min(inSpan.size(), outSpan.size());
         if (available != 0) {
             std::copy(inSpan.begin(), std::next(inSpan.begin(), static_cast<std::ptrdiff_t>(available)), outSpan.begin());
@@ -424,11 +417,11 @@ struct ArrayPortsNode : gr::Block<ArrayPortsNode<T>> {
     std::array<gr::PortOut<T, gr::Async>, nPorts> outputs;
 
     template<typename TInSpan, typename TOutSpan>
-    gr::work::Status processBulk(const std::span<TInSpan>& ins, const std::span<TOutSpan>& outs) {
+    gr::work::Status processBulk(std::span<TInSpan>& ins, std::span<TOutSpan>& outs) {
         for (std::size_t channelIndex = 0; channelIndex < ins.size(); ++channelIndex) {
-            gr::ConsumableSpan auto  inputSpan  = ins[channelIndex];
-            gr::PublishableSpan auto outputSpan = outs[channelIndex];
-            auto                     available  = std::min(inputSpan.size(), outputSpan.size());
+            gr::InputSpanLike auto  inputSpan  = ins[channelIndex];
+            gr::OutputSpanLike auto outputSpan = outs[channelIndex];
+            auto                    available  = std::min(inputSpan.size(), outputSpan.size());
 
             for (std::size_t valueIndex = 0; valueIndex < available; ++valueIndex) {
                 outputSpan[valueIndex] = inputSpan[valueIndex];
@@ -904,10 +897,8 @@ const boost::ut::suite<"reflFirstTypeName Tests"> _reflFirstTypeNameTests = [] {
     using namespace std::literals::string_literals;
 
     "std::complex"_test = []() {
-        expect(eq(reflFirstTypeName<std::complex<double>>(),
-                  "std::complex<double>"s));
-        expect(eq(reflFirstTypeName<std::complex<float>>(),
-                  "std::complex<float>"s));
+        expect(eq(reflFirstTypeName<std::complex<double>>(), "std::complex<double>"s));
+        expect(eq(reflFirstTypeName<std::complex<float>>(), "std::complex<float>"s));
     };
 };
 

--- a/core/test/qa_DynamicPort.cpp
+++ b/core/test/qa_DynamicPort.cpp
@@ -128,7 +128,7 @@ const boost::ut::suite PortApiTests = [] {
 
         expect(eq(buffers.streamBuffer.n_readers(), 1UZ));
 
-        PublishableSpan auto pSpan = writer.reserve<SpanReleasePolicy::ProcessAll>(32UZ);
+        WriterSpanLike auto pSpan = writer.reserve<SpanReleasePolicy::ProcessAll>(32UZ);
         std::iota(pSpan.begin(), pSpan.end(), 1);
         fmt::print("typed-port connected output vector: {}\n", pSpan);
     };

--- a/core/test/qa_GraphMessages.cpp
+++ b/core/test/qa_GraphMessages.cpp
@@ -57,7 +57,7 @@ const boost::ut::suite<"Graph Formatter Tests"> graphFormatterTests = [] {
 
 auto returnReplyMsg(gr::MsgPortIn& port) {
     expect(eq(port.streamReader().available(), 1UZ)) << "didn't receive a reply message";
-    ConsumableSpan auto span = port.streamReader().get<SpanReleasePolicy::ProcessAll>(1UZ);
+    ReaderSpanLike auto span = port.streamReader().get<SpanReleasePolicy::ProcessAll>(1UZ);
     Message             msg  = span[0];
     expect(span.consume(span.size()));
     fmt::print("Test got a reply: {}\n", msg);
@@ -351,10 +351,10 @@ const boost::ut::suite RunningGraphTests = [] {
 
         const auto& data     = reply.data.value();
         const auto& children = std::get<property_map>(data.at("children"s));
-        expect(eq(children.size(), 4));
+        expect(eq(children.size(), 4UZ));
 
         const auto& edges = std::get<property_map>(data.at("edges"s));
-        expect(eq(edges.size(), 4));
+        expect(eq(edges.size(), 4UZ));
     }
     scheduler.processScheduledMessages();
 

--- a/core/test/qa_Messages.cpp
+++ b/core/test/qa_Messages.cpp
@@ -63,20 +63,20 @@ struct ProcessMessageStdSpanBlock : gr::Block<ProcessMessageStdSpanBlock<T>> {
     void processMessages(gr::MsgPortInNamed<"__Builtin">&, std::span<const gr::Message>) {}
 };
 
-static_assert(!gr::traits::block::can_processMessagesForPortConsumableSpan<ProcessMessageStdSpanBlock<int>, gr::MsgPortInNamed<"__Builtin">>);
+static_assert(gr::traits::block::can_processMessagesForPortReaderSpan<ProcessMessageStdSpanBlock<int>, gr::MsgPortInNamed<"__Builtin">>);
 static_assert(gr::traits::block::can_processMessagesForPortStdSpan<ProcessMessageStdSpanBlock<int>, gr::MsgPortInNamed<"__Builtin">>);
 
 template<typename T>
-struct ProcessMessageConsumableSpanBlock : gr::Block<ProcessMessageConsumableSpanBlock<T>> {
+struct ProcessMessageReaderSpanBlock : gr::Block<ProcessMessageReaderSpanBlock<T>> {
     gr::PortIn<T> in;
 
     T processOne(T) { return {}; }
 
-    void processMessages(gr::MsgPortInNamed<"__Builtin">&, gr::ConsumableSpan auto) {}
+    void processMessages(gr::MsgPortInNamed<"__Builtin">&, gr::ReaderSpanLike auto) {}
 };
 
-static_assert(gr::traits::block::can_processMessagesForPortConsumableSpan<ProcessMessageConsumableSpanBlock<int>, gr::MsgPortInNamed<"__Builtin">>);
-static_assert(!gr::traits::block::can_processMessagesForPortStdSpan<ProcessMessageConsumableSpanBlock<int>, gr::MsgPortInNamed<"__Builtin">>);
+static_assert(gr::traits::block::can_processMessagesForPortReaderSpan<ProcessMessageReaderSpanBlock<int>, gr::MsgPortInNamed<"__Builtin">>);
+static_assert(!gr::traits::block::can_processMessagesForPortStdSpan<ProcessMessageReaderSpanBlock<int>, gr::MsgPortInNamed<"__Builtin">>);
 
 using namespace boost::ut;
 using namespace gr;
@@ -87,7 +87,7 @@ const boost::ut::suite MessagesTests = [] {
     using namespace gr;
 
     static auto returnReplyMsg = [](gr::MsgPortIn& port) {
-        ConsumableSpan auto span = port.streamReader().get<SpanReleasePolicy::ProcessAll>(1UZ);
+        ReaderSpanLike auto span = port.streamReader().get<SpanReleasePolicy::ProcessAll>(1UZ);
         Message             msg  = span[0];
         expect(span.consume(span.size()));
         return msg;

--- a/core/test/qa_Scheduler.cpp
+++ b/core/test/qa_Scheduler.cpp
@@ -71,7 +71,7 @@ struct ExpectSink : public gr::Block<ExpectSink<T>> {
         }
     }
 
-    [[nodiscard]] gr::work::Status processBulk(std::span<const T> input) noexcept {
+    [[nodiscard]] gr::work::Status processBulk(std::span<const T>& input) noexcept {
         tracer->trace(this->name);
         for (auto data : input) {
             count++;
@@ -292,7 +292,7 @@ struct BusyLoopBlock : public gr::Block<BusyLoopBlock<T>> {
     gr::Sequence   _produceCount{0};
     gr::Sequence   _invokeCount{0};
 
-    [[nodiscard]] constexpr gr::work::Status processBulk(gr::ConsumableSpan auto& input, gr::PublishableSpan auto& output) noexcept {
+    [[nodiscard]] constexpr gr::work::Status processBulk(gr::InputSpanLike auto& input, gr::OutputSpanLike auto& output) noexcept {
         auto produceCount = _produceCount.value();
         _invokeCount.incrementAndGet();
 

--- a/core/test/qa_Settings.cpp
+++ b/core/test/qa_Settings.cpp
@@ -162,7 +162,7 @@ struct Decimate : public Block<Decimate<T, Average>, SupportedTypes<float, doubl
         }
     }
 
-    constexpr work::Status processBulk(std::span<const T> input, std::span<T> output) noexcept {
+    constexpr work::Status processBulk(std::span<const T>& input, std::span<T>& output) noexcept {
         assert(this->output_chunk_size == gr::Size_t(1) && "block implements only basic decimation");
         assert(this->input_chunk_size != gr::Size_t(0) && "input_chunk_size must be non-zero");
 

--- a/core/test/qa_grc.cpp
+++ b/core/test/qa_grc.cpp
@@ -17,8 +17,8 @@ struct ArraySource : public gr::Block<ArraySource<T>> {
     std::array<gr::PortOut<T>, 2> outA{};
     std::array<gr::PortOut<T>, 2> outB{};
 
-    template<typename PublishableSpan1, typename PublishableSpan2>
-    gr::work::Status processBulk(PublishableSpan1&, PublishableSpan2&) { // TODO: needs proper explicit signature
+    template<gr::OutputSpanLike TOutputSpan1, gr::OutputSpanLike TOutputSpan2>
+    gr::work::Status processBulk(std::span<TOutputSpan1>&, std::span<TOutputSpan2>&) {
         return gr::work::Status::OK;
     }
 };
@@ -38,8 +38,8 @@ struct ArraySink : public gr::Block<ArraySink<T>> {
     gr::Annotated<std::vector<int16_t>, "int16_t vector setting">                   int16_vector;
     gr::Annotated<std::vector<std::complex<double>>, "std::complex vector setting"> complex_vector;
 
-    template<typename ConsumableSpan1, typename ConsumableSpan2>
-    gr::work::Status processBulk(ConsumableSpan1&, ConsumableSpan2&) { // TODO: needs proper explicit signature
+    template<gr::InputSpanLike TInputSpan1, gr::InputSpanLike TInputSpan2>
+    gr::work::Status processBulk(std::span<TInputSpan1>&, std::span<TInputSpan2>&) {
         return gr::work::Status::OK;
     }
 };


### PR DESCRIPTION
* `InputSpan` non-const, get() and consume() - non-const
* `ConstSpanLvalueLike` is replaced with `ConstSpanLike`, also `operator std::span<const T>&&() = delete;` is removed from `ReaderSpan`. 

### New names
Here is the new naming scheme (ConceptName -> ImplementationName)
* BufferLike -> CircularBuffer
  * BufferReaderLike -> CircularBuffer::Reader
    * ReaderSpanLike -> CircularBuffer::ReaderSpan
    * InputSpanLike -> Port::InputSpan
  * BufferWriterLike -> CircularBuffer::Writer
    * WriterSpanLike -> CircularBuffer::WriterSpan
    * OutputSpanLike -> Port::OutputSpan


### Important Note:
References are required for processBulk when manipulating Tags inside processBulk because InputSpan and OutputSpan have internal states (e.g., tagsPublished) that are unique to each instance. Copying these objects without proper state management can lead to incorrect behavior when the publishTag() method is called.
This issue must be resolved in future updates, see https://github.com/fair-acc/gnuradio4/issues/439
