### PR TITLE
Return a message when a Settings Context is removed

### DIFF
--- a/core/include/gnuradio-4.0/Block.hpp
+++ b/core/include/gnuradio-4.0/Block.hpp
@@ -1043,12 +1043,6 @@ protected:
         using enum gr::message::Command;
         assert(propertyName == block::property::kActiveContext);
 
-        if (message.cmd == Get) {
-            const auto& ctx = settings().activeContext();
-            message.data    = {{"context", ctx.context}, {"time", ctx.time}};
-            return message;
-        }
-
         if (message.cmd == Set) {
             if (!message.data.has_value()) {
                 throw gr::exception(fmt::format("block {} (aka. {}) cannot set {} w/o data msg: {}", unique_name, name, propertyName, message));
@@ -1082,8 +1076,11 @@ protected:
             if (!ctx.has_value()) {
                 throw gr::exception(fmt::format("propertyCallbackActiveContext - failed to activate context {}, msg: {}", contextStr, message));
             }
+        }
 
-            message.data = {{"context", ctx.value().context}};
+        if (message.cmd == Get || message.cmd == Set) {
+            const auto& ctx = settings().activeContext();
+            message.data    = {{"context", ctx.context}, {"time", ctx.time}};
             return message;
         }
 
@@ -1162,7 +1159,7 @@ protected:
             if (!settings().removeContext(ctx)) {
                 throw gr::exception(fmt::format("propertyCallbackSettingsCtx - could not delete context {}, msg: {}", ctx.context, message));
             }
-            return std::nullopt;
+            return message;
         }
 
         throw gr::exception(fmt::format("block {} property {} does not implement command {}, msg: {}", unique_name, propertyName, message.cmd, message));

--- a/core/test/qa_Messages.cpp
+++ b/core/test/qa_Messages.cpp
@@ -454,6 +454,7 @@ const boost::ut::suite MessagesTests = [] {
                 expect(eq(reply.endpoint, std::string(block::property::kActiveContext)));
                 expect(reply.data.has_value());
                 expect(reply.data.value().contains("context"));
+                expect(reply.data.value().contains("time"));
                 expect(eq("new_context"s, std::get<std::string>(reply.data.value().at("context"))));
             };
 
@@ -469,6 +470,7 @@ const boost::ut::suite MessagesTests = [] {
                 expect(eq(reply.endpoint, std::string(block::property::kActiveContext)));
                 expect(reply.data.has_value());
                 expect(reply.data.value().contains("context"));
+                expect(reply.data.value().contains("time"));
                 expect(eq("new_context"s, std::get<std::string>(reply.data.value().at("context"))));
             };
 
@@ -510,8 +512,9 @@ const boost::ut::suite MessagesTests = [] {
                 sendMessage<Disconnect>(toBlock, "" /* serviceName */, block::property::kSettingsCtx /* endpoint */, {{"context", "new_context"}, {"time", internalTimeForWasm}} /* data  */);
                 expect(nothrow([&] { unitTestBlock.processScheduledMessages(); })) << "manually execute processing of messages";
 
-                expect(eq(fromBlock.streamReader().available(), 0UZ)) << "should not receive a reply";
-                std::string activeContext = std::get<std::string>(unitTestBlock.settings().activeContext().context);
+                expect(eq(fromBlock.streamReader().available(), 1UZ)) << "didn't receive reply message";
+                const Message reply         = returnReplyMsg(fromBlock);
+                std::string   activeContext = std::get<std::string>(unitTestBlock.settings().activeContext().context);
                 expect(eq(""s, activeContext));
             };
 


### PR DESCRIPTION
Also always return current active context time when set/get