### PR TITLE
Restore connect<"out", 0> / to<"in", 0> functionality for arrays

### DIFF
--- a/blocks/soapy/src/soapy_example.cpp
+++ b/blocks/soapy/src/soapy_example.cpp
@@ -36,21 +36,21 @@ gr::Graph createGraph(std::string fileName1, std::string fileName2, gr::Size_t m
     if (fileName1.contains("null")) {
         fmt::println("write channel0 to NullSink");
         auto& fileSink1 = flow.emplaceBlock<testing::NullSink<TDataType>>();
-        expect(eq(gr::ConnectionResult::SUCCESS, flow.connect<"out0">(source).to<"in">(fileSink1))) << "error connecting NullSink1";
+        expect(eq(gr::ConnectionResult::SUCCESS, flow.connect<"out", 0UZ>(source).to<"in">(fileSink1))) << "error connecting NullSink1";
     } else {
         fmt::println("write to fileName1: {}", fileName1);
         auto& fileSink1 = flow.emplaceBlock<BasicFileSink<TDataType>>({{"file_name", fileName1}, {"mode", "multi"}, {"max_bytes_per_file", maxFileSize}});
-        expect(eq(gr::ConnectionResult::SUCCESS, flow.connect<"out0">(source).to<"in">(fileSink1))) << "error connecting BasicFileSink1";
+        expect(eq(gr::ConnectionResult::SUCCESS, flow.connect<"out", 0UZ>(source).to<"in">(fileSink1))) << "error connecting BasicFileSink1";
     }
 
     if (fileName2.contains("null")) {
         fmt::println("write channel1 to NullSink");
         auto& fileSink2 = flow.emplaceBlock<testing::NullSink<TDataType>>();
-        expect(eq(gr::ConnectionResult::SUCCESS, flow.connect<"out1">(source).to<"in">(fileSink2))) << "error connecting NullSink2";
+        expect(eq(gr::ConnectionResult::SUCCESS, flow.connect<"out", 1UZ>(source).to<"in">(fileSink2))) << "error connecting NullSink2";
     } else {
         fmt::println("write to fileName2: {}", fileName2);
         auto& fileSink2 = flow.emplaceBlock<BasicFileSink<TDataType>>({{"file_name", fileName2}, {"mode", "multi"}, {"max_bytes_per_file", maxFileSize}});
-        expect(eq(gr::ConnectionResult::SUCCESS, flow.connect<"out1">(source).to<"in">(fileSink2))) << "error connecting BasicFileSink2";
+        expect(eq(gr::ConnectionResult::SUCCESS, flow.connect<"out", 1UZ>(source).to<"in">(fileSink2))) << "error connecting BasicFileSink2";
     }
 
     return flow;

--- a/blocks/soapy/test/qa_Soapy.cpp
+++ b/blocks/soapy/test/qa_Soapy.cpp
@@ -327,8 +327,8 @@ const boost::ut::suite<"Soapy Block API "> soapyBlockAPI = [] {
         });
         auto& sink1  = flow.emplaceBlock<CountingSink<ValueType>>({{"n_samples_max", nSamples}});
         auto& sink2  = flow.emplaceBlock<CountingSink<ValueType>>({{"n_samples_max", nSamples}});
-        expect(eq(gr::ConnectionResult::SUCCESS, flow.connect<"out0">(source).to<"in">(sink1)));
-        expect(eq(gr::ConnectionResult::SUCCESS, flow.connect<"out1">(source).to<"in">(sink2)));
+        expect(eq(gr::ConnectionResult::SUCCESS, flow.connect<"out", 0UZ>(source).to<"in">(sink1)));
+        expect(eq(gr::ConnectionResult::SUCCESS, flow.connect<"out", 1UZ>(source).to<"in">(sink2)));
 
         auto sched = scheduler{std::move(flow), threadPool};
 

--- a/core/include/gnuradio-4.0/Block.hpp
+++ b/core/include/gnuradio-4.0/Block.hpp
@@ -60,7 +60,7 @@ template<std::size_t Index, PortType portFlavor, PortReflectable Self>
 
 template<fixed_string Name, PortReflectable Self>
 [[nodiscard]] constexpr auto& inputPort(Self* self) noexcept {
-    constexpr int Index = meta::indexForName<Name, traits::block::all_input_ports<Self>>();
+    constexpr int Index = traits::block::indexForName<Name, traits::block::all_input_ports<Self>>();
     if constexpr (Index == meta::default_message_port_index) {
         return self->msgIn;
     }
@@ -69,7 +69,7 @@ template<fixed_string Name, PortReflectable Self>
 
 template<fixed_string Name, PortReflectable Self>
 [[nodiscard]] constexpr auto& outputPort(Self* self) noexcept {
-    constexpr int Index = meta::indexForName<Name, traits::block::all_output_ports<Self>>();
+    constexpr int Index = traits::block::indexForName<Name, traits::block::all_output_ports<Self>>();
     if constexpr (Index == meta::default_message_port_index) {
         return self->msgOut;
     }

--- a/core/src/main.cpp
+++ b/core/src/main.cpp
@@ -178,7 +178,7 @@ int main() {
     }
 
     {
-        auto merged = merge<"out1", "original">(merge<"out0", "original">(duplicate<int, 4>(), scale<int, 2>()), scale<int, 2>());
+        auto merged = merge<"out#1", "original">(merge<"out#0", "original">(duplicate<int, 4>(), scale<int, 2>()), scale<int, 2>());
         reflectBlock(merged);
 
         // execute graph

--- a/core/test/qa_Block.cpp
+++ b/core/test/qa_Block.cpp
@@ -750,10 +750,10 @@ const boost::ut::suite<"Stride Tests"> _stride_tests = [] {
         sinks[2] = std::addressof(graph.emplaceBlock<TagSink<double, ProcessFunction::USE_PROCESS_ONE>>());
         sinks[3] = std::addressof(graph.emplaceBlock<TagSink<double, ProcessFunction::USE_PROCESS_ONE>>());
 
-        expect(eq(gr::ConnectionResult::SUCCESS, graph.connect<"out">(*sources[0]).to<"input0">(testNode)));
-        expect(eq(gr::ConnectionResult::SUCCESS, graph.connect<"out">(*sources[1]).to<"input1">(testNode)));
-        expect(eq(gr::ConnectionResult::SUCCESS, graph.connect<"out">(*sources[2]).to<"input2">(testNode)));
-        expect(eq(gr::ConnectionResult::SUCCESS, graph.connect<"out">(*sources[3]).to<"input3">(testNode)));
+        expect(eq(gr::ConnectionResult::SUCCESS, graph.connect<"out">(*sources[0]).to<"input", 0UZ>(testNode)));
+        expect(eq(gr::ConnectionResult::SUCCESS, graph.connect<"out">(*sources[1]).to<"input", 1UZ>(testNode)));
+        expect(eq(gr::ConnectionResult::SUCCESS, graph.connect<"out">(*sources[2]).to<"input", 2UZ>(testNode)));
+        expect(eq(gr::ConnectionResult::SUCCESS, graph.connect<"out">(*sources[3]).to<"input", 3UZ>(testNode)));
 
         // test also different connect API
         expect(eq(gr::ConnectionResult::SUCCESS, graph.connect(testNode, "output0"s, *sinks[0], "in"s)));

--- a/core/test/qa_grc.cpp
+++ b/core/test/qa_grc.cpp
@@ -229,10 +229,10 @@ connections:
             auto&      arraySource0 = graph1.emplaceBlock<ArraySource<double>>();
             auto&      arraySource1 = graph1.emplaceBlock<ArraySource<double>>();
 
-            expect(eq(ConnectionResult::SUCCESS, graph1.connect<"outA0">(arraySource0).to<"inB1">(arraySink)));
-            expect(eq(ConnectionResult::SUCCESS, graph1.connect<"outA1">(arraySource1).to<"inB0">(arraySink)));
-            expect(eq(ConnectionResult::SUCCESS, graph1.connect<"outB0">(arraySource0).to<"inA0">(arraySink)));
-            expect(eq(ConnectionResult::SUCCESS, graph1.connect<"outB1">(arraySource1).to<"inA1">(arraySink)));
+            expect(eq(ConnectionResult::SUCCESS, graph1.connect<"outA", 0>(arraySource0).to<"inB", 1>(arraySink)));
+            expect(eq(ConnectionResult::SUCCESS, graph1.connect<"outA", 1>(arraySource1).to<"inB", 0>(arraySink)));
+            expect(eq(ConnectionResult::SUCCESS, graph1.connect<"outB", 0>(arraySource0).to<"inA", 0>(arraySink)));
+            expect(eq(ConnectionResult::SUCCESS, graph1.connect<"outB", 1>(arraySource1).to<"inA", 1>(arraySink)));
 
             expect(graph1.reconnectAllEdges());
 

--- a/meta/include/gnuradio-4.0/meta/utils.hpp
+++ b/meta/include/gnuradio-4.0/meta/utils.hpp
@@ -471,29 +471,6 @@ concept t_or_simd = std::same_as<V, T> || any_simd<V, T>;
 template<typename T>
 concept complex_like = std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>;
 
-template<fixed_string Name, typename PortList>
-consteval std::size_t indexForName() {
-    auto helper = []<std::size_t... Ids>(std::index_sequence<Ids...>) {
-        auto static_name_for_index = [](auto id) {
-            using Port = typename PortList::template at<id>;
-            if constexpr (requires { Port::Name; }) {
-                return Port::Name;
-            } else {
-                // should never see a tuple here => needs to be flattened into given PortList earlier
-                return Port::value_type::Name;
-            }
-        };
-
-        constexpr int n_matches = ((static_name_for_index(std::integral_constant<size_t, Ids>()) == Name) + ...);
-        static_assert(n_matches <= 1, "Multiple ports with that name were found. The name must be unique. You can "
-                                      "still use a port index instead.");
-        static_assert(n_matches == 1, "No port with the given name exists.");
-        constexpr std::size_t result = (((static_name_for_index(std::integral_constant<size_t, Ids>()) == Name) * Ids) + ...);
-        return result;
-    };
-    return helper(std::make_index_sequence<PortList::size>());
-}
-
 // template<template<typename...> typename Type, typename... Items>
 // using find_type = decltype(std::tuple_cat(std::declval<std::conditional_t<is_instantiation_of<Items, Type>, std::tuple<Items>, std::tuple<>>>()...));
 


### PR DESCRIPTION
With my last PR `array<PortOut, 2> out` turned into two named ports: "out0" and "out1". Consequently, existing `connect<"out", 0>` calls had to be changed to `connect<"out0">`.

This commit introduces the following changes:

1. The ports are now named "out#0" and "out#1" so as to never clash with another port member named "out0", etc.

2. `connect<"out", 0>` & `to<"in", 0>` will now check for a port with the given name. If that doesn't exist try `name + '#' + index`. If that also doesn't exist try `name + index`. Thus, the above array of ports can be connected both via `connect<"out0">` and `connect<"out", 0>`.

3. The fallback to `name + index` allows indexing of explicitly numbered port members.

4. `merge` will refuse to merge `vector<Port>` with a helpful error message.

Implementation detail:

`indexForName` moved from `meta::` into `traits::block::` because that's where all the related port reflections on blocks are implemented.

TODO: Non-`MergedGraph` blocks can never have duplicate port names by construction now. However, `MergedGraph` blocks can have arbitrary duplication. Since indexing ports of `MergedGraph`s is also fairly brittle (the numbering is not intuitive and could change if we ever try to make it more intuitive) we should consider a naming scheme that disambiguates port names.