### PR TITLE
Bump Emscripten version to 3.1.66

### DIFF
--- a/core/benchmarks/CMakeLists.txt
+++ b/core/benchmarks/CMakeLists.txt
@@ -1,14 +1,24 @@
-function(add_gr_benchmark BM_NAME)
+if(NOT EMSCRIPTEN)
+  function(add_gr_benchmark BM_NAME)
     add_benchmark(${BM_NAME})
-    target_link_libraries(${BM_NAME} PRIVATE gnuradio-core fmt gr-basic gr-fileio gr-math gr-testing)
-    target_compile_options(${BM_NAME} PRIVATE -O3) # performance related benchmarks should be optimised during compile-time
-endfunction()
+    target_link_libraries(
+      ${BM_NAME}
+      PRIVATE gnuradio-core
+              fmt
+              gr-basic
+              gr-fileio
+              gr-math
+              gr-testing)
+    target_compile_options(${BM_NAME} PRIVATE -O3) # performance related benchmarks should be optimised during
+                                                   # compile-time
+  endfunction()
 
-add_gr_benchmark(bm_Buffer)
-add_gr_benchmark(bm_HistoryBuffer)
-add_gr_benchmark(bm_Profiler)
-add_gr_benchmark(bm_Scheduler)
-add_gr_benchmark(bm-nosonar_node_api)
-add_gr_benchmark(bm_fft)
-add_gr_benchmark(bm_sync)
-target_link_libraries(bm_fft PRIVATE gr-fourier)
+  add_gr_benchmark(bm_Buffer)
+  add_gr_benchmark(bm_HistoryBuffer)
+  add_gr_benchmark(bm_Profiler)
+  add_gr_benchmark(bm_Scheduler)
+  add_gr_benchmark(bm-nosonar_node_api)
+  add_gr_benchmark(bm_fft)
+  add_gr_benchmark(bm_sync)
+  target_link_libraries(bm_fft PRIVATE gr-fourier)
+endif()

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,7 @@ ENV JAVA_HOME=/opt/java/openjdk \
     LC_ALL=en_US.UTF-8 \
     CMAKE_MAKE_PROGRAM=ninja \
     EMSDK_HOME=/opt/emsdk \
-    EMSDK_VERSION=3.1.56
+    EMSDK_VERSION=3.1.66
 
 # Install compilers, package managers and build-tools
 # As we are using the the ubuntu prerelease llvm and cmake are fresh enough, readd these if the version is not sufficient anymore


### PR DESCRIPTION
The Emscripten issue, likely caused by resource exhaustion, was introduced in [PR #456](https://github.com/fair-acc/gnuradio4/pull/456). 

This PR fixes the problem by bumping to the new Emscripten version and removing benchmark tests from compilation.

The `qa_Message` test failed due to the new tests added in [PR #456](https://github.com/fair-acc/gnuradio4/pull/456). This issue went unnoticed because the same PR also introduced the Emscripten resource exhaustion problem.