### PR TITLE
Check if a port is connected or not

### DIFF
--- a/core/include/gnuradio-4.0/BlockTraits.hpp
+++ b/core/include/gnuradio-4.0/BlockTraits.hpp
@@ -1,8 +1,8 @@
 #ifndef GNURADIO_NODE_NODE_TRAITS_HPP
 #define GNURADIO_NODE_NODE_TRAITS_HPP
 
-#include <gnuradio-4.0/meta/utils.hpp>
 #include <gnuradio-4.0/meta/reflection.hpp>
+#include <gnuradio-4.0/meta/utils.hpp>
 
 #include "Port.hpp"
 #include "PortTraits.hpp"
@@ -24,7 +24,7 @@ class MergedGraph;
 
 template<typename T>
 concept PortReflectable = refl::reflectable<T> and std::same_as<std::remove_const_t<T>, typename T::derived_t>;
-}
+} // namespace gr
 
 namespace gr::traits::block {
 
@@ -204,6 +204,8 @@ static_assert(ReaderSpanLike<DummyReaderSpan<int>>);
 template<typename T>
 struct DummyInputSpan : public DummyReaderSpan<T> {
     DummyReaderSpan<gr::Tag> rawTags{};
+    bool                     isConnected = true;
+    bool                     isSync      = true;
     auto                     tags() { return std::views::empty<std::pair<Tag::signed_index_type, const property_map&>>; }
     [[nodiscard]] inline Tag getMergedTag(gr::Tag::signed_index_type /*untilLocalIndex*/) const { return {}; }
     void                     consumeTags(gr::Tag::signed_index_type /*untilLocalIndex*/) {}
@@ -240,6 +242,8 @@ static_assert(WriterSpanLike<DummyWriterSpan<int>>);
 template<typename T>
 struct DummyOutputSpan : public DummyWriterSpan<T> {
     DummyWriterSpan<gr::Tag> tags{};
+    bool                     isConnected = true;
+    bool                     isSync      = true;
 
     void publishTag(property_map&, gr::Tag::signed_index_type) {}
 };

--- a/core/test/qa_HierBlock.cpp
+++ b/core/test/qa_HierBlock.cpp
@@ -176,7 +176,7 @@ struct cout_sink : public gr::Block<cout_sink<T>> {
     }
 };
 
-gr::Graph make_graph(std::size_t events_count) {
+gr::Graph make_graph(std::size_t /*events_count*/) {
     gr::Graph graph;
 
     // auto& source_leftBlock  = graph.emplaceBlock<fixed_source<double>>({{"remaining_events_count", events_count}});


### PR DESCRIPTION
Currently, our implementation does not check whether a port is connected or if it is synchronous or asynchronous. We calculate the minimum number of processed samples across input and output ports, and only if both processedIn > 0 and processedOut > 0 do we forward tags.

This PR introduces a check to determine if a port is connected, which partially addresses the issue.

This PR helps to fix tag forwarding prolem for `Picoscope` block.

See https://github.com/fair-acc/gnuradio4/issues/444 for more explanations.
