### PR TITLE
Switch Sequence and Tag indices to unsigned

### DIFF
--- a/algorithm/include/gnuradio-4.0/algorithm/dataset/DataSetUtils.hpp
+++ b/algorithm/include/gnuradio-4.0/algorithm/dataset/DataSetUtils.hpp
@@ -74,7 +74,7 @@ template<DataSetLike TDataSet>
                 std::ranges::fill(tagVector, std::numeric_limits<TValueType>::lowest());
             }
             for (const auto& [index, tag] : dataSet.timing_events[i]) {
-                if (index < 0 || index >= static_cast<RelativeIndexTag::index_type>(tagVector.size())) {
+                if (index < 0 || index >= static_cast<std::ptrdiff_t>(tagVector.size())) {
                     continue;
                 }
                 tagVector[static_cast<std::size_t>(index)] = dataSet.signal_values[static_cast<std::size_t>(index)];
@@ -187,10 +187,7 @@ DataSet<T> waveform(WaveType waveType, size_t length, T samplingRate, T frequenc
 
         // check for zero crossing by seeing if the signs of previous and current values differ
         if ((previousValue < 0 && currentValue >= 0) || (previousValue > 0 && currentValue <= 0)) {
-            RelativeIndexTag tag;
-            tag.index       = static_cast<RelativeIndexTag::index_type>(i); // Position of the zero crossing
-            tag.map["type"] = "Zero Crossing";
-            dataSet.timing_events[0].emplace_back(tag);
+            dataSet.timing_events[0].emplace_back(static_cast<std::ptrdiff_t>(i), property_map{{"type", "Zero Crossing"}});
         }
         previousValue = currentValue;
     }

--- a/algorithm/include/gnuradio-4.0/algorithm/dataset/DataSetUtils.hpp
+++ b/algorithm/include/gnuradio-4.0/algorithm/dataset/DataSetUtils.hpp
@@ -74,7 +74,7 @@ template<DataSetLike TDataSet>
                 std::ranges::fill(tagVector, std::numeric_limits<TValueType>::lowest());
             }
             for (const auto& [index, tag] : dataSet.timing_events[i]) {
-                if (index < 0 || index >= static_cast<Tag::signed_index_type>(tagVector.size())) {
+                if (index < 0 || index >= static_cast<RelativeIndexTag::index_type>(tagVector.size())) {
                     continue;
                 }
                 tagVector[static_cast<std::size_t>(index)] = dataSet.signal_values[static_cast<std::size_t>(index)];
@@ -187,8 +187,8 @@ DataSet<T> waveform(WaveType waveType, size_t length, T samplingRate, T frequenc
 
         // check for zero crossing by seeing if the signs of previous and current values differ
         if ((previousValue < 0 && currentValue >= 0) || (previousValue > 0 && currentValue <= 0)) {
-            Tag tag;
-            tag.index       = static_cast<Tag::signed_index_type>(i); // Position of the zero crossing
+            RelativeIndexTag tag;
+            tag.index       = static_cast<RelativeIndexTag::index_type>(i); // Position of the zero crossing
             tag.map["type"] = "Zero Crossing";
             dataSet.timing_events[0].emplace_back(tag);
         }

--- a/blocks/basic/include/gnuradio-4.0/basic/DataSink.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/DataSink.hpp
@@ -655,9 +655,9 @@ private:
         std::optional<detail::Metadata> _pendingMetadata;
 
         // callback-only
-        std::size_t                   buffer_fill = 0;
-        std::vector<T>                buffer;
-        std::vector<Tag>              tag_buffer;
+        std::size_t      buffer_fill = 0;
+        std::vector<T>   buffer;
+        std::vector<Tag> tag_buffer;
 
         // polling-only
         std::weak_ptr<StreamingPoller<T>> polling_handler = {};

--- a/blocks/basic/include/gnuradio-4.0/basic/DataSink.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/DataSink.hpp
@@ -34,7 +34,7 @@ concept DataSetCallback = std::invocable<T, DataSet<V>>;
  * Stream callback functions receive the span of data, with optional tags and reference to the sink.
  */
 template<typename T, typename V>
-concept StreamCallback = std::invocable<T, std::span<const V>> || std::invocable<T, std::span<const V>, std::span<const Tag>> || std::invocable<T, std::span<const V>, std::span<const Tag>, const DataSink<V>&>;
+concept StreamCallback = std::invocable<T, std::span<const V>> || std::invocable<T, std::span<const V>, std::span<const RelativeIndexTag>> || std::invocable<T, std::span<const V>, std::span<const RelativeIndexTag>, const DataSink<V>&>;
 
 
 template<typename T, typename V>
@@ -70,14 +70,13 @@ struct StreamingPoller {
         }
 
         auto readData = reader.get(nProcess);
-        if constexpr (requires { fnc(std::span<const T>(), std::span<const Tag>()); }) {
-            auto       tags         = tag_reader.get();
-            const auto it           = std::find_if_not(tags.begin(), tags.end(), [until = static_cast<int64_t>(samples_read + nProcess)](const auto& tag) { return tag.index < until; });
-            auto       relevantTags = std::vector<Tag>(tags.begin(), it);
-            for (auto& t : relevantTags) {
-                t.index -= static_cast<int64_t>(samples_read);
-            }
-            fnc(readData, std::span<const Tag>(relevantTags));
+        if constexpr (requires { fnc(std::span<const T>(), std::span<const RelativeIndexTag>()); }) {
+            auto       tags             = tag_reader.get();
+            const auto it               = std::ranges::find_if_not(tags, [until = samples_read + nProcess](const auto& tag) { return tag.index < until; });
+            auto       relevantTagsView = std::span(tags.begin(), it) | std::views::transform([this](const auto& v) { return RelativeIndexTag{tagIndexDifference(v.index, samples_read), v.map}; });
+            auto       relevantTags     = std::vector(relevantTagsView.begin(), relevantTagsView.end());
+
+            fnc(readData, relevantTags);
             std::ignore = tags.consume(relevantTags.size());
         } else {
             auto tags   = tag_reader.get();
@@ -648,7 +647,7 @@ private:
     template<typename Callback>
     struct ContinuousListener : public AbstractListener {
         static constexpr auto hasCallback       = !std::is_same_v<Callback, gr::meta::null_type>;
-        static constexpr auto callbackTakesTags = std::is_invocable_v<Callback, std::span<const T>, std::span<const Tag>> || std::is_invocable_v<Callback, std::span<const T>, std::span<const Tag>, const DataSink<T>&>;
+        static constexpr auto callbackTakesTags = std::is_invocable_v<Callback, std::span<const T>, std::span<const RelativeIndexTag>> || std::is_invocable_v<Callback, std::span<const T>, std::span<const RelativeIndexTag>, const DataSink<T>&>;
 
         const DataSink<T>&              parent_sink;
         bool                            block           = false;
@@ -656,9 +655,9 @@ private:
         std::optional<detail::Metadata> _pendingMetadata;
 
         // callback-only
-        std::size_t      buffer_fill = 0;
-        std::vector<T>   buffer;
-        std::vector<Tag> tag_buffer;
+        std::size_t                   buffer_fill = 0;
+        std::vector<T>                buffer;
+        std::vector<RelativeIndexTag> tag_buffer;
 
         // polling-only
         std::weak_ptr<StreamingPoller<T>> polling_handler = {};
@@ -669,10 +668,10 @@ private:
 
         explicit ContinuousListener(std::shared_ptr<StreamingPoller<T>> poller, bool doBlock, const DataSink<T>& parent) : parent_sink(parent), block(doBlock), polling_handler{std::move(poller)} {}
 
-        inline void callCallback(std::span<const T> data, std::span<const Tag> tags) {
-            if constexpr (std::is_invocable_v<Callback, std::span<const T>, std::span<const Tag>, const DataSink<T>&>) {
+        inline void callCallback(std::span<const T> data, std::span<const RelativeIndexTag> tags) {
+            if constexpr (std::is_invocable_v<Callback, std::span<const T>, std::span<const RelativeIndexTag>, const DataSink<T>&>) {
                 callback(std::move(data), tags, parent_sink);
-            } else if constexpr (std::is_invocable_v<Callback, std::span<const T>, std::span<const Tag>>) {
+            } else if constexpr (std::is_invocable_v<Callback, std::span<const T>, std::span<const RelativeIndexTag>>) {
                 callback(std::move(data), tags);
             } else {
                 callback(std::move(data));
@@ -689,7 +688,7 @@ private:
                     std::ranges::copy(data.first(n), buffer.begin() + static_cast<std::ptrdiff_t>(buffer_fill));
                     if constexpr (callbackTakesTags) {
                         if (auto tag = detail::tagAndMetadata(tagData0, _pendingMetadata)) {
-                            tag_buffer.emplace_back(static_cast<Tag::signed_index_type>(buffer_fill), std::move(*tag));
+                            tag_buffer.emplace_back(static_cast<RelativeIndexTag::index_type>(buffer_fill), std::move(*tag));
                         }
                         _pendingMetadata.reset();
                         tagData0.reset();
@@ -708,7 +707,7 @@ private:
                 // send out complete chunks directly
                 while (data.size() >= buffer.size()) {
                     if constexpr (callbackTakesTags) {
-                        std::vector<Tag> tags;
+                        std::vector<RelativeIndexTag> tags;
                         if (auto tag = detail::tagAndMetadata(tagData0, _pendingMetadata)) {
                             tags.emplace_back(0, std::move(*tag));
                         }
@@ -745,7 +744,7 @@ private:
                 if (toWrite > 0) {
                     if (auto tag = detail::tagAndMetadata(tagData0, _pendingMetadata)) {
                         auto tw = poller->tag_writer.reserve(1);
-                        tw[0]   = {static_cast<Tag::signed_index_type>(samples_written), std::move(*tag)};
+                        tw[0]   = {static_cast<Tag::index_type>(samples_written), std::move(*tag)};
                         tw.publish(1);
                     }
                     _pendingMetadata.reset();
@@ -839,7 +838,7 @@ private:
                 const auto preSampleView = history.subspan(0UZ, std::min(preSamples, history.size()));
                 dataset.signal_values.insert(dataset.signal_values.end(), preSampleView.rbegin(), preSampleView.rend());
 
-                dataset.timing_events = {{{static_cast<Tag::signed_index_type>(preSampleView.size()), *tagData0}}};
+                dataset.timing_events = {{{static_cast<RelativeIndexTag::index_type>(preSampleView.size()), *tagData0}}};
                 pending_trigger_windows.push_back({.dataset = std::move(dataset), .pending_post_samples = postSamples});
             }
 
@@ -932,7 +931,7 @@ private:
                 if (obsr == trigger::MatchResult::NotMatching || obsr == trigger::MatchResult::Matching) {
                     if (pending_dataset) {
                         if (obsr == trigger::MatchResult::NotMatching) {
-                            pending_dataset->timing_events[0].push_back({static_cast<Tag::signed_index_type>(pending_dataset->signal_values.size()), *tagData0});
+                            pending_dataset->timing_events[0].push_back({static_cast<RelativeIndexTag::index_type>(pending_dataset->signal_values.size()), *tagData0});
                         }
                         bool published = this->publishDataSet(std::move(*pending_dataset));
                         if (published) {
@@ -1050,7 +1049,7 @@ private:
                 }
 
                 DataSet<T> dataset    = dataset_template;
-                dataset.timing_events = {{{-static_cast<Tag::signed_index_type>(it->delay), std::move(it->tag_data)}}};
+                dataset.timing_events = {{{-static_cast<RelativeIndexTag::index_type>(it->delay), std::move(it->tag_data)}}};
                 dataset.signal_values = {inData[it->pending_samples]};
                 bool published        = this->publishDataSet(std::move(dataset));
                 if (published) {

--- a/blocks/basic/include/gnuradio-4.0/basic/StreamToDataSet.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/StreamToDataSet.hpp
@@ -236,7 +236,7 @@ If multiple 'start' or 'stop' Tags arrive in a single merged tag, only one DataS
                 if (n_max.value > ds.signal_values.size()) { // do not add Tags if DataSet is full
                     const Tag& mergedTag = this->mergedInputTag();
                     if (!ds.timing_events.empty() && !mergedTag.map.empty() && accState.isActive) {
-                        ds.timing_events[0].emplace_back(RelativeIndexTag{static_cast<RelativeIndexTag::index_type>(ds.signal_values.size()), mergedTag.map});
+                        ds.timing_events[0].emplace_back(static_cast<std::ptrdiff_t>(ds.signal_values.size()), mergedTag.map);
                     }
                 }
 

--- a/blocks/basic/include/gnuradio-4.0/basic/StreamToDataSet.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/StreamToDataSet.hpp
@@ -236,7 +236,7 @@ If multiple 'start' or 'stop' Tags arrive in a single merged tag, only one DataS
                 if (n_max.value > ds.signal_values.size()) { // do not add Tags if DataSet is full
                     const Tag& mergedTag = this->mergedInputTag();
                     if (!ds.timing_events.empty() && !mergedTag.map.empty() && accState.isActive) {
-                        ds.timing_events[0].emplace_back(Tag{static_cast<Tag::signed_index_type>(ds.signal_values.size()), mergedTag.map});
+                        ds.timing_events[0].emplace_back(RelativeIndexTag{static_cast<RelativeIndexTag::index_type>(ds.signal_values.size()), mergedTag.map});
                     }
                 }
 

--- a/blocks/basic/include/gnuradio-4.0/basic/clock_source.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/clock_source.hpp
@@ -137,7 +137,7 @@ The 'tag_times[ns]:tag_value(string)' vectors control the emission of tags with 
 
         if (samplesToNextTag < samplesToNextTimeTag) {
             if (_nextTagIndex < tags.size() && samplesToNextTag <= samplesToProduce) {
-                const auto tagDeltaIndex = tags[_nextTagIndex].index - static_cast<Tag::index_type>(n_samples_produced); // position w.r.t. start of this chunk
+                const auto tagDeltaIndex = tags[_nextTagIndex].index - static_cast<std::size_t>(n_samples_produced); // position w.r.t. start of this chunk
                 if (verbose_console) {
                     gr::testing::print_tag(tags[_nextTagIndex], fmt::format("{}::processBulk(...)\t publish tag at  {:6}", this->name, n_samples_produced + tagDeltaIndex));
                 }

--- a/blocks/basic/include/gnuradio-4.0/basic/clock_source.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/clock_source.hpp
@@ -137,7 +137,7 @@ The 'tag_times[ns]:tag_value(string)' vectors control the emission of tags with 
 
         if (samplesToNextTag < samplesToNextTimeTag) {
             if (_nextTagIndex < tags.size() && samplesToNextTag <= samplesToProduce) {
-                const auto tagDeltaIndex = tags[_nextTagIndex].index - static_cast<Tag::signed_index_type>(n_samples_produced); // position w.r.t. start of this chunk
+                const auto tagDeltaIndex = tags[_nextTagIndex].index - static_cast<Tag::index_type>(n_samples_produced); // position w.r.t. start of this chunk
                 if (verbose_console) {
                     gr::testing::print_tag(tags[_nextTagIndex], fmt::format("{}::processBulk(...)\t publish tag at  {:6}", this->name, n_samples_produced + tagDeltaIndex));
                 }

--- a/blocks/basic/test/qa_StreamToDataSet.cpp
+++ b/blocks/basic/test/qa_StreamToDataSet.cpp
@@ -113,7 +113,7 @@ const boost::ut::suite<"StreamToDataSet Block"> selectorTest = [] {
     tag("visual") / "single trigger"_test              = [&runUIExample] { runUIExample(10, "CMD_DIAG_TRIGGER1", 30, 30); };
 };
 
-gr::Tag genTrigger(gr::Tag::index_type index, std::string triggerName, std::string triggerCtx = {}) {
+gr::Tag genTrigger(std::size_t index, std::string triggerName, std::string triggerCtx = {}) {
     return {index, {{gr::tag::TRIGGER_NAME.shortKey(), triggerName}, {gr::tag::TRIGGER_TIME.shortKey(), std::uint64_t(0)}, {gr::tag::TRIGGER_OFFSET.shortKey(), 0.f}, //
                        {gr::tag::TRIGGER_META_INFO.shortKey(), gr::property_map{{gr::tag::CONTEXT.shortKey(), triggerCtx}}}}};
 };
@@ -236,7 +236,7 @@ const boost::ut::suite<"StreamToDataSet test"> streamToDataSetTest = [] {
             expect(eq(timingEvt0.size(), nTags[i])) << [&]() {
                 std::string ret = fmt::format("DataSet nTags: {}\n", timingEvt0.size());
                 for (const auto& tag : timingEvt0) {
-                    ret += fmt::format("tag.index: {} .map: {}\n", tag.index, tag.map);
+                    ret += fmt::format("tag.index: {} .map: {}\n", tag.first, tag.second);
                 }
                 return ret;
             }();

--- a/blocks/basic/test/qa_StreamToDataSet.cpp
+++ b/blocks/basic/test/qa_StreamToDataSet.cpp
@@ -113,7 +113,7 @@ const boost::ut::suite<"StreamToDataSet Block"> selectorTest = [] {
     tag("visual") / "single trigger"_test              = [&runUIExample] { runUIExample(10, "CMD_DIAG_TRIGGER1", 30, 30); };
 };
 
-gr::Tag genTrigger(gr::Tag::signed_index_type index, std::string triggerName, std::string triggerCtx = {}) {
+gr::Tag genTrigger(gr::Tag::index_type index, std::string triggerName, std::string triggerCtx = {}) {
     return {index, {{gr::tag::TRIGGER_NAME.shortKey(), triggerName}, {gr::tag::TRIGGER_TIME.shortKey(), std::uint64_t(0)}, {gr::tag::TRIGGER_OFFSET.shortKey(), 0.f}, //
                        {gr::tag::TRIGGER_META_INFO.shortKey(), gr::property_map{{gr::tag::CONTEXT.shortKey(), triggerCtx}}}}};
 };
@@ -232,7 +232,7 @@ const boost::ut::suite<"StreamToDataSet test"> streamToDataSetTest = [] {
             expect(std::ranges::equal(ds.signal_values, expectedValues[i]));
 
             expect(fatal(eq(ds.timing_events.size(), 1UZ)));
-            const std::vector<Tag>& timingEvt0 = ds.timing_events[0];
+            const auto& timingEvt0 = ds.timing_events[0];
             expect(eq(timingEvt0.size(), nTags[i])) << [&]() {
                 std::string ret = fmt::format("DataSet nTags: {}\n", timingEvt0.size());
                 for (const auto& tag : timingEvt0) {

--- a/blocks/fileio/include/gnuradio-4.0/fileio/BasicFileIo.hpp
+++ b/blocks/fileio/include/gnuradio-4.0/fileio/BasicFileIo.hpp
@@ -244,7 +244,7 @@ Important: this implementation assumes a host-order, CPU architecture specific b
                     {std::string(tag::TRIGGER_TIME.shortKey()), settings::convertTimePointToUint64Ns(std::chrono::system_clock::now())}, //
                     {std::string(tag::TRIGGER_OFFSET.shortKey()), 0.f}                                                                   //
                 },
-                static_cast<Tag::index_type>(0));
+                0UZ);
             _emittedStartTrigger = true;
         }
 

--- a/blocks/fileio/include/gnuradio-4.0/fileio/BasicFileIo.hpp
+++ b/blocks/fileio/include/gnuradio-4.0/fileio/BasicFileIo.hpp
@@ -244,7 +244,7 @@ Important: this implementation assumes a host-order, CPU architecture specific b
                     {std::string(tag::TRIGGER_TIME.shortKey()), settings::convertTimePointToUint64Ns(std::chrono::system_clock::now())}, //
                     {std::string(tag::TRIGGER_OFFSET.shortKey()), 0.f}                                                                   //
                 },
-                static_cast<Tag::signed_index_type>(0));
+                static_cast<Tag::index_type>(0));
             _emittedStartTrigger = true;
         }
 

--- a/blocks/testing/include/gnuradio-4.0/testing/ImChartMonitor.hpp
+++ b/blocks/testing/include/gnuradio-4.0/testing/ImChartMonitor.hpp
@@ -48,7 +48,7 @@ struct ImChartMonitor : public Block<ImChartMonitor<T>, BlockingIO<false>, Drawa
             _historyBufferTags[1].index = 0;
             this->_mergedInputTag.map.clear(); // TODO: provide proper API for clearing tags
         } else {
-            _historyBufferTags.push_back(Tag(-1, property_map()));
+            _historyBufferTags.push_back(Tag(0UZ, property_map()));
         }
     }
 

--- a/blocks/testing/include/gnuradio-4.0/testing/TagMonitors.hpp
+++ b/blocks/testing/include/gnuradio-4.0/testing/TagMonitors.hpp
@@ -123,8 +123,8 @@ struct TagSource : public Block<TagSource<T, UseProcessVariant>> {
     T processOne() noexcept
     requires(UseProcessVariant == ProcessFunction::USE_PROCESS_ONE)
     {
-        const auto [tagGenerated, tagRepeatStarted] = generateTag(                                    //
-            [this](const auto& map, Tag::index_type tagOffset) { this->publishTag(map, tagOffset); }, //
+        const auto [tagGenerated, tagRepeatStarted] = generateTag(                                //
+            [this](const auto& map, std::size_t tagOffset) { this->publishTag(map, tagOffset); }, //
             "processOne(...)");
 
         _nSamplesProduced++;
@@ -150,8 +150,8 @@ struct TagSource : public Block<TagSource<T, UseProcessVariant>> {
     work::Status processBulk(OutputSpanLike auto& outSpan) noexcept
     requires(UseProcessVariant == ProcessFunction::USE_PROCESS_BULK)
     {
-        const auto [tagGenerated, tagRepeatStarted] = generateTag(                                    //
-            [&outSpan](const auto& map, Tag::index_type offset) { outSpan.publishTag(map, offset); }, //
+        const auto [tagGenerated, tagRepeatStarted] = generateTag(                                //
+            [&outSpan](const auto& map, std::size_t offset) { outSpan.publishTag(map, offset); }, //
             "processBulk(...)");
 
         const auto nSamplesRemainder = getNProducedSamplesRemainder();
@@ -211,7 +211,7 @@ private:
             if (verbose_console) {
                 print_tag(_tags[_tagIndex], fmt::format("{}::{}\t publish tag at  {:6}", this->name.value, processFunctionName, _nSamplesProduced));
             }
-            publishTagFn(_tags[_tagIndex].map, static_cast<Tag::index_type>(0));
+            publishTagFn(_tags[_tagIndex].map, 0UZ);
             this->_outputTagsChanged = true;
             _tagIndex++;
             if (repeat_tags && _tagIndex == _tags.size()) {

--- a/blocks/testing/include/gnuradio-4.0/testing/TagMonitors.hpp
+++ b/blocks/testing/include/gnuradio-4.0/testing/TagMonitors.hpp
@@ -123,8 +123,8 @@ struct TagSource : public Block<TagSource<T, UseProcessVariant>> {
     T processOne() noexcept
     requires(UseProcessVariant == ProcessFunction::USE_PROCESS_ONE)
     {
-        const auto [tagGenerated, tagRepeatStarted] = generateTag(                                           //
-            [this](const auto& map, Tag::signed_index_type tagOffset) { this->publishTag(map, tagOffset); }, //
+        const auto [tagGenerated, tagRepeatStarted] = generateTag(                                    //
+            [this](const auto& map, Tag::index_type tagOffset) { this->publishTag(map, tagOffset); }, //
             "processOne(...)");
 
         _nSamplesProduced++;
@@ -150,8 +150,8 @@ struct TagSource : public Block<TagSource<T, UseProcessVariant>> {
     work::Status processBulk(OutputSpanLike auto& outSpan) noexcept
     requires(UseProcessVariant == ProcessFunction::USE_PROCESS_BULK)
     {
-        const auto [tagGenerated, tagRepeatStarted] = generateTag(                                           //
-            [&outSpan](const auto& map, Tag::signed_index_type offset) { outSpan.publishTag(map, offset); }, //
+        const auto [tagGenerated, tagRepeatStarted] = generateTag(                                    //
+            [&outSpan](const auto& map, Tag::index_type offset) { outSpan.publishTag(map, offset); }, //
             "processBulk(...)");
 
         const auto nSamplesRemainder = getNProducedSamplesRemainder();
@@ -211,7 +211,7 @@ private:
             if (verbose_console) {
                 print_tag(_tags[_tagIndex], fmt::format("{}::{}\t publish tag at  {:6}", this->name.value, processFunctionName, _nSamplesProduced));
             }
-            publishTagFn(_tags[_tagIndex].map, static_cast<Tag::signed_index_type>(0));
+            publishTagFn(_tags[_tagIndex].map, static_cast<Tag::index_type>(0));
             this->_outputTagsChanged = true;
             _tagIndex++;
             if (repeat_tags && _tagIndex == _tags.size()) {

--- a/blocks/testing/include/gnuradio-4.0/testing/bm_test_helper.hpp
+++ b/blocks/testing/include/gnuradio-4.0/testing/bm_test_helper.hpp
@@ -46,7 +46,7 @@ template<typename T, std::size_t N_MIN = 1UZ, std::size_t N_MAX = N_MAX>
 struct sink : public gr::Block<sink<T, N_MIN, N_MAX>> {
     gr::PortIn<T, gr::RequiredSamples<N_MIN, N_MAX>> in;
     uint64_t                                         should_receive_n_samples = 0;
-    std::optional<gr::Tag::index_type>               _last_tag_position;
+    std::optional<std::size_t>                       _last_tag_position;
 
     GR_MAKE_REFLECTABLE(sink, in, should_receive_n_samples);
 

--- a/blocks/testing/include/gnuradio-4.0/testing/bm_test_helper.hpp
+++ b/blocks/testing/include/gnuradio-4.0/testing/bm_test_helper.hpp
@@ -46,7 +46,7 @@ template<typename T, std::size_t N_MIN = 1UZ, std::size_t N_MAX = N_MAX>
 struct sink : public gr::Block<sink<T, N_MIN, N_MAX>> {
     gr::PortIn<T, gr::RequiredSamples<N_MIN, N_MAX>> in;
     uint64_t                                         should_receive_n_samples = 0;
-    int64_t                                          _last_tag_position       = -1;
+    std::optional<gr::Tag::index_type>               _last_tag_position;
 
     GR_MAKE_REFLECTABLE(sink, in, should_receive_n_samples);
 

--- a/core/include/gnuradio-4.0/Block.hpp
+++ b/core/include/gnuradio-4.0/Block.hpp
@@ -800,12 +800,12 @@ public:
         return result;
     }
 
-    inline constexpr void publishTag(property_map&& tag_data, Tag::signed_index_type tagOffset = -1) noexcept { processPublishTag(std::move(tag_data), tagOffset); }
+    inline constexpr void publishTag(property_map&& tag_data, Tag::index_type tagOffset = 0UZ) noexcept { processPublishTag(std::move(tag_data), tagOffset); }
 
-    inline constexpr void publishTag(const property_map& tag_data, Tag::signed_index_type tagOffset = -1) noexcept { processPublishTag(tag_data, tagOffset); }
+    inline constexpr void publishTag(const property_map& tag_data, Tag::index_type tagOffset = 0UZ) noexcept { processPublishTag(tag_data, tagOffset); }
 
     template<PropertyMapType PropertyMap>
-    inline constexpr void processPublishTag(PropertyMap&& tagData, Tag::signed_index_type tagOffset) noexcept {
+    inline constexpr void processPublishTag(PropertyMap&& tagData, Tag::index_type tagOffset) noexcept {
         if (_outputTags.empty()) {
             _outputTags.emplace_back(Tag(tagOffset, std::forward<PropertyMap>(tagData)));
         } else {
@@ -828,12 +828,12 @@ public:
 
     inline constexpr void publishEoS() noexcept {
         const property_map& tag_data{{gr::tag::END_OF_STREAM, true}};
-        for_each_port([&tag_data](PortLike auto& outPort) { outPort.publishTag(tag_data, static_cast<Tag::signed_index_type>(outPort.streamWriter().nRequestedSamplesToPublish())); }, outputPorts<PortType::STREAM>(&self()));
+        for_each_port([&tag_data](PortLike auto& outPort) { outPort.publishTag(tag_data, static_cast<Tag::index_type>(outPort.streamWriter().nRequestedSamplesToPublish())); }, outputPorts<PortType::STREAM>(&self()));
     }
 
     inline constexpr void publishEoS(auto& outputSpanTuple) noexcept {
         const property_map& tagData{{gr::tag::END_OF_STREAM, true}};
-        for_each_writer_span([&tagData](auto& outSpan) { outSpan.publishTag(tagData, static_cast<Tag::signed_index_type>(outSpan.nRequestedSamplesToPublish())); }, outputSpanTuple);
+        for_each_writer_span([&tagData](auto& outSpan) { outSpan.publishTag(tagData, static_cast<Tag::index_type>(outSpan.nRequestedSamplesToPublish())); }, outputSpanTuple);
     }
 
     constexpr void requestStop() noexcept { emitErrorMessageIfAny("requestStop()", this->changeStateTo(lifecycle::State::REQUESTED_STOP)); }

--- a/core/include/gnuradio-4.0/Block.hpp
+++ b/core/include/gnuradio-4.0/Block.hpp
@@ -800,12 +800,12 @@ public:
         return result;
     }
 
-    inline constexpr void publishTag(property_map&& tag_data, Tag::index_type tagOffset = 0UZ) noexcept { processPublishTag(std::move(tag_data), tagOffset); }
+    inline constexpr void publishTag(property_map&& tag_data, std::size_t tagOffset = 0UZ) noexcept { processPublishTag(std::move(tag_data), tagOffset); }
 
-    inline constexpr void publishTag(const property_map& tag_data, Tag::index_type tagOffset = 0UZ) noexcept { processPublishTag(tag_data, tagOffset); }
+    inline constexpr void publishTag(const property_map& tag_data, std::size_t tagOffset = 0UZ) noexcept { processPublishTag(tag_data, tagOffset); }
 
     template<PropertyMapType PropertyMap>
-    inline constexpr void processPublishTag(PropertyMap&& tagData, Tag::index_type tagOffset) noexcept {
+    inline constexpr void processPublishTag(PropertyMap&& tagData, std::size_t tagOffset) noexcept {
         if (_outputTags.empty()) {
             _outputTags.emplace_back(Tag(tagOffset, std::forward<PropertyMap>(tagData)));
         } else {
@@ -828,12 +828,12 @@ public:
 
     inline constexpr void publishEoS() noexcept {
         const property_map& tag_data{{gr::tag::END_OF_STREAM, true}};
-        for_each_port([&tag_data](PortLike auto& outPort) { outPort.publishTag(tag_data, static_cast<Tag::index_type>(outPort.streamWriter().nRequestedSamplesToPublish())); }, outputPorts<PortType::STREAM>(&self()));
+        for_each_port([&tag_data](PortLike auto& outPort) { outPort.publishTag(tag_data, static_cast<std::size_t>(outPort.streamWriter().nRequestedSamplesToPublish())); }, outputPorts<PortType::STREAM>(&self()));
     }
 
     inline constexpr void publishEoS(auto& outputSpanTuple) noexcept {
         const property_map& tagData{{gr::tag::END_OF_STREAM, true}};
-        for_each_writer_span([&tagData](auto& outSpan) { outSpan.publishTag(tagData, static_cast<Tag::index_type>(outSpan.nRequestedSamplesToPublish())); }, outputSpanTuple);
+        for_each_writer_span([&tagData](auto& outSpan) { outSpan.publishTag(tagData, static_cast<std::size_t>(outSpan.nRequestedSamplesToPublish())); }, outputSpanTuple);
     }
 
     constexpr void requestStop() noexcept { emitErrorMessageIfAny("requestStop()", this->changeStateTo(lifecycle::State::REQUESTED_STOP)); }

--- a/core/include/gnuradio-4.0/BlockTraits.hpp
+++ b/core/include/gnuradio-4.0/BlockTraits.hpp
@@ -206,9 +206,9 @@ struct DummyInputSpan : public DummyReaderSpan<T> {
     DummyReaderSpan<gr::Tag> rawTags{};
     bool                     isConnected = true;
     bool                     isSync      = true;
-    auto                     tags() { return std::views::empty<std::pair<Tag::signed_index_type, const property_map&>>; }
-    [[nodiscard]] inline Tag getMergedTag(gr::Tag::signed_index_type /*untilLocalIndex*/) const { return {}; }
-    void                     consumeTags(gr::Tag::signed_index_type /*untilLocalIndex*/) {}
+    auto                     tags() { return std::views::empty<std::pair<Tag::index_type, const property_map&>>; }
+    [[nodiscard]] inline Tag getMergedTag(gr::Tag::index_type /*untilLocalIndex*/) const { return {}; }
+    void                     consumeTags(gr::Tag::index_type /*untilLocalIndex*/) {}
 };
 static_assert(ReaderSpanLike<DummyInputSpan<int>>);
 static_assert(InputSpanLike<DummyInputSpan<int>>);
@@ -245,7 +245,7 @@ struct DummyOutputSpan : public DummyWriterSpan<T> {
     bool                     isConnected = true;
     bool                     isSync      = true;
 
-    void publishTag(property_map&, gr::Tag::signed_index_type) {}
+    void publishTag(property_map&, gr::Tag::index_type) {}
 };
 static_assert(OutputSpanLike<DummyOutputSpan<int>>);
 

--- a/core/include/gnuradio-4.0/BlockTraits.hpp
+++ b/core/include/gnuradio-4.0/BlockTraits.hpp
@@ -206,9 +206,9 @@ struct DummyInputSpan : public DummyReaderSpan<T> {
     DummyReaderSpan<gr::Tag> rawTags{};
     bool                     isConnected = true;
     bool                     isSync      = true;
-    auto                     tags() { return std::views::empty<std::pair<Tag::index_type, const property_map&>>; }
-    [[nodiscard]] inline Tag getMergedTag(gr::Tag::index_type /*untilLocalIndex*/) const { return {}; }
-    void                     consumeTags(gr::Tag::index_type /*untilLocalIndex*/) {}
+    auto                     tags() { return std::views::empty<std::pair<std::size_t, const property_map&>>; }
+    [[nodiscard]] inline Tag getMergedTag(std::size_t /*untilLocalIndex*/) const { return {}; }
+    void                     consumeTags(std::size_t /*untilLocalIndex*/) {}
 };
 static_assert(ReaderSpanLike<DummyInputSpan<int>>);
 static_assert(InputSpanLike<DummyInputSpan<int>>);
@@ -245,7 +245,7 @@ struct DummyOutputSpan : public DummyWriterSpan<T> {
     bool                     isConnected = true;
     bool                     isSync      = true;
 
-    void publishTag(property_map&, gr::Tag::index_type) {}
+    void publishTag(property_map&, std::size_t) {}
 };
 static_assert(OutputSpanLike<DummyOutputSpan<int>>);
 

--- a/core/include/gnuradio-4.0/Buffer.hpp
+++ b/core/include/gnuradio-4.0/Buffer.hpp
@@ -72,7 +72,7 @@ concept WriterSpanLike = std::ranges::contiguous_range<T> && std::ranges::output
 template<class T>
 concept BufferReaderLike = requires(T /*const*/ t, const std::size_t nItems) {
     { t.get(nItems) }; // TODO: get() returns CircularBuffer::ReaderSpan
-    { t.position() } -> std::same_as<std::make_signed_t<std::size_t>>;
+    { t.position() } -> std::same_as<std::size_t>;
     { t.available() } -> std::same_as<std::size_t>;
     { t.buffer() };
     { t.nSamplesConsumed() } -> std::same_as<std::size_t>;

--- a/core/include/gnuradio-4.0/BufferSkeleton.hpp
+++ b/core/include/gnuradio-4.0/BufferSkeleton.hpp
@@ -55,7 +55,7 @@ class BufferSkeleton {
             return true;
         }
 
-        [[nodiscard]] constexpr std::make_signed_t<std::size_t> position() const noexcept { return -1; }
+        [[nodiscard]] constexpr std::size_t position() const noexcept { return 0; }
 
         [[nodiscard]] constexpr std::size_t available() const noexcept { return 0; }
     };

--- a/core/include/gnuradio-4.0/CircularBuffer.hpp
+++ b/core/include/gnuradio-4.0/CircularBuffer.hpp
@@ -227,10 +227,10 @@ enum class WriterSpanReservePolicy {
  */
 template<typename T, std::size_t SIZE = std::dynamic_extent, ProducerType producerType = ProducerType::Single, WaitStrategyLike TWaitStrategy = SleepingWaitStrategy>
 class CircularBuffer {
-    using Allocator         = std::pmr::polymorphic_allocator<T>;
-    using BufferType        = CircularBuffer<T, SIZE, producerType, TWaitStrategy>;
-    using ClaimType         = detail::producer_type_v<SIZE, producerType, TWaitStrategy>;
-    using signed_index_type = Sequence::signed_index_type;
+    using Allocator  = std::pmr::polymorphic_allocator<T>;
+    using BufferType = CircularBuffer<T, SIZE, producerType, TWaitStrategy>;
+    using ClaimType  = detail::producer_type_v<SIZE, producerType, TWaitStrategy>;
+    using index_type = Sequence::index_type;
 
     struct BufferImpl {
         Allocator                 _allocator{};
@@ -295,9 +295,9 @@ class CircularBuffer {
         using pointer          = typename std::span<T>::reverse_iterator;
 
         explicit WriterSpan(Writer<U>* parent) noexcept : _parent(parent) { _parent->_instanceCount++; };
-        explicit constexpr WriterSpan(Writer<U>* parent, std::size_t index, signed_index_type sequence, std::size_t nSlotsToClaim) noexcept : _parent(parent) {
+        explicit constexpr WriterSpan(Writer<U>* parent, std::size_t index, index_type sequence, std::size_t nSlotsToClaim) noexcept : _parent(parent) {
             _parent->_index        = index;
-            _parent->_offset       = sequence - static_cast<signed_index_type>(nSlotsToClaim);
+            _parent->_offset       = sequence - nSlotsToClaim;
             _parent->_internalSpan = std::span<T>(&_parent->_buffer->_data.data()[index], nSlotsToClaim);
             _parent->_instanceCount++;
         }
@@ -335,7 +335,7 @@ class CircularBuffer {
                     std::copy(&data[size], &data[size + nSecondHalf], &data[0]);
                 }
                 _parent->_buffer->_claimStrategy.publish(_parent->_offset, _parent->_nRequestedSamplesToPublish);
-                _parent->_offset += static_cast<signed_index_type>(_parent->_nRequestedSamplesToPublish);
+                _parent->_offset += _parent->_nRequestedSamplesToPublish;
 #ifndef NDEBUG
                 if constexpr (isMultiProducerStrategy()) {
                     if (!isFullyPublished()) {
@@ -398,12 +398,12 @@ class CircularBuffer {
 
         // doesn't have to be atomic because this writer is accessed (by design) always by the same thread.
         // These are the parameters for WriterSpan, only one WriterSpan can be reserved per writer
-        std::size_t       _nRequestedSamplesToPublish{0UZ}; // controls how many samples were already requested for publishing, multiple publish() calls are allowed
-        bool              _isPublishRequested{true};        // controls if publish() was invoked
-        std::size_t       _index{0UZ};
-        signed_index_type _offset{0};
-        std::span<T>      _internalSpan{};     // internal span is managed by Writer and is shared across all WriterSpans reserved by this Writer
-        std::size_t       _instanceCount{0UZ}; // number of WriterSpan instances
+        std::size_t  _nRequestedSamplesToPublish{0UZ}; // controls how many samples were already requested for publishing, multiple publish() calls are allowed
+        bool         _isPublishRequested{true};        // controls if publish() was invoked
+        std::size_t  _index{0UZ};
+        index_type   _offset{0};
+        std::span<T> _internalSpan{};     // internal span is managed by Writer and is shared across all WriterSpans reserved by this Writer
+        std::size_t  _instanceCount{0UZ}; // number of WriterSpan instances
 
     public:
         Writer() = delete;
@@ -446,9 +446,9 @@ class CircularBuffer {
                 return WriterSpan<U, policy>(this);
             }
 
-            const std::optional<signed_index_type> sequence = _buffer->_claimStrategy.tryNext(nSamples);
+            const std::optional<index_type> sequence = _buffer->_claimStrategy.tryNext(nSamples);
             if (sequence.has_value()) {
-                const std::size_t index = (static_cast<std::size_t>(sequence.value()) + _buffer->_size - nSamples) % _buffer->_size;
+                const std::size_t index = (sequence.value() + _buffer->_size - nSamples) % _buffer->_size;
                 return WriterSpan<U, policy>(this, index, sequence.value(), nSamples);
             } else {
                 return WriterSpan<U, policy>(this);
@@ -466,14 +466,14 @@ class CircularBuffer {
             }
 
             const auto        sequence = _buffer->_claimStrategy.next(nSamples);
-            const std::size_t index    = (static_cast<std::size_t>(sequence) + _buffer->_size - nSamples) % _buffer->_size;
+            const std::size_t index    = (sequence + _buffer->_size - nSamples) % _buffer->_size;
             return WriterSpan<U, policy>(this, index, sequence, nSamples);
         }
 
-        [[nodiscard]] constexpr signed_index_type position() const noexcept { return _buffer->_claimStrategy._publishCursor.value(); }
-        [[nodiscard]] constexpr std::size_t       available() const noexcept { return static_cast<std::size_t>(_buffer->_claimStrategy.getRemainingCapacity()); }
-        [[nodiscard]] constexpr bool              isPublishRequested() const noexcept { return _isPublishRequested; }
-        [[nodiscard]] constexpr std::size_t       nRequestedSamplesToPublish() const noexcept { return _nRequestedSamplesToPublish; };
+        [[nodiscard]] constexpr index_type  position() const noexcept { return _buffer->_claimStrategy._publishCursor.value(); }
+        [[nodiscard]] constexpr std::size_t available() const noexcept { return _buffer->_claimStrategy.getRemainingCapacity(); }
+        [[nodiscard]] constexpr bool        isPublishRequested() const noexcept { return _isPublishRequested; }
+        [[nodiscard]] constexpr std::size_t nRequestedSamplesToPublish() const noexcept { return _nRequestedSamplesToPublish; };
 
     private:
         constexpr void checkIfCanReserveAndAbortIfNeeded() const noexcept {
@@ -601,7 +601,7 @@ class CircularBuffer {
             _parent->_nSamplesFirstGet           = std::numeric_limits<std::size_t>::max();
             _parent->_nRequestedSamplesToConsume = std::numeric_limits<std::size_t>::max();
             if constexpr (strict_check) {
-                if (nSamples <= 0) {
+                if (nSamples == 0) {
                     return true;
                 }
 
@@ -609,7 +609,7 @@ class CircularBuffer {
                     return false;
                 }
             }
-            _parent->_readIndexCached  = _parent->_readIndex->addAndGet(static_cast<signed_index_type>(nSamples));
+            _parent->_readIndexCached  = _parent->_readIndex->addAndGet(nSamples);
             _parent->_nSamplesConsumed = nSamples;
             return true;
         }
@@ -626,7 +626,7 @@ class CircularBuffer {
         using BufferTypeLocal = std::shared_ptr<BufferImpl>;
 
         std::shared_ptr<Sequence> _readIndex = std::make_shared<Sequence>();
-        signed_index_type         _readIndexCached;
+        index_type                _readIndexCached;
         BufferTypeLocal           _buffer;                                                    // controls buffer life-cycle, the rest are cache optimisations
         std::size_t               _nSamplesFirstGet{std::numeric_limits<std::size_t>::max()}; // Maximum number of samples returned by the first call to get() (when reader is consumed). Subsequent calls to get(), without calling consume() again, will return up to _nSamplesFirstGet.
         std::size_t               _instanceCount{0UZ};                                        // number of ReaderSpan instances
@@ -638,7 +638,7 @@ class CircularBuffer {
 
         std::size_t bufferIndex() const noexcept {
             const auto bitmask = _buffer->_size - 1;
-            return static_cast<std::size_t>(_readIndexCached) & bitmask;
+            return _readIndexCached & bitmask;
         }
 
     public:
@@ -699,9 +699,9 @@ class CircularBuffer {
             return ReaderSpan<U, policy>(this, bufferIndex(), nSamples);
         }
 
-        [[nodiscard]] constexpr signed_index_type position() const noexcept { return _readIndexCached; }
+        [[nodiscard]] constexpr index_type position() const noexcept { return _readIndexCached; }
 
-        [[nodiscard]] constexpr std::size_t available() const noexcept { return static_cast<std::size_t>(_buffer->_claimStrategy._publishCursor.value() - _readIndexCached); }
+        [[nodiscard]] constexpr std::size_t available() const noexcept { return _buffer->_claimStrategy._publishCursor.value() - _readIndexCached; }
     }; // class Reader
     // static_assert(BufferReaderLike<Reader<T>>);
 

--- a/core/include/gnuradio-4.0/ClaimStrategy.hpp
+++ b/core/include/gnuradio-4.0/ClaimStrategy.hpp
@@ -126,7 +126,7 @@ public:
 
         std::size_t currentReserveCursor;
         std::size_t nextReserveCursor;
-        SpinWait   spinWait;
+        SpinWait    spinWait;
         do {
             currentReserveCursor = _reserveCursor.value();
             nextReserveCursor    = currentReserveCursor + nSlotsToClaim;

--- a/core/include/gnuradio-4.0/ClaimStrategy.hpp
+++ b/core/include/gnuradio-4.0/ClaimStrategy.hpp
@@ -18,22 +18,22 @@
 namespace gr {
 
 template<typename T>
-concept ClaimStrategyLike = requires(T /*const*/ t, const Sequence::signed_index_type sequence, const Sequence::signed_index_type offset, const std::size_t nSlotsToClaim) {
-    { t.next(nSlotsToClaim) } -> std::same_as<Sequence::signed_index_type>;
-    { t.tryNext(nSlotsToClaim) } -> std::same_as<std::optional<Sequence::signed_index_type>>;
-    { t.getRemainingCapacity() } -> std::same_as<Sequence::signed_index_type>;
+concept ClaimStrategyLike = requires(T /*const*/ t, const Sequence::index_type sequence, const Sequence::index_type offset, const std::size_t nSlotsToClaim) {
+    { t.next(nSlotsToClaim) } -> std::same_as<Sequence::index_type>;
+    { t.tryNext(nSlotsToClaim) } -> std::same_as<std::optional<Sequence::index_type>>;
+    { t.getRemainingCapacity() } -> std::same_as<Sequence::index_type>;
     { t.publish(offset, nSlotsToClaim) } -> std::same_as<void>;
 };
 
 template<std::size_t SIZE = std::dynamic_extent, WaitStrategyLike TWaitStrategy = BusySpinWaitStrategy>
 class alignas(hardware_constructive_interference_size) SingleProducerStrategy {
-    using signed_index_type = Sequence::signed_index_type;
+    using index_type = Sequence::index_type;
 
     const std::size_t _size = SIZE;
 
 public:
     Sequence                                                _publishCursor;                      // slots are published and ready to be read until _publishCursor
-    signed_index_type                                       _reserveCursor{kInitialCursorValue}; // slots can be reserved starting from _reserveCursor, no need for atomics since this is called by a single publisher
+    index_type                                              _reserveCursor{kInitialCursorValue}; // slots can be reserved starting from _reserveCursor, no need for atomics since this is called by a single publisher
     TWaitStrategy                                           _waitStrategy;
     std::shared_ptr<std::vector<std::shared_ptr<Sequence>>> _readSequences{std::make_shared<std::vector<std::shared_ptr<Sequence>>>()}; // list of dependent reader sequences
 
@@ -42,34 +42,34 @@ public:
     SingleProducerStrategy(const SingleProducerStrategy&&) = delete;
     void operator=(const SingleProducerStrategy&)          = delete;
 
-    signed_index_type next(const std::size_t nSlotsToClaim = 1) noexcept {
-        assert((nSlotsToClaim > 0 && nSlotsToClaim <= static_cast<std::size_t>(_size)) && "nSlotsToClaim must be > 0 and <= bufferSize");
+    index_type next(const std::size_t nSlotsToClaim = 1) noexcept {
+        assert((nSlotsToClaim > 0 && nSlotsToClaim <= _size) && "nSlotsToClaim must be > 0 and <= bufferSize");
 
         SpinWait spinWait;
-        while (getRemainingCapacity() < static_cast<signed_index_type>(nSlotsToClaim)) { // while not enough slots in buffer
+        while (getRemainingCapacity() < nSlotsToClaim) { // while not enough slots in buffer
             if constexpr (hasSignalAllWhenBlocking<TWaitStrategy>) {
                 _waitStrategy.signalAllWhenBlocking();
             }
             spinWait.spinOnce();
         }
-        _reserveCursor += static_cast<signed_index_type>(nSlotsToClaim);
+        _reserveCursor += nSlotsToClaim;
         return _reserveCursor;
     }
 
-    [[nodiscard]] std::optional<signed_index_type> tryNext(const std::size_t nSlotsToClaim) noexcept {
-        assert((nSlotsToClaim > 0 && nSlotsToClaim <= static_cast<std::size_t>(_size)) && "nSlotsToClaim must be > 0 and <= bufferSize");
+    [[nodiscard]] std::optional<index_type> tryNext(const std::size_t nSlotsToClaim) noexcept {
+        assert((nSlotsToClaim > 0 && nSlotsToClaim <= _size) && "nSlotsToClaim must be > 0 and <= bufferSize");
 
-        if (getRemainingCapacity() < static_cast<signed_index_type>(nSlotsToClaim)) { // not enough slots in buffer
+        if (getRemainingCapacity() < nSlotsToClaim) { // not enough slots in buffer
             return std::nullopt;
         }
-        _reserveCursor += static_cast<signed_index_type>(nSlotsToClaim);
+        _reserveCursor += nSlotsToClaim;
         return _reserveCursor;
     }
 
-    [[nodiscard]] forceinline signed_index_type getRemainingCapacity() const noexcept { return static_cast<signed_index_type>(_size) - (_reserveCursor - getMinReaderCursor()); }
+    [[nodiscard]] forceinline index_type getRemainingCapacity() const noexcept { return _size - (_reserveCursor - getMinReaderCursor()); }
 
-    void publish(signed_index_type offset, std::size_t nSlotsToClaim) {
-        const auto sequence = offset + static_cast<signed_index_type>(nSlotsToClaim);
+    void publish(index_type offset, std::size_t nSlotsToClaim) {
+        const auto sequence = offset + nSlotsToClaim;
         _publishCursor.setValue(sequence);
         _reserveCursor = sequence;
         if constexpr (hasSignalAllWhenBlocking<TWaitStrategy>) {
@@ -78,7 +78,7 @@ public:
     }
 
 private:
-    [[nodiscard]] forceinline signed_index_type getMinReaderCursor() const noexcept {
+    [[nodiscard]] forceinline index_type getMinReaderCursor() const noexcept {
         if (_readSequences->empty()) {
             return kInitialCursorValue;
         }
@@ -99,7 +99,7 @@ static_assert(ClaimStrategyLike<SingleProducerStrategy<1024, NoWaitStrategy>>);
 template<std::size_t SIZE = std::dynamic_extent, WaitStrategyLike TWaitStrategy = BusySpinWaitStrategy>
 requires(SIZE == std::dynamic_extent || std::has_single_bit(SIZE))
 class alignas(hardware_constructive_interference_size) MultiProducerStrategy {
-    using signed_index_type = Sequence::signed_index_type;
+    using index_type = Sequence::index_type;
 
     AtomicBitset<SIZE> _slotStates; // tracks the state of each ringbuffer slot, true -> completed and ready to be read
     const std::size_t  _size = SIZE;
@@ -125,16 +125,16 @@ public:
     MultiProducerStrategy(const MultiProducerStrategy&&) = delete;
     void operator=(const MultiProducerStrategy&)         = delete;
 
-    [[nodiscard]] signed_index_type next(std::size_t nSlotsToClaim = 1) {
-        assert((nSlotsToClaim > 0 && nSlotsToClaim <= static_cast<std::size_t>(_size)) && "nSlotsToClaim must be > 0 and <= bufferSize");
+    [[nodiscard]] index_type next(std::size_t nSlotsToClaim = 1) {
+        assert((nSlotsToClaim > 0 && nSlotsToClaim <= _size) && "nSlotsToClaim must be > 0 and <= bufferSize");
 
-        signed_index_type currentReserveCursor;
-        signed_index_type nextReserveCursor;
-        SpinWait          spinWait;
+        index_type currentReserveCursor;
+        index_type nextReserveCursor;
+        SpinWait   spinWait;
         do {
             currentReserveCursor = _reserveCursor.value();
-            nextReserveCursor    = currentReserveCursor + static_cast<signed_index_type>(nSlotsToClaim);
-            if (nextReserveCursor - getMinReaderCursor() > static_cast<signed_index_type>(_size)) { // not enough slots in buffer
+            nextReserveCursor    = currentReserveCursor + nSlotsToClaim;
+            if (nextReserveCursor - getMinReaderCursor() > _size) { // not enough slots in buffer
                 if constexpr (hasSignalAllWhenBlocking<TWaitStrategy>) {
                     _waitStrategy.signalAllWhenBlocking();
                 }
@@ -148,38 +148,38 @@ public:
         return nextReserveCursor;
     }
 
-    [[nodiscard]] std::optional<signed_index_type> tryNext(std::size_t nSlotsToClaim = 1) noexcept {
-        assert((nSlotsToClaim > 0 && nSlotsToClaim <= static_cast<std::size_t>(_size)) && "nSlotsToClaim must be > 0 and <= bufferSize");
+    [[nodiscard]] std::optional<index_type> tryNext(std::size_t nSlotsToClaim = 1) noexcept {
+        assert((nSlotsToClaim > 0 && nSlotsToClaim <= _size) && "nSlotsToClaim must be > 0 and <= bufferSize");
 
-        signed_index_type currentReserveCursor;
-        signed_index_type nextReserveCursor;
+        index_type currentReserveCursor;
+        index_type nextReserveCursor;
 
         do {
             currentReserveCursor = _reserveCursor.value();
-            nextReserveCursor    = currentReserveCursor + static_cast<signed_index_type>(nSlotsToClaim);
-            if (nextReserveCursor - getMinReaderCursor() > static_cast<signed_index_type>(_size)) { // not enough slots in buffer
+            nextReserveCursor    = currentReserveCursor + nSlotsToClaim;
+            if (nextReserveCursor - getMinReaderCursor() > _size) { // not enough slots in buffer
                 return std::nullopt;
             }
         } while (!_reserveCursor.compareAndSet(currentReserveCursor, nextReserveCursor));
         return nextReserveCursor;
     }
 
-    [[nodiscard]] forceinline signed_index_type getRemainingCapacity() const noexcept { return static_cast<signed_index_type>(_size) - (_reserveCursor.value() - getMinReaderCursor()); }
+    [[nodiscard]] forceinline index_type getRemainingCapacity() const noexcept { return _size - (_reserveCursor.value() - getMinReaderCursor()); }
 
-    void publish(signed_index_type offset, std::size_t nSlotsToClaim) {
+    void publish(index_type offset, std::size_t nSlotsToClaim) {
         if (nSlotsToClaim == 0) {
             return;
         }
-        setSlotsStates(offset, offset + static_cast<signed_index_type>(nSlotsToClaim), true);
+        setSlotsStates(offset, offset + nSlotsToClaim, true);
 
         // ensure publish cursor is only advanced after all prior slots are published
-        signed_index_type currentPublishCursor;
-        signed_index_type nextPublishCursor;
+        index_type currentPublishCursor;
+        index_type nextPublishCursor;
         do {
             currentPublishCursor = _publishCursor.value();
             nextPublishCursor    = currentPublishCursor;
 
-            while (_slotStates.test(static_cast<std::size_t>(nextPublishCursor) & _mask) && static_cast<std::size_t>(nextPublishCursor - currentPublishCursor) < _slotStates.size()) {
+            while (_slotStates.test(nextPublishCursor & _mask) && nextPublishCursor - currentPublishCursor < _slotStates.size()) {
                 nextPublishCursor++;
             }
         } while (!_publishCursor.compareAndSet(currentPublishCursor, nextPublishCursor));
@@ -193,18 +193,19 @@ public:
     }
 
 private:
-    [[nodiscard]] forceinline signed_index_type getMinReaderCursor() const noexcept {
+    [[nodiscard]] forceinline index_type getMinReaderCursor() const noexcept {
         if (_readSequences->empty()) {
             return kInitialCursorValue;
         }
         return std::ranges::min(*_readSequences | std::views::transform([](const auto& cursor) { return cursor->value(); }));
     }
 
-    void setSlotsStates(signed_index_type seqBegin, signed_index_type seqEnd, bool value) {
-        assert(static_cast<std::size_t>(seqEnd - seqBegin) <= _size && "Begin cannot overturn end");
-        const std::size_t beginSet  = static_cast<std::size_t>(seqBegin) & _mask;
-        const std::size_t endSet    = static_cast<std::size_t>(seqEnd) & _mask;
-        const auto        diffReset = static_cast<std::size_t>(seqEnd - seqBegin);
+    void setSlotsStates(index_type seqBegin, index_type seqEnd, bool value) {
+        assert(seqBegin <= seqEnd);
+        assert(seqEnd - seqBegin <= _size && "Begin cannot overturn end");
+        const std::size_t beginSet  = seqBegin & _mask;
+        const std::size_t endSet    = seqEnd & _mask;
+        const auto        diffReset = seqEnd - seqBegin;
 
         if (beginSet <= endSet && diffReset < _size) {
             _slotStates.set(beginSet, endSet, value);

--- a/core/include/gnuradio-4.0/DataSet.hpp
+++ b/core/include/gnuradio-4.0/DataSet.hpp
@@ -73,7 +73,7 @@ concept DataSetLike = TensorLike<T> && requires(T t, const std::size_t n_items) 
 
     // meta data
     requires std::is_same_v<decltype(t.meta_information), std::vector<typename T::pmt_map>>;
-    requires std::is_same_v<decltype(t.timing_events), std::vector<std::vector<RelativeIndexTag>>>;
+    requires std::is_same_v<decltype(t.timing_events), std::vector<std::vector<std::pair<std::ptrdiff_t, property_map>>>>;
 };
 
 template<typename T>
@@ -101,8 +101,8 @@ struct DataSet {
     std::vector<std::vector<T>> signal_ranges{};     // [[min_0, max_0], [min_1, max_1], …] used for communicating, for example, HW limits
 
     // meta data
-    std::vector<pmt_map>                       meta_information{};
-    std::vector<std::vector<RelativeIndexTag>> timing_events{};
+    std::vector<pmt_map>                                              meta_information{};
+    std::vector<std::vector<std::pair<std::ptrdiff_t, property_map>>> timing_events{};
 
     GR_MAKE_REFLECTABLE(DataSet, timestamp, axis_names, axis_units, axis_values, extents, layout, signal_names, signal_quantities, signal_units, signal_values, signal_errors, signal_ranges, meta_information, timing_events);
 };

--- a/core/include/gnuradio-4.0/DataSet.hpp
+++ b/core/include/gnuradio-4.0/DataSet.hpp
@@ -73,7 +73,7 @@ concept DataSetLike = TensorLike<T> && requires(T t, const std::size_t n_items) 
 
     // meta data
     requires std::is_same_v<decltype(t.meta_information), std::vector<typename T::pmt_map>>;
-    requires std::is_same_v<decltype(t.timing_events), std::vector<std::vector<Tag>>>;
+    requires std::is_same_v<decltype(t.timing_events), std::vector<std::vector<RelativeIndexTag>>>;
 };
 
 template<typename T>
@@ -101,8 +101,8 @@ struct DataSet {
     std::vector<std::vector<T>> signal_ranges{};     // [[min_0, max_0], [min_1, max_1], …] used for communicating, for example, HW limits
 
     // meta data
-    std::vector<pmt_map>          meta_information{};
-    std::vector<std::vector<Tag>> timing_events{};
+    std::vector<pmt_map>                       meta_information{};
+    std::vector<std::vector<RelativeIndexTag>> timing_events{};
 
     GR_MAKE_REFLECTABLE(DataSet, timestamp, axis_names, axis_units, axis_values, extents, layout, signal_names, signal_quantities, signal_units, signal_values, signal_errors, signal_ranges, meta_information, timing_events);
 };

--- a/core/include/gnuradio-4.0/Port.hpp
+++ b/core/include/gnuradio-4.0/Port.hpp
@@ -1,6 +1,7 @@
 #ifndef GNURADIO_PORT_HPP
 #define GNURADIO_PORT_HPP
 
+#include <algorithm>
 #include <any>
 #include <complex>
 #include <set>
@@ -282,7 +283,7 @@ struct Async {};
  * - Merging Tags: Use `getMergedTag(untilLocalIndex)` to obtain a single tag that merges all tags up to `untilLocalIndex` and including first sample.
  */
 template<typename T>
-concept InputSpanLike = std::ranges::contiguous_range<T> && ConstSpanLike<T> && requires(T& span, gr::Tag::signed_index_type n) {
+concept InputSpanLike = std::ranges::contiguous_range<T> && ConstSpanLike<T> && requires(T& span, gr::Tag::index_type n) {
     { span.consume(0) };
     { span.isConnected } -> std::convertible_to<bool>;
     { span.isSync } -> std::convertible_to<bool>;
@@ -306,7 +307,7 @@ concept InputSpanLike = std::ranges::contiguous_range<T> && ConstSpanLike<T> && 
  * - Publishing Tags: Use `publishTag(tagData, tagOffset)` to publish tags. `tagOffset` is relative to the first sample.
  */
 template<typename T>
-concept OutputSpanLike = std::ranges::contiguous_range<T> && std::ranges::output_range<T, std::remove_cvref_t<typename T::value_type>> && SpanLike<T> && requires(T& span, property_map& tagData, Tag::signed_index_type tagOffset) {
+concept OutputSpanLike = std::ranges::contiguous_range<T> && std::ranges::output_range<T, std::remove_cvref_t<typename T::value_type>> && SpanLike<T> && requires(T& span, property_map& tagData, Tag::index_type tagOffset) {
     span.publish(0UZ);
     { span.isConnected } -> std::convertible_to<bool>;
     { span.isSync } -> std::convertible_to<bool>;
@@ -447,14 +448,14 @@ struct Port {
 
     template<SpanReleasePolicy spanReleasePolicy>
     struct InputSpan : public ReaderSpanType<spanReleasePolicy> {
-        TagReaderSpanType      rawTags;
-        Tag::signed_index_type streamIndex;
-        bool                   isConnected = true; // true if Port is connected
-        bool                   isSync      = true; // true if  Port is Sync
+        TagReaderSpanType rawTags;
+        Tag::index_type   streamIndex;
+        bool              isConnected = true; // true if Port is connected
+        bool              isSync      = true; // true if  Port is Sync
 
         InputSpan(std::size_t nSamples, ReaderType& reader, TagReaderType& tagReader, bool connected, bool sync) //
             : ReaderSpanType<spanReleasePolicy>(reader.template get<spanReleasePolicy>(nSamples)),               //
-              rawTags(getTags(static_cast<gr::Tag::signed_index_type>(nSamples), tagReader, reader.position())), //
+              rawTags(getTags(static_cast<gr::Tag::index_type>(nSamples), tagReader, reader.position())),        //
               streamIndex{reader.position()}, isConnected(connected), isSync(sync) {};
 
         InputSpan(const InputSpan&)            = default;
@@ -475,42 +476,32 @@ struct Port {
         }
 
         [[nodiscard]] auto tags() {
-            return std::views::transform(rawTags, [this](auto& tag) { return std::make_pair(std::max(tag.index, 0l) - streamIndex, std::ref(tag.map)); });
+            return std::views::transform(rawTags, [this](auto& tag) { return std::make_pair(tagIndexDifference(tag.index, streamIndex), std::ref(tag.map)); });
         }
 
-        void consumeTags(gr::Tag::signed_index_type untilLocalIndex) {
+        void consumeTags(gr::Tag::index_type untilLocalIndex) {
             std::size_t tagsToConsume = static_cast<std::size_t>(std::ranges::count_if(rawTags | std::views::take_while([untilLocalIndex, this](auto& t) { return t.index <= streamIndex + untilLocalIndex; }), [](auto /*v*/) { return true; }));
             std::ignore               = rawTags.tryConsume(tagsToConsume);
         }
 
-        [[nodiscard]] inline Tag getMergedTag(gr::Tag::signed_index_type untilLocalIndex = 0) const {
+        [[nodiscard]] inline Tag getMergedTag(gr::Tag::index_type untilLocalIndex = 0) const {
             auto mergeSrcMapInto = [](const property_map& sourceMap, property_map& destinationMap) {
                 assert(&sourceMap != &destinationMap);
                 for (const auto& [key, value] : sourceMap) {
                     destinationMap.insert_or_assign(key, value);
                 }
             };
-            Tag result{-1, {}};
+            Tag result{0UZ, {}};
             std::ranges::for_each(rawTags | std::views::take_while([untilLocalIndex, this](auto& t) { return t.index <= streamIndex + untilLocalIndex; }), [&mergeSrcMapInto, &result](const Tag& tag) { mergeSrcMapInto(tag.map, result.map); });
             return result;
         }
 
     private:
-        auto getTags(gr::Tag::signed_index_type nSamples, TagReaderType& reader, gr::Tag::signed_index_type _currentStreamOffset) {
-            std::size_t nTagsProcessed    = 0UZ;
-            bool        properTagDistance = false;
-            for (const Tag& tag : reader.get(reader.available())) {
-                const bool tagIsWithinRange = (tag.index != -1) && tag.index < _currentStreamOffset + nSamples;
-                if ((!properTagDistance && tag.index < 0) || tagIsWithinRange) { // 'index == -1' wildcard Tag index -> process unconditionally
-                    nTagsProcessed++;
-                    if (tagIsWithinRange) { // detected regular Tag position, ignore and stop at further wildcard Tags
-                        properTagDistance = true;
-                    }
-                } else {
-                    break; // Tag is wildcard (index == -1) after a regular or newer than the present reading position (+ offset)
-                }
-            }
-            return reader.get(nTagsProcessed);
+        auto getTags(gr::Tag::index_type nSamples, TagReaderType& reader, gr::Tag::index_type currentStreamOffset) {
+            const auto tags = reader.get(reader.available());
+            const auto it   = std::ranges::find_if_not(tags, [nSamples, currentStreamOffset](const auto& tag) { return tag.index < currentStreamOffset + nSamples; });
+            const auto n    = static_cast<std::size_t>(std::distance(tags.begin(), it));
+            return reader.get(n);
         }
     }; // end of InputSpan
     static_assert(ReaderSpanLike<InputSpan<gr::SpanReleasePolicy::ProcessAll>>);
@@ -521,19 +512,19 @@ struct Port {
 
     template<SpanReleasePolicy spanReleasePolicy, WriterSpanReservePolicy spanReservePolicy>
     struct OutputSpan : public WriterSpanType<spanReleasePolicy> {
-        TagWriterSpanType      tags;
-        Tag::signed_index_type streamIndex;
-        std::size_t            tagsPublished{0UZ};
-        bool                   isConnected = true; // true if Port is connected
-        bool                   isSync      = true; // true if  Port is Sync
+        TagWriterSpanType tags;
+        Tag::index_type   streamIndex;
+        std::size_t       tagsPublished{0UZ};
+        bool              isConnected = true; // true if Port is connected
+        bool              isSync      = true; // true if  Port is Sync
 
-        constexpr OutputSpan(std::size_t nSamples, WriterType& streamWriter, TagWriterType& tagsWriter, Tag::signed_index_type streamOffset, bool connected, bool sync) noexcept //
+        constexpr OutputSpan(std::size_t nSamples, WriterType& streamWriter, TagWriterType& tagsWriter, Tag::index_type streamOffset, bool connected, bool sync) noexcept //
         requires(spanReservePolicy == WriterSpanReservePolicy::Reserve)
             : WriterSpanType<spanReleasePolicy>(streamWriter.template reserve<spanReleasePolicy>(nSamples)), //
               tags(tagsWriter.template reserve<SpanReleasePolicy::ProcessNone>(tagsWriter.available())),     //
               streamIndex{streamOffset}, isConnected(connected), isSync(sync) {};
 
-        constexpr OutputSpan(std::size_t nSamples, WriterType& streamWriter, TagWriterType& tagsWriter, Tag::signed_index_type streamOffset, bool connected, bool sync) noexcept //
+        constexpr OutputSpan(std::size_t nSamples, WriterType& streamWriter, TagWriterType& tagsWriter, Tag::index_type streamOffset, bool connected, bool sync) noexcept //
         requires(spanReservePolicy == WriterSpanReservePolicy::TryReserve)
             : WriterSpanType<spanReleasePolicy>(streamWriter.template tryReserve<spanReleasePolicy>(nSamples)), //
               tags(tagsWriter.template tryReserve<SpanReleasePolicy::ProcessNone>(tagsWriter.available())),     //
@@ -550,14 +541,14 @@ struct Port {
             }
         }
 
-        inline constexpr void publishTag(property_map&& tagData, Tag::signed_index_type tagOffset = -1) noexcept { processPublishTag(std::move(tagData), tagOffset); }
+        inline constexpr void publishTag(property_map&& tagData, Tag::index_type tagOffset = 0UZ) noexcept { processPublishTag(std::move(tagData), tagOffset); }
 
-        inline constexpr void publishTag(const property_map& tagData, Tag::signed_index_type tagOffset = -1) noexcept { processPublishTag(tagData, tagOffset); }
+        inline constexpr void publishTag(const property_map& tagData, Tag::index_type tagOffset = 0UZ) noexcept { processPublishTag(tagData, tagOffset); }
 
     private:
         template<PropertyMapType PropertyMap>
-        inline constexpr void processPublishTag(PropertyMap&& tagData, Tag::signed_index_type tagOffset) noexcept {
-            const auto index = streamIndex + static_cast<gr::Tag::signed_index_type>(tagOffset);
+        inline constexpr void processPublishTag(PropertyMap&& tagData, Tag::index_type tagOffset) noexcept {
+            const auto index = streamIndex + static_cast<gr::Tag::index_type>(tagOffset);
 
             if (tagsPublished > 0) {
                 auto& lastTag = tags[tagsPublished - 1];
@@ -822,13 +813,13 @@ public:
         return OutputSpan<spanReleasePolicy, WriterSpanReservePolicy::TryReserve>(nSamples, streamWriter(), tagWriter(), streamWriter().position(), this->isConnected(), this->isSynchronous());
     }
 
-    inline constexpr void publishTag(property_map&& tag_data, Tag::signed_index_type tagOffset = -1) noexcept
+    inline constexpr void publishTag(property_map&& tag_data, Tag::index_type tagOffset = 0UZ) noexcept
     requires(kIsOutput)
     {
         processPublishTag(std::move(tag_data), tagOffset);
     }
 
-    inline constexpr void publishTag(const property_map& tag_data, Tag::signed_index_type tagOffset = -1) noexcept
+    inline constexpr void publishTag(const property_map& tag_data, Tag::index_type tagOffset = 0UZ) noexcept
     requires(kIsOutput)
     {
         processPublishTag(tag_data, tagOffset);
@@ -857,12 +848,11 @@ public:
 
 private:
     template<PropertyMapType PropertyMap>
-    inline constexpr void processPublishTag(PropertyMap&& tag_data, Tag::signed_index_type tagOffset) noexcept
+    inline constexpr void processPublishTag(PropertyMap&& tag_data, Tag::index_type tagOffset) noexcept
     requires(kIsOutput)
     {
-        const auto newTagIndex = tagOffset < 0 ? tagOffset : streamWriter().position() + tagOffset;
-
-        if (isConnected() && tagOffset >= 0 && (_cachedTag.index != newTagIndex && _cachedTag.index != -1)) { // do not cache tags that have an explicit index
+        const auto newTagIndex = streamWriter().position() + tagOffset;
+        if (isConnected() && _cachedTag.index != newTagIndex) {
             publishPendingTags();
         }
         _cachedTag.index = newTagIndex;
@@ -875,7 +865,7 @@ private:
                 _cachedTag.map.insert_or_assign(key, value);
             }
         }
-        if (isConnected() && (tagOffset != -1L || _cachedTag.map.contains(gr::tag::END_OF_STREAM))) { // force tag publishing for explicitly published tags or EOS
+        if (isConnected()) {
             publishPendingTags();
         }
     }
@@ -1115,41 +1105,39 @@ static_assert(PortLike<DynamicPort>);
 
 namespace detail {
 template<typename T>
-concept TagPredicate = requires(const T& t, const Tag& tag, Tag::signed_index_type readPosition) {
+concept TagPredicate = requires(const T& t, const Tag& tag, Tag::index_type readPosition) {
     { t(tag, readPosition) } -> std::convertible_to<bool>;
 };
-inline constexpr TagPredicate auto defaultTagMatcher    = [](const Tag& tag, Tag::signed_index_type readPosition) noexcept { return tag.index >= readPosition; };
-inline constexpr TagPredicate auto defaultEOSTagMatcher = [](const Tag& tag, Tag::signed_index_type readPosition) noexcept {
-    auto eosTagIter = tag.map.find(gr::tag::END_OF_STREAM);
-    if (eosTagIter != tag.map.end() && eosTagIter->second == true) {
-        if (tag.index >= readPosition || tag.index < 0) {
-            return true;
-        }
+inline constexpr TagPredicate auto defaultTagMatcher    = [](const Tag& tag, Tag::index_type readPosition) noexcept { return tag.index >= readPosition; };
+inline constexpr TagPredicate auto defaultEOSTagMatcher = [](const Tag& tag, Tag::index_type readPosition) noexcept {
+    if (tag.index < readPosition) {
+        return false;
     }
-    return false;
+    auto eosTagIter = tag.map.find(gr::tag::END_OF_STREAM);
+    return eosTagIter != tag.map.end() && eosTagIter->second == true;
 };
 } // namespace detail
 
-inline constexpr std::optional<std::size_t> nSamplesToNextTagConditional(PortLike auto& port, detail::TagPredicate auto& predicate, Tag::signed_index_type readOffset) {
+inline constexpr std::optional<std::size_t> nSamplesToNextTagConditional(PortLike auto& port, detail::TagPredicate auto& predicate, Tag::index_type readOffset) {
     ReaderSpanLike auto tagData = port.tagReader().get();
     if (!port.isConnected() || tagData.empty()) [[likely]] {
         return std::nullopt; // default: no tags in sight
     }
-    const Tag::signed_index_type readPosition = port.streamReader().position();
+    const Tag::index_type readPosition = port.streamReader().position();
 
-    // at least one tag is present -> if tag is not on the first tag position read up to the tag position, or if the tag has a special 'index = -1'
+    // at least one tag is present -> if tag is not on the first tag position read up to the tag position
     const auto firstMatchingTag = std::ranges::find_if(tagData, [&](const auto& tag) { return predicate(tag, readPosition + readOffset); });
     std::ignore                 = tagData.consume(0UZ);
     if (firstMatchingTag != tagData.end()) {
-        return static_cast<std::size_t>(std::max(firstMatchingTag->index - readPosition, Tag::signed_index_type(0))); // Tags in the past will have a negative distance -> deliberately map them to '0'
+        return static_cast<std::size_t>(std::max(firstMatchingTag->index - readPosition, Tag::index_type(0))); // Tags in the past will have a negative distance -> deliberately map them to '0'
     } else {
         return std::nullopt;
     }
 }
 
-inline constexpr std::optional<std::size_t> nSamplesUntilNextTag(PortLike auto& port, Tag::signed_index_type offset = 0) { return nSamplesToNextTagConditional(port, detail::defaultTagMatcher, offset); }
+inline constexpr std::optional<std::size_t> nSamplesUntilNextTag(PortLike auto& port, Tag::index_type offset = 0) { return nSamplesToNextTagConditional(port, detail::defaultTagMatcher, offset); }
 
-inline constexpr std::optional<std::size_t> samples_to_eos_tag(PortLike auto& port, Tag::signed_index_type offset = 0) { return nSamplesToNextTagConditional(port, detail::defaultEOSTagMatcher, offset); }
+inline constexpr std::optional<std::size_t> samples_to_eos_tag(PortLike auto& port, Tag::index_type offset = 0) { return nSamplesToNextTagConditional(port, detail::defaultEOSTagMatcher, offset); }
 
 } // namespace gr
 

--- a/core/include/gnuradio-4.0/Sequence.hpp
+++ b/core/include/gnuradio-4.0/Sequence.hpp
@@ -35,38 +35,32 @@ static constexpr const std::size_t kInitialCursorValue = 0L;
  * around the volatile field.
  */
 class Sequence {
-public:
-    using index_type = std::size_t;
-
-private:
-    alignas(hardware_destructive_interference_size) std::atomic<index_type> _fieldsValue{};
+    alignas(hardware_destructive_interference_size) std::atomic<std::size_t> _fieldsValue{};
 
 public:
     Sequence(const Sequence&)       = delete;
     Sequence(const Sequence&&)      = delete;
     void operator=(const Sequence&) = delete;
 
-    explicit Sequence(index_type initialValue = kInitialCursorValue) noexcept : _fieldsValue(initialValue) {}
+    explicit Sequence(std::size_t initialValue = kInitialCursorValue) noexcept : _fieldsValue(initialValue) {}
 
-    [[nodiscard]] forceinline index_type value() const noexcept { return std::atomic_load_explicit(&_fieldsValue, std::memory_order_acquire); }
-    forceinline void                     setValue(const index_type value) noexcept { std::atomic_store_explicit(&_fieldsValue, value, std::memory_order_release); }
+    [[nodiscard]] forceinline std::size_t value() const noexcept { return std::atomic_load_explicit(&_fieldsValue, std::memory_order_acquire); }
+    forceinline void                      setValue(const std::size_t value) noexcept { std::atomic_store_explicit(&_fieldsValue, value, std::memory_order_release); }
 
-    [[nodiscard]] forceinline bool compareAndSet(index_type expectedSequence, index_type nextSequence) noexcept {
+    [[nodiscard]] forceinline bool compareAndSet(std::size_t expectedSequence, std::size_t nextSequence) noexcept {
         // atomically set the value to the given updated value if the current value == the
         // expected value (true, otherwise folse).
         return std::atomic_compare_exchange_strong(&_fieldsValue, &expectedSequence, nextSequence);
     }
 
-    [[maybe_unused]] forceinline index_type incrementAndGet() noexcept { return std::atomic_fetch_add(&_fieldsValue, 1L) + 1L; }
-    [[nodiscard]] forceinline index_type    addAndGet(index_type value) noexcept { return std::atomic_fetch_add(&_fieldsValue, value) + value; }
-    [[nodiscard]] forceinline index_type    subAndGet(index_type value) noexcept { return std::atomic_fetch_sub(&_fieldsValue, value) - value; }
-    void                                    wait(index_type oldValue) const noexcept { atomic_wait_explicit(&_fieldsValue, oldValue, std::memory_order_acquire); }
+    [[maybe_unused]] forceinline std::size_t incrementAndGet() noexcept { return std::atomic_fetch_add(&_fieldsValue, 1L) + 1L; }
+    [[nodiscard]] forceinline std::size_t addAndGet(std::size_t value) noexcept { return std::atomic_fetch_add(&_fieldsValue, value) + value; }
+    [[nodiscard]] forceinline std::size_t   subAndGet(std::size_t value) noexcept { return std::atomic_fetch_sub(&_fieldsValue, value) - value; }
+    void                                    wait(std::size_t oldValue) const noexcept { atomic_wait_explicit(&_fieldsValue, oldValue, std::memory_order_acquire); }
     void                                    notify_all() noexcept { _fieldsValue.notify_all(); }
 };
 
 namespace detail {
-
-using index_type = Sequence::index_type;
 
 /**
  * Get the minimum sequence from an array of Sequences.
@@ -75,11 +69,11 @@ using index_type = Sequence::index_type;
  * \param minimum an initial default minimum.  If the array is empty this value will
  * returned. \returns the minimum sequence found or lon.MaxValue if the array is empty.
  */
-inline index_type getMinimumSequence(const std::vector<std::shared_ptr<Sequence>>& sequences, index_type minimum = std::numeric_limits<index_type>::max()) noexcept {
+inline std::size_t getMinimumSequence(const std::vector<std::shared_ptr<Sequence>>& sequences, std::size_t minimum = std::numeric_limits<std::size_t>::max()) noexcept {
     // Note that calls to getMinimumSequence get rather expensive with sequences.size() because
     // each Sequence lives on its own cache line. Also, this is no reasonable loop for vectorization.
     for (const auto& s : sequences) {
-        const index_type v = s->value();
+        const std::size_t v = s->value();
         if (v < minimum) {
             minimum = v;
         }
@@ -98,7 +92,7 @@ inline index_type getMinimumSequence(const std::vector<std::shared_ptr<Sequence>
 #endif
 
 inline void addSequences(std::shared_ptr<std::vector<std::shared_ptr<Sequence>>>& sequences, const Sequence& cursor, const std::vector<std::shared_ptr<Sequence>>& sequencesToAdd) {
-    index_type                                              cursorSequence;
+    std::size_t                                             cursorSequence;
     std::shared_ptr<std::vector<std::shared_ptr<Sequence>>> updatedSequences;
     std::shared_ptr<std::vector<std::shared_ptr<Sequence>>> currentSequences;
 

--- a/core/include/gnuradio-4.0/Sequence.hpp
+++ b/core/include/gnuradio-4.0/Sequence.hpp
@@ -55,9 +55,9 @@ public:
 
     [[maybe_unused]] forceinline std::size_t incrementAndGet() noexcept { return std::atomic_fetch_add(&_fieldsValue, 1L) + 1L; }
     [[nodiscard]] forceinline std::size_t addAndGet(std::size_t value) noexcept { return std::atomic_fetch_add(&_fieldsValue, value) + value; }
-    [[nodiscard]] forceinline std::size_t   subAndGet(std::size_t value) noexcept { return std::atomic_fetch_sub(&_fieldsValue, value) - value; }
-    void                                    wait(std::size_t oldValue) const noexcept { atomic_wait_explicit(&_fieldsValue, oldValue, std::memory_order_acquire); }
-    void                                    notify_all() noexcept { _fieldsValue.notify_all(); }
+    [[nodiscard]] forceinline std::size_t subAndGet(std::size_t value) noexcept { return std::atomic_fetch_sub(&_fieldsValue, value) - value; }
+    void                                  wait(std::size_t oldValue) const noexcept { atomic_wait_explicit(&_fieldsValue, oldValue, std::memory_order_acquire); }
+    void                                  notify_all() noexcept { _fieldsValue.notify_all(); }
 };
 
 namespace detail {

--- a/core/include/gnuradio-4.0/Sequence.hpp
+++ b/core/include/gnuradio-4.0/Sequence.hpp
@@ -26,7 +26,7 @@ using std::hardware_destructive_interference_size;
 inline constexpr std::size_t hardware_destructive_interference_size  = 64;
 inline constexpr std::size_t hardware_constructive_interference_size = 64;
 #endif
-static constexpr const std::make_signed_t<std::size_t> kInitialCursorValue = 0L;
+static constexpr const std::size_t kInitialCursorValue = 0L;
 
 /**
  * Concurrent sequence class used for tracking the progress of the ring buffer and event
@@ -36,36 +36,37 @@ static constexpr const std::make_signed_t<std::size_t> kInitialCursorValue = 0L;
  */
 class Sequence {
 public:
-    using signed_index_type = std::make_signed_t<std::size_t>;
+    using index_type = std::size_t;
 
 private:
-    alignas(hardware_destructive_interference_size) std::atomic<signed_index_type> _fieldsValue{};
+    alignas(hardware_destructive_interference_size) std::atomic<index_type> _fieldsValue{};
 
 public:
     Sequence(const Sequence&)       = delete;
     Sequence(const Sequence&&)      = delete;
     void operator=(const Sequence&) = delete;
 
-    explicit Sequence(signed_index_type initialValue = kInitialCursorValue) noexcept : _fieldsValue(initialValue) {}
+    explicit Sequence(index_type initialValue = kInitialCursorValue) noexcept : _fieldsValue(initialValue) {}
 
-    [[nodiscard]] forceinline signed_index_type value() const noexcept { return std::atomic_load_explicit(&_fieldsValue, std::memory_order_acquire); }
-    forceinline void                            setValue(const signed_index_type value) noexcept { std::atomic_store_explicit(&_fieldsValue, value, std::memory_order_release); }
+    [[nodiscard]] forceinline index_type value() const noexcept { return std::atomic_load_explicit(&_fieldsValue, std::memory_order_acquire); }
+    forceinline void                     setValue(const index_type value) noexcept { std::atomic_store_explicit(&_fieldsValue, value, std::memory_order_release); }
 
-    [[nodiscard]] forceinline bool compareAndSet(signed_index_type expectedSequence, signed_index_type nextSequence) noexcept {
+    [[nodiscard]] forceinline bool compareAndSet(index_type expectedSequence, index_type nextSequence) noexcept {
         // atomically set the value to the given updated value if the current value == the
         // expected value (true, otherwise folse).
         return std::atomic_compare_exchange_strong(&_fieldsValue, &expectedSequence, nextSequence);
     }
 
-    [[maybe_unused]] forceinline signed_index_type incrementAndGet() noexcept { return std::atomic_fetch_add(&_fieldsValue, 1L) + 1L; }
-    [[nodiscard]] forceinline signed_index_type    addAndGet(signed_index_type value) noexcept { return std::atomic_fetch_add(&_fieldsValue, value) + value; }
-    void                                           wait(signed_index_type oldValue) const noexcept { atomic_wait_explicit(&_fieldsValue, oldValue, std::memory_order_acquire); }
-    void                                           notify_all() noexcept { _fieldsValue.notify_all(); }
+    [[maybe_unused]] forceinline index_type incrementAndGet() noexcept { return std::atomic_fetch_add(&_fieldsValue, 1L) + 1L; }
+    [[nodiscard]] forceinline index_type    addAndGet(index_type value) noexcept { return std::atomic_fetch_add(&_fieldsValue, value) + value; }
+    [[nodiscard]] forceinline index_type    subAndGet(index_type value) noexcept { return std::atomic_fetch_sub(&_fieldsValue, value) - value; }
+    void                                    wait(index_type oldValue) const noexcept { atomic_wait_explicit(&_fieldsValue, oldValue, std::memory_order_acquire); }
+    void                                    notify_all() noexcept { _fieldsValue.notify_all(); }
 };
 
 namespace detail {
 
-using signed_index_type = Sequence::signed_index_type;
+using index_type = Sequence::index_type;
 
 /**
  * Get the minimum sequence from an array of Sequences.
@@ -74,11 +75,11 @@ using signed_index_type = Sequence::signed_index_type;
  * \param minimum an initial default minimum.  If the array is empty this value will
  * returned. \returns the minimum sequence found or lon.MaxValue if the array is empty.
  */
-inline signed_index_type getMinimumSequence(const std::vector<std::shared_ptr<Sequence>>& sequences, signed_index_type minimum = std::numeric_limits<signed_index_type>::max()) noexcept {
+inline index_type getMinimumSequence(const std::vector<std::shared_ptr<Sequence>>& sequences, index_type minimum = std::numeric_limits<index_type>::max()) noexcept {
     // Note that calls to getMinimumSequence get rather expensive with sequences.size() because
     // each Sequence lives on its own cache line. Also, this is no reasonable loop for vectorization.
     for (const auto& s : sequences) {
-        const signed_index_type v = s->value();
+        const index_type v = s->value();
         if (v < minimum) {
             minimum = v;
         }
@@ -97,7 +98,7 @@ inline signed_index_type getMinimumSequence(const std::vector<std::shared_ptr<Se
 #endif
 
 inline void addSequences(std::shared_ptr<std::vector<std::shared_ptr<Sequence>>>& sequences, const Sequence& cursor, const std::vector<std::shared_ptr<Sequence>>& sequencesToAdd) {
-    signed_index_type                                       cursorSequence;
+    index_type                                              cursorSequence;
     std::shared_ptr<std::vector<std::shared_ptr<Sequence>>> updatedSequences;
     std::shared_ptr<std::vector<std::shared_ptr<Sequence>>> currentSequences;
 

--- a/core/include/gnuradio-4.0/Tag.hpp
+++ b/core/include/gnuradio-4.0/Tag.hpp
@@ -65,15 +65,13 @@ concept PropertyMapType = std::same_as<std::decay_t<T>, property_map>;
  * may choose to chunk the data based on the MIN_SAMPLES/MAX_SAMPLES criteria only, or in addition break-up the stream
  * so that there is only one tag per scheduler iteration. Multiple tags on the same sample shall be merged to one.
  */
-template<typename TIndex>
-struct alignas(hardware_constructive_interference_size) BasicTag {
-    using index_type = TIndex;
-    index_type   index{0};
+struct alignas(hardware_constructive_interference_size) Tag {
+    std::size_t  index{0UZ};
     property_map map{};
 
-    GR_MAKE_REFLECTABLE(BasicTag, index, map);
+    GR_MAKE_REFLECTABLE(Tag, index, map);
 
-    bool operator==(const BasicTag& other) const = default;
+    bool operator==(const Tag& other) const = default;
 
     // TODO: do we need the convenience methods below?
     void reset() noexcept {
@@ -104,21 +102,6 @@ struct alignas(hardware_constructive_interference_size) BasicTag {
     void insert_or_assign(const std::pair<std::string, pmtv::pmt>& value) { map[value.first] = value.second; }
 
     void insert_or_assign(const std::string& key, const pmtv::pmt& value) { map[key] = value; }
-};
-
-using Tag              = BasicTag<std::size_t>;
-using RelativeIndexTag = BasicTag<std::make_signed_t<std::size_t>>;
-
-constexpr std::make_signed_t<std::size_t> tagIndexDifference(Tag::index_type x, Tag::index_type y) {
-    // assuming that tag indices and stream position are never further apart than half the range of the index type,
-    // assume integer overflow if they are.
-    using signed_type         = std::make_signed_t<Tag::index_type>;
-    constexpr auto half_range = std::numeric_limits<Tag::index_type>::max() / 2;
-    auto           d          = x - y;
-    if (d > half_range) {
-        return -static_cast<signed_type>(y - x);
-    }
-    return static_cast<signed_type>(d);
 };
 
 } // namespace gr

--- a/core/include/gnuradio-4.0/WaitStrategy.hpp
+++ b/core/include/gnuradio-4.0/WaitStrategy.hpp
@@ -27,8 +27,8 @@ namespace gr {
  * \returns the sequence that is available which may be greater than the requested sequence.
  */
 template<typename T>
-inline constexpr bool isWaitStrategy = requires(T /*const*/ t, const Sequence::index_type sequence, const Sequence &cursor, std::vector<std::shared_ptr<Sequence>> &dependentSequences) {
-    { t.waitFor(sequence, cursor, dependentSequences) } -> std::same_as<Sequence::index_type>;
+inline constexpr bool isWaitStrategy = requires(T /*const*/ t, const std::size_t sequence, const Sequence &cursor, std::vector<std::shared_ptr<Sequence>> &dependentSequences) {
+    { t.waitFor(sequence, cursor, dependentSequences) } -> std::same_as<std::size_t>;
 };
 static_assert(!isWaitStrategy<int>);
 
@@ -55,7 +55,7 @@ class BlockingWaitStrategy {
     std::condition_variable_any _conditionVariable;
 
 public:
-    Sequence::index_type waitFor(const Sequence::index_type sequence, const Sequence &cursor, const std::vector<std::shared_ptr<Sequence>> &dependentSequences) {
+    std::size_t waitFor(const std::size_t sequence, const Sequence &cursor, const std::vector<std::shared_ptr<Sequence>> &dependentSequences) {
         if (cursor.value() < sequence) {
             std::unique_lock uniqueLock(_gate);
 
@@ -65,7 +65,7 @@ public:
             }
         }
 
-        Sequence::index_type availableSequence;
+        std::size_t availableSequence;
         while ((availableSequence = detail::getMinimumSequence(dependentSequences)) < sequence) {
             // optional: barrier check alert
         }
@@ -86,8 +86,8 @@ static_assert(WaitStrategyLike<BlockingWaitStrategy>);
  * It is best used when threads can be bound to specific CPU cores.
  */
 struct BusySpinWaitStrategy {
-    Sequence::index_type waitFor(const Sequence::index_type sequence, const Sequence & /*cursor*/, const std::vector<std::shared_ptr<Sequence>> &dependentSequences) const {
-        Sequence::index_type availableSequence;
+    std::size_t waitFor(const std::size_t sequence, const Sequence & /*cursor*/, const std::vector<std::shared_ptr<Sequence>> &dependentSequences) const {
+        std::size_t availableSequence;
         while ((availableSequence = detail::getMinimumSequence(dependentSequences)) < sequence) {
             // optional: barrier check alert
         }
@@ -111,7 +111,7 @@ public:
         : _retries(retries) {
     }
 
-    Sequence::index_type waitFor(const Sequence::index_type sequence, const Sequence & /*cursor*/, const std::vector<std::shared_ptr<Sequence>> &dependentSequences) const {
+    std::size_t waitFor(const std::size_t sequence, const Sequence & /*cursor*/, const std::vector<std::shared_ptr<Sequence>> &dependentSequences) const {
         auto       counter    = _retries;
         const auto waitMethod = [&counter]() {
             // optional: barrier check alert
@@ -126,7 +126,7 @@ public:
             }
         };
 
-        Sequence::index_type availableSequence;
+        std::size_t availableSequence;
         while ((availableSequence = detail::getMinimumSequence(dependentSequences)) < sequence) {
             waitMethod();
         }
@@ -151,7 +151,7 @@ public:
     explicit TimeoutBlockingWaitStrategy(Clock::duration timeout)
         : _timeout(timeout) {}
 
-    Sequence::index_type waitFor(const Sequence::index_type sequence, const Sequence &cursor, const std::vector<std::shared_ptr<Sequence>> &dependentSequences) {
+    std::size_t waitFor(const std::size_t sequence, const Sequence &cursor, const std::vector<std::shared_ptr<Sequence>> &dependentSequences) {
         auto timeSpan = std::chrono::duration_cast<std::chrono::microseconds>(_timeout);
 
         if (cursor.value() < sequence) {
@@ -166,7 +166,7 @@ public:
             }
         }
 
-        Sequence::index_type availableSequence;
+        std::size_t availableSequence;
         while ((availableSequence = detail::getMinimumSequence(dependentSequences)) < sequence) {
             // optional: barrier check alert
         }
@@ -190,7 +190,7 @@ class YieldingWaitStrategy {
     const std::size_t _spinTries = 100;
 
 public:
-    Sequence::index_type waitFor(const Sequence::index_type sequence, const Sequence & /*cursor*/, const std::vector<std::shared_ptr<Sequence>> &dependentSequences) const {
+    std::size_t waitFor(const std::size_t sequence, const Sequence & /*cursor*/, const std::vector<std::shared_ptr<Sequence>> &dependentSequences) const {
         auto       counter    = _spinTries;
         const auto waitMethod = [&counter]() {
             // optional: barrier check alert
@@ -202,7 +202,7 @@ public:
             }
         };
 
-        Sequence::index_type availableSequence;
+        std::size_t availableSequence;
         while ((availableSequence = detail::getMinimumSequence(dependentSequences)) < sequence) {
             waitMethod();
         }
@@ -214,7 +214,7 @@ static_assert(WaitStrategyLike<YieldingWaitStrategy>);
 static_assert(!hasSignalAllWhenBlocking<YieldingWaitStrategy>);
 
 struct NoWaitStrategy {
-    Sequence::index_type waitFor(const Sequence::index_type sequence, const Sequence & /*cursor*/, const std::vector<std::shared_ptr<Sequence>> & /*dependentSequences*/) const {
+    std::size_t waitFor(const std::size_t sequence, const Sequence & /*cursor*/, const std::vector<std::shared_ptr<Sequence>> & /*dependentSequences*/) const {
         // wait for nothing
         return sequence;
     }
@@ -327,8 +327,8 @@ public:
  * Latency spikes can occur after quiet periods.
  */
 struct SpinWaitWaitStrategy {
-    Sequence::index_type waitFor(const Sequence::index_type sequence, const Sequence & /*cursor*/, const std::vector<std::shared_ptr<Sequence>> &dependentSequence) const {
-        Sequence::index_type availableSequence;
+    std::size_t waitFor(const std::size_t sequence, const Sequence & /*cursor*/, const std::vector<std::shared_ptr<Sequence>> &dependentSequence) const {
+        std::size_t availableSequence;
 
         SpinWait     spinWait;
         while ((availableSequence = detail::getMinimumSequence(dependentSequence)) < sequence) {

--- a/core/test/qa_PerformanceMonitor.cpp
+++ b/core/test/qa_PerformanceMonitor.cpp
@@ -61,10 +61,10 @@ int main(int argc, char* argv[]) {
     auto&              src          = testGraph.emplaceBlock<TagSource<float, ProcessFunction::USE_PROCESS_BULK>>(srcParameter);
 
     // parameters of generated Tags
-    gr::Tag::index_type nSamplesPerTag    = 10000;
-    bool                tagWithAutoUpdate = false;
-    std::string         tagName           = tagWithAutoUpdate ? "sample_rate" : "some_random_name_1234";
-    std::string         outputCsvFilePath = "";
+    std::size_t nSamplesPerTag    = 10000UZ;
+    bool        tagWithAutoUpdate = false;
+    std::string tagName           = tagWithAutoUpdate ? "sample_rate" : "some_random_name_1234";
+    std::string outputCsvFilePath = "";
 
     if (outFilePath != "") {
         outputCsvFilePath = outFilePath;

--- a/core/test/qa_PerformanceMonitor.cpp
+++ b/core/test/qa_PerformanceMonitor.cpp
@@ -61,10 +61,10 @@ int main(int argc, char* argv[]) {
     auto&              src          = testGraph.emplaceBlock<TagSource<float, ProcessFunction::USE_PROCESS_BULK>>(srcParameter);
 
     // parameters of generated Tags
-    gr::Tag::signed_index_type nSamplesPerTag    = 10000;
-    bool                       tagWithAutoUpdate = false;
-    std::string                tagName           = tagWithAutoUpdate ? "sample_rate" : "some_random_name_1234";
-    std::string                outputCsvFilePath = "";
+    gr::Tag::index_type nSamplesPerTag    = 10000;
+    bool                tagWithAutoUpdate = false;
+    std::string         tagName           = tagWithAutoUpdate ? "sample_rate" : "some_random_name_1234";
+    std::string         outputCsvFilePath = "";
 
     if (outFilePath != "") {
         outputCsvFilePath = outFilePath;

--- a/core/test/qa_Port.cpp
+++ b/core/test/qa_Port.cpp
@@ -57,7 +57,7 @@ const boost::ut::suite PortTests = [] {
             auto tagSpan   = tagWriter.tryReserve(5);
             expect(eq(writeSpan.size(), 6UZ));
             expect(eq(tagSpan.size(), 5UZ));
-            tagSpan[0] = {-1, {{"id", "tag@-1"}, {"id0", true}}};
+            tagSpan[0] = {0, {{"id", "tag@100"}, {"id0", true}}};
             tagSpan[1] = {1, {{"id", "tag@101"}, {"id1", true}}};
             tagSpan[2] = {3, {{"id", "tag@103"}, {"id3", true}}};
             tagSpan[3] = {4, {{"id", "tag@104"}, {"id4", true}}};
@@ -68,10 +68,10 @@ const boost::ut::suite PortTests = [] {
         }
         { // partial consume
             auto data = in.get<SpanReleasePolicy::ProcessAll>(6);
-            expect(std::ranges::equal(data.rawTags, std::vector<gr::Tag>{{-1, {{"id", "tag@-1"}, {"id0", true}}}, {1, {{"id", "tag@101"}, {"id1", true}}}, {3, {{"id", "tag@103"}, {"id3", true}}}, {4, {{"id", "tag@104"}, {"id4", true}}}, {5, {{"id", "tag@105"}, {"id5", true}}}}));
-            expect(equalTags(data.tags(), std::vector{std::make_pair(0L, gr::property_map{{"id", "tag@-1"}, {"id0", true}}), std::make_pair(1L, gr::property_map{{"id", "tag@101"}, {"id1", true}}), std::make_pair(3L, gr::property_map{{"id", "tag@103"}, {"id3", true}}), std::make_pair(4L, gr::property_map{{"id", "tag@104"}, {"id4", true}}), std::make_pair(5L, gr::property_map{{"id", "tag@105"}, {"id5", true}})}));
+            expect(std::ranges::equal(data.rawTags, std::vector<gr::Tag>{{0, {{"id", "tag@100"}, {"id0", true}}}, {1, {{"id", "tag@101"}, {"id1", true}}}, {3, {{"id", "tag@103"}, {"id3", true}}}, {4, {{"id", "tag@104"}, {"id4", true}}}, {5, {{"id", "tag@105"}, {"id5", true}}}}));
+            expect(equalTags(data.tags(), std::vector{std::make_pair(0L, gr::property_map{{"id", "tag@100"}, {"id0", true}}), std::make_pair(1L, gr::property_map{{"id", "tag@101"}, {"id1", true}}), std::make_pair(3L, gr::property_map{{"id", "tag@103"}, {"id3", true}}), std::make_pair(4L, gr::property_map{{"id", "tag@104"}, {"id4", true}}), std::make_pair(5L, gr::property_map{{"id", "tag@105"}, {"id5", true}})}));
             expect(std::ranges::equal(data, std::views::iota(100) | std::views::take(6)));
-            expect(data.getMergedTag() == gr::Tag{-1, {{"id", "tag@-1"}, {"id0", true}}});
+            expect(data.getMergedTag() == gr::Tag{0UZ, {{"id", "tag@100"}, {"id0", true}}});
             expect(data.consume(3));
         }
         { // full consume
@@ -79,21 +79,21 @@ const boost::ut::suite PortTests = [] {
             expect(std::ranges::equal(data.rawTags, std::vector<gr::Tag>{{1, {{"id", "tag@101"}, {"id1", true}}}, {3, {{"id", "tag@103"}, {"id3", true}}}, {4, {{"id", "tag@104"}, {"id4", true}}}}));
             expect(equalTags(data.tags(), std::vector{std::make_pair(-2L, gr::property_map{{"id", "tag@101"}, {"id1", true}}), std::make_pair(0L, gr::property_map{{"id", "tag@103"}, {"id3", true}}), std::make_pair(1L, gr::property_map{{"id", "tag@104"}, {"id4", true}})}));
             expect(std::ranges::equal(data, std::views::iota(100) | std::views::drop(3) | std::views::take(2)));
-            expect(data.getMergedTag() == gr::Tag{-1, {{"id", "tag@103"}, {"id1", true}, {"id3", true}}});
+            expect(data.getMergedTag() == gr::Tag{0UZ, {{"id", "tag@103"}, {"id1", true}, {"id3", true}}});
         }
         { // get empty range
             auto data = in.get<SpanReleasePolicy::ProcessAll>(0);
             expect(std::ranges::equal(data.rawTags, std::vector<gr::Tag>{{4, {{"id", "tag@104"}, {"id4", true}}}}));
             expect(equalTags(data.tags(), std::vector{std::make_pair(-1L, gr::property_map{{"id", "tag@104"}, {"id4", true}})}));
             expect(std::ranges::equal(data, std::ranges::empty_view<int>()));
-            expect(data.getMergedTag() == gr::Tag{-1, {{"id", "tag@104"}, {"id4", true}}});
+            expect(data.getMergedTag() == gr::Tag{0UZ, {{"id", "tag@104"}, {"id4", true}}});
         }
         { // get last sample
             auto data = in.get<SpanReleasePolicy::ProcessAll>(1);
             expect(std::ranges::equal(data.rawTags, std::vector<gr::Tag>{{4, {{"id", "tag@104"}, {"id4", true}}}, {5, {{"id", "tag@105"}, {"id5", true}}}}));
             expect(equalTags(data.tags(), std::vector{std::make_pair(-1L, gr::property_map{{"id", "tag@104"}, {"id4", true}}), std::make_pair(0L, property_map{{"id", "tag@105"}, {"id5", true}})}));
             expect(std::ranges::equal(data, std::views::iota(100) | std::views::drop(5) | std::views::take(1)));
-            expect(data.getMergedTag() == gr::Tag{-1, {{"id", "tag@105"}, {"id4", true}, {"id5", true}}});
+            expect(data.getMergedTag() == gr::Tag{0UZ, {{"id", "tag@105"}, {"id4", true}, {"id5", true}}});
         }
     };
 

--- a/core/test/qa_Scheduler.cpp
+++ b/core/test/qa_Scheduler.cpp
@@ -311,7 +311,7 @@ struct BusyLoopBlock : public gr::Block<BusyLoopBlock<T>> {
 
         fmt::println("##BusyLoopBlock produces data _invokeCount: {}", _invokeCount.value());
         std::ranges::copy(input.begin(), input.end(), output.begin());
-        produceCount = _produceCount.addAndGet(-1L);
+        produceCount = _produceCount.subAndGet(1L);
         return OK;
     }
 };

--- a/core/test/qa_Scheduler.cpp
+++ b/core/test/qa_Scheduler.cpp
@@ -674,7 +674,7 @@ const boost::ut::suite<"SchedulerTests"> SchedulerTests = [] {
         expect(monitor.in.isConnected()) << "monitor.in is connected";
         expect(monitor.out.isConnected()) << "monitor.out is connected";
 
-        expect(eq(0, scheduler.graph().progress().value())) << "initial progress definition (0)";
+        expect(eq(0UZ, scheduler.graph().progress().value())) << "initial progress definition (0)";
         std::expected<void, Error> schedulerResult;
         auto                       schedulerThread = std::thread([&scheduler, &schedulerResult] { schedulerResult = scheduler.runAndWait(); });
         expect(awaitCondition(2s, [&scheduler] { return scheduler.state() == lifecycle::State::RUNNING; })) << "scheduler thread up and running w/ timeout";

--- a/core/test/qa_Settings.cpp
+++ b/core/test/qa_Settings.cpp
@@ -902,7 +902,7 @@ const boost::ut::suite TransactionTests = [] {
         const auto         timeNow      = std::chrono::system_clock::now();
 
         for (std::size_t i = 0; i < 10; i++) {
-            src._tags.push_back(gr::Tag(static_cast<gr::Tag::index_type>(i), {{"sample_rate", static_cast<float>(i)}}));
+            src._tags.push_back(gr::Tag(i, {{"sample_rate", static_cast<float>(i)}}));
         }
         // this sample_rates should not be applied
         src._tags.push_back({15, {{"sample_rate", 15.f}, {std::string(gr::tag::TRIGGER_TIME.shortKey()), settings::convertTimePointToUint64Ns(timeNow + std::chrono::seconds(20))}, //

--- a/core/test/qa_Settings.cpp
+++ b/core/test/qa_Settings.cpp
@@ -902,7 +902,7 @@ const boost::ut::suite TransactionTests = [] {
         const auto         timeNow      = std::chrono::system_clock::now();
 
         for (std::size_t i = 0; i < 10; i++) {
-            src._tags.push_back(gr::Tag(static_cast<gr::Tag::signed_index_type>(i), {{"sample_rate", static_cast<float>(i)}}));
+            src._tags.push_back(gr::Tag(static_cast<gr::Tag::index_type>(i), {{"sample_rate", static_cast<float>(i)}}));
         }
         // this sample_rates should not be applied
         src._tags.push_back({15, {{"sample_rate", 15.f}, {std::string(gr::tag::TRIGGER_TIME.shortKey()), settings::convertTimePointToUint64Ns(timeNow + std::chrono::seconds(20))}, //

--- a/core/test/qa_Tags.cpp
+++ b/core/test/qa_Tags.cpp
@@ -46,7 +46,7 @@ or next chunk, whichever is closer. Also adds an "offset" key to the tag map sig
         std::copy(inSamples.begin(), inSamples.end(), outSamples.begin());
         std::size_t tagsForwarded = 0;
         for (gr::Tag tag : inSamples.rawTags) {
-            if (tag.index < (inSamples.streamIndex + (static_cast<gr::Tag::index_type>(inSamples.size()) + 1) / 2)) {
+            if (tag.index < (inSamples.streamIndex + (inSamples.size() + 1) / 2)) {
                 tag.insert_or_assign("offset", sampling_rate * static_cast<double>(tag.index - inSamples.streamIndex));
                 outSamples.publishTag(tag.map, 0);
                 tagsForwarded++;

--- a/core/test/qa_Tags.cpp
+++ b/core/test/qa_Tags.cpp
@@ -46,7 +46,7 @@ or next chunk, whichever is closer. Also adds an "offset" key to the tag map sig
         std::copy(inSamples.begin(), inSamples.end(), outSamples.begin());
         std::size_t tagsForwarded = 0;
         for (gr::Tag tag : inSamples.rawTags) {
-            if (tag.index < (inSamples.streamIndex + (static_cast<gr::Tag::signed_index_type>(inSamples.size()) + 1) / 2)) {
+            if (tag.index < (inSamples.streamIndex + (static_cast<gr::Tag::index_type>(inSamples.size()) + 1) / 2)) {
                 tag.insert_or_assign("offset", sampling_rate * static_cast<double>(tag.index - inSamples.streamIndex));
                 outSamples.publishTag(tag.map, 0);
                 tagsForwarded++;
@@ -87,7 +87,6 @@ const boost::ut::suite TagTests = [] {
     using namespace gr;
 
     static_assert(sizeof(Tag) % 64 == 0, "needs to meet L1 cache size");
-    static_assert(gr::refl::class_name<gr::Tag> == "gr::Tag");
     static_assert(gr::refl::data_member_count<Tag> == 2, "index and map being declared");
     static_assert(gr::refl::data_member_name<Tag, 0> == "index", "class field index is public API");
     static_assert(gr::refl::data_member_name<Tag, 1> == "map", "class field map is public API");

--- a/core/test/qa_buffer.cpp
+++ b/core/test/qa_buffer.cpp
@@ -70,7 +70,7 @@ const boost::ut::suite BasicConceptsTests = [] {
 
         // runtime interface tests
         expect(eq(reader.available(), 0UZ));
-        expect(eq(reader.position(), std::make_signed_t<std::size_t>{kInitialCursorValue}));
+        expect(eq(reader.position(), kInitialCursorValue));
         ReaderSpanLike auto cSpan = reader.get(0UZ);
         expect(nothrow([&cSpan] { expect(eq(cSpan.size(), 0UZ)); })) << typeName << "throws" << "\n";
         expect(nothrow([&cSpan] { expect(cSpan.consume(0UZ)); }));
@@ -100,11 +100,11 @@ const boost::ut::suite SequenceTests = [] {
 
     "Sequence"_test = [] {
         using namespace gr;
-        using signed_index_type = std::make_signed_t<std::size_t>;
+        using index_type = Sequence::index_type;
 #if not defined(__APPLE__)
         expect(eq(alignof(Sequence), 64UZ));
 #endif
-        expect(eq(0L, kInitialCursorValue));
+        expect(eq(index_type(0), kInitialCursorValue));
         expect(nothrow([] { Sequence(); }));
         expect(nothrow([] { Sequence(2); }));
 
@@ -112,38 +112,38 @@ const boost::ut::suite SequenceTests = [] {
         expect(eq(s1.value(), kInitialCursorValue));
 
         const auto s2 = Sequence(2);
-        expect(eq(s2.value(), signed_index_type{2}));
+        expect(eq(s2.value(), index_type{2}));
 
         expect(nothrow([&s1] { s1.setValue(3); }));
-        expect(eq(s1.value(), signed_index_type{3}));
+        expect(eq(s1.value(), index_type{3}));
 
         expect(nothrow([&s1] { expect(s1.compareAndSet(3, 4)); }));
-        expect(nothrow([&s1] { expect(eq(s1.value(), signed_index_type{4})); }));
+        expect(nothrow([&s1] { expect(eq(s1.value(), index_type{4})); }));
         expect(nothrow([&s1] { expect(!s1.compareAndSet(3, 5)); }));
-        expect(eq(s1.value(), signed_index_type{4}));
+        expect(eq(s1.value(), index_type{4}));
 
-        expect(eq(s1.incrementAndGet(), signed_index_type{5}));
-        expect(eq(s1.value(), signed_index_type{5}));
-        expect(eq(s1.addAndGet(2), signed_index_type{7}));
-        expect(eq(s1.value(), signed_index_type{7}));
+        expect(eq(s1.incrementAndGet(), index_type{5}));
+        expect(eq(s1.value(), index_type{5}));
+        expect(eq(s1.addAndGet(2), index_type{7}));
+        expect(eq(s1.value(), index_type{7}));
 
         std::shared_ptr<std::vector<std::shared_ptr<Sequence>>> sequences{std::make_shared<std::vector<std::shared_ptr<Sequence>>>()};
-        expect(eq(gr::detail::getMinimumSequence(*sequences), std::numeric_limits<signed_index_type>::max()));
-        expect(eq(gr::detail::getMinimumSequence(*sequences, 2), signed_index_type{2}));
+        expect(eq(gr::detail::getMinimumSequence(*sequences), std::numeric_limits<index_type>::max()));
+        expect(eq(gr::detail::getMinimumSequence(*sequences, 2), index_type{2}));
         sequences->emplace_back(std::make_shared<Sequence>(4));
-        expect(eq(gr::detail::getMinimumSequence(*sequences), signed_index_type{4}));
-        expect(eq(gr::detail::getMinimumSequence(*sequences, 5), signed_index_type{4}));
-        expect(eq(gr::detail::getMinimumSequence(*sequences, 2), signed_index_type{2}));
+        expect(eq(gr::detail::getMinimumSequence(*sequences), index_type{4}));
+        expect(eq(gr::detail::getMinimumSequence(*sequences, 5), index_type{4}));
+        expect(eq(gr::detail::getMinimumSequence(*sequences, 2), index_type{2}));
 
         auto cursor = std::make_shared<Sequence>(10);
         auto s3     = std::make_shared<Sequence>(1);
         expect(eq(sequences->size(), 1UZ));
-        expect(eq(gr::detail::getMinimumSequence(*sequences), signed_index_type{4}));
+        expect(eq(gr::detail::getMinimumSequence(*sequences), index_type{4}));
         expect(nothrow([&sequences, &cursor, &s3] { gr::detail::addSequences(sequences, *cursor, {s3}); }));
         expect(eq(sequences->size(), 2UZ));
         // newly added sequences are set automatically to the cursor/write position
-        expect(eq(s3->value(), signed_index_type{10}));
-        expect(eq(gr::detail::getMinimumSequence(*sequences), signed_index_type{4}));
+        expect(eq(s3->value(), index_type{10}));
+        expect(eq(gr::detail::getMinimumSequence(*sequences), index_type{4}));
 
         expect(nothrow([&sequences, &cursor] { gr::detail::removeSequence(sequences, cursor); }));
         expect(eq(sequences->size(), 2UZ));

--- a/core/test/qa_buffer.cpp
+++ b/core/test/qa_buffer.cpp
@@ -100,11 +100,10 @@ const boost::ut::suite SequenceTests = [] {
 
     "Sequence"_test = [] {
         using namespace gr;
-        using index_type = Sequence::index_type;
 #if not defined(__APPLE__)
         expect(eq(alignof(Sequence), 64UZ));
 #endif
-        expect(eq(index_type(0), kInitialCursorValue));
+        expect(eq(0UZ, kInitialCursorValue));
         expect(nothrow([] { Sequence(); }));
         expect(nothrow([] { Sequence(2); }));
 
@@ -112,38 +111,38 @@ const boost::ut::suite SequenceTests = [] {
         expect(eq(s1.value(), kInitialCursorValue));
 
         const auto s2 = Sequence(2);
-        expect(eq(s2.value(), index_type{2}));
+        expect(eq(s2.value(), 2UZ));
 
         expect(nothrow([&s1] { s1.setValue(3); }));
-        expect(eq(s1.value(), index_type{3}));
+        expect(eq(s1.value(), 3UZ));
 
         expect(nothrow([&s1] { expect(s1.compareAndSet(3, 4)); }));
-        expect(nothrow([&s1] { expect(eq(s1.value(), index_type{4})); }));
+        expect(nothrow([&s1] { expect(eq(s1.value(), 4UZ)); }));
         expect(nothrow([&s1] { expect(!s1.compareAndSet(3, 5)); }));
-        expect(eq(s1.value(), index_type{4}));
+        expect(eq(s1.value(), 4UZ));
 
-        expect(eq(s1.incrementAndGet(), index_type{5}));
-        expect(eq(s1.value(), index_type{5}));
-        expect(eq(s1.addAndGet(2), index_type{7}));
-        expect(eq(s1.value(), index_type{7}));
+        expect(eq(s1.incrementAndGet(), 5UZ));
+        expect(eq(s1.value(), 5UZ));
+        expect(eq(s1.addAndGet(2), 7UZ));
+        expect(eq(s1.value(), 7UZ));
 
         std::shared_ptr<std::vector<std::shared_ptr<Sequence>>> sequences{std::make_shared<std::vector<std::shared_ptr<Sequence>>>()};
-        expect(eq(gr::detail::getMinimumSequence(*sequences), std::numeric_limits<index_type>::max()));
-        expect(eq(gr::detail::getMinimumSequence(*sequences, 2), index_type{2}));
+        expect(eq(gr::detail::getMinimumSequence(*sequences), std::numeric_limits<std::size_t>::max()));
+        expect(eq(gr::detail::getMinimumSequence(*sequences, 2), 2UZ));
         sequences->emplace_back(std::make_shared<Sequence>(4));
-        expect(eq(gr::detail::getMinimumSequence(*sequences), index_type{4}));
-        expect(eq(gr::detail::getMinimumSequence(*sequences, 5), index_type{4}));
-        expect(eq(gr::detail::getMinimumSequence(*sequences, 2), index_type{2}));
+        expect(eq(gr::detail::getMinimumSequence(*sequences), 4UZ));
+        expect(eq(gr::detail::getMinimumSequence(*sequences, 5), 4UZ));
+        expect(eq(gr::detail::getMinimumSequence(*sequences, 2), 2UZ));
 
         auto cursor = std::make_shared<Sequence>(10);
         auto s3     = std::make_shared<Sequence>(1);
         expect(eq(sequences->size(), 1UZ));
-        expect(eq(gr::detail::getMinimumSequence(*sequences), index_type{4}));
+        expect(eq(gr::detail::getMinimumSequence(*sequences), 4UZ));
         expect(nothrow([&sequences, &cursor, &s3] { gr::detail::addSequences(sequences, *cursor, {s3}); }));
         expect(eq(sequences->size(), 2UZ));
         // newly added sequences are set automatically to the cursor/write position
-        expect(eq(s3->value(), index_type{10}));
-        expect(eq(gr::detail::getMinimumSequence(*sequences), index_type{4}));
+        expect(eq(s3->value(), 10UZ));
+        expect(eq(gr::detail::getMinimumSequence(*sequences), 4UZ));
 
         expect(nothrow([&sequences, &cursor] { gr::detail::removeSequence(sequences, cursor); }));
         expect(eq(sequences->size(), 2UZ));


### PR DESCRIPTION
This PR changes sequence and tag index types to unsigned (std::size_t).

There's three cases where we need relative tag indices though:

 - Port::tags() provides the tags with indices relative to stream position. (these are of typestd::pair<index,map> anyway, so no extra type needed)
 - DataSet::timing_events are relative to the first sample in the set, and can
   be negative (e.g. for DataSink's snapshot acquisition mode, the trigger is
   in the past.
 - DataSink callback and pollers use tags relative to the current data chunk.

For the latter two, use RelativeIndexTag, which have a signed index type.

This doesn't actually handle overflow of the std::size_t, which I think would be an issue in the CircularBuffer impl (which relies on monotonously growing indices), so the question is if an overflow here is a realistic scenario we need to care about.