### PR TITLE
Implement PowerMetrics, PowerFactor, SystemUnbalance Blocks, and Configurable Filters with UncertainValue<T> Support

### DIFF
--- a/blocks/CMakeLists.txt
+++ b/blocks/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(basic)
+add_subdirectory(electrical)
 add_subdirectory(fileio)
 add_subdirectory(filter)
 add_subdirectory(fourier)

--- a/blocks/electrical/CMakeLists.txt
+++ b/blocks/electrical/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_library(gr-electrical INTERFACE)
+target_link_libraries(gr-electrical INTERFACE gnuradio-core gnuradio-algorithm)
+target_include_directories(gr-electrical INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
+                                                   $<INSTALL_INTERFACE:include/>)
+
+if(ENABLE_TESTING)
+  add_subdirectory(test)
+endif()

--- a/blocks/electrical/include/gnuradio-4.0/electrical/PowerEstimators.hpp
+++ b/blocks/electrical/include/gnuradio-4.0/electrical/PowerEstimators.hpp
@@ -1,0 +1,250 @@
+#ifndef POWERESTIMATORS_HPP
+#define POWERESTIMATORS_HPP
+
+#include <algorithm>
+#include <cmath>
+#include <numbers>
+#include <vector>
+
+#include <gnuradio-4.0/Block.hpp>
+#include <gnuradio-4.0/BlockRegistry.hpp>
+
+#include <gnuradio-4.0/HistoryBuffer.hpp>
+#include <gnuradio-4.0/algorithm/filter/FilterTool.hpp>
+#include <gnuradio-4.0/meta/UncertainValue.hpp>
+
+namespace gr::electrical {
+
+template<typename T, std::size_t nPhases>
+requires(std::floating_point<T> or std::is_arithmetic_v<meta::fundamental_base_value_type_t<T>>)
+struct PowerMetrics : Block<PowerMetrics<T, nPhases>> {
+    using Description = Doc<R""(@brief PowerMetrics
+
+Computes per-phase active power (P), reactive power (Q), apparent power (S), RMS voltage (U_rms), and RMS current (I_rms)
+for single-phase or multi-phase electrical systems. It processes voltage and current inputs,
+applies low-pass filters to calculate average values, and outputs decimated results at a specified rate.
+
+[0] "IEEE Standard Definitions for the Measurement of Electric Power Quantities Under Sinusoidal, Nonsinusoidal,
+    Balanced, or Unbalanced Conditions," in IEEE Std 1459-2010 (Revision of IEEE Std 1459-2000), vol., no., pp.1-50,
+    19 March 2010, doi: 10.1109/IEEESTD.2010.5439063, https://ieeexplore.ieee.org/document/5439063
+)"">;
+    // ports
+    std::vector<PortIn<T>> U{nPhases};
+    std::vector<PortIn<T>> I{nPhases};
+
+    std::vector<PortOut<T>> P{nPhases}; // active power (in-phase)
+    std::vector<PortOut<T>> Q{nPhases}; // reactive power (i.e. 90-degree out of phase component)
+    std::vector<PortOut<T>> S{nPhases}; // apparent power (i.e. U*I)
+    std::vector<PortOut<T>> U_rms{nPhases};
+    std::vector<PortOut<T>> I_rms{nPhases};
+
+    // settings
+    Annotated<float, "sample_rate", gr::Unit<"Hz">>                               sample_rate{10'000.f};
+    Annotated<gr::Size_t, "decimation factor", Doc<"decimation_factor">, Visible> decim{100U};
+
+    GR_MAKE_REFLECTABLE(PowerMetrics, U, I, P, Q, S, U_rms, I_rms, sample_rate, decim);
+
+    // private state for exponential moving average (EMA)
+    using FilterImpl = std::conditional_t<UncertainValueLike<T>, filter::ErrorPropagatingFilter<T>, filter::Filter<meta::fundamental_base_value_type_t<T>>>;
+
+    std::array<FilterImpl, nPhases> _lpVoltageSquared;
+    std::array<FilterImpl, nPhases> _lpCurrentSquared;
+    std::array<FilterImpl, nPhases> _lpActivePower;
+
+    void initFilters() {
+        using namespace gr::filter;
+        using ValueType = meta::fundamental_base_value_type_t<T>;
+
+        const double cutoff_frequency = 0.5 * static_cast<double>(sample_rate) / static_cast<double>(decim);
+        const auto   filter_init      = [&, cutoff_frequency](auto) {                                                    //
+            return FilterImpl(iir::designFilter<ValueType>(Type::LOWPASS,                                         //
+                       FilterParameters{.order = 2UZ, .fLow = cutoff_frequency, .fs = static_cast<double>(sample_rate)}, //
+                       iir::Design::BUTTERWORTH));
+        };
+
+        constexpr auto indices = std::views::iota(0UZ, nPhases);
+        std::ranges::transform(indices, _lpVoltageSquared.begin(), filter_init);
+        std::ranges::transform(indices, _lpCurrentSquared.begin(), filter_init);
+        std::ranges::transform(indices, _lpActivePower.begin(), filter_init);
+    }
+
+    void settingsChanged(const property_map& /*oldSettings*/, const property_map& /*newSettings*/) { initFilters(); }
+
+    template<typename TInputSpanType, typename TOutputSpanType>
+    constexpr work::Status processBulk(std::span<TInputSpanType>& voltage, std::span<TInputSpanType>& current,                         // inputs
+        std::span<TOutputSpanType>& activePower, std::span<TOutputSpanType>& reactivePower, std::span<TOutputSpanType>& apparentPower, // power outputs
+        std::span<TOutputSpanType>& rmsVoltage, std::span<TOutputSpanType>& rmsCurrent) {
+        for (std::size_t phaseIdx = 0UZ; phaseIdx < nPhases; ++phaseIdx) { // process each phase
+            for (std::size_t i = 0UZ; i < voltage[phaseIdx].size(); ++i) { // iterate over samples
+                const T u_i = voltage[phaseIdx][i];
+                const T i_i = current[phaseIdx][i];
+
+                const T p_i    = u_i * i_i;                                         // instantaneous power
+                const T ema_p  = _lpActivePower[phaseIdx].processOne(p_i);          // update exponential moving average for power
+                const T ema_u2 = _lpVoltageSquared[phaseIdx].processOne(u_i * u_i); // update exponential moving average for voltage squared
+                const T ema_i2 = _lpCurrentSquared[phaseIdx].processOne(i_i * i_i); // update exponential moving average for current squared
+
+                if (i % static_cast<std::size_t>(decim) == 0UZ) {
+                    const std::size_t outIdx = i / static_cast<std::size_t>(decim);
+                    const T           u_rms  = math::sqrt(ema_u2);
+                    const T           i_rms  = math::sqrt(ema_i2);
+
+                    const T S_i = u_rms * i_rms;                                         // apparent power
+                    T       Q_i = math::sqrt(std::max(S_i * S_i - ema_p * ema_p, T(0))); // reactive power
+
+                    activePower[phaseIdx][outIdx]   = ema_p;
+                    reactivePower[phaseIdx][outIdx] = Q_i;
+                    apparentPower[phaseIdx][outIdx] = S_i;
+
+                    rmsVoltage[phaseIdx][outIdx] = u_rms;
+                    rmsCurrent[phaseIdx][outIdx] = i_rms;
+                }
+            }
+        }
+
+        return work::Status::OK;
+    }
+};
+
+template<typename T>
+requires(std::floating_point<T> or std::is_arithmetic_v<meta::fundamental_base_value_type_t<T>>)
+using ThreePhasePowerMetrics = PowerMetrics<T, 3UZ>;
+
+static_assert(BlockLike<ThreePhasePowerMetrics<float>>, "block constraints not satisfied");
+static_assert(BlockLike<ThreePhasePowerMetrics<UncertainValue<float>>>, "block constraints not satisfied");
+static_assert(gr::HasProcessBulkFunction<ThreePhasePowerMetrics<float>>);
+static_assert(gr::HasProcessBulkFunction<ThreePhasePowerMetrics<UncertainValue<float>>>);
+
+template<typename T>
+requires(std::floating_point<T> or std::is_arithmetic_v<meta::fundamental_base_value_type_t<T>>)
+using SinglePhasePowerMetrics = PowerMetrics<T, 1UZ>;
+static_assert(BlockLike<SinglePhasePowerMetrics<float>>, "block constraints not satisfied");
+
+template<typename T, std::size_t nPhases>
+requires(std::floating_point<T> or std::is_arithmetic_v<meta::fundamental_base_value_type_t<T>>)
+struct PowerFactor : gr::Block<PowerFactor<T, nPhases>> {
+    using Description = Doc<R""(@brief PowerFactor
+
+Calculates the power factor and phase angle for each phase using active power (P) and apparent power (S) inputs.
+It computes the power factor as cos(𝜙)=P/S, and the phase angle 𝜙=arccos(P/S), ensuring values are within valid ranges.
+)"">;
+    // ports
+    std::vector<PortIn<T>>  P{nPhases}; // active power
+    std::vector<PortIn<T>>  S{nPhases}; // apparent power
+    std::vector<PortOut<T>> power_factor{nPhases};
+    std::vector<PortOut<T>> phase{nPhases};
+
+    GR_MAKE_REFLECTABLE(PowerFactor, P, S, power_factor, phase);
+
+    template<typename TInputSpanType, typename TOutputSpanType>
+    constexpr work::Status processBulk(std::span<TInputSpanType> pIn, std::span<TInputSpanType> sIn, //
+        std::span<TOutputSpanType> powerFactorOut, std::span<TOutputSpanType> phaseAngle) {
+        for (std::size_t phaseIdx = 0; phaseIdx < nPhases; ++phaseIdx) {
+            const std::size_t n_samples = pIn[phaseIdx].size();
+
+            for (std::size_t n = 0; n < n_samples; ++n) {
+                T P_i = pIn[phaseIdx][n];
+                T S_i = sIn[phaseIdx][n];
+
+                T cos_phi = S_i != T(0) ? P_i / S_i : T(0); // avoid division by zero
+                cos_phi   = std::clamp(cos_phi, T(-1), T(1));
+
+                T phi = std::acos(gr::value(cos_phi));
+
+                powerFactorOut[phaseIdx][n] = cos_phi;
+                phaseAngle[phaseIdx][n]     = phi;
+            }
+        }
+
+        return work::Status::OK;
+    }
+};
+
+template<typename T>
+using SinglePhasePowerFactorCalculator = PowerFactor<T, 1>;
+
+template<typename T>
+using ThreePhasePowerFactorCalculator = PowerFactor<T, 3>;
+
+template<typename T, std::size_t nPhases>
+requires((std::floating_point<T> or std::is_arithmetic_v<meta::fundamental_base_value_type_t<T>>) && (nPhases > 1)) // unbalance calculation requires at least two phases
+struct SystemUnbalance : Block<SystemUnbalance<T, nPhases>> {
+    using Description = Doc<R""(@brief SystemUnbalance
+
+Computes the total active power, voltage unbalance, and current unbalance in multi-phase systems. Unbalance percentages
+are calculated based on the maximum deviation from average RMS values across all phases.
+
+[0] IEC 61000-4-30 Electromagnetic compatibility (EMC) - Part 4-30:
+    Testing and measurement techniques - Power quality measurement methods, https://webstore.iec.ch/en/publication/21844
+)"">;
+
+    // ports
+    std::vector<PortIn<T>> voltage_rms_inputs{nPhases};  // U_rms_in
+    std::vector<PortIn<T>> current_rms_inputs{nPhases};  // I_rms_in
+    std::vector<PortIn<T>> active_power_inputs{nPhases}; // P_in
+
+    PortOut<T> total_active_power_output; // P_total_out
+    PortOut<T> voltage_unbalance_output;  // U_unbalance_out
+    PortOut<T> current_unbalance_output;  // I_unbalance_out
+
+    GR_MAKE_REFLECTABLE(SystemUnbalance, voltage_rms_inputs, current_rms_inputs, active_power_inputs, total_active_power_output, voltage_unbalance_output, current_unbalance_output);
+
+    template<typename TInputSpanType>
+    constexpr work::Status processBulk(std::span<TInputSpanType>& rmsUIn, std::span<TInputSpanType>& rmsIIn, std::span<TInputSpanType>& PIn, //
+        std::span<T>& totalP, std::span<T>& unbalancedU, std::span<T>& unbalancedI) {
+        const std::size_t n_samples = rmsUIn[0].size();
+
+        for (std::size_t n = 0; n < n_samples; ++n) {
+            T                      P_total = T(0);
+            std::array<T, nPhases> U_rms_values;
+            std::array<T, nPhases> I_rms_values;
+
+            for (std::size_t phaseIdx = 0; phaseIdx < nPhases; ++phaseIdx) {
+                U_rms_values[phaseIdx] = rmsUIn[phaseIdx][n];
+                I_rms_values[phaseIdx] = rmsIIn[phaseIdx][n];
+                P_total += PIn[phaseIdx][n];
+            }
+
+            // voltage unbalance
+            T U_avg      = std::accumulate(U_rms_values.begin(), U_rms_values.end(), T(0)) / static_cast<T>(nPhases);
+            T deltaU_max = std::transform_reduce(
+                U_rms_values.begin(), U_rms_values.end(), T(0), //
+                [](T a, T b) { return std::max(a, b); },        // reduction operator
+                [U_avg](T U_i) { return std::abs(gr::value(U_i - U_avg)); });
+
+            T VoltageUnbalance = gr::value(U_avg) > 0 ? (deltaU_max / U_avg) * T(100) : T(0);
+
+            // current Unbalance
+            T I_avg       = std::accumulate(I_rms_values.begin(), I_rms_values.end(), T(0)) / static_cast<T>(nPhases);
+            T Delta_I_max = *std::max_element(I_rms_values.begin(), I_rms_values.end(), //
+                [I_avg](T a, T b) { return std::abs(gr::value(a - I_avg)) < std::abs(gr::value(b - I_avg)); });
+            Delta_I_max   = std::abs(gr::value(Delta_I_max - I_avg));
+
+            T CurrentUnbalance = gr::value(I_avg) > 0 ? (Delta_I_max / I_avg) * T(100) : T(0);
+
+            // output values
+            totalP[n]      = P_total;
+            unbalancedU[n] = VoltageUnbalance;
+            unbalancedI[n] = CurrentUnbalance;
+        }
+
+        return work::Status::OK;
+    }
+};
+
+template<typename T>
+using TwoPhaseSystemUnbalanceCalculator = SystemUnbalance<T, 2>;
+
+template<typename T>
+using ThreePhaseSystemUnbalanceCalculator = SystemUnbalance<T, 3>;
+
+} // namespace gr::electrical
+
+inline static auto registerPowerMetrics = gr::registerBlock<gr::electrical::ThreePhasePowerMetrics, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>>(gr::globalBlockRegistry())              //
+                                          + gr::registerBlock<gr::electrical::SinglePhasePowerMetrics, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>>(gr::globalBlockRegistry())           //
+                                          + gr::registerBlock<gr::electrical::SinglePhasePowerFactorCalculator, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>>(gr::globalBlockRegistry())  //
+                                          + gr::registerBlock<gr::electrical::ThreePhasePowerFactorCalculator, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>>(gr::globalBlockRegistry())   //
+                                          + gr::registerBlock<gr::electrical::TwoPhaseSystemUnbalanceCalculator, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>>(gr::globalBlockRegistry()) //
+                                          + gr::registerBlock<gr::electrical::ThreePhaseSystemUnbalanceCalculator, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>>(gr::globalBlockRegistry());
+
+#endif // POWERESTIMATORS_HPP

--- a/blocks/electrical/test/CMakeLists.txt
+++ b/blocks/electrical/test/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_ut_test(qa_PowerEstimators)
+target_link_libraries(qa_PowerEstimators PRIVATE gr-electrical)

--- a/blocks/electrical/test/qa_PowerEstimators.cpp
+++ b/blocks/electrical/test/qa_PowerEstimators.cpp
@@ -1,0 +1,284 @@
+#include <boost/ut.hpp>
+
+#include <cmath>
+#include <random>
+
+#include <fmt/format.h>
+
+#include <gnuradio-4.0/Block.hpp>
+#include <gnuradio-4.0/Graph.hpp>
+#include <gnuradio-4.0/Scheduler.hpp>
+
+#include <gnuradio-4.0/electrical/PowerEstimators.hpp>
+#include <gnuradio-4.0/meta/UncertainValue.hpp>
+
+const boost::ut::suite<"Power Metrics Estimators"> powerEstimatorTests = [] {
+    using namespace boost::ut;
+    using namespace gr::electrical;
+
+    constexpr static float                freq           = 50.0f;    // Hz
+    constexpr static float                duration       = 1.0f;     // seconds
+    constexpr static float                sample_rate    = 10000.0f; // Hz
+    constexpr static float                output_rate    = 50.0f;    // Hz
+    constexpr static float                noiseAmplitude = 0.01f;    // rel. noise amplitude
+    constexpr static float                V_rms          = 230.0f;
+    constexpr static float                I_rms          = 10.0f;
+    constexpr static float                V_peak         = V_rms * std::numbers::sqrt2_v<float>;
+    constexpr static float                I_peak         = I_rms * std::numbers::sqrt2_v<float>;
+    constexpr static std::array<float, 3> phaseShift     = {+0.0f, -2.0f * std::numbers::pi_v<float> / 3.0f, +2.0f * std::numbers::pi_v<float> / 3.0f};
+    constexpr static std::array<float, 3> phaseOffset{0.1f, 0.2f, 0.3f};
+
+    "[Single, ThreePhase]PowerMetrics"_test =
+        []<typename TestParam>() {
+            using T                        = typename TestParam::first_type;
+            constexpr std::size_t kNPhases = TestParam::second_type::value;
+
+            // small phase delay for current in each phase
+            std::array<float, kNPhases> current_phase_delays = {};
+            current_phase_delays.fill(0.0f); // Initialize to zero
+            current_phase_delays[0] = 0.1f;  // phase delay in radians
+            if constexpr (kNPhases > 1) {
+                current_phase_delays[1] = 0.2f;
+                current_phase_delays[2] = 0.3f;
+            }
+
+            // create voltage and current signals
+            const auto                      nSamplesIn = static_cast<std::size_t>(duration * sample_rate);
+            std::vector<std::vector<T>>     voltageIn(kNPhases, std::vector<T>(nSamplesIn));
+            std::vector<std::vector<T>>     currentIn(kNPhases, std::vector<T>(nSamplesIn));
+            std::mt19937                    rng(42);                     // fixed seed for reproducibility
+            std::normal_distribution<float> noise(0.0f, noiseAmplitude); // 1% measurement noise
+
+            for (std::size_t phase = 0; phase < kNPhases; ++phase) {
+                float voltage_phase = phaseShift[phase];
+                float current_phase = phaseShift[phase] + current_phase_delays[phase];
+
+                for (std::size_t n = 0; n < nSamplesIn; ++n) {
+                    const float t       = static_cast<float>(n) / sample_rate;
+                    float       voltage = V_peak * (std::sin(2.0f * std::numbers::pi_v<float> * freq * t + voltage_phase) + noise(rng));
+                    float       current = I_peak * (std::sin(2.0f * std::numbers::pi_v<float> * freq * t + current_phase) + noise(rng));
+
+                    if constexpr (std::is_same_v<T, float>) {
+                        voltageIn[phase][n] = voltage;
+                        currentIn[phase][n] = current;
+                    } else { // T is gr::UncertainValue<float>
+                        voltageIn[phase][n] = gr::UncertainValue<float>(voltage, std::abs(V_peak) * noiseAmplitude);
+                        currentIn[phase][n] = gr::UncertainValue<float>(current, std::abs(V_peak) * noiseAmplitude);
+                    }
+                }
+            }
+
+            // prepare actual unit-test
+            const std::string         testName = fmt::format("{}", gr::meta::type_name<PowerMetrics<T, kNPhases>>());
+            PowerMetrics<T, kNPhases> block;
+            block.decim = sample_rate / output_rate;
+            block.initFilters();
+
+            // prepare input spans
+            std::vector<std::span<const T>> voltageSpans;
+            std::vector<std::span<const T>> currentSpans;
+
+            for (std::size_t i = 0; i < kNPhases; ++i) {
+                voltageSpans.emplace_back(voltageIn[i]);
+                currentSpans.emplace_back(currentIn[i]);
+            }
+
+            std::span<std::span<const T>> spanInVoltage(voltageSpans);
+            std::span<std::span<const T>> spanInCurrent(currentSpans);
+
+            // prepare output vectors
+            std::size_t                 nSamplesOut = nSamplesIn / block.decim;
+            std::vector<std::vector<T>> activePowerVec(kNPhases, std::vector<T>(nSamplesOut));
+            std::vector<std::vector<T>> reactivePowerVec(kNPhases, std::vector<T>(nSamplesOut));
+            std::vector<std::vector<T>> apparentPowerVec(kNPhases, std::vector<T>(nSamplesOut));
+            std::vector<std::vector<T>> rmsVoltageVec(kNPhases, std::vector<T>(nSamplesOut));
+            std::vector<std::vector<T>> rmsCurrentVec(kNPhases, std::vector<T>(nSamplesOut));
+
+            // prepare output spans
+            std::vector<std::span<T>> activePowerSpans;
+            std::vector<std::span<T>> reactivePowerSpans;
+            std::vector<std::span<T>> apparentPowerSpans;
+            std::vector<std::span<T>> rmsVoltageSpans;
+            std::vector<std::span<T>> rmsCurrentSpans;
+
+            for (std::size_t i = 0; i < kNPhases; ++i) {
+                activePowerSpans.emplace_back(activePowerVec[i]);
+                reactivePowerSpans.emplace_back(reactivePowerVec[i]);
+                apparentPowerSpans.emplace_back(apparentPowerVec[i]);
+                rmsVoltageSpans.emplace_back(rmsVoltageVec[i]);
+                rmsCurrentSpans.emplace_back(rmsCurrentVec[i]);
+            }
+
+            std::span<std::span<T>> activePower(activePowerSpans);
+            std::span<std::span<T>> reactivePower(reactivePowerSpans);
+            std::span<std::span<T>> apparentPower(apparentPowerSpans);
+            std::span<std::span<T>> rmsVoltage(rmsVoltageSpans);
+            std::span<std::span<T>> rmsCurrent(rmsCurrentSpans);
+
+            // call processBulk
+            expect(block.processBulk(spanInVoltage, spanInCurrent, //
+                       activePower, reactivePower, apparentPower,  //
+                       rmsVoltage, rmsCurrent) == gr::work::Status::OK);
+
+            // Check outputs - compute expected values
+            float expected_rms_voltage = V_rms;
+            float expected_rms_current = I_rms;
+            float tolerance_voltage    = expected_rms_voltage * 0.05f; // 5% tolerance
+            float tolerance_current    = expected_rms_current * 0.05f; // 5% tolerance
+
+            for (std::size_t phase = 0; phase < kNPhases; ++phase) {
+                float cos_phi = std::cos(current_phase_delays[phase]);
+                float sin_phi = std::sin(current_phase_delays[phase]);
+
+                float expected_active_power   = V_rms * I_rms * cos_phi;
+                float expected_reactive_power = V_rms * I_rms * sin_phi;
+                float expected_apparent_power = V_rms * I_rms;
+
+                float tolerance_power = expected_apparent_power * 0.1f; // 10% tolerance due to noise and filter settling
+
+                // last output sample
+                const std::size_t lastIdx = nSamplesOut - 1;
+                if constexpr (std::is_same_v<T, float>) { // T = float
+                    expect(approx(activePower[phase][lastIdx], expected_active_power, tolerance_power)) << fmt::format("{}: active power mismatch", testName);
+                    expect(approx(reactivePower[phase][lastIdx], expected_reactive_power, tolerance_power)) << fmt::format("{}: reactive power mismatch", testName);
+                    expect(approx(apparentPower[phase][lastIdx], expected_apparent_power, tolerance_power)) << fmt::format("{}: Apparent power mismatch", testName);
+                    expect(approx(rmsVoltage[phase][lastIdx], expected_rms_voltage, tolerance_voltage)) << fmt::format("{}: RMS voltage mismatch", testName);
+                    expect(approx(rmsCurrent[phase][lastIdx], expected_rms_current, tolerance_current)) << fmt::format("{}: RMS current mismatch", testName);
+                } else { // T = gr::UncertainValue<float>
+                    expect(approx(gr::value(activePower[phase][lastIdx]), expected_active_power, tolerance_power)) << fmt::format("{}: Active power value mismatch", testName);
+                    expect(gt(gr::uncertainty(activePower[phase][lastIdx]), 0.0f)) << fmt::format("{}: Active power uncertainty is zero", testName, activePower[phase][lastIdx]);
+
+                    expect(approx(gr::value(reactivePower[phase][lastIdx]), expected_reactive_power, tolerance_power)) << fmt::format("{}: Reactive power value mismatch", testName);
+                    expect(gt(gr::uncertainty(reactivePower[phase][lastIdx]), 0.0f)) << fmt::format("{}: Reactive power uncertainty {} is zero", testName, reactivePower[phase][lastIdx]);
+
+                    expect(approx(gr::value(apparentPower[phase][lastIdx]), expected_apparent_power, tolerance_power)) << fmt::format("{}: Apparent power value mismatch", testName);
+                    expect(gt(gr::uncertainty(apparentPower[phase][lastIdx]), 0.0f)) << fmt::format("{}: Apparent power uncertainty {} is zero", testName, apparentPower[phase][lastIdx]);
+
+                    expect(approx(gr::value(rmsVoltage[phase][lastIdx]), expected_rms_voltage, tolerance_voltage)) << fmt::format("{}: RMS voltage value mismatch", testName);
+                    expect(gt(gr::uncertainty(rmsVoltage[phase][lastIdx]), 0.0f)) << fmt::format("{}: RMS voltage uncertainty {} is zero", testName, rmsVoltage[phase][lastIdx]);
+
+                    expect(approx(gr::value(rmsCurrent[phase][lastIdx]), expected_rms_current, tolerance_current)) << fmt::format("{}: RMS current value mismatch", testName);
+                    expect(gt(gr::uncertainty(rmsCurrent[phase][lastIdx]), 0.0f)) << fmt::format("{}: RMS current uncertainty {} is zero", testName, rmsCurrent[phase][lastIdx]);
+                }
+            }
+        } |
+        std::tuple{
+            std::pair<float, std::integral_constant<std::size_t, 1>>{},                     //
+            std::pair<gr::UncertainValue<float>, std::integral_constant<std::size_t, 1>>{}, //
+            std::pair<float, std::integral_constant<std::size_t, 3>>{},                     //
+            std::pair<gr::UncertainValue<float>, std::integral_constant<std::size_t, 3>>{}  //
+        };
+
+    "PowerFactor"_test = []<typename TestParam>() {
+        using T                        = typename TestParam::first_type;
+        constexpr std::size_t kNPhases = TestParam::second_type::value;
+
+        PowerFactor<T, kNPhases> block;
+
+        std::vector<std::vector<T>> vecInActivePower(kNPhases);   // P
+        std::vector<std::vector<T>> vecInApparentPower(kNPhases); // S
+        std::vector<std::vector<T>> vecOutPowerFactor(kNPhases);
+        std::vector<std::vector<T>> vecOutPhaseAngle(kNPhases);
+        std::vector<T>              expectedPowerFactor(kNPhases);
+        std::vector<T>              expectedPhaseAngle(kNPhases);
+
+        for (std::size_t phaseIdx = 0; phaseIdx < kNPhases; ++phaseIdx) {
+            const auto cos_phi = static_cast<T>(std::cos(phaseOffset[phaseIdx]));
+            const auto S_i     = static_cast<T>(V_rms * I_rms);
+
+            vecInApparentPower[phaseIdx].push_back(S_i);
+            vecInActivePower[phaseIdx].push_back(S_i * cos_phi);
+            vecOutPowerFactor[phaseIdx].resize(1UZ);
+            vecOutPhaseAngle[phaseIdx].resize(1UZ);
+
+            expectedPowerFactor[phaseIdx] = cos_phi;
+            expectedPhaseAngle[phaseIdx]  = static_cast<T>(phaseOffset[phaseIdx]);
+        }
+
+        // prepare input and output spans
+        std::vector<std::span<const T>> spanInP;
+        std::vector<std::span<const T>> spanInS;
+        std::vector<std::span<T>>       spanOutPowerFactor;
+        std::vector<std::span<T>>       spanOutPhaseAngle;
+        for (std::size_t i = 0; i < kNPhases; ++i) {
+            spanInP.push_back(vecInActivePower[i]);
+            spanInS.push_back(vecInApparentPower[i]);
+            spanOutPowerFactor.push_back(vecOutPowerFactor[i]);
+            spanOutPhaseAngle.push_back(vecOutPhaseAngle[i]);
+        }
+
+        expect(block.processBulk(std::span{spanInP}, std::span{spanInS}, std::span{spanOutPowerFactor}, std::span{spanOutPhaseAngle}) == gr::work::Status::OK);
+
+        for (std::size_t phaseIdx = 0; phaseIdx < kNPhases; ++phaseIdx) {
+            expect(approx(spanOutPowerFactor[phaseIdx][0], expectedPowerFactor[phaseIdx], 1e-5)) << fmt::format("power factor mismatch for phase {}", phaseIdx);
+            expect(approx(spanOutPhaseAngle[phaseIdx][0], expectedPhaseAngle[phaseIdx], 1e-5)) << fmt::format("phase angle mismatch for phase {}", phaseIdx);
+        }
+    } | std::tuple{std::pair<double, std::integral_constant<std::size_t, 1>>{}, std::pair<double, std::integral_constant<std::size_t, 3>>{}};
+
+    "SystemUnbalance"_test = [] {
+        using T                        = double;
+        constexpr std::size_t kNPhases = 3;
+
+        SystemUnbalance<T, kNPhases> block;
+
+        // slight unbalance in voltages and currents
+        std::array<T, kNPhases> inU_rms = {T(V_rms), T(V_rms * 1.01f), T(V_rms * 0.99f)};
+        std::array<T, kNPhases> inI_rms = {T(I_rms), T(I_rms * 1.02f), T(I_rms * 0.98f)};
+
+        T                       expectedTotalP = 0.0;
+        std::array<T, kNPhases> activePower{};
+        for (std::size_t i = 0; i < kNPhases; ++i) {
+            T cosPhi       = static_cast<T>(std::cos(phaseOffset[i]));
+            T P_i          = inU_rms[i] * inI_rms[i] * cosPhi;
+            activePower[i] = P_i;
+            expectedTotalP += P_i;
+        }
+
+        // expected voltage and current unbalance
+        const T U_avg                    = std::accumulate(inU_rms.begin(), inU_rms.end(), T(0)) / static_cast<T>(kNPhases);
+        const T I_avg                    = std::accumulate(inI_rms.begin(), inI_rms.end(), T(0)) / static_cast<T>(kNPhases);
+        const T deltaU_max               = std::abs(*std::ranges::max_element(inU_rms, [U_avg](T a, T b) { return std::abs(a - U_avg) < std::abs(b - U_avg); }) - U_avg);
+        const T VoltageUnbalanceExpected = (deltaU_max / U_avg) * 100.0;
+        const T Delta_I_max              = std::abs(*std::ranges::max_element(inI_rms, [I_avg](T a, T b) { return std::abs(a - I_avg) < std::abs(b - I_avg); }) - I_avg);
+
+        T CurrentUnbalanceExpected = (Delta_I_max / I_avg) * 100.0;
+
+        // prepare input and output spans
+        std::vector<std::vector<T>> vecInU_rms(kNPhases);
+        std::vector<std::vector<T>> vecInI_rms(kNPhases);
+        std::vector<std::vector<T>> vecInActivePower(kNPhases);
+        std::vector<T>              vecOutTotalP(1UZ);
+        std::vector<T>              vecOutUnbalancedU(1UZ);
+        std::vector<T>              vecOutUnbalancedI(1UZ);
+
+        for (std::size_t i = 0UZ; i < kNPhases; ++i) {
+            vecInU_rms[i].push_back(inU_rms[i]);
+            vecInI_rms[i].push_back(inI_rms[i]);
+            vecInActivePower[i].push_back(activePower[i]);
+        }
+
+        std::vector<std::span<const T>> spanInU_rms;
+        std::vector<std::span<const T>> spanInI_rms;
+        std::vector<std::span<const T>> spanInP_in;
+        for (std::size_t i = 0; i < kNPhases; ++i) {
+            spanInU_rms.emplace_back(vecInU_rms[i]);
+            spanInI_rms.emplace_back(vecInI_rms[i]);
+            spanInP_in.emplace_back(vecInActivePower[i]);
+        }
+        std::span<std::span<const T>> spanSpanInU_rms(spanInU_rms);
+        std::span<std::span<const T>> spanSpanInI_rms(spanInI_rms);
+        std::span<std::span<const T>> spanSpanInP_in(spanInP_in);
+        std::span<T>                  spanOutTotalP(vecOutTotalP);
+        std::span<T>                  spanOutUnbalancedU(vecOutUnbalancedU);
+        std::span<T>                  spanOutUnbalancedI(vecOutUnbalancedI);
+
+        expect(block.processBulk(spanSpanInU_rms, spanSpanInI_rms, spanSpanInP_in, // inputs
+                   spanOutTotalP, spanOutUnbalancedU, spanOutUnbalancedI) == gr::work::Status::OK);
+
+        expect(approx(vecOutTotalP[0], expectedTotalP, expectedTotalP * 0.01)) << "total active power mismatch";
+        expect(approx(vecOutUnbalancedU[0], VoltageUnbalanceExpected, 0.1)) << "voltage unbalance mismatch";
+        expect(approx(vecOutUnbalancedI[0], CurrentUnbalanceExpected, 0.1)) << "current unbalance mismatch";
+    };
+};
+
+int main() { /* not needed for UT */ }

--- a/meta/include/gnuradio-4.0/meta/UncertainValue.hpp
+++ b/meta/include/gnuradio-4.0/meta/UncertainValue.hpp
@@ -45,23 +45,18 @@ struct UncertainValue {
 
     explicit(false) constexpr UncertainValue(T value_) noexcept : value(value_), uncertainty(static_cast<T>(0)) {}
 
-    constexpr UncertainValue(const UncertainValue &) noexcept = default;
-    constexpr UncertainValue(UncertainValue &&) noexcept      = default;
-    constexpr UncertainValue &
-    operator=(const UncertainValue &) noexcept
-            = default;
-    ~UncertainValue() = default;
+    constexpr UncertainValue(const UncertainValue&) noexcept            = default;
+    constexpr UncertainValue(UncertainValue&&) noexcept                 = default;
+    constexpr UncertainValue& operator=(const UncertainValue&) noexcept = default;
+    ~UncertainValue()                                                   = default;
 
-    constexpr UncertainValue &
-    operator=(const T &other) noexcept {
+    constexpr UncertainValue& operator=(const T& other) noexcept {
         value       = other;
         uncertainty = static_cast<T>(0);
         return *this;
     }
 
-    auto
-    operator<=>(UncertainValue const &) const
-            = default;
+    auto operator<=>(UncertainValue const&) const = default;
 };
 
 template<typename T>
@@ -71,24 +66,22 @@ template<typename T>
 concept UncertainValueLike = gr::meta::is_instantiation_of<T, UncertainValue>;
 
 template<typename T>
-    requires arithmetic_or_complex_like<meta::fundamental_base_value_type_t<T>>
-[[nodiscard]] inline constexpr auto
-value(const T &val) noexcept {
+requires arithmetic_or_complex_like<meta::fundamental_base_value_type_t<T>>
+[[nodiscard]] inline constexpr auto value(const T& val) noexcept {
     if constexpr (UncertainValueLike<T>) {
         return val.value;
     } else {
-        val;
+        return val;
     }
 }
 
 template<typename T>
-    requires arithmetic_or_complex_like<meta::fundamental_base_value_type_t<T>>
-[[nodiscard]] inline constexpr auto
-uncertainty(const T &val) noexcept {
+requires arithmetic_or_complex_like<meta::fundamental_base_value_type_t<T>>
+[[nodiscard]] inline constexpr auto uncertainty(const T& val) noexcept {
     if constexpr (UncertainValueLike<T>) {
         return val.uncertainty;
     } else {
-        return T();
+        return meta::fundamental_base_value_type_t<T>(0);
     }
 }
 
@@ -113,23 +106,22 @@ using UncertainValueType_t = detail::UncertainValueValueType<T>::type;
 // resolution)
 
 template<typename T, typename U, typename ValueTypeT = UncertainValueType_t<T>, typename ValueTypeU = UncertainValueType_t<U>>
-    requires(UncertainValueLike<T> || UncertainValueLike<U>) && std::is_same_v<meta::fundamental_base_value_type_t<ValueTypeT>, meta::fundamental_base_value_type_t<ValueTypeU>>
-[[nodiscard]] inline constexpr auto
-operator+(const T &lhs, const U &rhs) noexcept {
+requires(UncertainValueLike<T> || UncertainValueLike<U>) && std::is_same_v<meta::fundamental_base_value_type_t<ValueTypeT>, meta::fundamental_base_value_type_t<ValueTypeU>>
+[[nodiscard]] inline constexpr auto operator+(const T& lhs, const U& rhs) noexcept {
     if constexpr (UncertainValueLike<T> && UncertainValueLike<U>) {
         using ResultType = decltype(lhs.value + rhs.value);
         if constexpr (meta::complex_like<ValueTypeT> || meta::complex_like<ValueTypeU>) {
             // we are dealing with complex numbers -> use the standard uncorrelated calculation.
-            ResultType newUncertainty = { std::hypot(std::real(lhs.uncertainty), std::real(rhs.uncertainty)), std::hypot(std::imag(lhs.uncertainty), std::imag(rhs.uncertainty)) };
-            return UncertainValue<ResultType>{ lhs.value + rhs.value, newUncertainty };
+            ResultType newUncertainty = {std::hypot(std::real(lhs.uncertainty), std::real(rhs.uncertainty)), std::hypot(std::imag(lhs.uncertainty), std::imag(rhs.uncertainty))};
+            return UncertainValue<ResultType>{lhs.value + rhs.value, newUncertainty};
         } else {
             // both ValueType[T,U] are arithmetic uncertainties
-            return UncertainValue<ResultType>{ lhs.value + rhs.value, std::hypot(lhs.uncertainty, rhs.uncertainty) };
+            return UncertainValue<ResultType>{lhs.value + rhs.value, std::hypot(lhs.uncertainty, rhs.uncertainty)};
         }
     } else if constexpr (UncertainValueLike<T> && arithmetic_or_complex_like<ValueTypeU>) {
-        return T{ lhs.value + rhs, lhs.uncertainty };
+        return T{lhs.value + rhs, lhs.uncertainty};
     } else if constexpr (arithmetic_or_complex_like<ValueTypeT> && UncertainValueLike<U>) {
-        return U{ lhs + rhs.value, rhs.uncertainty };
+        return U{lhs + rhs.value, rhs.uncertainty};
     } else {
         static_assert(gr::meta::always_false<T>, "branch should never reach here due to default '+' definition");
         return lhs + rhs; // unlikely to be called due to default '+' definition
@@ -137,94 +129,85 @@ operator+(const T &lhs, const U &rhs) noexcept {
 }
 
 template<UncertainValueLike T, typename U>
-inline constexpr T &
-operator+=(T &lhs, const U &rhs) noexcept {
+inline constexpr T& operator+=(T& lhs, const U& rhs) noexcept {
     lhs = lhs + rhs;
     return lhs;
 }
 
 template<UncertainValueLike T, typename ValueTypeT = UncertainValueType_t<T>>
-inline constexpr T
-operator+(const T &val) {
+inline constexpr T operator+(const T& val) {
     if constexpr (meta::complex_like<ValueTypeT>) {
         return val;
     } else {
-        return { std::abs(val.value), std::abs(val.uncertainty) };
+        return {std::abs(val.value), std::abs(val.uncertainty)};
     }
 }
 
 template<typename T, typename U, typename ValueTypeT = UncertainValueType_t<T>, typename ValueTypeU = UncertainValueType_t<U>>
-    requires(UncertainValueLike<T> || UncertainValueLike<U>) && std::is_same_v<meta::fundamental_base_value_type_t<ValueTypeT>, meta::fundamental_base_value_type_t<ValueTypeU>>
-[[nodiscard]] inline constexpr auto
-operator-(const T &lhs, const U &rhs) noexcept {
+requires(UncertainValueLike<T> || UncertainValueLike<U>) && std::is_same_v<meta::fundamental_base_value_type_t<ValueTypeT>, meta::fundamental_base_value_type_t<ValueTypeU>>
+[[nodiscard]] inline constexpr auto operator-(const T& lhs, const U& rhs) noexcept {
     if constexpr (UncertainValueLike<T> && UncertainValueLike<U>) {
         using ResultType = decltype(lhs.value - rhs.value);
         if constexpr (meta::complex_like<ValueTypeT> || meta::complex_like<ValueTypeU>) {
             // we are dealing with complex numbers -> use the standard uncorrelated calculation.
-            ResultType newUncertainty = { std::hypot(std::real(lhs.uncertainty), std::real(rhs.uncertainty)), std::hypot(std::imag(lhs.uncertainty), std::imag(rhs.uncertainty)) };
-            return UncertainValue<ResultType>{ lhs.value - rhs.value, newUncertainty };
+            ResultType newUncertainty = {std::hypot(std::real(lhs.uncertainty), std::real(rhs.uncertainty)), std::hypot(std::imag(lhs.uncertainty), std::imag(rhs.uncertainty))};
+            return UncertainValue<ResultType>{lhs.value - rhs.value, newUncertainty};
         } else {
             // both ValueType[T,U] are arithmetic uncertainties
-            return UncertainValue<ResultType>{ lhs.value - rhs.value, std::hypot(lhs.uncertainty, rhs.uncertainty) };
+            return UncertainValue<ResultType>{lhs.value - rhs.value, std::hypot(lhs.uncertainty, rhs.uncertainty)};
         }
     } else if constexpr (UncertainValueLike<T> && arithmetic_or_complex_like<ValueTypeU>) {
-        return T{ lhs.value - rhs, lhs.uncertainty };
+        return T{lhs.value - rhs, lhs.uncertainty};
     } else if constexpr (arithmetic_or_complex_like<ValueTypeT> && UncertainValueLike<U>) {
-        return U{ lhs - rhs.value, rhs.uncertainty };
+        return U{lhs - rhs.value, rhs.uncertainty};
     } else {
         static_assert(gr::meta::always_false<T>, "branch should never reach here due to default '-' definition");
     }
 }
 
 template<UncertainValueLike T, typename U>
-inline constexpr T &
-operator-=(T &lhs, const U &rhs) noexcept {
+inline constexpr T& operator-=(T& lhs, const U& rhs) noexcept {
     lhs = lhs - rhs;
     return lhs;
 }
 
 template<UncertainValueLike T>
-inline constexpr T
-operator-(const T &val) {
-    return { -val.value, val.uncertainty };
+inline constexpr T operator-(const T& val) {
+    return {-val.value, val.uncertainty};
 }
 
 template<typename T, typename U, typename ValueTypeT = UncertainValueType_t<T>, typename ValueTypeU = UncertainValueType_t<U>>
-    requires(UncertainValueLike<T> || UncertainValueLike<U>) && std::is_same_v<meta::fundamental_base_value_type_t<ValueTypeT>, meta::fundamental_base_value_type_t<ValueTypeU>>
-[[nodiscard]] inline constexpr auto
-operator*(const T &lhs, const U &rhs) noexcept {
+requires(UncertainValueLike<T> || UncertainValueLike<U>) && std::is_same_v<meta::fundamental_base_value_type_t<ValueTypeT>, meta::fundamental_base_value_type_t<ValueTypeU>>
+[[nodiscard]] inline constexpr auto operator*(const T& lhs, const U& rhs) noexcept {
     if constexpr (UncertainValueLike<T> && UncertainValueLike<U>) {
         using ResultType = decltype(lhs.value * rhs.value);
         if constexpr (meta::complex_like<ValueTypeT> || meta::complex_like<ValueTypeU>) {
             // we are dealing with complex numbers -> use standard uncorrelated calculation
-            ResultType newUncertainty = { std::hypot(std::real(lhs.value) * std::real(rhs.uncertainty), std::real(rhs.value) * std::real(lhs.uncertainty)),
-                                          std::hypot(std::imag(lhs.value) * std::imag(rhs.uncertainty), std::imag(rhs.value) * std::imag(lhs.uncertainty)) };
-            return UncertainValue<ResultType>{ lhs.value * rhs.value, newUncertainty };
+            ResultType newUncertainty = {std::hypot(std::real(lhs.value) * std::real(rhs.uncertainty), std::real(rhs.value) * std::real(lhs.uncertainty)), std::hypot(std::imag(lhs.value) * std::imag(rhs.uncertainty), std::imag(rhs.value) * std::imag(lhs.uncertainty))};
+            return UncertainValue<ResultType>{lhs.value * rhs.value, newUncertainty};
         } else {
             // both ValueType[T,U] are arithmetic uncertainties
             auto combinedUncertainty = std::hypot(lhs.value * rhs.uncertainty, rhs.value * lhs.uncertainty);
-            return UncertainValue<ResultType>{ lhs.value * rhs.value, combinedUncertainty };
+            return UncertainValue<ResultType>{lhs.value * rhs.value, combinedUncertainty};
         }
     } else if constexpr (UncertainValueLike<T> && arithmetic_or_complex_like<ValueTypeU>) {
-        return T{ lhs.value * rhs, lhs.uncertainty * rhs };
+        return T{lhs.value * rhs, lhs.uncertainty * rhs};
     } else if constexpr (arithmetic_or_complex_like<ValueTypeT> && UncertainValueLike<U>) {
-        return U{ lhs * rhs.value, lhs * rhs.uncertainty };
+        return U{lhs * rhs.value, lhs * rhs.uncertainty};
     } else {
         static_assert(gr::meta::always_false<T>, "branch should never reach here due to default '*' definition");
     }
 }
 
 template<UncertainValueLike T, typename U>
-inline constexpr T &
-operator*=(T &lhs, const U &rhs) noexcept {
+inline constexpr T& operator*=(T& lhs, const U& rhs) noexcept {
     lhs = lhs * rhs;
     return lhs;
 }
 
 template<typename T, typename U, typename ValueTypeT = UncertainValueType_t<T>, typename ValueTypeU = UncertainValueType_t<U>>
-    requires(UncertainValueLike<T> || UncertainValueLike<U>) && std::is_same_v<meta::fundamental_base_value_type_t<ValueTypeT>, meta::fundamental_base_value_type_t<ValueTypeU>>
-[[nodiscard]] inline constexpr auto
-operator/(const T &lhs, const U &rhs) noexcept {
+requires(UncertainValueLike<T> || UncertainValueLike<U>) && std::is_same_v<meta::fundamental_base_value_type_t<ValueTypeT>, meta::fundamental_base_value_type_t<ValueTypeU>>
+[[nodiscard]] inline constexpr auto operator/(const T& lhs, const U& rhs) noexcept {
     if constexpr (UncertainValueLike<T> && UncertainValueLike<U>) {
         using ResultType = decltype(lhs.value * rhs.value);
         if constexpr (meta::complex_like<ValueTypeT> || meta::complex_like<ValueTypeU>) {
@@ -232,35 +215,32 @@ operator/(const T &lhs, const U &rhs) noexcept {
             ResultType newUncertainty;
             if constexpr (std::is_arithmetic_v<ValueTypeT> && meta::complex_like<ValueTypeU>) {
                 // LHS is real, RHS is complex
-                newUncertainty = { std::sqrt(std::pow(lhs.uncertainty / std::real(rhs.value), 2)), std::sqrt(std::pow(std::imag(rhs.uncertainty) * lhs.value / std::norm(rhs.value), 2)) };
+                newUncertainty = {std::sqrt(std::pow(lhs.uncertainty / std::real(rhs.value), 2)), std::sqrt(std::pow(std::imag(rhs.uncertainty) * lhs.value / std::norm(rhs.value), 2))};
             } else if constexpr (meta::complex_like<ValueTypeT> && std::is_arithmetic_v<ValueTypeU>) {
                 // LHS is complex, RHS is real
-                newUncertainty = { std::hypot(std::real(lhs.uncertainty) / rhs.value, rhs.uncertainty * std::real(lhs.value) / std::pow(rhs.value, 2)),
-                                   std::sqrt(std::pow(std::imag(lhs.uncertainty) / rhs.value, 2)) };
+                newUncertainty = {std::hypot(std::real(lhs.uncertainty) / rhs.value, rhs.uncertainty * std::real(lhs.value) / std::pow(rhs.value, 2)), std::sqrt(std::pow(std::imag(lhs.uncertainty) / rhs.value, 2))};
             } else {
-                newUncertainty = { std::hypot(std::real(lhs.uncertainty) / std::real(rhs.value), std::real(rhs.uncertainty) * std::real(lhs.value) / std::norm(rhs.value)),
-                                   std::hypot(std::imag(lhs.uncertainty) / std::imag(rhs.value), std::imag(rhs.uncertainty) * std::imag(lhs.value) / std::norm(rhs.value)) };
+                newUncertainty = {std::hypot(std::real(lhs.uncertainty) / std::real(rhs.value), std::real(rhs.uncertainty) * std::real(lhs.value) / std::norm(rhs.value)), std::hypot(std::imag(lhs.uncertainty) / std::imag(rhs.value), std::imag(rhs.uncertainty) * std::imag(lhs.value) / std::norm(rhs.value))};
             }
 
-            return UncertainValue<ResultType>{ lhs.value / rhs.value, newUncertainty };
+            return UncertainValue<ResultType>{lhs.value / rhs.value, newUncertainty};
         } else {
             // both ValueType[T,U] are arithmetic uncertainties
-            auto combinedUncertainty = std::hypot(lhs.uncertainty / rhs.value, rhs.uncertainty * lhs.value / std::pow(rhs.value, 2));
-            return UncertainValue<ResultType>{ lhs.value / rhs.value, combinedUncertainty };
+            ResultType combinedUncertainty = std::hypot(lhs.uncertainty / rhs.value, rhs.uncertainty * lhs.value / std::pow(rhs.value, 2));
+            return UncertainValue<ResultType>{lhs.value / rhs.value, combinedUncertainty};
         }
     } else if constexpr (UncertainValueLike<T> && arithmetic_or_complex_like<ValueTypeU>) {
-        return T{ lhs.value / rhs, lhs.uncertainty / std::abs(rhs) };
+        return T{lhs.value / rhs, lhs.uncertainty / std::abs(rhs)};
     } else if constexpr (arithmetic_or_complex_like<ValueTypeT> && UncertainValueLike<U>) {
         auto rhsMagSquared = std::norm(rhs.value);
-        return U{ lhs / rhs.value, rhs.uncertainty * std::abs(lhs) / rhsMagSquared };
+        return U{lhs / rhs.value, rhs.uncertainty * std::abs(lhs) / rhsMagSquared};
     } else {
         static_assert(gr::meta::always_false<T>, "branch should never reach here due to default '/' definition");
     }
 }
 
 template<UncertainValueLike T, typename U>
-inline constexpr T &
-operator/=(T &lhs, const U &rhs) noexcept {
+inline constexpr T& operator/=(T& lhs, const U& rhs) noexcept {
     lhs = lhs / rhs;
     return lhs;
 }
@@ -270,72 +250,79 @@ operator/=(T &lhs, const U &rhs) noexcept {
 namespace gr::math {
 
 template<gr::UncertainValueLike T, std::floating_point U, typename ValueTypeT = gr::UncertainValueType_t<T>>
-    requires std::is_same_v<gr::meta::fundamental_base_value_type_t<ValueTypeT>, U> || std::integral<U>
-[[nodiscard]] inline constexpr T
-pow(const T &base, U exponent) noexcept {
-    if (base.value == 0.0) [[unlikely]] {
+requires std::is_same_v<gr::meta::fundamental_base_value_type_t<ValueTypeT>, U> || std::integral<U>
+[[nodiscard]] inline constexpr T pow(const T& base, U exponent) noexcept {
+    if (base.value == static_cast<meta::fundamental_base_value_type_t<ValueTypeT>>(0)) [[unlikely]] {
         if (exponent == 0) [[unlikely]] {
-            return T{ 1, 0 };
+            return T{1, 0};
         } else {
-            return T{ 0, 0 };
+            return T{0, 0};
         }
     }
 
     ValueTypeT newValue = std::pow(base.value, exponent);
     if constexpr (gr::meta::complex_like<ValueTypeT>) {
         auto val = exponent / base.value * newValue;
-        return T{ newValue, std::sqrt(val * std::conj(val)) * base.uncertainty };
+        return T{newValue, std::sqrt(val * std::conj(val)) * base.uncertainty};
     } else {
-        return T{ newValue, std::abs(newValue * exponent * base.uncertainty / base.value) };
+        return T{newValue, std::abs(newValue * exponent * base.uncertainty / base.value)};
     }
 }
 
 template<gr::UncertainValueLike T, gr::UncertainValueLike U, typename ValueTypeT = gr::UncertainValueType_t<T>, typename ValueTypeU = gr::UncertainValueType_t<T>>
-    requires std::is_same_v<gr::meta::fundamental_base_value_type_t<ValueTypeT>, gr::meta::fundamental_base_value_type_t<ValueTypeU>>
-[[nodiscard]] inline constexpr T
-pow(const T &base, const U &exponent) noexcept {
+requires std::is_same_v<gr::meta::fundamental_base_value_type_t<ValueTypeT>, gr::meta::fundamental_base_value_type_t<ValueTypeU>>
+[[nodiscard]] inline constexpr T pow(const T& base, const U& exponent) noexcept {
     if (base.value == 0.0) [[unlikely]] {
         if (exponent.value == static_cast<ValueTypeU>(0)) [[unlikely]] {
-            return T{ 1, 0 };
+            return T{1, 0};
         } else {
-            return T{ 0, 0 };
+            return T{0, 0};
         }
     }
 
     ValueTypeT newValue = std::pow(base.value, exponent.value);
     if constexpr (gr::meta::complex_like<ValueTypeT>) {
         auto hypot = [](auto a, auto b) { return std::sqrt(std::real(a * std::conj(a) + b * std::conj(b))); }; // c*c⃰ == is always real valued
-        return T{ newValue, hypot(exponent.value / base.value * newValue * base.uncertainty, std::log(base.value) * newValue * exponent.uncertainty) };
+        return T{newValue, hypot(exponent.value / base.value * newValue * base.uncertainty, std::log(base.value) * newValue * exponent.uncertainty)};
     } else {
-        return T{ newValue, std::abs(newValue) * std::hypot(exponent.value / base.value * base.uncertainty, std::log(base.value) * exponent.uncertainty) };
+        return T{newValue, std::abs(newValue) * std::hypot(exponent.value / base.value * base.uncertainty, std::log(base.value) * exponent.uncertainty)};
     }
 }
 
-template<gr::UncertainValueLike T>
-[[nodiscard]] inline constexpr T
-sqrt(const T &value) noexcept {
-    return gr::math::pow(value, 0.5);
-}
-
-template<gr::UncertainValueLike T, typename ValueTypeT = gr::UncertainValueType_t<T>>
-[[nodiscard]] inline constexpr T
-sin(const T &x) noexcept {
-    return T{ std::sin(x.value), std::abs(std::cos(x.value) * x.uncertainty) };
-}
-
-template<gr::UncertainValueLike T, typename ValueTypeT = gr::UncertainValueType_t<T>>
-[[nodiscard]] inline constexpr T
-cos(const T &x) noexcept {
-    return T{ std::cos(x.value), std::abs(std::sin(x.value) * x.uncertainty) };
-}
-
-template<gr::UncertainValueLike T, typename ValueTypeT = gr::UncertainValueType_t<T>>
-[[nodiscard]] inline constexpr T
-exp(const T &x) noexcept {
-    if constexpr (gr::meta::complex_like<ValueTypeT>) {
-        return gr::math::pow(gr::UncertainValue<ValueTypeT>{ std::numbers::e_v<typename ValueTypeT::value_type>, static_cast<ValueTypeT>(0) }, x);
+template<typename T>
+[[nodiscard]] inline constexpr T sqrt(const T& value) noexcept {
+    if constexpr (gr::UncertainValueLike<T>) {
+        using ValueType = meta::fundamental_base_value_type_t<T>;
+        return gr::math::pow(value, ValueType(0.5));
     } else {
-        return gr::math::pow(gr::UncertainValue<ValueTypeT>{ std::numbers::e_v<ValueTypeT>, static_cast<ValueTypeT>(0) }, x);
+        return std::sqrt(value);
+    }
+}
+
+template<typename T>
+[[nodiscard]] inline constexpr T sin(const T& x) noexcept {
+    if constexpr (gr::UncertainValueLike<T>) {
+        return T{std::sin(x.value), std::abs(std::cos(x.value) * x.uncertainty)};
+    } else {
+        return std::sin(x);
+    }
+}
+
+template<typename T>
+[[nodiscard]] inline constexpr T cos(const T& x) noexcept {
+    if constexpr (gr::UncertainValueLike<T>) {
+        return T{std::cos(x.value), std::abs(std::sin(x.value) * x.uncertainty)};
+    } else {
+        return std::cos(x);
+    }
+}
+
+template<gr::UncertainValueLike T, typename ValueTypeT = gr::UncertainValueType_t<T>>
+[[nodiscard]] inline constexpr T exp(const T& x) noexcept {
+    if constexpr (gr::meta::complex_like<ValueTypeT>) {
+        return gr::math::pow(gr::UncertainValue<ValueTypeT>{std::numbers::e_v<typename ValueTypeT::value_type>, static_cast<ValueTypeT>(0)}, x);
+    } else {
+        return gr::math::pow(gr::UncertainValue<ValueTypeT>{std::numbers::e_v<ValueTypeT>, static_cast<ValueTypeT>(0)}, x);
     }
 }
 

--- a/meta/test/qa_UncertainValue.cpp
+++ b/meta/test/qa_UncertainValue.cpp
@@ -11,12 +11,11 @@
 namespace test::detail {
 
 template<class TLhs, class TRhs, class TEpsilon>
-[[nodiscard]] constexpr auto
-approx(const TLhs &lhs, const TRhs &rhs, const TEpsilon &epsilon) {
+[[nodiscard]] constexpr auto approx(const TLhs& lhs, const TRhs& rhs, const TEpsilon& epsilon) {
     if constexpr (gr::meta::complex_like<TLhs>) {
-        return boost::ut::detail::and_{ boost::ut::detail::approx_{ lhs.real(), rhs.real(), epsilon }, boost::ut::detail::approx_{ lhs.imag(), rhs.imag(), epsilon } };
+        return boost::ut::detail::and_{boost::ut::detail::approx_{lhs.real(), rhs.real(), epsilon}, boost::ut::detail::approx_{lhs.imag(), rhs.imag(), epsilon}};
     } else {
-        return boost::ut::detail::approx_{ lhs, rhs, epsilon };
+        return boost::ut::detail::approx_{lhs, rhs, epsilon};
     }
 }
 } // namespace test::detail
@@ -29,36 +28,41 @@ const boost::ut::suite uncertainValue = [] {
 
     if (std::getenv("DISABLE_SENSITIVE_TESTS") == nullptr) {
         // conditionally enable visual tests outside the CI
-        boost::ext::ut::cfg<override> = { .tag = { "visual", "benchmarks" } };
+        boost::ext::ut::cfg<override> = {.tag = {"visual", "benchmarks"}};
     }
 
     "addition UncertainValue + UncertainValue"_test = [] {
-        constexpr UncertainValue<double> a{ 10.0, 3.0 };
-        constexpr UncertainValue<double> b{ 20.0, 4.0 };
+        constexpr UncertainValue<double> a{10.0, 3.0};
+        constexpr UncertainValue<double> b{20.0, 4.0};
 
-        expect(30.0_d == (a + b).value) << "value: 10. + 20.";
-        expect(5.0_d == (a + b).uncertainty) << "uncertainty: sqrt(3.0^2 + 4.0^2) = sqrt(9 + 16) = sqrt(25) = 5"; //
+        expect(eq(30.0_d, (a + b).value)) << "value: 10. + 20.";
+        expect(eq(30.0_d, gr::value(a + b))) << "value(10. + 20.)";
+        expect(eq(30.0_d, gr::value(30.0_d))) << "value(double = 30.) = double(30.)";
+        expect(eq(5.0_d, (a + b).uncertainty)) << "uncertainty: sqrt(3.0^2 + 4.0^2) = sqrt(9 + 16) = sqrt(25) = 5";
+        expect(eq(5.0_d, gr::uncertainty(a + b))) << "uncertainty: sqrt(3.0^2 + 4.0^2) = sqrt(9 + 16) = sqrt(25) = 5";
+        expect(!UncertainValueLike<double>);
+        expect(eq(0.0_d, gr::uncertainty(42.0_d))) << "uncertainty(42_d) -> fundamental double type has no uncertainty";
     };
 
     "addition UncertainValue + arithmetic value"_test = [] {
-        UncertainValue<double> a{ 10.0, 3.0 };
-        const double           b{ 20.0 };
+        UncertainValue a{10.0, 3.0};
+        const double   b{20.0};
 
-        expect(30.0_d == (a + b).value) << "value: 10. + 20.";
-        expect(3.0_d == (a + b).uncertainty) << "uncertainty: 3.0 (no change)";
+        expect(eq(30.0_d, (a + b).value)) << "value: 10. + 20.";
+        expect(eq(3.0_d, (a + b).uncertainty)) << "uncertainty: 3.0 (no change)";
     };
 
     "addition arithmetic value + UncertainValue"_test = [] {
-        double                 a{ 10.0 };
-        UncertainValue<double> b{ 20.0, 4.0 };
+        double                 a{10.0};
+        UncertainValue<double> b{20.0, 4.0};
 
         expect(30.0_d == (a + b).value) << "value: 10. + 20.";
         expect(4.0_d == (a + b).uncertainty) << "uncertainty: 3.0 (no change)";
     };
 
     "addition arithmetic value + arithmetic value"_test = [] {
-        constexpr const double a{ 10.0 };
-        constexpr const double b{ 20.0 };
+        constexpr const double a{10.0};
+        constexpr const double b{20.0};
 
         constexpr UncertainValue<double> result1 = a + b;       // lvalue assignment
         constexpr UncertainValue<double> result2 = 10.0 + 20.0; // rvalue assignment
@@ -69,21 +73,21 @@ const boost::ut::suite uncertainValue = [] {
     };
 
     "operator += UncertainValue"_test = [] {
-        UncertainValue<double> a{ 10.0, 2.0 };
-        UncertainValue<double> b{ 5.0, 1.5 };
+        UncertainValue<double> a{10.0, 2.0};
+        UncertainValue<double> b{5.0, 1.5};
         a += b;
         expect(eq(15.0, a.value));
         expect(eq(2.5, a.uncertainty)); // Assuming appropriate uncertainty calculation
     };
 
     "operator+(UncertainValue&)"_test = [] {
-        constexpr UncertainValue<double> orig{ -4.0, -0.5 };
+        constexpr UncertainValue<double> orig{-4.0, -0.5};
         UncertainValue<double>           inverted = +orig;
 
         expect(eq(inverted.value, 4.0));
         expect(eq(inverted.uncertainty, 0.5));
 
-        constexpr UncertainValue<std::complex<double>> corig{ -4.0, -0.5 };
+        constexpr UncertainValue<std::complex<double>> corig{-4.0, -0.5};
         constexpr UncertainValue<std::complex<double>> cinverted = +corig;
 
         expect(eq(cinverted.value, corig.value)); // N.B. does not modify complex values
@@ -91,32 +95,32 @@ const boost::ut::suite uncertainValue = [] {
     };
 
     "subtraction UncertainValue - UncertainValue"_test = [] {
-        constexpr UncertainValue<double> a{ 20.0, 3.0 };
-        constexpr UncertainValue<double> b{ 10.0, 4.0 };
+        constexpr UncertainValue<double> a{20.0, 3.0};
+        constexpr UncertainValue<double> b{10.0, 4.0};
 
         expect(10.0_d == (a - b).value) << "value: 20. - 10.";
         expect(5.0_d == (a - b).uncertainty) << "uncertainty: sqrt(3.0^2 + 4.0^2) = sqrt(9 + 16) = sqrt(25) = 5";
     };
 
     "subtraction UncertainValue - arithmetic value"_test = [] {
-        constexpr UncertainValue<double> a{ 20.0, 3.0 };
-        constexpr const double           b{ 10.0 };
+        constexpr UncertainValue<double> a{20.0, 3.0};
+        constexpr const double           b{10.0};
 
         expect(10.0_d == (a - b).value) << "value: 20. - 10.";
         expect(3.0_d == (a - b).uncertainty) << "uncertainty: 3.0 (no change)";
     };
 
     "subtraction arithmetic value - UncertainValue"_test = [] {
-        constexpr double                 a{ 20.0 };
-        constexpr UncertainValue<double> b{ 10.0, 4.0 };
+        constexpr double                 a{20.0};
+        constexpr UncertainValue<double> b{10.0, 4.0};
 
         expect(10.0_d == (a - b).value) << "value: 20. - 10.";
         expect(4.0_d == (a - b).uncertainty) << "uncertainty: sqrt(3.0^2 + 4.0^2) = sqrt(9 + 16) = sqrt(25) = 5";
     };
 
     "subtraction arithmetic value - arithmetic value"_test = [] {
-        constexpr double a{ 20.0 };
-        constexpr double b{ 10.0 };
+        constexpr double a{20.0};
+        constexpr double b{10.0};
 
         constexpr UncertainValue<double> result = a - b;
         expect(constant<10.0_d == result.value>) << "value: 20. - 10.";
@@ -124,16 +128,16 @@ const boost::ut::suite uncertainValue = [] {
     };
 
     "operator -= UncertainValue"_test = [] {
-        constexpr UncertainValue<double> a0{ 4.0, 0.5 };
-        UncertainValue<double>           a{ 4.0, 0.5 };
-        UncertainValue<double>           b{ 3.0, 0.2 };
+        constexpr UncertainValue<double> a0{4.0, 0.5};
+        UncertainValue<double>           a{4.0, 0.5};
+        UncertainValue<double>           b{3.0, 0.2};
         a -= b;
         expect(eq((a0 - b).value, a.value));
         expect(eq((a0 - b).uncertainty, a.uncertainty)); // Assuming appropriate uncertainty calculation
     };
 
     "operator-(UncertainValue&)"_test = [] {
-        constexpr UncertainValue<double> orig{ 4.0, 0.5 };
+        constexpr UncertainValue<double> orig{4.0, 0.5};
         constexpr UncertainValue<double> inverted = -orig;
 
         expect(eq(inverted.value, -orig.value));
@@ -141,32 +145,32 @@ const boost::ut::suite uncertainValue = [] {
     };
 
     "multiplication UncertainValue * UncertainValue"_test = [] {
-        constexpr UncertainValue<double> a{ 4.0, 0.5 };
-        constexpr UncertainValue<double> b{ 3.0, 0.5 };
+        constexpr UncertainValue<double> a{4.0, 0.5};
+        constexpr UncertainValue<double> b{3.0, 0.5};
 
         expect(12.0_d == (a * b).value) << "value: 4. * 3.";
         expect(2.5_d == (a * b).uncertainty) << "uncertainty: sqrt((4*0.5)^2 + (3*0.5)^2) = sqrt(4 + 2.25) = sqrt(6.25) = 2.5";
     };
 
     "multiplication UncertainValue * arithmetic value"_test = [] {
-        constexpr UncertainValue<double> a{ 4.0, 0.5 };
-        constexpr double                 b{ 3.0 };
+        constexpr UncertainValue<double> a{4.0, 0.5};
+        constexpr double                 b{3.0};
 
         expect(12.0_d == (a * b).value) << "value: 4. * 3.";
         expect(1.5_d == (a * b).uncertainty) << "uncertainty: 0.5 * 3 = 1.5";
     };
 
     "multiplication arithmetic value * UncertainValue"_test = [] {
-        constexpr double                 a{ 4.0 };
-        constexpr UncertainValue<double> b{ 3.0, 0.5 };
+        constexpr double                 a{4.0};
+        constexpr UncertainValue<double> b{3.0, 0.5};
 
         expect(constant<12.0_d == (a * b).value>) << "value: 4. * 3.";
         expect(constant<2.0_d == (a * b).uncertainty>) << "uncertainty: 0.5 * 4 = 1.5";
     };
 
     "multiplication arithmetic value * arithmetic value"_test = [] {
-        constexpr double a{ 4.0 };
-        constexpr double b{ 3.0 };
+        constexpr double a{4.0};
+        constexpr double b{3.0};
 
         constexpr UncertainValue<double> result = a * b;
         expect(constant<12.0_d == result.value>) << "value: 4. * 3.";
@@ -174,41 +178,41 @@ const boost::ut::suite uncertainValue = [] {
     };
 
     "operator *= UncertainValue"_test = [] {
-        constexpr UncertainValue<double> a0{ 4.0, 0.5 };
-        UncertainValue<double>           a{ 4.0, 0.5 };
-        UncertainValue<double>           b{ 3.0, 0.2 };
+        constexpr UncertainValue<double> a0{4.0, 0.5};
+        UncertainValue<double>           a{4.0, 0.5};
+        UncertainValue<double>           b{3.0, 0.2};
         a *= b;
         expect(eq((a0 * b).value, a.value));
         expect(eq((a0 * b).uncertainty, a.uncertainty)); // Assuming appropriate uncertainty calculation
     };
 
     "division UncertainValue / UncertainValue"_test = [] {
-        constexpr UncertainValue<double> a{ 16.0, 2.0 };
-        constexpr UncertainValue<double> b{ 4.0, 0.5 };
+        constexpr UncertainValue<double> a{16.0, 2.0};
+        constexpr UncertainValue<double> b{4.0, 0.5};
 
         expect(4.0_d == (a / b).value) << "value: 16. / 4.";
         expect(0.707_d == (a / b).uncertainty) << "uncertainty: sqrt((2/4)^2 + (16*0.5/4^2)^2) = sqrt(0.25 + 0.25) = sqrt(0.5) ≈ 0.707";
     };
 
     "division UncertainValue / arithmetic value"_test = [] {
-        constexpr UncertainValue<double> a{ 16.0, 2.0 };
-        constexpr const double           b{ 4.0 };
+        constexpr UncertainValue<double> a{16.0, 2.0};
+        constexpr const double           b{4.0};
 
         expect(4.0_d == (a / b).value) << "value: 16. / 4.";
         expect(0.5_d == (a / b).uncertainty) << "uncertainty: 2.0 / 4 = 0.5";
     };
 
     "division arithmetic value / UncertainValue"_test = [] {
-        constexpr double                 a{ 16.0 };
-        constexpr UncertainValue<double> b{ 4.0, 0.5 };
+        constexpr double                 a{16.0};
+        constexpr UncertainValue<double> b{4.0, 0.5};
 
         expect(4.0_d == (a / b).value) << "value: 16. / 4.";
         expect(0.5_d == (a / b).uncertainty);
     };
 
     "division arithmetic value / arithmetic value"_test = [] {
-        constexpr double a{ 16.0 };
-        constexpr double b{ 4.0 };
+        constexpr double a{16.0};
+        constexpr double b{4.0};
 
         constexpr UncertainValue<double> result = a / b;
         expect(constant<4.0_d == result.value>) << "value: 16. / 4.";
@@ -216,9 +220,9 @@ const boost::ut::suite uncertainValue = [] {
     };
 
     "operator /= UncertainValue"_test = [] {
-        constexpr UncertainValue<double> a0{ 4.0, 0.5 };
-        UncertainValue<double>           a{ 4.0, 0.5 };
-        UncertainValue<double>           b{ 3.0, 0.2 };
+        constexpr UncertainValue<double> a0{4.0, 0.5};
+        UncertainValue<double>           a{4.0, 0.5};
+        UncertainValue<double>           b{3.0, 0.2};
         a /= b;
         expect(eq((a0 / b).value, a.value));
         expect(eq((a0 / b).uncertainty, a.uncertainty)); // Assuming appropriate uncertainty calculation
@@ -227,56 +231,56 @@ const boost::ut::suite uncertainValue = [] {
     // Complex Addition Tests
     using Complex                                                     = std::complex<double>;
     "addition UncertainValue<Complex> + UncertainValue<Complex>"_test = [] {
-        UncertainValue<Complex> a{ 10.0 + 5.0i, 3.0 + 4.0i };
-        UncertainValue<Complex> b{ 20.0 + 10.0i, 4.0 + 3.0i };
+        UncertainValue<Complex> a{10.0 + 5.0i, 3.0 + 4.0i};
+        UncertainValue<Complex> b{20.0 + 10.0i, 4.0 + 3.0i};
 
         expect(approx(30.0 + 15.0i, (a + b).value, 1e-9)) << "value: (10 + 5i) + (20 + 10i)";
         expect(approx(5.0 + 5.0i, (a + b).uncertainty, 1e-9)) << "uncertainty: sqrt((3^2 + 4^2), (1^2 + 2^2))";
     };
 
     "addition UncertainValue<Complex> + Complex"_test = [] {
-        UncertainValue<Complex> a{ 10.0 + 5.0i, 3.0 + 4.0i };
-        Complex                 b{ 20.0 + 10.0i };
+        UncertainValue<Complex> a{10.0 + 5.0i, 3.0 + 4.0i};
+        Complex                 b{20.0 + 10.0i};
 
         expect(approx(30.0 + 15.0i, (a + b).value, 1e-9)) << "value: (10 + 5i) + (20 + 10i)";
         expect(approx(3.0 + 4.0i, (a + b).uncertainty, 1e-9)) << "uncertainty: 3 + 4i (no change)";
     };
 
     "addition Complex + UncertainValue<Complex>"_test = [] {
-        Complex                 a{ 10.0 + 5.0i };
-        UncertainValue<Complex> b{ 20.0 + 10.0i, 4.0 + 2.0i };
+        Complex                 a{10.0 + 5.0i};
+        UncertainValue<Complex> b{20.0 + 10.0i, 4.0 + 2.0i};
 
         expect(approx(30.0 + 15.0i, (a + b).value, 1e-9)) << "value: (10 + 5i) + (20 + 10i)";
         expect(approx(4.0 + 2.0i, (a + b).uncertainty, 1e-9)) << "uncertainty: 4 + 2i (no change)";
     };
 
     "addition UncertainValue<Complex> + arithmetic value"_test = [] {
-        UncertainValue<Complex> a{ 10.0 + 5.0i, 3.0 + 4.0i };
-        UncertainValue<double>  b{ 20.0, 4.0 };
+        UncertainValue<Complex> a{10.0 + 5.0i, 3.0 + 4.0i};
+        UncertainValue<double>  b{20.0, 4.0};
 
         expect(approx(30.0 + 5.0i, (a + b).value, 1e-9)) << "value: (10 + 5i) + (20 + 10i)";
         expect(approx(5.0 + 4.0i, (a + b).uncertainty, 1e-9)) << "uncertainty: 3 + 4i (no change)";
     };
 
     "addition UncertainValue<Complex> + UncertainValue<arithmetic>"_test = [] {
-        UncertainValue<Complex> a{ 10.0 + 5.0i, 3.0 + 4.0i };
-        double                  b{ 20.0 };
+        UncertainValue<Complex> a{10.0 + 5.0i, 3.0 + 4.0i};
+        double                  b{20.0};
 
         expect(approx(30.0 + 5.0i, (a + b).value, 1e-9)) << "value: (10 + 5i) + (20 + 10i)";
         expect(approx(3.0 + 4.0i, (a + b).uncertainty, 1e-9)) << "uncertainty: 3 + 4i (no change)";
     };
 
     "addition UncertainValue<arithmetic> + UncertainValue<Complex>"_test = [] {
-        UncertainValue<double>  a{ 10.0, 3.0 };
-        UncertainValue<Complex> b{ 20.0 + 10.0i, 4.0 + 2.0i };
+        UncertainValue<double>  a{10.0, 3.0};
+        UncertainValue<Complex> b{20.0 + 10.0i, 4.0 + 2.0i};
 
         expect(approx(30.0 + 10.0i, (a + b).value, 1e-9)) << "value: (10 + 5i) + (20 + 10i)";
         expect(approx(5.0 + 2.0i, (a + b).uncertainty, 1e-9)) << "uncertainty: sqrt((3^2 + 4^2), (1^2 + 2^2))";
     };
 
     "addition arithmetic value + UncertainValue<Complex>"_test = [] {
-        double                  a{ 10.0 };
-        UncertainValue<Complex> b{ 20.0 + 10.0i, 4.0 + 2.0i };
+        double                  a{10.0};
+        UncertainValue<Complex> b{20.0 + 10.0i, 4.0 + 2.0i};
 
         expect(approx(30.0 + 10.0i, (a + b).value, 1e-9)) << "value: (10 + 5i) + (20 + 10i)";
         expect(approx(4.0 + 2.0i, (a + b).uncertainty, 1e-9)) << "uncertainty: 4 + 2i (no change)";
@@ -284,56 +288,56 @@ const boost::ut::suite uncertainValue = [] {
 
     // Complex Subtraction Tests
     "subtraction UncertainValue<Complex> - UncertainValue<Complex>"_test = [] {
-        UncertainValue<Complex> a{ 20.0 + 10.0i, 3.0 + 4.0i };
-        UncertainValue<Complex> b{ 10.0 + 5.0i, 4.0 + 3.0i };
+        UncertainValue<Complex> a{20.0 + 10.0i, 3.0 + 4.0i};
+        UncertainValue<Complex> b{10.0 + 5.0i, 4.0 + 3.0i};
 
         expect(approx(10.0 + 5.0i, (a - b).value, 1e-9)) << "value: (20 + 10i) - (10 + 5i)";
         expect(approx(5.0 + 5.0i, (a - b).uncertainty, 1e-9)) << "uncertainty: sqrt((3^2 + 4^2), (1^2 + 2^2))";
     };
 
     "subtraction UncertainValue<Complex> - Complex"_test = [] {
-        UncertainValue<Complex> a{ 20.0 + 10.0i, 3.0 + 1.0i };
-        Complex                 b{ 10.0 + 5.0i };
+        UncertainValue<Complex> a{20.0 + 10.0i, 3.0 + 1.0i};
+        Complex                 b{10.0 + 5.0i};
 
         expect(approx(10.0 + 5.0i, (a - b).value, 1e-9)) << "value: (20 + 10i) - (10 + 5i)";
         expect(approx(3.0 + 1.0i, (a - b).uncertainty, 1e-9)) << "uncertainty: 3 + 1i (no change)";
     };
 
     "subtraction Complex - UncertainValue<Complex>"_test = [] {
-        Complex                 a{ 20.0 + 10.0i };
-        UncertainValue<Complex> b{ 10.0 + 5.0i, 4.0 + 2.0i };
+        Complex                 a{20.0 + 10.0i};
+        UncertainValue<Complex> b{10.0 + 5.0i, 4.0 + 2.0i};
 
         expect(approx(10.0 + 5.0i, (a - b).value, 1e-9)) << "value: (20 + 10i) - (10 + 5i)";
         expect(approx(4.0 + 2.0i, (a - b).uncertainty, 1e-9)) << "uncertainty: 4 + 2i (no change)";
     };
 
     "subtraction UncertainValue<Complex> - arithmetic value"_test = [] {
-        UncertainValue<Complex> a{ 20.0 + 10.0i, 3.0 + 4.0i };
-        double                  b{ 10.0 };
+        UncertainValue<Complex> a{20.0 + 10.0i, 3.0 + 4.0i};
+        double                  b{10.0};
 
         expect(approx(10.0 + 10.0i, (a - b).value, 1e-9)) << "value: (20 + 10i) - 10";
         expect(approx(3.0 + 4.0i, (a - b).uncertainty, 1e-9)) << "uncertainty: 3 + 4i (no change)";
     };
 
     "subtraction UncertainValue<Complex> - UncertainValue<arithmetic>"_test = [] {
-        UncertainValue<Complex> a{ 20.0 + 10.0i, 3.0 + 4.0i };
-        UncertainValue<double>  b{ 10.0, 4.0 };
+        UncertainValue<Complex> a{20.0 + 10.0i, 3.0 + 4.0i};
+        UncertainValue<double>  b{10.0, 4.0};
 
         expect(approx(10.0 + 10.0i, (a - b).value, 1e-9)) << "value: (20 + 10i) - 10";
         expect(approx(5.0 + 4.0i, (a - b).uncertainty, 1e-9)) << "uncertainty: sqrt((3^2 + 4^2), (4^2))";
     };
 
     "subtraction arithmetic value - UncertainValue<Complex>"_test = [] {
-        double                  a{ 20.0 };
-        UncertainValue<Complex> b{ 10.0 + 5.0i, 4.0 + 3.0i };
+        double                  a{20.0};
+        UncertainValue<Complex> b{10.0 + 5.0i, 4.0 + 3.0i};
 
         expect(approx(10.0 - 5.0i, (a - b).value, 1e-9)) << "value: 20 - (10 + 5i)";
         expect(approx(4.0 + 3.0i, (a - b).uncertainty, 1e-9)) << "uncertainty: 4 + 3i (no change)";
     };
 
     "subtraction UncertainValue<arithmetic> - UncertainValue<Complex>"_test = [] {
-        UncertainValue<double>  a{ 20.0, 3.0 };
-        UncertainValue<Complex> b{ 10.0 + 5.0i, 4.0 + 2.0i };
+        UncertainValue<double>  a{20.0, 3.0};
+        UncertainValue<Complex> b{10.0 + 5.0i, 4.0 + 2.0i};
 
         expect(approx(10.0 - 5.0i, (a - b).value, 1e-9)) << "value: 20 - (10 + 5i)";
         expect(approx(5.0 + 2.0i, (a - b).uncertainty, 1e-9)) << "uncertainty: sqrt((3^2), (4^2 + 2^2))";
@@ -341,56 +345,56 @@ const boost::ut::suite uncertainValue = [] {
 
     // Complex Multiplication Tests
     "multiplication UncertainValue<Complex> * UncertainValue<Complex>"_test = [] {
-        UncertainValue<Complex> a{ 2.0 + 3.0i, .75 + 4.0i };
-        UncertainValue<Complex> b{ 4.0 + 5.0i, 2.0 + 3.0i };
+        UncertainValue<Complex> a{2.0 + 3.0i, .75 + 4.0i};
+        UncertainValue<Complex> b{4.0 + 5.0i, 2.0 + 3.0i};
 
         expect(approx(-7.0 + 22.0i, (a * b).value, 1e-9));
         expect(approx(5.0 + 21.9317i, (a * b).uncertainty, 1e-3));
     };
 
     "multiplication UncertainValue<Complex> * Complex"_test = [] {
-        UncertainValue<Complex> a{ 2.0 + 3.0i, 0.2 + 0.3i };
-        Complex                 b{ 4.0 + 5.0i };
+        UncertainValue<Complex> a{2.0 + 3.0i, 0.2 + 0.3i};
+        Complex                 b{4.0 + 5.0i};
 
         expect(approx(-7.0 + 22.0i, (a * b).value, 1e-9)) << "value: (2 + 3i) * (4 + 5i)";
         expect(approx(-0.7 + 2.2i, (a * b).uncertainty, 1e-9));
     };
 
     "multiplication Complex * UncertainValue<Complex>"_test = [] {
-        Complex                 a{ 2.0 + 3.0i };
-        UncertainValue<Complex> b{ 4.0 + 5.0i, 0.4 + 0.5i };
+        Complex                 a{2.0 + 3.0i};
+        UncertainValue<Complex> b{4.0 + 5.0i, 0.4 + 0.5i};
 
         expect(approx(-7.0 + 22.0i, (a * b).value, 1e-9)) << "value: (2 + 3i) * (4 + 5i)";
         expect(approx(-0.7 + 2.2i, (a * b).uncertainty, 1e-9));
     };
 
     "multiplication UncertainValue<Complex> * arithmetic value"_test = [] {
-        UncertainValue<Complex> a{ 2.0 + 3.0i, 0.2 + 0.3i };
-        double                  b{ 4.0 };
+        UncertainValue<Complex> a{2.0 + 3.0i, 0.2 + 0.3i};
+        double                  b{4.0};
 
         expect(approx(8.0 + 12.0i, (a * b).value, 1e-9)) << "value: (2 + 3i) * 4";
         expect(approx(0.8 + 1.2i, (a * b).uncertainty, 1e-9));
     };
 
     "multiplication UncertainValue<Complex> * UncertainValue<arithmetic>"_test = [] {
-        UncertainValue<Complex> a{ 2.0 + 3.0i, 0.2 + 0.3i };
-        UncertainValue<double>  b{ 4.0, 0.4 };
+        UncertainValue<Complex> a{2.0 + 3.0i, 0.2 + 0.3i};
+        UncertainValue<double>  b{4.0, 0.4};
 
         expect(approx(8.0 + 12.0i, (a * b).value, 1e-9)) << "value: (2 + 3i) * 4";
         expect(approx(1.13137 + 0.0i, (a * b).uncertainty, 1e-3));
     };
 
     "multiplication arithmetic value * UncertainValue<Complex>"_test = [] {
-        double                  a{ 2.0 };
-        UncertainValue<Complex> b{ 4.0 + 5.0i, 0.4 + 0.5i };
+        double                  a{2.0};
+        UncertainValue<Complex> b{4.0 + 5.0i, 0.4 + 0.5i};
 
         expect(approx(8.0 + 10.0i, (a * b).value, 1e-9)) << "value: 2 * (4 + 5i)";
         expect(approx(0.8 + 1.0i, (a * b).uncertainty, 1e-9)) << "uncertainty: 2 * (0.4 + 0.5i)";
     };
 
     "multiplication UncertainValue<arithmetic> * UncertainValue<Complex>"_test = [] {
-        UncertainValue<double>  a{ 2.0, 0.2 };
-        UncertainValue<Complex> b{ 4.0 + 5.0i, 0.4 + 0.5i };
+        UncertainValue<double>  a{2.0, 0.2};
+        UncertainValue<Complex> b{4.0 + 5.0i, 0.4 + 0.5i};
 
         expect(approx(8.0 + 10.0i, (a * b).value, 1e-9)) << "value: 2 * (4 + 5i)";
         expect(approx(1.13137 + 0i, (a * b).uncertainty, 1e-3));
@@ -398,56 +402,56 @@ const boost::ut::suite uncertainValue = [] {
 
     // Complex Division Tests
     "division UncertainValue<Complex> / UncertainValue<Complex>"_test = [] {
-        UncertainValue<Complex> a{ 8.0 + 6.0i, 0.8 + 0.6i };
-        UncertainValue<Complex> b{ 3.0 + 4.0i, 0.3 + 0.4i };
+        UncertainValue<Complex> a{8.0 + 6.0i, 0.8 + 0.6i};
+        UncertainValue<Complex> b{3.0 + 4.0i, 0.3 + 0.4i};
 
         expect(approx((8.0 + 6.0i) / (3.0 + 4.0i), (a / b).value, 1e-9)) << "value: (8 + 6i) / (3 + 4i)";
         expect(approx(0.28342 + 0.17809i, (a / b).uncertainty, 1e-3));
     };
 
     "division UncertainValue<Complex> / Complex"_test = [] {
-        UncertainValue<Complex> a{ 2.0 + 3.0i, 0.2 + 0.3i };
-        Complex                 b{ 4.0 + 5.0i };
+        UncertainValue<Complex> a{2.0 + 3.0i, 0.2 + 0.3i};
+        Complex                 b{4.0 + 5.0i};
 
         expect(approx((2.0 + 3.0i) / (4.0 + 5.0i), (a / b).value, 1e-9)) << "value: (2 + 3i) / (4 + 5i)";
         expect(approx(0.0312348 + 0.0468521i, (a / b).uncertainty, 1e-3));
     };
 
     "division Complex / UncertainValue<Complex>"_test = [] {
-        Complex                 a{ 2.0 + 3.0i };
-        UncertainValue<Complex> b{ 4.0 + 5.0i, 0.4 + 0.5i };
+        Complex                 a{2.0 + 3.0i};
+        UncertainValue<Complex> b{4.0 + 5.0i, 0.4 + 0.5i};
 
         expect(approx((2.0 + 3.0i) / (4.0 + 5.0i), (a / b).value, 1e-9)) << "value: (2 + 3i) / (4 + 5i)";
         expect(approx(0.0351761 + 0.0439701i, (a / b).uncertainty, 1e-3));
     };
 
     "division UncertainValue<Complex> / arithmetic value"_test = [] {
-        UncertainValue<Complex> a{ 2.0 + 3.0i, 0.2 + 0.3i };
-        double                  b{ 4.0 };
+        UncertainValue<Complex> a{2.0 + 3.0i, 0.2 + 0.3i};
+        double                  b{4.0};
 
         expect(approx((2.0 + 3.0i) / 4.0, (a / b).value, 1e-9)) << "value: (2 + 3i) / 4";
         expect(approx((0.2 + 0.3i) / 4.0, (a / b).uncertainty, 1e-9)) << "uncertainty: (0.2 + 0.3i) / 4";
     };
 
     "division UncertainValue<Complex> / UncertainValue<arithmetic>"_test = [] {
-        UncertainValue<Complex> a{ 2.0 + 3.0i, 0.2 + 0.3i };
-        UncertainValue<double>  b{ 4.0, 0.4 };
+        UncertainValue<Complex> a{2.0 + 3.0i, 0.2 + 0.3i};
+        UncertainValue<double>  b{4.0, 0.4};
 
         expect(approx((2.0 + 3.0i) / 4.0, (a / b).value, 1e-9)) << "value: (2 + 3i) / 4";
         expect(approx(0.0707107 + 0.075i, (a / b).uncertainty, 1e-3));
     };
 
     "division arithmetic value / UncertainValue<Complex>"_test = [] {
-        double                  a{ 2.0 };
-        UncertainValue<Complex> b{ 4.0 + 5.0i, 0.4 + 0.5i };
+        double                  a{2.0};
+        UncertainValue<Complex> b{4.0 + 5.0i, 0.4 + 0.5i};
 
         expect(approx(2.0 / (4.0 + 5.0i), (a / b).value, 1e-9)) << "value: 2 / (4 + 5i)";
         expect(approx(0.0195122 + 0.0243902i, (a / b).uncertainty, 1e-3));
     };
 
     "division UncertainValue<arithmetic> / UncertainValue<Complex>"_test = [] {
-        UncertainValue<double>  a{ 2.0, 0.2 };
-        UncertainValue<Complex> b{ 4.0 + 5.0i, 0.4 + 0.5i };
+        UncertainValue<double>  a{2.0, 0.2};
+        UncertainValue<Complex> b{4.0 + 5.0i, 0.4 + 0.5i};
 
         expect(approx(2.0 / (4.0 + 5.0i), (a / b).value, 1e-9)) << "value: 2 / (4 + 5i)";
         expect(approx(0.05 + 0.0243902i, (a / b).uncertainty, 1e-3));
@@ -457,57 +461,57 @@ const boost::ut::suite uncertainValue = [] {
 
     "std::pow(UncertainValue<arithmetic>, arithmetic)"_test = [] {
         using Un = UncertainValue<double>;
-        expect(eq(4.0, (gr::math::pow(Un{ 2.0, 1.0 }, 2.0)).value));
-        expect(eq(4.0, (gr::math::pow(Un{ 2.0, 1.0 }, 2.0)).uncertainty));
+        expect(eq(4.0, (gr::math::pow(Un{2.0, 1.0}, 2.0)).value));
+        expect(eq(4.0, (gr::math::pow(Un{2.0, 1.0}, 2.0)).uncertainty));
 
-        expect(eq(0.0, (gr::math::pow(Un{ 0.0, 1.0 }, 2.0)).value));
-        expect(eq(0.0, (gr::math::pow(Un{ 0.0, 1.0 }, 2.0)).uncertainty));
+        expect(eq(0.0, (gr::math::pow(Un{0.0, 1.0}, 2.0)).value));
+        expect(eq(0.0, (gr::math::pow(Un{0.0, 1.0}, 2.0)).uncertainty));
 
-        expect(eq(1.0, (gr::math::pow(Un{ 3.0, 1.0 }, 0.0)).value));
-        expect(eq(0.0, (gr::math::pow(Un{ 3.0, 1.0 }, 0.0)).uncertainty));
+        expect(eq(1.0, (gr::math::pow(Un{3.0, 1.0}, 0.0)).value));
+        expect(eq(0.0, (gr::math::pow(Un{3.0, 1.0}, 0.0)).uncertainty));
 
-        expect(eq(1.0, (gr::math::pow(Un{ 0.0, 1.0 }, 0.0)).value));
-        expect(eq(0.0, (gr::math::pow(Un{ 0.0, 1.0 }, 0.0)).uncertainty));
+        expect(eq(1.0, (gr::math::pow(Un{0.0, 1.0}, 0.0)).value));
+        expect(eq(0.0, (gr::math::pow(Un{0.0, 1.0}, 0.0)).uncertainty));
     };
 
     "gr::math::pow(UncertainValue<arithmetic>, UncertainValue<arithmetic>)"_test = [] {
         using Un = UncertainValue<double>;
         using std::numbers::e;
 
-        expect(eq(e * e, (gr::math::pow(Un{ e, e * 2.0 }, Un{ 2.0, 3.0 })).value));
-        expect(approx(e * e * 5.0, (gr::math::pow(Un{ e, e * 2.0 }, Un{ 2.0, 3.0 })).uncertainty, 1e-3));
+        expect(eq(e * e, (gr::math::pow(Un{e, e * 2.0}, Un{2.0, 3.0})).value));
+        expect(approx(e * e * 5.0, (gr::math::pow(Un{e, e * 2.0}, Un{2.0, 3.0})).uncertainty, 1e-3));
 
         // reproduce previous special case of uncertain value + arithmetic, here via setting uncertainty of exponent to 0
-        expect(eq(4.0, (gr::math::pow(Un{ 2.0, 1.0 }, Un{ 2.0, 0.0 })).value));
-        expect(eq(4.0, (gr::math::pow(Un{ 2.0, 1.0 }, Un{ 2.0, 0.0 })).uncertainty));
+        expect(eq(4.0, (gr::math::pow(Un{2.0, 1.0}, Un{2.0, 0.0})).value));
+        expect(eq(4.0, (gr::math::pow(Un{2.0, 1.0}, Un{2.0, 0.0})).uncertainty));
 
-        expect(eq(0.0, (gr::math::pow(Un{ 0.0, 1.0 }, Un{ 2.0, 0.0 })).value));
-        expect(eq(0.0, (gr::math::pow(Un{ 0.0, 1.0 }, Un{ 2.0, 0.0 })).uncertainty));
+        expect(eq(0.0, (gr::math::pow(Un{0.0, 1.0}, Un{2.0, 0.0})).value));
+        expect(eq(0.0, (gr::math::pow(Un{0.0, 1.0}, Un{2.0, 0.0})).uncertainty));
 
-        expect(eq(1.0, (gr::math::pow(Un{ 3.0, 1.0 }, Un{ 0.0, 0.0 })).value));
-        expect(eq(0.0, (gr::math::pow(Un{ 3.0, 1.0 }, Un{ 0.0, 0.0 })).uncertainty));
+        expect(eq(1.0, (gr::math::pow(Un{3.0, 1.0}, Un{0.0, 0.0})).value));
+        expect(eq(0.0, (gr::math::pow(Un{3.0, 1.0}, Un{0.0, 0.0})).uncertainty));
 
-        expect(eq(1.0, (gr::math::pow(Un{ 0.0, 1.0 }, Un{ 0.0, 0.0 })).value));
-        expect(eq(0.0, (gr::math::pow(Un{ 0.0, 1.0 }, Un{ 0.0, 0.0 })).uncertainty));
+        expect(eq(1.0, (gr::math::pow(Un{0.0, 1.0}, Un{0.0, 0.0})).value));
+        expect(eq(0.0, (gr::math::pow(Un{0.0, 1.0}, Un{0.0, 0.0})).uncertainty));
 
-        expect(eq(0.0, (gr::math::pow(Un{ 0.0, 0.1 }, Un{ 2.0, 0.1 })).value));
-        expect(eq(0.0, (gr::math::pow(Un{ 0.0, 0.1 }, Un{ 2.0, 0.1 })).uncertainty));
+        expect(eq(0.0, (gr::math::pow(Un{0.0, 0.1}, Un{2.0, 0.1})).value));
+        expect(eq(0.0, (gr::math::pow(Un{0.0, 0.1}, Un{2.0, 0.1})).uncertainty));
     };
 
     "gr::math::pow(UncertainValue<std::complex<double>, arithmetic)"_test = [] {
         using ComplexUncertain = UncertainValue<std::complex<double>>;
 
         {
-            ComplexUncertain base{ { std::sqrt(2.0), std::sqrt(2.0) }, 0.1 + 0.1i };
+            ComplexUncertain base{{std::sqrt(2.0), std::sqrt(2.0)}, 0.1 + 0.1i};
             double           exponent = 2.0;
 
             gr::UncertainValueLike auto result = gr::math::pow(base, exponent);
             expect(approx(std::pow(base.value, exponent), result.value, 1e-9));
-            expect(approx(std::complex<double>{ 0.4, 0.4 }, result.uncertainty, 1e-6));
+            expect(approx(std::complex<double>{0.4, 0.4}, result.uncertainty, 1e-6));
         }
 
         {
-            ComplexUncertain base{ 0.0 + 0.0i, 0.1 + 0.1i };
+            ComplexUncertain base{0.0 + 0.0i, 0.1 + 0.1i};
             double           exponent = 2.0;
 
             gr::UncertainValueLike auto result = gr::math::pow(base, exponent);
@@ -516,7 +520,7 @@ const boost::ut::suite uncertainValue = [] {
         }
 
         {
-            ComplexUncertain base{ 1.0 + 2.0i, 0.1 + 0.1i };
+            ComplexUncertain base{1.0 + 2.0i, 0.1 + 0.1i};
             double           exponent = 0.0;
 
             gr::UncertainValueLike auto result = gr::math::pow(base, exponent);
@@ -525,7 +529,7 @@ const boost::ut::suite uncertainValue = [] {
         }
 
         {
-            ComplexUncertain base{ 0.0, 0.1 + 0.1i };
+            ComplexUncertain base{0.0, 0.1 + 0.1i};
             double           exponent = 0.0;
 
             gr::UncertainValueLike auto result = gr::math::pow(base, exponent);
@@ -539,66 +543,66 @@ const boost::ut::suite uncertainValue = [] {
         using Un               = UncertainValue<double>;
 
         {
-            ComplexUncertain base{ { std::sqrt(2.0), std::sqrt(2.0) }, 0.1 + 0.1i };
-            Un               exponent = { 2.0, 0.0 };
+            ComplexUncertain base{{std::sqrt(2.0), std::sqrt(2.0)}, 0.1 + 0.1i};
+            Un               exponent = {2.0, 0.0};
 
             gr::UncertainValueLike auto result = gr::math::pow(base, exponent);
             expect(approx(std::pow(base.value, exponent.value), result.value, 1e-9));
-            expect(approx(std::complex<double>{ 0.565685, 0 }, result.uncertainty, 1e-6)); // calculated with Wolfram
+            expect(approx(std::complex<double>{0.565685, 0}, result.uncertainty, 1e-6)); // calculated with Wolfram
         }
 
         {
-            ComplexUncertain base{ { std::sqrt(2.0), std::sqrt(2.0) }, 0.1 + 0.1i };
-            ComplexUncertain exponent = { { 2.0 }, { 0.0 } };
+            ComplexUncertain base{{std::sqrt(2.0), std::sqrt(2.0)}, 0.1 + 0.1i};
+            ComplexUncertain exponent = {{2.0}, {0.0}};
 
             gr::UncertainValueLike auto result = gr::math::pow(base, exponent);
             expect(approx(std::pow(base.value, exponent.value), result.value, 1e-9));
-            expect(approx(std::complex<double>{ 0.565685, 0.0 }, result.uncertainty, 1e-6)); // calculated with Wolfram
+            expect(approx(std::complex<double>{0.565685, 0.0}, result.uncertainty, 1e-6)); // calculated with Wolfram
         }
 
         {
-            ComplexUncertain base{ { std::sqrt(2.0), std::sqrt(2.0) }, 0.1 + 0.1i };
-            Un               exponent = { 2.0, 0.1 };
+            ComplexUncertain base{{std::sqrt(2.0), std::sqrt(2.0)}, 0.1 + 0.1i};
+            Un               exponent = {2.0, 0.1};
 
             gr::UncertainValueLike auto result = gr::math::pow(base, exponent);
             expect(approx(std::pow(base.value, exponent.value), result.value, 1e-9));
-            expect(approx(std::complex<double>{ 0.703966, 0.0 }, result.uncertainty, 1e-3)); // calculated with Wolfram
+            expect(approx(std::complex<double>{0.703966, 0.0}, result.uncertainty, 1e-3)); // calculated with Wolfram
         }
 
         {
-            ComplexUncertain base{ { std::sqrt(2.0), std::sqrt(2.0) }, 0.1 + 0.1i };
-            ComplexUncertain exponent{ { 2.0 }, 0.1 + 0.1i };
+            ComplexUncertain base{{std::sqrt(2.0), std::sqrt(2.0)}, 0.1 + 0.1i};
+            ComplexUncertain exponent{{2.0}, 0.1 + 0.1i};
 
             gr::UncertainValueLike auto result = gr::math::pow(base, exponent);
             expect(approx(std::pow(base.value, exponent.value), result.value, 1e-9));
-            expect(approx(std::complex<double>{ 0.81923, 0.0 }, result.uncertainty, 1e-3)); // calculated with Wolfram
+            expect(approx(std::complex<double>{0.81923, 0.0}, result.uncertainty, 1e-3)); // calculated with Wolfram
         }
 
         {
-            ComplexUncertain base{ { 0.0, 0.0 }, { 0.1, 0.1 } };
-            Un               exponent = { 2.0, 0.0 };
+            ComplexUncertain base{{0.0, 0.0}, {0.1, 0.1}};
+            Un               exponent = {2.0, 0.0};
 
             gr::UncertainValueLike auto result = gr::math::pow(base, exponent);
-            expect(approx(std::complex<double>{ 0.0, 0.0 }, result.value, 1e-9));
-            expect(approx(std::complex<double>{ 0.0, 0.0 }, result.uncertainty, 1e-9));
+            expect(approx(std::complex<double>{0.0, 0.0}, result.value, 1e-9));
+            expect(approx(std::complex<double>{0.0, 0.0}, result.uncertainty, 1e-9));
         }
 
         {
-            ComplexUncertain base{ { 1.0, 2.0 }, { 0.1, 0.1 } };
-            Un               exponent = { 0.0, 0.0 };
+            ComplexUncertain base{{1.0, 2.0}, {0.1, 0.1}};
+            Un               exponent = {0.0, 0.0};
 
             gr::UncertainValueLike auto result = gr::math::pow(base, exponent);
-            expect(approx(std::complex<double>{ 1.0, 0.0 }, result.value, 1e-9));
-            expect(approx(std::complex<double>{ 0.0, 0.0 }, result.uncertainty, 1e-9));
+            expect(approx(std::complex<double>{1.0, 0.0}, result.value, 1e-9));
+            expect(approx(std::complex<double>{0.0, 0.0}, result.uncertainty, 1e-9));
         }
 
         {
-            ComplexUncertain base{ { 0.0 }, { 0.1, 0.1 } };
-            Un               exponent = { 0.0, 0.0 };
+            ComplexUncertain base{{0.0}, {0.1, 0.1}};
+            Un               exponent = {0.0, 0.0};
 
             gr::UncertainValueLike auto result = gr::math::pow(base, exponent);
-            expect(approx(std::complex<double>{ 1.0, 0.0 }, result.value, 1e-9));
-            expect(approx(std::complex<double>{ 0.0, 0.0 }, result.uncertainty, 1e-9));
+            expect(approx(std::complex<double>{1.0, 0.0}, result.value, 1e-9));
+            expect(approx(std::complex<double>{0.0, 0.0}, result.uncertainty, 1e-9));
         }
     };
 
@@ -606,14 +610,14 @@ const boost::ut::suite uncertainValue = [] {
         using UncertainDouble = UncertainValue<double>;
 
         {
-            UncertainDouble             value{ 4.0, 0.2 }; // sqrt(4) = 2, uncertainty should be 0.2 / (2*2) = 0.05
+            UncertainDouble             value{4.0, 0.2}; // sqrt(4) = 2, uncertainty should be 0.2 / (2*2) = 0.05
             gr::UncertainValueLike auto result = gr::math::sqrt(value);
             expect(approx(2.0, result.value, 1e-9));
             expect(approx(0.05, result.uncertainty, 1e-9));
         }
 
         {
-            UncertainDouble             value{ 0.0, 0.1 }; // sqrt(0) = 0, uncertainty should be 0
+            UncertainDouble             value{0.0, 0.1}; // sqrt(0) = 0, uncertainty should be 0
             gr::UncertainValueLike auto result = gr::math::sqrt(value);
             expect(approx(0.0, result.value, 1e-9));
             expect(approx(0.0, result.uncertainty, 1e-9));
@@ -624,25 +628,30 @@ const boost::ut::suite uncertainValue = [] {
         using ComplexUncertain = UncertainValue<std::complex<double>>;
 
         {
-            ComplexUncertain            value{ { 4.0, 4.0 }, { 0.2, 0.2 } }; // sqrt(4+4i)
+            ComplexUncertain            value{{4.0, 4.0}, {0.2, 0.2}}; // sqrt(4+4i)
             gr::UncertainValueLike auto result = gr::math::sqrt(value);
             expect(approx(std::sqrt(value.value), result.value, 1e-9));
-            expect(approx(std::complex<double>{ 0.0420448, 0.0420448 }, result.uncertainty, 1e-3));
+            expect(approx(std::complex<double>{0.0420448, 0.0420448}, result.uncertainty, 1e-3));
         }
 
         {
-            ComplexUncertain            value{ { 0.0, 0.0 }, { 0.1, 0.1 } }; // sqrt(0+0i)
+            ComplexUncertain            value{{0.0, 0.0}, {0.1, 0.1}}; // sqrt(0+0i)
             gr::UncertainValueLike auto result = gr::math::sqrt(value);
-            expect(approx(std::complex<double>{ 0.0, 0.0 }, result.value, 1e-9));
-            expect(approx(std::complex<double>{ 0.0, 0.0 }, result.uncertainty, 1e-9));
+            expect(approx(std::complex<double>{0.0, 0.0}, result.value, 1e-9));
+            expect(approx(std::complex<double>{0.0, 0.0}, result.uncertainty, 1e-9));
         }
     };
 
-    "basic box-car low-pass filter examples"_test = [] {
-        UncertainValue value{ 4.0, 1.0 };
+    "gr::math::sqrt(non UncertainValue)"_test = [] {
+        expect(approx(gr::math::sqrt(4.f), 2.f, 1e-9f)) << "sqrt(float)";
+        expect(approx(gr::math::sqrt(4.), 2., 1e-9)) << "sqrt(double)";
+    };
 
-        UncertainValue sum1{ 0.0, 0.0 };
-        UncertainValue sum2{ 0.0, 0.0 };
+    "basic box-car low-pass filter examples"_test = [] {
+        UncertainValue value{4.0, 1.0};
+
+        UncertainValue sum1{0.0, 0.0};
+        UncertainValue sum2{0.0, 0.0};
         for (std::size_t i = 0UZ; i < 16UZ; i++) {
             sum1 += value / 16.0;
             sum2 = sum2 + value / 16.0;
@@ -654,10 +663,10 @@ const boost::ut::suite uncertainValue = [] {
     };
 
     "basic IIR low-pass filter examples"_test = [] {
-        UncertainValue   ref{ 4.0, 1.0 };
+        UncertainValue   ref{4.0, 1.0};
         constexpr double alpha = 0.05;
 
-        UncertainValue value{ 0.0, 1.0 };
+        UncertainValue value{0.0, 1.0};
         for (std::size_t i = 0UZ; i < 1000UZ; i++) {
             value = (1.0 - alpha) * value + alpha * ref;
         }
@@ -667,8 +676,8 @@ const boost::ut::suite uncertainValue = [] {
 
     boost::ut::tag("visual") / "visual examples"_test = [] {
         // uncorrelated values
-        UncertainValue uValueA{ 4.0, 2.0 };
-        UncertainValue uValueB{ 2.0, 1.0 };
+        UncertainValue uValueA{4.0, 2.0};
+        UncertainValue uValueB{2.0, 1.0};
         static_assert(UncertainValueLike<decltype(uValueA)>);
         static_assert(!UncertainValueLike<double>);
 
@@ -687,8 +696,8 @@ const boost::ut::suite uncertainValue = [] {
 
         // complex values
         using namespace std::complex_literals;
-        UncertainValue uValueAC{ 4. + 1i, +1. + 1i };
-        UncertainValue uValueBC{ 2. - 1i, +2. + 2i };
+        UncertainValue uValueAC{4. + 1i, +1. + 1i};
+        UncertainValue uValueBC{2. - 1i, +2. + 2i};
 
         fmt::print("uncorrelated values - complex:\n");
         fmt::print("{} + {} = {}\n", uValueAC, uValueBC, uValueAC + uValueBC);
@@ -707,49 +716,49 @@ const boost::ut::suite uncertainValueTrigonometric = [] {
 
     "gr::math::sin(UncertainValue<…>)"_test = [] {
         {
-            UncertainValue<double>      x{ pi / 6, 0.01 }; // 30 degrees
+            UncertainValue<double>      x{pi / 6, 0.01}; // 30 degrees
             gr::UncertainValueLike auto result = gr::math::sin(x);
             expect(approx(0.5, result.value, 1e-6)) << "sin(π/6)";
             expect(approx(0.01 * std::cos(pi / 6), result.uncertainty, 1e-6)) << "Uncertainty in sin(π/6)";
         }
 
         {
-            UncertainValue<double>      x{ pi / 3, 0.1 }; // 60 degrees
+            UncertainValue<double>      x{pi / 3, 0.1}; // 60 degrees
             gr::UncertainValueLike auto result = gr::math::sin(x);
             expect(approx(std::sqrt(3) / 2, result.value, 1e-6)) << "sin(π/3)";
             expect(approx(0.1 * std::cos(pi / 3), result.uncertainty, 1e-6)) << "Uncertainty in sin(π/3)";
         }
 
         {
-            UncertainValue<std::complex<double>> x{ 1.0 + 2.0i, 0.1 + 0.2i };
+            UncertainValue<std::complex<double>> x{1.0 + 2.0i, 0.1 + 0.2i};
             gr::UncertainValueLike auto          result = gr::math::sin(x);
 
             expect(approx(std::sin(x.value), result.value, 1e-6));
-            expect(approx(std::complex<double>{ 0.81994, 0 }, result.uncertainty, 1e-6)); // TODO check
+            expect(approx(std::complex<double>{0.81994, 0}, result.uncertainty, 1e-6)); // TODO check
         }
     };
 
     "gr::math::cos(UncertainValue<…>)"_test = [] {
         {
-            UncertainValue<double>      x{ pi / 3, 0.01 }; // 60 degrees
+            UncertainValue<double>      x{pi / 3, 0.01}; // 60 degrees
             gr::UncertainValueLike auto result = gr::math::cos(x);
             expect(approx(0.5, result.value, 1e-6)) << "cos(π/3)";
             expect(approx(0.01 * std::sin(pi / 3), result.uncertainty, 1e-6)) << "Uncertainty in cos(π/3)";
         }
 
         {
-            UncertainValue<double>      x{ pi / 6, 0.1 }; // 30 degrees
+            UncertainValue<double>      x{pi / 6, 0.1}; // 30 degrees
             gr::UncertainValueLike auto result = gr::math::cos(x);
             expect(approx(std::sqrt(3) / 2, result.value, 1e-6)) << "cos(π/6)";
             expect(approx(0.1 * std::sin(pi / 6), result.uncertainty, 1e-6)) << "Uncertainty in cos(π/6)";
         }
 
         {
-            UncertainValue<std::complex<double>> x{ 1.0 + 1.0i, 0.1 + 0.1i };
+            UncertainValue<std::complex<double>> x{1.0 + 1.0i, 0.1 + 0.1i};
             gr::UncertainValueLike auto          result = gr::math::cos(x);
 
             expect(approx(std::cos(x.value), result.value, 1e-6));
-            expect(approx(std::complex<double>{ 0.20441, 0 }, result.uncertainty, 1e-6)); // TODO check
+            expect(approx(std::complex<double>{0.20441, 0}, result.uncertainty, 1e-6)); // TODO check
         }
     };
 };
@@ -762,7 +771,7 @@ const boost::ut::suite uncertainValueExpTests = [] {
     using std::numbers::pi;
 
     "gr::math::exp(UncertainValue<arithmetic>)"_test = [] {
-        UncertainValue<double>      x{ 2.0, 0.1 }; // x = 2.0 ± 0.1
+        UncertainValue<double>      x{2.0, 0.1}; // x = 2.0 ± 0.1
         gr::UncertainValueLike auto result              = gr::math::exp(x);
         auto                        expectedValue       = std::exp(x.value);
         auto                        expectedUncertainty = std::exp(x.value) * x.uncertainty; // d(exp(x))/dx = exp(x)
@@ -773,7 +782,7 @@ const boost::ut::suite uncertainValueExpTests = [] {
 
     "gr::math::exp(UncertainValue<complex>)"_test = [] {
         {
-            UncertainValue<std::complex<double>> x{ { 1.0, 2.0 }, { 0.1, 0.1 } }; // x = (1.0 + 2.0i) ± (0.1 + 0.1i)
+            UncertainValue<std::complex<double>> x{{1.0, 2.0}, {0.1, 0.1}}; // x = (1.0 + 2.0i) ± (0.1 + 0.1i)
             gr::UncertainValueLike auto          result = gr::math::exp(x);
             //            auto                                 expectedUncertainty = std::complex<double>{
             //                std::hypot(std::exp(x.value.real()) * std::cos(x.value.imag()) * x.uncertainty.real(), std::exp(x.value.real()) * std::sin(x.value.imag()) * x.uncertainty.imag()),
@@ -785,16 +794,14 @@ const boost::ut::suite uncertainValueExpTests = [] {
         }
         {
             using std::numbers::pi;
-            UncertainValue<std::complex<double>> x{ { 0.0, 0 * pi / 2 }, { 0.1, 0.1 } }; // x = i * pi / 2 ± (0.1 + 0.1i)
+            UncertainValue<std::complex<double>> x{{0.0, 0 * pi / 2}, {0.1, 0.1}}; // x = i * pi / 2 ± (0.1 + 0.1i)
 
             expect(approx(std::exp(x.value), gr::math::exp(x).value, 1e-6));
-            expect(approx(gr::math::sin(UncertainValue<std::complex<double>>{ { pi / 2 }, { 0.1, 0.1 } }).value, gr::math::exp(x).value, 1e-6));
+            expect(approx(gr::math::sin(UncertainValue<std::complex<double>>{{pi / 2}, {0.1, 0.1}}).value, gr::math::exp(x).value, 1e-6));
             // expect(approx(std::sin(UncertainValue<std::complex<double>>{ { pi / 2 }, { 0.1, 0.1 } }).uncertainty, std::exp(x).uncertainty, 1e-6)); // TODO: check if uncertainties are propagated as
             // absolute (real-valued only) or retain their complex nature)
         }
     };
 };
 
-int
-main() { /* tests are statically executed */
-}
+int main() { /* tests are statically executed */ }


### PR DESCRIPTION
## Summary

This pull request introduces new blocks and features to enhance power system analysis capabilities, along with supporting uncertainty propagation through `UncertainValue<T>`. It also includes minor fixes and improvements across the codebase.

## New Blocks

### 1. **PowerMetrics<T, nPhases>**

- **Functionality**: Computes per-phase:
  - Active Power (P)
  - Reactive Power (Q)
  - Apparent Power (S)
  - RMS Voltage (U_rms)
  - RMS Current (I_rms)
- **Features**:
  - Supports both single-phase and multi-phase electrical systems (`nPhases` as a non-type template parameter).
  - Processes voltage and current inputs, applies low-pass filters to calculate average values.
  - Outputs decimated results at a specified rate.

### 2. **PowerFactor<T, nPhases>**

- **Functionality**: Calculates power factor and phase angle for each phase using active power (P) and apparent power (S) inputs.
- **Calculations**:
  - Power Factor: \( \cos(\phi) = \frac{P}{S} \)
  - Phase Angle: \( \phi = \arccos\left(\frac{P}{S}\right) \)
- **Features**:
  - Ensures values are within valid ranges to prevent computational errors.

### 3. **SystemUnbalance<T, nPhases>**

- **Functionality**: Computes:
  - Total Active Power
  - Voltage Unbalance (%)
  - Current Unbalance (%)
- **Calculations**:
  - Unbalance percentages are based on the maximum deviation from average RMS values across all phases.
- **Features**:
  - Suitable for multi-phase systems (requires at least two phases).

### 4. Configurable **BasicFilter<T>**

- **Functionality**: Provides a configurable filtering tool with support for:
  - Filter Types: IIR or FIR
  - Filter Responses: Low-pass, Band-pass, High-pass, Band-stop
  - Modes: Decimating and Non-decimating
- **Features**:
  - Based on user-configurable parameters for flexibility.
  - Supports both fundamental floating-point types and `UncertainValue<T>` types.
- **Benefit**: Enhances signal processing capabilities with uncertainty propagation through the filtering process.

## Support for UncertainValue<T>

- **Integration**: All new blocks (`PowerMetrics`, `PowerFactor`, `SystemUnbalance`, and `BasicFilter`) support both fundamental floating-point types and types wrapped with `UncertainValue<T>`.

## Minor Fixes and Improvements

- **Execution Policy**: Changed default execution policy from `std::execution::seq` to `std::execution::unseq` to potentially improve performance through vectorization.
- **Filter Tools**:
  - Added missing default constructors for `Filter` and `ErrorPropagatingFilter`.
  - Fixed erroneous use of `std::forward<...>` in `ErrorPropagatingFilter`.
- **UncertainValue<T> Enhancements**:
  - Added missing non-uncertainty value returns.
  - Extended support for `sqrt()`, `sin()`, and `cos()` functions to work with all underlying types.
 - **Global Block Registry**: Registered all new blocks, making them available for integration into the system and for use in applications.

## References
- **[0]** IEEE Std 1459-2010: "IEEE Standard Definitions for the Measurement of Electric Power Quantities Under Sinusoidal, Nonsinusoidal, Balanced, or Unbalanced Conditions"
- **[1]** IEC 61000-4-30: "Electromagnetic compatibility (EMC) - Part 4-30: Testing and measurement techniques - Power quality measurement methods"