### PR TITLE
Add DataSetSink block

### DIFF
--- a/blocks/basic/include/gnuradio-4.0/basic/DataSink.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/DataSink.hpp
@@ -446,11 +446,13 @@ public:
 
     template<StreamCallback<T> Callback>
     void registerStreamingCallback(std::size_t maxChunkSize, Callback&& callback) {
+        std::lock_guard lg(_listener_mutex);
         addListener(std::make_unique<ContinuousListener<Callback>>(maxChunkSize, std::forward<Callback>(callback), *this), false);
     }
 
     template<trigger::Matcher M, DataSetCallback<T> Callback>
     void registerTriggerCallback(M&& matcher, std::size_t preSamples, std::size_t postSamples, Callback&& callback) {
+        std::lock_guard lg(_listener_mutex);
         addListener(std::make_unique<TriggerListener<Callback, M>>(std::forward<M>(matcher), preSamples, postSamples, std::forward<Callback>(callback)), false);
         ensureHistorySize(preSamples);
     }


### PR DESCRIPTION
Add sink to export DataSet<T> streams. This block is a simpler DataSink
(which operates of non-DataSet streams), basically handing out the
incoming data sets as is, allowing basic filtering.