### PR TITLE
extended BlockModel::draw(const property_map&) API

### DIFF
--- a/core/include/gnuradio-4.0/BlockModel.hpp
+++ b/core/include/gnuradio-4.0/BlockModel.hpp
@@ -356,7 +356,7 @@ public:
 
     [[nodiscard]] virtual work::Result work(std::size_t requested_work) = 0;
 
-    [[nodiscard]] virtual work::Status draw() = 0;
+    [[nodiscard]] virtual work::Status draw(const property_map& config = {}) = 0;
 
     [[nodiscard]] virtual block::Category blockCategory() const { return block::Category::NormalBlock; }
 
@@ -452,9 +452,9 @@ public:
 
     [[nodiscard]] constexpr work::Result work(std::size_t requested_work = std::numeric_limits<std::size_t>::max()) override { return blockRef().work(requested_work); }
 
-    constexpr work::Status draw() override {
-        if constexpr (requires { blockRef().draw(); }) {
-            return blockRef().draw();
+    constexpr work::Status draw(const property_map& config = {}) override {
+        if constexpr (requires { blockRef().draw(config); }) {
+            return blockRef().draw(config);
         }
         return work::Status::ERROR;
     }

--- a/core/test/qa_HierBlock.cpp
+++ b/core/test/qa_HierBlock.cpp
@@ -97,7 +97,7 @@ public:
         return {requested_work, requested_work, ok ? gr::work::Status::DONE : gr::work::Status::ERROR};
     }
 
-    gr::work::Status draw() override { return gr::work::Status::OK; }
+    gr::work::Status draw(const property_map& config = {}) override { return gr::work::Status::OK; }
 
     void processScheduledMessages() override {
         // TODO


### PR DESCRIPTION
needed to pass some optional non-global UI constraints to the specific block e.g. in case the same block is redrawn in two different UI views.