### PR TITLE
Fix qa_Message

### DIFF
--- a/core/test/qa_Messages.cpp
+++ b/core/test/qa_Messages.cpp
@@ -675,6 +675,9 @@ const boost::ut::suite MessagesTests = [] {
         auto schedulerThread = std::thread([&scheduler] { scheduler.runAndWait(); });
 
         client.join();
+        while (source.state() != lifecycle::State::STOPPED) {
+            std::this_thread::sleep_for(10ms);
+        }
         schedulerThread.join();
     } | schedulingPolicies;
 };


### PR DESCRIPTION
After making changes to ClockSource and fixing a bug where it wasn't functioning properly (see https://github.com/fair-acc/gnuradio4/pull/449), I noticed that the `qa_Message` test named "Settings handling via scheduler" started failing.

Previously, the test used ClockSource, which essentially produced no samples due to the bug. After my fix, the test began to fail because `ClockSource` started producing samples as expected.

Upon further investigation, I found that the issue isn't with the message handling but rather with BlockingIO—since `ClockSource` has the `BlockingIO` attribute. I created a small unit test that reproduces the error reliably.

The core problem is that` ClockSource` continues running in a separate thread for some time, and the detection mechanism to determine whether it has completed isn't always accurate.

This PR includes:
- Additional verification that a `BlockingIO` block is in `STOPPED` state.
- Add new unit test in `qa_Block`.