### PR TITLE
Manual Tag Forwarding with InputSpan and OutputSpan API

### DIFF
--- a/blocks/basic/test/qa_Selector.cpp
+++ b/blocks/basic/test/qa_Selector.cpp
@@ -19,9 +19,13 @@ struct TestParams {
     std::vector<std::pair<gr::Size_t, gr::Size_t>> mapping;
     std::vector<std::vector<double>>               inValues;
     std::vector<std::vector<double>>               outValues;
+    std::vector<std::vector<gr::Tag>>              inTags;
+    std::vector<std::vector<gr::Tag>>              outTags;
     gr::Size_t                                     monitorSource;
     std::vector<double>                            monitorValues;
     bool                                           backPressure;
+    std::vector<gr::Size_t>                        nSamplesSelectorInput; // check back pressure
+    bool                                           syncCombinedPorts{true};
     bool                                           ignoreOrder{false};
 };
 
@@ -42,35 +46,30 @@ void execute_selector_test(TestParams params) {
     std::ranges::transform(params.mapping, mapIn.begin(), [](auto& p) { return p.first; });
     std::ranges::transform(params.mapping, mapOut.begin(), [](auto& p) { return p.second; });
 
-    selector = std::addressof(graph.emplaceBlock<gr::basic::Selector<double>>({{"n_inputs", nSources}, //
-        {"n_outputs", nSinks},                                                                         //
-        {"map_in", mapIn},                                                                             //
-        {"map_out", mapOut},                                                                           //
-        {"back_pressure", params.backPressure}}));
+    selector = std::addressof(graph.emplaceBlock<gr::basic::Selector<double>>({{"n_inputs", nSources}, {"n_outputs", nSinks}, {"map_in", mapIn}, {"map_out", mapOut}, {"back_pressure", params.backPressure}, {"sync_combined_ports", params.syncCombinedPorts}, {"disconnect_on_done", false}}));
 
     for (gr::Size_t i = 0; i < nSources; ++i) {
-        sources.push_back(std::addressof(graph.emplaceBlock<TagSource<double>>({{"n_samples_max", params.nSamples}, {"values", params.inValues[i]}})));
+        sources.push_back(std::addressof(graph.emplaceBlock<TagSource<double>>({{"n_samples_max", params.nSamples}, {"values", params.inValues[i]}, {"disconnect_on_done", false}})));
         expect(sources[i]->settings().applyStagedParameters().forwardParameters.empty());
+        sources[i]->_tags = params.inTags[i];
         expect(gr::ConnectionResult::SUCCESS == graph.connect(*sources[i], "out"s, *selector, "inputs#"s + std::to_string(i)));
     }
 
     for (gr::Size_t i = 0; i < nSinks; ++i) {
-        sinks.push_back(std::addressof(graph.emplaceBlock<TagSink<double, ProcessFunction::USE_PROCESS_ONE>>()));
+        sinks.push_back(std::addressof(graph.emplaceBlock<TagSink<double, ProcessFunction::USE_PROCESS_ONE>>({{"disconnect_on_done", false}})));
         expect(sinks[i]->settings().applyStagedParameters().forwardParameters.empty());
         expect(gr::ConnectionResult::SUCCESS == graph.connect(*selector, "outputs#"s + std::to_string(i), *sinks[i], "in"s));
     }
 
-    TagSink<double, ProcessFunction::USE_PROCESS_ONE>* monitorSink = std::addressof(graph.emplaceBlock<TagSink<double, ProcessFunction::USE_PROCESS_ONE>>());
+    TagSink<double, ProcessFunction::USE_PROCESS_ONE>* monitorSink = std::addressof(graph.emplaceBlock<TagSink<double, ProcessFunction::USE_PROCESS_ONE>>({{"disconnect_on_done", false}}));
     expect(monitorSink->settings().applyStagedParameters().forwardParameters.empty());
     expect(gr::ConnectionResult::SUCCESS == graph.connect<"monitor">(*selector).to<"in">(*monitorSink));
 
     gr::scheduler::Simple sched{std::move(graph)};
     expect(sched.runAndWait().has_value());
 
-    if (!params.backPressure) {
-        for (const auto& input : selector->inputs) {
-            expect(eq(input.streamReader().available(), 0U));
-        }
+    for (std::size_t i = 0; i < selector->inputs.size(); i++) {
+        expect(eq(selector->inputs[i].streamReader().available(), params.nSamplesSelectorInput[i]));
     }
 
     for (std::size_t i = 0; i < sinks.size(); i++) {
@@ -79,6 +78,10 @@ void execute_selector_test(TestParams params) {
             std::ranges::sort(params.outValues[i]);
         }
         expect(std::ranges::equal(sinks[i]->_samples, params.outValues[i])) << fmt::format("sinks[{}]->_samples does not match to expected values:\nSink:{}\nExpected:{}\n", i, sinks[i]->_samples, params.outValues[i]);
+    }
+
+    for (std::size_t i = 0; i < sinks.size(); i++) {
+        expect(equal_tag_lists(sinks[i]->_tags, params.outTags[i], {}));
     }
 }
 
@@ -93,7 +96,7 @@ const boost::ut::suite SelectorTest = [] {
         expect(eq(block_nop.n_outputs, 0U));
         expect(eq(block_nop.inputs.size(), 0U));
         expect(eq(block_nop.outputs.size(), 0U));
-        expect(eq(block_nop._internalMapping.size(), 0U));
+        expect(eq(block_nop._internalMappingInOut.size(), 0U));
 
         Selector<double> block({{"name", "block"}, {"n_inputs", 4U}, {"n_outputs", 3U}});
         block.init(block.progress, block.ioThreadPool);
@@ -101,7 +104,7 @@ const boost::ut::suite SelectorTest = [] {
         expect(eq(block.n_outputs, 3U));
         expect(eq(block.inputs.size(), 4U));
         expect(eq(block.outputs.size(), 3U));
-        expect(eq(block._internalMapping.size(), 0U));
+        expect(eq(block._internalMappingInOut.size(), 0U));
     };
 
     "basic Selector<T>"_test = [] {
@@ -109,147 +112,215 @@ const boost::ut::suite SelectorTest = [] {
         const std::vector<uint32_t> outputMap{1U, 0U};
         Selector<T>                 block({{"n_inputs", 3U}, {"n_outputs", 2U}, {"map_in", std::vector<gr::Size_t>{0U, 1U}}, {"map_out", outputMap}}); // N.B. 3rd input is unconnected
         block.init(block.progress, block.ioThreadPool);
-        expect(eq(block._internalMapping.size(), 2U));
+        expect(eq(block._internalMappingInOut.size(), 2U));
 
-        using internal_mapping_t = decltype(block._internalMapping);
-        expect(block._internalMapping == internal_mapping_t{{0U, {outputMap[0]}}, {1U, {outputMap[1]}}});
+        using internal_mapping_t = decltype(block._internalMappingInOut);
+        expect(block._internalMappingInOut == internal_mapping_t{{0U, {outputMap[0]}}, {1U, {outputMap[1]}}});
     };
+
+    gr::Tag tag1{1, {{"key1", "value1"}}};
+    gr::Tag tag2{2, {{"key2", "value2"}}};
+    gr::Tag tag3{3, {{"key3", "value3"}}};
 
     // Tests without the back pressure
 
-    "Selector<T> 1 to 1 mapping"_test = [] {
+    "Selector<T> 1 to 1 mapping"_test = [tag1, tag2, tag3] {
         execute_selector_test({.nSamples = 5,                                                   //
             .mapping                     = {{0, 0}, {1, 1}, {2, 2}},                            //
             .inValues                    = {{1}, {2}, {3}},                                     //
             .outValues                   = {{1, 1, 1, 1, 1}, {2, 2, 2, 2, 2}, {3, 3, 3, 3, 3}}, //
-            .monitorSource               = -1U,                                                 //
-            .monitorValues               = {},                                                  //
+            .inTags                      = {{tag1}, {tag2}, {tag3}},                            //
+            .outTags                     = {{tag1}, {tag2}, {tag3}},
+            .monitorSource               = -1U, //
+            .monitorValues               = {},  //
             .backPressure                = false,
-            .ignoreOrder                 = false});
+            .nSamplesSelectorInput       = {0, 0, 0},
+            .ignoreOrder                 = true});
     };
 
-    "Selector<T> only one input used"_test = [] {
+    "Selector<T> only one input used"_test = [tag1, tag2, tag3] {
         execute_selector_test({.nSamples = 5,                         //
             .mapping                     = {{1, 1}},                  //
             .inValues                    = {{1}, {2}, {3}},           //
             .outValues                   = {{}, {2, 2, 2, 2, 2}, {}}, //
-            .monitorSource               = -1U,                       //
-            .monitorValues               = {},                        //
+            .inTags                      = {{tag1}, {tag2}, {tag3}},  //
+            .outTags                     = {{}, {tag2}, {}},
+            .monitorSource               = -1U, //
+            .monitorValues               = {},  //
             .backPressure                = false,
+            .nSamplesSelectorInput       = {0, 0, 0},
+            .ignoreOrder                 = true});
+    };
+
+    "Selector<T> all for one synch_combined_ports = false"_test = [tag1, tag2, tag3] {
+        const Tag newTag1{6, tag1.map};
+        const Tag newTag2{10, tag2.map};
+        const Tag newTag3{13, tag3.map};
+        execute_selector_test({.nSamples = 5,                                                       //
+            .mapping                     = {{0, 1}, {1, 1}, {2, 1}},                                //
+            .inValues                    = {{1}, {2}, {3}},                                         //
+            .outValues                   = {{}, {1, 2, 2, 3, 3, 3, 1, 1, 1, 1, 2, 2, 2, 3, 3}, {}}, //
+            .inTags                      = {{tag1}, {tag2}, {tag3}},                                //
+            .outTags                     = {{}, {newTag1, newTag2, newTag3}, {}},
+            .monitorSource               = -1U, //
+            .monitorValues               = {},  //
+            .backPressure                = false,
+            .nSamplesSelectorInput       = {0, 0, 0},
+            .syncCombinedPorts           = false,
             .ignoreOrder                 = false});
     };
 
-    "Selector<T> all for one"_test = [] {
+    "Selector<T> all for one synch_combined_ports = true"_test = [tag1, tag2, tag3] {
+        const Tag newTag1{3, tag1.map};
+        const Tag newTag2{7, tag2.map};
+        const Tag newTag3{11, tag3.map};
         execute_selector_test({.nSamples = 5,                                                       //
             .mapping                     = {{0, 1}, {1, 1}, {2, 1}},                                //
             .inValues                    = {{1}, {2}, {3}},                                         //
             .outValues                   = {{}, {1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3}, {}}, //
-            .monitorSource               = -1U,                                                     //
-            .monitorValues               = {},                                                      //
+            .inTags                      = {{tag1}, {tag2}, {tag3}},                                //
+            .outTags                     = {{}, {newTag1, newTag2, newTag3}, {}},
+            .monitorSource               = -1U, //
+            .monitorValues               = {},  //
             .backPressure                = false,
-            .ignoreOrder                 = true});
+            .nSamplesSelectorInput       = {0, 0, 0},
+            .syncCombinedPorts           = true,
+            .ignoreOrder                 = false});
     };
 
-    "Selector<T> one for all"_test = [] {
+    "Selector<T> one for all"_test = [tag1, tag2, tag3] {
         execute_selector_test({.nSamples = 5,                                                   //
             .mapping                     = {{1, 0}, {1, 1}, {1, 2}},                            //
             .inValues                    = {{1}, {2}, {3}},                                     //
             .outValues                   = {{2, 2, 2, 2, 2}, {2, 2, 2, 2, 2}, {2, 2, 2, 2, 2}}, //
-            .monitorSource               = -1U,                                                 //
-            .monitorValues               = {},                                                  //
+            .inTags                      = {{tag1}, {tag2}, {tag3}},                            //
+            .outTags                     = {{tag2}, {tag2}, {tag2}},
+            .monitorSource               = -1U, //
+            .monitorValues               = {},  //
             .backPressure                = false,
+            .nSamplesSelectorInput       = {0, 0, 0},
             .ignoreOrder                 = false});
     };
 
     // tests with the back pressure
 
-    "Selector<T> 1 to 1 mapping, with back pressure"_test = [] {
+    "Selector<T> 1 to 1 mapping, with back pressure"_test = [tag1, tag2, tag3] {
         execute_selector_test({.nSamples = 5,                                                   //
             .mapping                     = {{0, 0}, {1, 1}, {2, 2}},                            //
             .inValues                    = {{1}, {2}, {3}},                                     //
             .outValues                   = {{1, 1, 1, 1, 1}, {2, 2, 2, 2, 2}, {3, 3, 3, 3, 3}}, //
-            .monitorSource               = -1U,                                                 //
-            .monitorValues               = {},                                                  //
+            .inTags                      = {{tag1}, {tag2}, {tag3}},                            //
+            .outTags                     = {{tag1}, {tag2}, {tag3}},
+            .monitorSource               = -1U, //
+            .monitorValues               = {},  //
             .backPressure                = true,
+            .nSamplesSelectorInput       = {0, 0, 0},
             .ignoreOrder                 = false});
     };
 
-    "Selector<T> only one input used, with back pressure"_test = [] {
+    "Selector<T> only one input used, with back pressure"_test = [tag1, tag2, tag3] {
         execute_selector_test({.nSamples = 5,                         //
             .mapping                     = {{1, 1}},                  //
             .inValues                    = {{1}, {2}, {3}},           //
             .outValues                   = {{}, {2, 2, 2, 2, 2}, {}}, //
-            .monitorSource               = -1U,                       //
-            .monitorValues               = {},                        //
+            .inTags                      = {{tag1}, {tag2}, {tag3}},  //
+            .outTags                     = {{}, {tag2}, {}},
+            .monitorSource               = -1U, //
+            .monitorValues               = {},  //
             .backPressure                = true,
+            .nSamplesSelectorInput       = {5, 0, 5},
             .ignoreOrder                 = false});
     };
 
-    "Selector<T> all for one, with back pressure"_test = [] {
+    "Selector<T> all for one, with back pressure"_test = [tag1, tag2, tag3] {
+        const Tag newTag1{3, tag1.map};
+        const Tag newTag2{7, tag2.map};
+        const Tag newTag3{11, tag3.map};
         execute_selector_test({.nSamples = 5,                                                       //
             .mapping                     = {{0, 1}, {1, 1}, {2, 1}},                                //
             .inValues                    = {{1}, {2}, {3}},                                         //
             .outValues                   = {{}, {1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3}, {}}, //
-            .monitorSource               = -1U,                                                     //
-            .monitorValues               = {},                                                      //
+            .inTags                      = {{tag1}, {tag2}, {tag3}},                                //
+            .outTags                     = {{}, {newTag1, newTag2, newTag3}, {}},
+            .monitorSource               = -1U, //
+            .monitorValues               = {},  //
             .backPressure                = true,
-            .ignoreOrder                 = true});
+            .nSamplesSelectorInput       = {0, 0, 0},
+            .ignoreOrder                 = false});
     };
 
-    "Selector<T> one for all, with back pressure"_test = [] {
+    "Selector<T> one for all, with back pressure"_test = [tag1, tag2, tag3] {
         execute_selector_test({.nSamples = 5,                                                   //
             .mapping                     = {{1, 0}, {1, 1}, {1, 2}},                            //
             .inValues                    = {{1}, {2}, {3}},                                     //
             .outValues                   = {{2, 2, 2, 2, 2}, {2, 2, 2, 2, 2}, {2, 2, 2, 2, 2}}, //
-            .monitorSource               = -1U,                                                 //
-            .monitorValues               = {},                                                  //
+            .inTags                      = {{tag1}, {tag2}, {tag3}},                            //
+            .outTags                     = {{tag2}, {tag2}, {tag2}},
+            .monitorSource               = -1U, //
+            .monitorValues               = {},  //
             .backPressure                = true,
+            .nSamplesSelectorInput       = {5, 0, 5},
             .ignoreOrder                 = false});
     };
 
     // Tests with a monitor
 
-    "Selector<T> 1 to 1 mapping, with monitor, monitor source already mapped"_test = [] {
+    "Selector<T> 1 to 1 mapping, with monitor, monitor source already mapped"_test = [tag1, tag2, tag3] {
         execute_selector_test({.nSamples = 5,                                                   //
             .mapping                     = {{0, 0}, {1, 1}, {2, 2}},                            //
             .inValues                    = {{1}, {2}, {3}},                                     //
             .outValues                   = {{1, 1, 1, 1, 1}, {2, 2, 2, 2, 2}, {3, 3, 3, 3, 3}}, //
-            .monitorSource               = 0U,                                                  //
-            .monitorValues               = {1, 1, 1, 1, 1},                                     //
+            .inTags                      = {{tag1}, {tag2}, {tag3}},                            //
+            .outTags                     = {{tag1}, {tag2}, {tag3}},
+            .monitorSource               = 0U,              // set monitor index
+            .monitorValues               = {1, 1, 1, 1, 1}, //
             .backPressure                = false,
+            .nSamplesSelectorInput       = {0, 0, 0},
             .ignoreOrder                 = false});
     };
 
-    "Selector<T> only one input used, with monitor, monitor source not mapped"_test = [] {
+    "Selector<T> only one input used, with monitor, monitor source not mapped"_test = [tag1, tag2, tag3] {
         execute_selector_test({.nSamples = 5,                         //
             .mapping                     = {{1, 1}},                  //
             .inValues                    = {{1}, {2}, {3}},           //
             .outValues                   = {{}, {2, 2, 2, 2, 2}, {}}, //
-            .monitorSource               = 0U,                        //
-            .monitorValues               = {1, 1, 1, 1, 1},           //
+            .inTags                      = {{tag1}, {tag2}, {tag3}},  //
+            .outTags                     = {{}, {tag2}, {}},
+            .monitorSource               = 0U,              // set monitor index
+            .monitorValues               = {1, 1, 1, 1, 1}, // monitor has values even if port is not mapped
             .backPressure                = false,
+            .nSamplesSelectorInput       = {0, 0, 0},
             .ignoreOrder                 = false});
     };
 
-    "Selector<T> all for one, with monitor, monitor source already mapped"_test = [] {
+    "Selector<T> all for one, with monitor, monitor source already mapped"_test = [tag1, tag2, tag3] {
+        const Tag newTag1{3, tag1.map};
+        const Tag newTag2{7, tag2.map};
+        const Tag newTag3{11, tag3.map};
         execute_selector_test({.nSamples = 5,                                                       //
             .mapping                     = {{0, 1}, {1, 1}, {2, 1}},                                //
             .inValues                    = {{1}, {2}, {3}},                                         //
             .outValues                   = {{}, {1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3}, {}}, //
-            .monitorSource               = 1U,                                                      //
-            .monitorValues               = {2, 2, 2, 2, 2},                                         //
+            .inTags                      = {{tag1}, {tag2}, {tag3}},                                //
+            .outTags                     = {{}, {newTag1, newTag2, newTag3}, {}},
+            .monitorSource               = 1U,              // set monitor index
+            .monitorValues               = {2, 2, 2, 2, 2}, //
             .backPressure                = false,
+            .nSamplesSelectorInput       = {0, 0, 0},
             .ignoreOrder                 = true});
     };
 
-    "Selector<T> one for all, with monitor, monitor source already mapped"_test = [] {
+    "Selector<T> one for all, with monitor, monitor source already mapped"_test = [tag1, tag2, tag3] {
         execute_selector_test({.nSamples = 5,                                                   //
             .mapping                     = {{1, 0}, {1, 1}, {1, 2}},                            //
             .inValues                    = {{1}, {2}, {3}},                                     //
             .outValues                   = {{2, 2, 2, 2, 2}, {2, 2, 2, 2, 2}, {2, 2, 2, 2, 2}}, //
-            .monitorSource               = 1U,                                                  //
-            .monitorValues               = {2, 2, 2, 2, 2},                                     //
+            .inTags                      = {{tag1}, {tag2}, {tag3}},                            //
+            .outTags                     = {{tag2}, {tag2}, {tag2}},
+            .monitorSource               = 1U,              //
+            .monitorValues               = {2, 2, 2, 2, 2}, //
             .backPressure                = false,
+            .nSamplesSelectorInput       = {0, 0, 0},
             .ignoreOrder                 = false});
     };
 };

--- a/blocks/testing/include/gnuradio-4.0/testing/TagMonitors.hpp
+++ b/blocks/testing/include/gnuradio-4.0/testing/TagMonitors.hpp
@@ -163,6 +163,7 @@ struct TagSource : public Block<TagSource<T, UseProcessVariant>> {
             if (_tagIndex < _tags.size()) {
                 if (static_cast<gr::Size_t>(_tags[_tagIndex].index) > nSamplesRemainder) {
                     nextTagIn = static_cast<gr::Size_t>(_tags[_tagIndex].index) - nSamplesRemainder;
+                    nextTagIn = std::min(nextTagIn, n_samples_max - _nSamplesProduced);
                 }
             } else {
                 nextTagIn = isInfinite() ? static_cast<gr::Size_t>(outSpan.size()) : n_samples_max - _nSamplesProduced;

--- a/core/include/gnuradio-4.0/Tag.hpp
+++ b/core/include/gnuradio-4.0/Tag.hpp
@@ -28,28 +28,6 @@ inline constexpr std::size_t hardware_constructive_interference_size = 64;
 
 namespace gr {
 
-/***
- * Controls automatic propagation of stream tags on sync ports.
- *       ```
- *     ┌───────┐      ┌───────┐     ┌───────┐      ┌───────┐
- *    ┌┤       ├┐    ┌┤       ├┐   ┌┤       ├┐    ┌┤       ├┐
- *    ││       ││    ││ ────► ││   ││ ────► ││    ││       ││
- *    └┤       ├┘    └┤  \ /  ├┘   └┤       ├┘    └┤work(){├┘
- *     │       │      │   X   │     │       │      │ get();│
- *    ┌┤       ├┐    ┌┤  / \  ├┐   ┌┤       ├┐    ┌┤ pub();├┐
- *    ││       ││    ││ ────► ││   ││ ────► ││    ││}      ││
- *    └┤       ├┘    └┤       ├┘   └┤       ├┘    └┤       ├┘
- *     └───────┘      └───────┘     └───────┘      └───────┘
- *       `DONT`      `ALL_TO_ALL   `ONE_TO_ONE`   `TPP_CUSTOM`
- * ```
- */
-enum class TagPropagationPolicy {
-    TPP_DONT       = 0, /*!< Scheduler doesn't propagate tags from in- to output. The block itself is free to insert tags. */
-    TPP_ALL_TO_ALL = 1, /*!< Propagate tags from all in- to all outputs. The scheduler takes care of that. */
-    TPP_ONE_TO_ONE = 2, /*!< Propagate tags from n. input to n. output. Requires same number of in- and outputs */
-    TPP_CUSTOM     = 3  /*!< Like TPP_DONT, but signals the block it should implement application-specific forwarding behaviour. */
-};
-
 using property_map = pmtv::map_t;
 
 template<typename T>

--- a/core/include/gnuradio-4.0/annotated.hpp
+++ b/core/include/gnuradio-4.0/annotated.hpp
@@ -70,6 +70,23 @@ struct BlockingIO {
 };
 
 /**
+ * @brief Disable default tag forwarding.
+ *
+ * There are two types of tag forwarding: (1) default All-To-All, and (2) user-implemented.
+ *
+ * By default, tag forwarding operates as All-To-All. Before tags on input ports are forwarded, they are merged.
+ * If a block has multiple ports and tags on these ports contain maps with identical keys, only one value for each key
+ * will be retained in the merged tag. This may lead to potential information loss, as it’s not guaranteed which
+ * value will be kept.
+ *
+ * This default behavior is generally sufficient. However, if it’s not suitable for your use case, you can disable it
+ * by adding the `NoDefaultTagForwarding` attribute to the template parameters. In such cases, the block should implement
+ * custom tag forwarding in the `processBulk` function. The `InputSpanLike` and `OutputSpanLike` APIs are available to simplify
+ * with custom tag forwarding.
+ */
+struct NoDefaultTagForwarding {};
+
+/**
  * @brief Annotates block, indicating to perform resampling based on the provided `inputChunkSize` and `outputChunkSize`.
  * For each `inputChunkSize` input samples, `outputChunkSize` output samples are published.
  * Thus the total number of input/output samples can be calculated as `nInput = k * inputChunkSize` and `nOutput = k * outputChunkSize`.

--- a/core/test/qa_Tags.cpp
+++ b/core/test/qa_Tags.cpp
@@ -35,8 +35,7 @@ or next chunk, whichever is closer. Also adds an "offset" key to the tag map sig
 
     GR_MAKE_REFLECTABLE(RealignTagsToChunks, inPort, outPort);
 
-    double                                    sampling_rate = 1.0;
-    constexpr static gr::TagPropagationPolicy tag_policy    = gr::TagPropagationPolicy::TPP_DONT;
+    double sampling_rate = 1.0;
 
     // TODO: References are required here because InputSpan and OutputSpan have internal states
     // (e.g., tagsPublished) that are unique to each instance. Copying these objects without proper


### PR DESCRIPTION
The changes include:
* Removed TagPropagationPolicy and introduced NoDefaultTagForwarding
* Resolved tag forwarding for scenarios where some output ports are `Async` and lack samples (Closes #444)
* Updated Selector block as a test case and example for manual tag forwarding (#452)
* Added `synch_combined_ports` parameter and possibility to have item-by-item interleaved output for multi mapped output ports
* Added tag propagation test to qa_Selector
* Added back pressure test to qa_Selector
* Added unit test in qa_Block to handle cases where input_chunk_size > 1 and input range has multiple tags
* Fix: Port::consumeTags to make untilLocalIndex exclusive
* Fix: Port::mergedTag to make untilLocalIndex exclusive
* Fix: TagMonitor to limit nSamples to the remaining samples for processing

```cpp
/**
 * @brief Disable default tag forwarding.
 *
 * There are two types of tag forwarding: (1) default All-To-All, and (2) user-implemented.
 *
 * By default, tag forwarding operates as All-To-All. Before tags on input ports are forwarded, they are merged.
 * If a block has multiple ports and tags on these ports contain maps with identical keys, only one value for each key
 * will be retained in the merged tag. This may lead to potential information loss, as it’s not guaranteed which
 * value will be kept.
 *
 * This default behavior is generally sufficient. However, if it’s not suitable for your use case, you can disable it
 * by adding the `NoDefaultTagForwarding` attribute to the template parameters. In such cases, the block should implement
 * custom tag forwarding in the `processBulk` function. The `InputSpanLike` and `OutputSpanLike` APIs are available to simplify
 * with custom tag forwarding.
 */
struct NoDefaultTagForwarding {};
```