### PR TITLE
Fix qa_Messages on Emscripten build

### DIFF
--- a/core/include/gnuradio-4.0/Block.hpp
+++ b/core/include/gnuradio-4.0/Block.hpp
@@ -1068,7 +1068,8 @@ protected:
         assert(propertyName == block::property::kActiveContext);
 
         if (message.cmd == Get) {
-            message.data = {{"context", settings().activeContext().context}};
+            const auto& ctx = settings().activeContext();
+            message.data    = {{"context", ctx.context}, {"time", ctx.time}};
             return message;
         }
 


### PR DESCRIPTION
Issue here is that on WASM we have offsets added to our Context.time which then get's out of sync to what the client sent.