### PR TITLE
Implement SyncBlock

### DIFF
--- a/blocks/basic/include/gnuradio-4.0/basic/StreamToDataSet.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/StreamToDataSet.hpp
@@ -320,10 +320,8 @@ private:
 
     void copyInputSamplesToHistory(InputSpanLike auto& inSamples, std::size_t maxSamplesToCopy) {
         if (n_pre > 0) {
-            const auto samplesToCopy          = std::min(maxSamplesToCopy, inSamples.size());
-            const auto end                    = std::next(inSamples.begin(), static_cast<std::ptrdiff_t>(samplesToCopy));
-            const auto optimizedSamplesToCopy = std::min(static_cast<std::size_t>(_history.capacity()), samplesToCopy);
-            _history.push_back_bulk(std::prev(end, static_cast<std::ptrdiff_t>(optimizedSamplesToCopy)), end);
+            const auto samplesToCopy = std::min(maxSamplesToCopy, inSamples.size());
+            _history.push_back_bulk(inSamples.begin(), std::next(inSamples.begin(), static_cast<std::ptrdiff_t>(samplesToCopy)));
         }
     }
 

--- a/blocks/basic/include/gnuradio-4.0/basic/SyncBlock.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/SyncBlock.hpp
@@ -1,0 +1,363 @@
+#ifndef GNURADIO_SYNC_BLOCK_HPP
+#define GNURADIO_SYNC_BLOCK_HPP
+
+#include <gnuradio-4.0/Block.hpp>
+#include <gnuradio-4.0/HistoryBuffer.hpp>
+
+namespace gr::basic {
+
+using namespace gr;
+
+using SyncBlockDoc = Doc<R""(
+
+The SyncBlock synchronizes data streams across multiple inputs.
+It addresses key scenarios including initial time shifts, clock drift, and significant delays.
+The SyncBlock synchronises input samples based on synchronization tags and
+publishes desynchronization tags with information about number of samples that were dropped.
+
+### Important Prerequisites
+The sample rate must be the same across all input ports.
+
+For the examples provided, consider the following:
+1) Samples (`s1, s2, ...`) represent samples where the index indicates their sequence of arrival.
+2) Samples for different ports may vary (`s1` for `port1` may may not be equal to `s1` for `port2`)
+3) Illustrated with examples for two inputs (`in1`, `in2`) and two outputs (`out1`, `out2`) for simplicity:
+```text
+       +-------------------------------+
+in1 +-+|                               |+-+ out1
+    +-+|                               |+-+
+       |          SyncBlock            |
+in2 +-+|                               |+-+ out2
+    +-+|                               |+-+
+       +-------------------------------+
+```
+
+### Implementing `SyncBlock`: Key Scenarios
+When designing a `SyncBlock`, consider the following four scenarios:
+
+#### 1. Time Shift at Start
+Devices may initiate data transmission at different times, leading to a time shift in data arrival.
+
+Example:
+```text
+                 T1                         T1,TD1
+                  ↓                            ↓
+in1: s2-s3-s4-s5-s6      →  out1: s2-s3-s4-s5-s6
+
+                    T1                        T1
+                     ↓                         ↓
+in2: s1-s2-s3-s4-s5-s6   →  out2: s2-s3-s4-s5-s6
+```
+Both ports align with synchronization tag `T1` at sample `s6`.
+Samples received before `T1` are also included in the output, resulting in `out1` and `out2` both outputting `s2-s3-s4-s5-s6`.
+Note that the synchronization tags are forwarded further.
+In addition a desync tag (`TD1`) is published for `out1` which includes information about number of dropped samples.
+
+#### 2. Clock Drift
+This scenario accounts for a clock drift - minor timing discrepancy, such as several PPM (±1 sample per 100,000 samples).
+
+Example:
+```text
+     T1          T2               T1          T2
+      ↓           ↓                ↓           ↓
+in1: s1-s2-s3-s4-s5      →  out1: s1-s2-s3-s4-s5
+
+     T1             T2            T1         T2,TD2
+      ↓              ↓             ↓           ↓
+in2: s1-s2-s3-s4-s5-s6   →  out2: s1-s2-s3-s4-s6
+```
+Post-synchronization with `T1`, the `SyncBlock` adjusts to align the samples, dropping any excess samples.
+The `out1` is `s1-s2-s3-s4-s5`, the `out2` is `s1-s2-s3-s4-s6`. `s5` sample is skipped in the examples.
+In addition a desync tag (`TD2`) is published for port `out2` which includes information about number of dropped samples.
+
+#### 3a. Time-Out: no data
+This situation involves a significant delay in data reception (> time-out).
+
+```text
+     T1                  T2                T1         TD1      T2
+      ↓                   ↓                 ↓          ↓        ↓
+in1: s1-s2-....-s5-s6-s7-s8-s9    →  out1: s1-s2   →  s5-s6-s7-s8-s9
+
+     T1                   T2               T1         TD1      T2
+      ↓                    ↓                ↓          ↓        ↓
+in2: s1-s2-s3-s4-s5-s6-s7-s8-s9   →  out2: s1-s2   →  s5-s6-s7-s8-s9
+```
+
+New synchronization occurs with `s8`, including prior samples (`s5-s6-s7`) in the output after the desync period.
+`SyncBlock` publishes desynchronization tag (`TD1`) for all ports to indicate data stream desynchronization.
+
+#### 3b. Time-Out: no tag
+```text
+     T1                T3                  T1         TD1        T3
+      ↓                 ↓                   ↓         ↓           ↓
+in1: s1-s2-s3-s4-s5-s6-s7-s8-s9   →  out1: s1-s2  →  s3-s4-s5-s6-s7-s8-s9
+
+     T1    T2          T3                  T1        T2          T3
+      ↓     ↓           ↓                   ↓         ↓           ↓
+in2: s1-s2-s3-s4-s5-s6-s7-s8-s9   →  out2: s1-s2  →  s3-s4-s5-s6-s7-s8-s9
+```
+If port `in2` receives `T2` but port `in1` did not before a timeout, the `SyncBlock` awaits the next sync tag to attempt data alignment.
+The prior samples to `T3` (`s3-s4-s5-s6`) will be also included.
+
+#### 4. Zero padding (optional) -> timeout and zero padding to be discussed see https://github.com/fair-acc/gnuradio4/issues/466
+similar to 3a, this situation involves a significant delay in data reception (> time-out),
+but in this case `SyncBlock` publishes "zeros" after timeout.
+
+```text
+     T1              T2                    T1        TD1       T2
+      ↓               ↓                     ↓        ↓          ↓
+in1: s1-s2-...-s6-s7-s8-s9         → out1: s1-s2  →  0-0-0-0-0-s8-s9
+
+     T1                   T2              T1                        T2
+      ↓                    ↓               ↓                         ↓
+in2: s1-s2-s3-s4-s5-s6-s7-s8-s9   → out2: s1-s2  →   s3-s4-s5-s6-s7-s8-s9
+```
+`SyncBlock` publishes desynchronization tag (`TD1`) with the first "zero" sample.
+New synchronization occurs with `s8`, prior samples (`s6-s7`) are NOT included to the output for zero padding.
+
+Note: We assume that desynchronization should not exceed the buffer size of the SyncBlock; if it does, the samples will be dropped.
+)"">;
+
+template<typename T>
+struct SyncBlock : public gr::Block<SyncBlock<T>, NoDefaultTagForwarding, SyncBlockDoc> {
+    std::vector<gr::PortIn<T, gr::Async>> inputs;
+    std::vector<gr::PortOut<T>>           outputs;
+
+    // settings
+    Annotated<gr::Size_t, "n_ports", gr::Visible, gr::Doc<"variable number of in/out ports">, gr::Limits<1U, 32U>> n_ports          = 0U;
+    Annotated<gr::Size_t, "max_history_size", Doc<"Max size of history">>                                          max_history_size = 32000U; // should be less than actual buffer size (better < 80%)
+    Annotated<std::string, "filter", Doc<"trigger name filter">>                                                   filter           = "";
+    Annotated<std::uint64_t, "tolerance", Doc<"trigger time tolerance [ns]">>                                      tolerance        = 5ULL;
+
+    GR_MAKE_REFLECTABLE(SyncBlock, inputs, outputs, n_ports, max_history_size, filter, tolerance);
+
+    bool                     _isStreamSynchronized = false;
+    std::vector<std::size_t> _nDroppedSamples{}; // number of dropped samples, to be sent with desynchronized tag
+
+    int _processBulkCounter = 0;
+
+    struct SyncData {
+        std::size_t index; // sync index
+        std::size_t nPre;  // number of pre samples, sample with sync index is not included
+        std::size_t nPost; // number of post samples, sample with sync index is not included
+    };
+
+    void settingsChanged(const property_map& oldSettings, const property_map& newSettings) {
+        if (newSettings.contains("n_ports") && oldSettings.at("n_ports") != newSettings.at("n_ports")) {
+            // if one of the port is already connected and n_ports was changed then throw
+            bool inConnected  = std::any_of(inputs.begin(), inputs.end(), [](const auto& port) { return port.isConnected(); });
+            bool outConnected = std::any_of(outputs.begin(), outputs.end(), [](const auto& port) { return port.isConnected(); });
+            if (inConnected || outConnected) {
+                throw gr::exception("Number of input/output ports cannot be changed after Graph initialization.");
+            }
+            fmt::print("{}: configuration changed: n_ports {} -> {}\n", this->name, oldSettings.at("n_ports"), newSettings.at("n_ports"));
+            inputs.resize(n_ports);
+            outputs.resize(n_ports);
+            _nDroppedSamples.resize(n_ports, 0UZ);
+        }
+
+        if (newSettings.contains("max_history_size")) {
+            // should be less than actual buffer size (better < 80%)
+            // The logic has to be implemented when the new Port API is available
+        }
+    }
+
+    template<InputSpanLike TInput, OutputSpanLike TOutput>
+    gr::work::Status processBulk(const std::span<TInput>& ins, std::span<TOutput>& outs) {
+        std::size_t nPorts = ins.size();
+
+        const std::vector<SyncData> syncData = synchronize(ins);
+        const bool                  canSync  = !syncData.empty();
+
+        if (canSync) {
+            const std::size_t minPre            = std::ranges::min(syncData | std::views::transform([](const SyncData& data) { return data.nPre; }));
+            const std::size_t minPost           = std::ranges::min(syncData | std::views::transform([](const SyncData& data) { return data.nPost; }));
+            const std::size_t minSamplesOut     = std::ranges::min(outs | std::views::transform([&](const auto& out) { return out.size(); }));
+            const std::size_t nSamplesToPublish = std::min(minPre + 1 + minPost, minSamplesOut);
+
+            for (std::size_t i = 0UZ; i < ins.size(); i++) {
+                const std::size_t nSamplesToDrop    = syncData[i].index - minPre;
+                const std::size_t nSamplesToConsume = nSamplesToDrop + nSamplesToPublish;
+
+                std::ranges::copy_n(ins[i].begin() + nSamplesToDrop, static_cast<std::ptrdiff_t>(nSamplesToPublish), outs[i].begin());
+                const std::size_t totalDroppedSamples = _nDroppedSamples[i] + nSamplesToDrop;
+
+                publishDroppedSamplesTagIfNotZero(outs[i], totalDroppedSamples);
+                publishInputTags(ins[i], outs[i], nSamplesToDrop, nSamplesToPublish);
+                _nDroppedSamples[i] = 0UZ;
+
+                ins[i].consume(nSamplesToConsume);
+                ins[i].consumeTags(nSamplesToConsume);
+                outs[i].publish(nSamplesToPublish);
+            }
+            _isStreamSynchronized = true;
+        } else {
+            const std::size_t minSamplesBeforeSyncTag = std::ranges::min(ins | std::views::transform([&](const auto& in) { return getNSamplesBeforeSyncTag(in); }));
+            const std::size_t minSamplesOut           = std::ranges::min(outs | std::views::transform([&](const auto& out) { return out.size(); }));
+            const std::size_t nSamplesToCopy          = std::min(minSamplesBeforeSyncTag, minSamplesOut);
+            if (_isStreamSynchronized && nSamplesToCopy > 0UZ) { // all streams are in sync -> write sample before first Sync tag
+                for (std::size_t i = 0; i < nPorts; i++) {
+                    std::ranges::copy_n(ins[i].begin(), static_cast<std::ptrdiff_t>(nSamplesToCopy), outs[i].begin());
+
+                    publishDroppedSamplesTagIfNotZero(outs[i], _nDroppedSamples[i]);
+                    publishInputTags(ins[i], outs[i], 0UZ, nSamplesToCopy);
+
+                    _nDroppedSamples[i] = 0UZ;
+
+                    ins[i].consume(nSamplesToCopy);
+                    ins[i].consumeTags(nSamplesToCopy);
+                    outs[i].publish(nSamplesToCopy);
+                }
+            } else { // streams are NOT in sync -> check back pressure and drop samples if needed
+                for (std::size_t i = 0; i < nPorts; i++) {
+                    const std::size_t nSamplesToDrop = ins[i].size() < static_cast<std::size_t>(max_history_size) ? 0UZ : ins[i].size() - static_cast<std::size_t>(max_history_size);
+                    if (nSamplesToDrop != 0UZ) {
+                        ins[i].consume(nSamplesToDrop);
+                        ins[i].consumeTags(nSamplesToDrop);
+
+                        _nDroppedSamples[i] += nSamplesToDrop;
+                        outs[i].publish(0UZ);
+                        _isStreamSynchronized = false;
+                    }
+                }
+            }
+        }
+        for (std::size_t i = 0; i < nPorts; i++) {
+            if (!ins[i].isConsumeRequested()) {
+                ins[i].consume(0UZ);
+                ins[i].consumeTags(0UZ);
+                outs[i].publish(0UZ);
+            }
+        }
+        return gr::work::Status::OK;
+    }
+
+    constexpr void publishDroppedSamplesTagIfNotZero(OutputSpanLike auto& out, std::size_t nDroppedSamples) {
+        if (nDroppedSamples > 0UZ) {
+            out.publishTag({{gr::tag::N_DROPPED_SAMPLES.shortKey(), nDroppedSamples}}, 0UZ);
+        }
+    }
+
+    constexpr void publishInputTags(InputSpanLike auto& in, OutputSpanLike auto& out, std::size_t nDroppedSamples, std::size_t nSamplesToPublish) {
+        const auto tags = in.tags();
+        for (const auto& tag : tags) {
+            if (tag.first >= nDroppedSamples && tag.first < nSamplesToPublish + nDroppedSamples) {
+                out.publishTag(tag.second, tag.first - nDroppedSamples);
+            }
+        }
+    }
+
+    template<InputSpanLike TInput>
+    [[nodiscard]] constexpr std::vector<SyncData> synchronize(const std::span<TInput>& ins) {
+        const std::uint64_t syncTime = findSyncTime(ins);
+        if (syncTime == std::numeric_limits<std::uint64_t>::max()) {
+            return {};
+        }
+
+        std::vector<SyncData> syncData;
+        syncData.reserve(ins.size());
+        for (const auto& inSpan : ins) {
+            for (const auto& tag : inSpan.rawTags) {
+                const std::size_t relativeTagIndex = getRelativeTagIndex(inSpan, tag);
+                if (isTimeDifferenceWithinTolerance(getTime(tag), syncTime) && relativeTagIndex != std::numeric_limits<std::size_t>::max()) {
+                    const std::size_t nPre  = getAvailablePreSamples(inSpan, relativeTagIndex);
+                    const std::size_t nPost = getAvailablePostSamples(inSpan, relativeTagIndex);
+                    syncData.push_back({relativeTagIndex, nPre, nPost});
+                    break;
+                }
+            }
+        }
+
+        assert(ins.size() == syncData.size());
+
+        return syncData;
+    }
+
+    template<InputSpanLike TInput>
+    [[nodiscard]] constexpr std::uint64_t findSyncTime(const std::span<TInput>& ins) {
+        std::vector<std::vector<std::uint64_t>> syncTimesPerInSpan; // Collect sync times for each input span
+        syncTimesPerInSpan.reserve(ins.size());
+        std::set<std::uint64_t> allSyncTimes; // Collect all unique sync times, ordered
+        for (const auto& inSpan : ins) {
+            std::vector<std::uint64_t> syncTimes;
+            for (const auto& tag : inSpan.rawTags) {
+                const std::size_t relativeTagIndex = getRelativeTagIndex(inSpan, tag);
+                if (isSyncTag(tag) && relativeTagIndex < inSpan.size() && relativeTagIndex != std::numeric_limits<std::size_t>::max()) {
+                    const std::uint64_t time = getTime(tag);
+                    syncTimes.push_back(time);
+                    allSyncTimes.insert(time);
+                }
+            }
+            syncTimesPerInSpan.push_back(std::move(syncTimes));
+        }
+
+        // Find the earliest sync time present in all input spans within tolerance
+        auto findInAllIt = std::ranges::find_if(allSyncTimes, [&](const auto& curTime) { //
+            return std::ranges::all_of(syncTimesPerInSpan, [&](const auto& syncTimes) {  //
+                return std::ranges::any_of(syncTimes, [&](const auto& t) { return isTimeDifferenceWithinTolerance(curTime, t); });
+            });
+        });
+
+        return findInAllIt != allSyncTimes.end() ? *findInAllIt : std::numeric_limits<std::uint64_t>::max();
+    }
+
+    [[nodiscard]] constexpr std::size_t getAvailablePreSamples(const InputSpanLike auto& in, std::size_t syncIndex) {
+        // Check if there’s an earlier sync tag that cannot be synchronized; if so, calculate available samples only up to that tag.
+        const auto foundTag = std::ranges::find_if(in.rawTags, [&](const auto& tag) { return getRelativeTagIndex(in, tag) < syncIndex && isSyncTag(tag); });
+        if (foundTag != in.rawTags.end()) {
+            return syncIndex - getRelativeTagIndex(in, *foundTag) - 1;
+        }
+        return syncIndex;
+    }
+
+    [[nodiscard]] constexpr std::size_t getAvailablePostSamples(const InputSpanLike auto& in, std::size_t syncIndex) {
+        // Check if there’s a later sync tag; if so, calculate available samples only up to that tag.
+        auto foundTag = std::ranges::find_if(in.rawTags, [&](const auto& tag) {
+            const std::size_t relativeTagIndex = getRelativeTagIndex(in, tag);
+            return relativeTagIndex > syncIndex && relativeTagIndex < in.size() && isSyncTag(tag);
+        });
+        if (foundTag != in.rawTags.end()) {
+            return getRelativeTagIndex(in, *foundTag) - syncIndex - 1;
+        }
+        return in.size() - syncIndex - 1;
+    }
+
+    [[nodiscard]] std::size_t getNSamplesBeforeSyncTag(const InputSpanLike auto& in) const {
+        for (const auto& tag : in.rawTags) {
+            const std::size_t relativeTagIndex = getRelativeTagIndex(in, tag);
+            if (isSyncTag(tag) && relativeTagIndex != std::numeric_limits<std::size_t>::max()) {
+                return std::min(relativeTagIndex, in.size()); // tags are ordered, return distance to the first sync tag
+            }
+        }
+        return in.size();
+    }
+
+    [[nodiscard]] constexpr bool isTimeDifferenceWithinTolerance(std::uint64_t t1, std::uint64_t t2) { return ((t1 > t2) ? t1 - t2 : t2 - t1) < tolerance; }
+
+    [[nodiscard]] constexpr bool isSyncTag(const gr::Tag& tag) const {
+        const std::string keyTriggerName = gr::tag::TRIGGER_NAME.shortKey();
+        const std::string keyTriggerTime = gr::tag::TRIGGER_TIME.shortKey();
+
+        if (tag.map.contains(keyTriggerName) && std::holds_alternative<std::string>(tag.map.at(keyTriggerName)) && (filter == "" || tag.map.at(keyTriggerName) == filter) //
+            && tag.map.contains(keyTriggerTime) && std::holds_alternative<uint64_t>(tag.map.at(keyTriggerTime))) {
+            return true;
+        }
+        return false;
+    }
+
+    [[nodiscard]] constexpr std::uint64_t getTime(const gr::Tag& tag) const {
+        const std::string keyTriggerTime = gr::tag::TRIGGER_TIME.shortKey();
+        if (tag.map.contains(keyTriggerTime) && std::holds_alternative<uint64_t>(tag.map.at(keyTriggerTime))) {
+            return std::get<std::uint64_t>(tag.map.at(keyTriggerTime));
+        }
+        return 0ULL;
+    }
+
+    [[nodiscard]] constexpr std::size_t getRelativeTagIndex(const InputSpanLike auto& in, const Tag& tag) const { //
+        return tag.index >= in.streamIndex ? tag.index - in.streamIndex : std::numeric_limits<std::size_t>::max();
+    }
+};
+
+} // namespace gr::basic
+
+#endif // GNURADIO_SYNC_BLOCK_HPP

--- a/blocks/basic/test/CMakeLists.txt
+++ b/blocks/basic/test/CMakeLists.txt
@@ -7,8 +7,10 @@ if (ENABLE_BLOCK_REGISTRY AND ENABLE_BLOCK_PLUGINS)
     add_ut_test(qa_BasicKnownBlocks)
 endif ()
 add_ut_test(qa_StreamToDataSet)
+add_ut_test(qa_SyncBlock)
 
 message(STATUS "###Python Include Dirs: ${Python3_INCLUDE_DIRS}")
 if (PYTHON_AVAILABL AND ENABLE_BLOCK_REGISTRY AND ENABLE_BLOCK_PLUGINS)
     add_ut_test(qa_PythonBlock)
 endif ()
+

--- a/blocks/basic/test/qa_SyncBlock.cpp
+++ b/blocks/basic/test/qa_SyncBlock.cpp
@@ -1,0 +1,205 @@
+#include <boost/ut.hpp>
+#include <gnuradio-4.0/Graph.hpp>
+#include <gnuradio-4.0/Scheduler.hpp>
+#include <gnuradio-4.0/basic/SyncBlock.hpp>
+#include <gnuradio-4.0/testing/TagMonitors.hpp>
+
+#include <fmt/format.h>
+
+struct TestParams {
+    std::string   testName       = "";
+    gr::Size_t    nSamples       = 0U;                                        // 0 -> take inValues[i].size()
+    gr::Size_t    maxHistorySize = 0U;                                        // if 0 -> take default
+    std::string   filter         = "";                                        // if "" -> take default
+    std::uint64_t tolerance      = std::numeric_limits<std::uint64_t>::max(); // if max() -> take default
+
+    std::vector<std::vector<int>>     inValues;
+    std::vector<std::vector<gr::Tag>> inTags;
+    std::vector<std::vector<int>>     expectedValues;
+    std::vector<std::vector<gr::Tag>> expectedTags;
+    std::size_t                       expectedNSamples = 0UZ;
+};
+
+void runTest(const TestParams& par) {
+    using namespace boost::ut;
+    using namespace gr;
+    using namespace gr::basic;
+    using namespace gr::testing;
+
+    expect(eq(par.inValues.size(), par.inTags.size()));
+
+    gr::Graph graph;
+
+    std::size_t nPorts = par.inValues.size();
+
+    property_map syncBlockParams = {{"n_ports", static_cast<gr::Size_t>(nPorts)}};
+    if (par.maxHistorySize != 0) {
+        syncBlockParams.insert_or_assign("max_history_size", par.maxHistorySize);
+    }
+    if (par.tolerance != std::numeric_limits<std::uint64_t>::max()) {
+        syncBlockParams.insert_or_assign("tolerance", par.tolerance);
+    }
+    if (par.filter != "") {
+        syncBlockParams.insert_or_assign("filter", par.filter);
+    }
+    auto& syncBlock = graph.emplaceBlock<SyncBlock<int>>(syncBlockParams);
+
+    std::vector<TagSource<int, ProcessFunction::USE_PROCESS_BULK>*> sources;
+    std::vector<TagSink<int, ProcessFunction::USE_PROCESS_BULK>*>   sinks;
+
+    for (std::size_t i = 0; i < nPorts; i++) {
+        property_map srcParams = {{"values", par.inValues[i]}, {"verbose_console", false}, {"disconnect_on_done", false}};
+        if (par.nSamples != 0) {
+            srcParams.insert_or_assign("n_samples_max", par.nSamples);
+        } else {
+            srcParams.insert_or_assign("n_samples_max", static_cast<gr::Size_t>(par.inValues[i].size()));
+        }
+
+        sources.push_back(std::addressof(graph.emplaceBlock<TagSource<int, ProcessFunction::USE_PROCESS_BULK>>(srcParams)));
+        sources[i]->_tags = par.inTags[i];
+        expect(gr::ConnectionResult::SUCCESS == graph.connect(*sources[i], "out"s, syncBlock, "inputs#"s + std::to_string(i)));
+    }
+
+    for (std::size_t i = 0; i < nPorts; i++) {
+        property_map sinkParams = {{"verbose_console", false}, {"disconnect_on_done", false}};
+        if (par.expectedValues.empty()) {
+            sinkParams.insert_or_assign("log_samples", false);
+        }
+        sinks.push_back(std::addressof(graph.emplaceBlock<TagSink<int, ProcessFunction::USE_PROCESS_BULK>>(sinkParams)));
+        expect(gr::ConnectionResult::SUCCESS == graph.connect(syncBlock, "outputs#"s + std::to_string(i), *sinks[i], "in"s));
+    }
+
+    gr::scheduler::Simple sched{std::move(graph)};
+    sched.runAndWait();
+
+    for (std::size_t i = 0; i < sinks.size(); i++) {
+        if (par.expectedValues.empty()) {
+            expect(eq(par.expectedNSamples, sinks[i]->_nSamplesProduced));
+        } else {
+            expect(std::ranges::equal(sinks[i]->_samples, par.expectedValues[i])) << fmt::format("sinks[{}]->_samples does not match to expected values:\nSink:{}\nExpected:{}\n", i, sinks[i]->_samples, par.expectedValues[i]);
+        }
+    }
+
+    for (std::size_t i = 0; i < sinks.size(); i++) {
+        expect(equal_tag_lists(sinks[i]->_tags, par.expectedTags[i], {}));
+    }
+}
+
+gr::Tag genSyncTag(std::size_t index, std::uint64_t triggerTime, std::string triggerName = "TriggerName") { //
+    return {index, {{gr::tag::TRIGGER_NAME.shortKey(), triggerName}, {gr::tag::TRIGGER_TIME.shortKey(), triggerTime}}};
+};
+
+gr::Tag genDropTag(std::size_t index, std::uint64_t nSamplesDropped) { //
+    return {index, {{gr::tag::N_DROPPED_SAMPLES.shortKey(), nSamplesDropped}}};
+};
+
+gr::Tag genDropSyncTag(std::size_t index, std::uint64_t nSamplesDropped, std::uint64_t triggerTime, std::string triggerName = "TriggerName") { //
+    return {index, {{gr::tag::N_DROPPED_SAMPLES.shortKey(), nSamplesDropped}, {gr::tag::TRIGGER_NAME.shortKey(), triggerName}, {gr::tag::TRIGGER_TIME.shortKey(), triggerTime}}};
+};
+
+const boost::ut::suite SyncBlockTests = [] {
+    using namespace boost::ut;
+    using namespace gr;
+    using namespace gr::basic;
+    using namespace gr::testing;
+
+    "SyncBlock basic test"_test = [] {
+        runTest({                                                                                             //
+            .tolerance = 2ULL,                                                                                //
+            .inValues  =                                                                                      //
+            {                                                                                                 //
+                {1, 0, 1, 2, 3, 0, 1, 2, 3, 4, 0, 1},                                                         //
+                {1, 2, 0, 1, 2, 3, 4, 0, 1, 2, 3, 0, 1, 2},                                                   //
+                {1, 2, 3, 0, 1, 2, 3, 4, 5, 0, 1, 2, 0, 1, 2, 3}},                                            //
+            .inTags =                                                                                         //
+            {                                                                                                 //
+                {genSyncTag(1, 99), genSyncTag(5, 201), genSyncTag(10, 301)},                                 //
+                {genSyncTag(2, 100), genSyncTag(7, 199), genSyncTag(11, 299)},                                //
+                {genSyncTag(3, 101), genSyncTag(9, 200), genSyncTag(12, 300)}},                               //
+            .expectedValues =                                                                                 //
+            {                                                                                                 //
+                {1, 0, 1, 2, 3, 0, 1, 2, 0, 1},                                                               //
+                {2, 0, 1, 2, 3, 0, 1, 2, 0, 1},                                                               //
+                {3, 0, 1, 2, 3, 0, 1, 2, 0, 1}},                                                              //
+            .expectedTags =                                                                                   //
+            {                                                                                                 //
+                {genSyncTag(1, 99), genSyncTag(5, 201), genDropSyncTag(8, 2, 301)},                           //
+                {genDropTag(0, 1), genSyncTag(1, 100), genDropSyncTag(5, 1, 199), genDropSyncTag(8, 1, 299)}, //
+                {genDropTag(0, 2), genSyncTag(1, 101), genDropSyncTag(5, 2, 200), genSyncTag(8, 300)}}});
+    };
+
+    "SyncBlock missing tag test"_test = [] {
+        runTest({                                                              //
+            .tolerance = 2ULL,                                                 //
+            .inValues  =                                                       //
+            {                                                                  //
+                {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11},                        //
+                {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11},                        //
+                {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}},                       //
+            .inTags =                                                          //
+            {                                                                  //
+                {genSyncTag(1, 100), genSyncTag(5, 200), genSyncTag(10, 300)}, //
+                {genSyncTag(2, 100), genSyncTag(10, 300)},                     //
+                {genSyncTag(4, 200), genSyncTag(10, 300)}},                    //
+            .expectedValues =                                                  //
+            {                                                                  //
+                {5, 6, 7, 8, 9, 10, 11},                                       //
+                {5, 6, 7, 8, 9, 10, 11},                                       //
+                {5, 6, 7, 8, 9, 10, 11}},                                      //
+            .expectedTags =                                                    //
+            {                                                                  //
+                {genDropSyncTag(0, 5, 200), genSyncTag(5, 300)},               // Sample 5 was copied to the output, including the sync tag, even though the tag was not used
+                {genDropTag(0, 5), genSyncTag(5, 300)},                        //
+                {genDropTag(0, 5), genSyncTag(5, 300)}}});
+    };
+
+    "SyncBlock isSync test"_test = [] {
+        runTest({                                                                                                                           //
+            .nSamples       = 300'000,                                                                                                      //
+            .maxHistorySize = 32'000,                                                                                                       //
+            .tolerance      = 2ULL,                                                                                                         //
+            .inValues       = {{}, {}},                                                                                                     //
+            .inTags         =                                                                                                               //
+            {                                                                                                                               //
+                {genSyncTag(10, 100), genSyncTag(100'100, 200), genSyncTag(201'000, 300)},                                                  //
+                {genSyncTag(1, 100), genSyncTag(100'000, 200), genSyncTag(200'000, 300)}},                                                  //
+            .expectedValues = {},                                                                                                           //                                                           //
+            .expectedTags   =                                                                                                               //
+            {                                                                                                                               //
+                {genDropTag(0, 9), genSyncTag(1, 100), genDropTag(65537, 91), genSyncTag(100'000, 200), genDropSyncTag(200'000, 900, 300)}, // 65537 -> depends on buffer size
+                {genSyncTag(1, 100), genSyncTag(100'000, 200), genSyncTag(200'000, 300)}},                                                  //
+            .expectedNSamples = 299'000});
+    };
+
+    "SyncBlock back pressure test"_test = [] {
+        runTest({                                                                          //
+            .nSamples       = 300'000,                                                     //
+            .maxHistorySize = 32'000,                                                      //
+            .tolerance      = 2ULL,                                                        //
+            .inValues       = {{}, {}},                                                    //
+            .inTags         =                                                              //
+            {                                                                              //
+                {genSyncTag(1, 100), genSyncTag(1000, 200), genSyncTag(200'000, 300)},     //
+                {genSyncTag(1, 100), genSyncTag(100'000, 200), genSyncTag(200'000, 300)}}, //
+            .expectedValues = {},                                                          //
+            .expectedTags   =                                                              //
+            {                                                                              //
+                {genSyncTag(1, 100), genDropTag(1000, 167000), genSyncTag(33'000, 300)},   //
+                {genSyncTag(1, 100), genDropTag(1000, 167000), genSyncTag(33'000, 300)}},  //
+            .expectedNSamples = 133'000});
+    };
+
+    "SyncBlock back pressure test 2"_test = [] {
+        runTest({                                                                                                                   //
+            .nSamples         = 300'000,                                                                                            //
+            .maxHistorySize   = 32'000,                                                                                             //
+            .tolerance        = 2ULL,                                                                                               //
+            .inValues         = {{}, {}},                                                                                           //
+            .inTags           = {{genSyncTag(100'000, 100)}, {genSyncTag(101'000, 100)}},                                           //
+            .expectedValues   = {},                                                                                                 //
+            .expectedTags     = {{genDropTag(0, 68000), genSyncTag(32'000, 100)}, {genDropTag(0, 69000), genSyncTag(32'000, 100)}}, //
+            .expectedNSamples = 231'000});
+    };
+};
+
+int main() {}

--- a/core/benchmarks/CMakeLists.txt
+++ b/core/benchmarks/CMakeLists.txt
@@ -1,4 +1,4 @@
-function (add_gr_benchmark BM_NAME)
+function(add_gr_benchmark BM_NAME)
     add_benchmark(${BM_NAME})
     target_link_libraries(${BM_NAME} PRIVATE gnuradio-core fmt gr-basic gr-fileio gr-math gr-testing)
     target_compile_options(${BM_NAME} PRIVATE -O3) # performance related benchmarks should be optimised during compile-time
@@ -10,4 +10,5 @@ add_gr_benchmark(bm_Profiler)
 add_gr_benchmark(bm_Scheduler)
 add_gr_benchmark(bm-nosonar_node_api)
 add_gr_benchmark(bm_fft)
+add_gr_benchmark(bm_sync)
 target_link_libraries(bm_fft PRIVATE gr-fourier)

--- a/core/benchmarks/bm_sync.cpp
+++ b/core/benchmarks/bm_sync.cpp
@@ -1,0 +1,110 @@
+#include <benchmark.hpp>
+
+#include <functional>
+
+#include <gnuradio-4.0/BlockTraits.hpp>
+#include <gnuradio-4.0/Graph.hpp>
+#include <gnuradio-4.0/Scheduler.hpp>
+#include <gnuradio-4.0/basic/Selector.hpp>
+#include <gnuradio-4.0/basic/SyncBlock.hpp>
+#include <gnuradio-4.0/testing/NullSources.hpp>
+#include <gnuradio-4.0/testing/TagMonitors.hpp>
+
+inline constexpr std::size_t nRepeats = 1; // must be 1 at the moment
+inline constexpr gr::Size_t  nPorts   = 2U;
+inline constexpr gr::Size_t  nSamples = 4'000'000'000;
+
+gr::Tag genSyncTag(std::size_t index, std::uint64_t triggerTime, std::string triggerName = "TriggerName") { //
+    return {index, {{gr::tag::TRIGGER_NAME.shortKey(), triggerName}, {gr::tag::TRIGGER_TIME.shortKey(), triggerTime}}};
+};
+
+template<typename TBlock>
+void runTest() {
+    using namespace boost::ut;
+    using namespace benchmark;
+    using namespace gr;
+    using namespace gr::basic;
+    using namespace gr::testing;
+
+    gr::Graph graph;
+
+    const std::size_t nTags = 1; // we need at least 1 tag to synchronize samples
+
+    property_map perfBlockProperties;
+    if constexpr (std::is_same_v<TBlock, gr::basic::SyncBlock<int>>) {
+        perfBlockProperties = {{"n_ports", nPorts}};
+    } else if constexpr (std::is_same_v<TBlock, gr::basic::Selector<int>>) {
+        auto                    iotaView = std::views::iota(gr::Size_t(0), nPorts);
+        std::vector<gr::Size_t> indMap(iotaView.begin(), iotaView.end());
+        perfBlockProperties = {{"n_inputs", nPorts}, {"n_outputs", nPorts}, {"map_in", indMap}, {"map_out", indMap}};
+    } else {
+        throw std::invalid_argument("incorrect TBlock type");
+    }
+
+    auto& perfBlock = graph.emplaceBlock<TBlock>(perfBlockProperties);
+
+    std::vector<TagSource<int, ProcessFunction::USE_PROCESS_BULK>*> sources;
+    std::vector<TagSink<int, ProcessFunction::USE_PROCESS_BULK>*>   sinks;
+
+    for (std::size_t i = 0; i < nPorts; i++) {
+        property_map srcParams = {{"n_samples_max", nSamples}, {"verbose_console", false}, {"disconnect_on_done", false}};
+        sources.push_back(std::addressof(graph.emplaceBlock<TagSource<int, ProcessFunction::USE_PROCESS_BULK>>(srcParams)));
+        for (std::size_t iT = 0; iT < nTags; iT++) {
+            const std::size_t   index = iT * nSamples / nTags + 1;
+            const std::uint64_t time  = iT * 100;
+            sources[i]->_tags.push_back(genSyncTag(index, time));
+        }
+        expect(gr::ConnectionResult::SUCCESS == graph.connect(*sources[i], "out"s, perfBlock, "inputs#"s + std::to_string(i)));
+    }
+
+    for (std::size_t i = 0; i < nPorts; i++) {
+        property_map sinkParams = {{"log_samples", false}, {"log_tags", false}, {"verbose_console", false}, {"disconnect_on_done", false}};
+        sinks.push_back(std::addressof(graph.emplaceBlock<TagSink<int, ProcessFunction::USE_PROCESS_BULK>>(sinkParams)));
+        expect(gr::ConnectionResult::SUCCESS == graph.connect(perfBlock, "outputs#"s + std::to_string(i), *sinks[i], "in"s));
+    }
+
+    gr::scheduler::Simple sched{std::move(graph)};
+    ::benchmark::benchmark<nRepeats>(fmt::format("src->{}->sink", gr::meta::type_name<TBlock>()), nSamples) = [&]() {
+        sched.runAndWait();
+        expect(eq(sinks[0]->_nSamplesProduced, nSamples));
+    };
+}
+
+void runTestPureCopy() {
+    using namespace boost::ut;
+    using namespace benchmark;
+    using namespace gr;
+    using namespace gr::basic;
+    using namespace gr::testing;
+
+    gr::Graph graph;
+
+    std::vector<TagSource<int, ProcessFunction::USE_PROCESS_BULK>*> sources;
+    std::vector<TagSink<int, ProcessFunction::USE_PROCESS_BULK>*>   sinks;
+    std::vector<Copy<int>*>                                         copies;
+
+    for (std::size_t i = 0; i < nPorts; i++) {
+        property_map srcParams = {{"n_samples_max", nSamples}, {"verbose_console", false}, {"disconnect_on_done", false}};
+        sources.push_back(std::addressof(graph.emplaceBlock<TagSource<int, ProcessFunction::USE_PROCESS_BULK>>(srcParams)));
+        copies.push_back(std::addressof(graph.emplaceBlock<Copy<int>>()));
+        property_map sinkParams = {{"log_samples", false}, {"log_tags", false}, {"verbose_console", false}, {"disconnect_on_done", false}};
+        sinks.push_back(std::addressof(graph.emplaceBlock<TagSink<int, ProcessFunction::USE_PROCESS_BULK>>(sinkParams)));
+
+        expect(gr::ConnectionResult::SUCCESS == graph.connect(*sources[i], "out"s, *copies[i], "in"s));
+        expect(gr::ConnectionResult::SUCCESS == graph.connect(*copies[i], "out"s, *sinks[i], "in"s));
+    }
+
+    gr::scheduler::Simple sched{std::move(graph)};
+    ::benchmark::benchmark<nRepeats>("src->copy->sink", nSamples) = [&]() {
+        sched.runAndWait();
+        expect(eq(sinks[0]->_nSamplesProduced, nSamples));
+    };
+}
+
+inline const boost::ut::suite _constexpr_bm = [] {
+    runTest<gr::basic::SyncBlock<int>>();
+    runTest<gr::basic::Selector<int>>();
+    runTestPureCopy();
+};
+
+int main() { /* not needed by the UT framework */ }

--- a/core/include/gnuradio-4.0/HistoryBuffer.hpp
+++ b/core/include/gnuradio-4.0/HistoryBuffer.hpp
@@ -102,7 +102,9 @@ public:
      */
     template<typename Iter>
     constexpr void push_back_bulk(Iter cbegin, Iter cend) noexcept {
-        for (auto it = cbegin; it != cend; ++it) {
+        const auto nSamplesToCopy = std::distance(cbegin, cend);
+        Iter       optimizedBegin = static_cast<std::size_t>(nSamplesToCopy) > _capacity ? std::prev(cend, static_cast<std::ptrdiff_t>(_capacity)) : cbegin;
+        for (auto it = optimizedBegin; it != cend; ++it) {
             push_back(*it);
         }
     }
@@ -112,9 +114,7 @@ public:
      */
     template<typename Range>
     constexpr void push_back_bulk(const Range& range) noexcept {
-        for (const auto& item : range) {
-            push_back(item);
-        }
+        push_back_bulk(range.cbegin(), range.cend());
     }
 
     /**

--- a/core/include/gnuradio-4.0/Tag.hpp
+++ b/core/include/gnuradio-4.0/Tag.hpp
@@ -170,6 +170,7 @@ inline EM_CONSTEXPR_STATIC DefaultTag<"signal_name", std::string, "", "signal na
 inline EM_CONSTEXPR_STATIC DefaultTag<"signal_unit", std::string, "", "signal's physical SI unit"> SIGNAL_UNIT;
 inline EM_CONSTEXPR_STATIC DefaultTag<"signal_min", float, "a.u.", "signal physical max. (e.g. DAQ) limit"> SIGNAL_MIN;
 inline EM_CONSTEXPR_STATIC DefaultTag<"signal_max", float, "a.u.", "signal physical max. (e.g. DAQ) limit"> SIGNAL_MAX;
+inline EM_CONSTEXPR_STATIC DefaultTag<"n_dropped_samples", std::size_t, "", "number of dropped samples"> N_DROPPED_SAMPLES;
 inline EM_CONSTEXPR_STATIC DefaultTag<"trigger_name", std::string> TRIGGER_NAME;
 inline EM_CONSTEXPR_STATIC DefaultTag<"trigger_time", uint64_t, "ns", "UTC-based time-stamp"> TRIGGER_TIME;
 inline EM_CONSTEXPR_STATIC DefaultTag<"trigger_offset", float, "s", "sample delay w.r.t. the trigger (e.g.compensating analog group delays)"> TRIGGER_OFFSET;
@@ -179,7 +180,7 @@ inline EM_CONSTEXPR_STATIC DefaultTag<"reset_default", bool, "", "reset block st
 inline EM_CONSTEXPR_STATIC DefaultTag<"store_default", bool, "", "store block settings as default"> STORE_DEFAULTS;
 inline EM_CONSTEXPR_STATIC DefaultTag<"end_of_stream", bool, "", "end of stream, receiver should change to DONE state"> END_OF_STREAM;
 
-inline constexpr std::array<std::string_view, 14> kDefaultTags = {"sample_rate", "signal_name", "signal_quantity", "signal_unit", "signal_min", "signal_max", "trigger_name", "trigger_time", "trigger_offset", "trigger_meta_info", "context", "reset_default", "store_default", "end_of_stream"};
+inline constexpr std::array<std::string_view, 15> kDefaultTags = {"sample_rate", "signal_name", "signal_quantity", "signal_unit", "signal_min", "signal_max", "n_dropped_samples", "trigger_name", "trigger_time", "trigger_offset", "trigger_meta_info", "context", "reset_default", "store_default", "end_of_stream"};
 
 } // namespace tag
 

--- a/core/test/qa_buffer.cpp
+++ b/core/test/qa_buffer.cpp
@@ -792,10 +792,10 @@ const boost::ut::suite HistoryBufferTest = [] {
         auto               in = std::vector{1, 2, 3, 4, 5, 6};
         hb_overflow.push_back_bulk(in.begin(), in.end());
         expect(eq(hb_overflow[0], 6));
-        hb_overflow.push_back_bulk(std::vector{7, 8, 9});
-        expect(eq(hb_overflow[0], 9));
-        hb_overflow.push_back_bulk(std::array{10, 11, 12});
-        expect(eq(hb_overflow[0], 12));
+        hb_overflow.push_back_bulk(std::vector{7, 8, 9, 10, 11, 12, 13, 14});
+        expect(eq(hb_overflow[0], 14));
+        hb_overflow.push_back_bulk(std::array{15, 16, 17});
+        expect(eq(hb_overflow[0], 17));
 
         // Test with different types, e.g., double
         HistoryBuffer<double> hb_double(5);


### PR DESCRIPTION
- This PR introduces a `SyncBlock` to synchronize data streams across multiple inputs that have the same sample rate. 
- It addresses key scenarios including initial time shifts, clock drift, and significant delays. 
- The `SyncBlock` synchronises input samples based on synchronization tags and publishes desynchronization tags with information about number of samples that were dropped.
- Add `bm_sync` for performance comparison

```
┌──────────────benchmark:───────────────┬──────┬──CPU branch misses───┬─ops/s─┬──mean──┬─<CPU-I>─┬───CPU cache misses───┬─stddev─┬─#N─┬─CTX-SW─┬─total time─┬─min─┬─median─┬─max─┐
│ src->gr::basic::SyncBlock<int>->sink  │ PASS │ 3.10M / 382M =  0.8% │  4.7G │ 843 ms │    930m │ 494M / 1.77G = 27.9% │        │    │     1  │     843 ms │     │        │     │
│ src->gr::basic::Selector<int>->sink   │ PASS │  394k / 363M =  0.1% │  4.7G │ 851 ms │    907m │ 409M / 1.86G = 22.0% │        │    │     2  │     851 ms │     │        │     │
│ src->copy->sink                       │ PASS │  403k / 125M =  0.3% │  4.8G │ 835 ms │    651m │ 337M / 1.94G = 17.3% │        │    │     2  │     835 ms │     │        │     │
└───────────────────────────────────────┴──────┴──────────────────────┴───────┴────────┴─────────┴──────────────────────┴────────┴────┴────────┴────────────┴─────┴────────┴─────┘
```

Related follow-up issue: #466 