### PR TITLE
Add Schmitt Trigger Block with Uncertainty Support and Optional Interpolation

### DIFF
--- a/algorithm/include/gnuradio-4.0/algorithm/SchmittTrigger.hpp
+++ b/algorithm/include/gnuradio-4.0/algorithm/SchmittTrigger.hpp
@@ -1,0 +1,276 @@
+#ifndef SCHMITTTRIGGER_HPP
+#define SCHMITTTRIGGER_HPP
+
+#include <cmath>
+#include <cstddef>
+
+#include <gnuradio-4.0/HistoryBuffer.hpp>
+#include <gnuradio-4.0/meta/UncertainValue.hpp>
+
+namespace gr::trigger {
+
+/**
+ * @brief Enumeration for the interpolation methods used for sub-sample
+ * precision.
+ */
+enum class InterpolationMethod {
+    NO_INTERPOLATION           = 0,
+    BASIC_LINEAR_INTERPOLATION = 1, /// basic linear interpolation
+    LINEAR_INTERPOLATION       = 2, /// interpolation via linear regression over multiple samples
+    POLYNOMIAL_INTERPOLATION   = 3  /// Savitzky–Golay filter-based methods
+};
+
+enum class EdgeDetection { NONE = 0, RISING = 1, FALLING = 2 };
+
+/**
+ * @brief A real-time capable digital Schmitt trigger implementation.
+ *
+ * @see https://en.wikipedia.org/wiki/Schmitt_trigger
+ * This class processes input samples and detects rising and falling edges based on specified thresholds.
+ * It supports sub-sample precision through various interpolation methods:
+ *  * NO_INTERPOLATION: nomen est omen
+ *  * BASIC_LINEAR_INTERPOLATION: basic linear interpolation based on the new and previous sample
+ *  * LINEAR_INTERPOLATION: interpolation via linear regression over the samples between when
+ *    the lower and upper threshold has been crossed and vice versa
+ *  * POLYNOMIAL_INTERPOLATION: Savitzky–Golay filter-based methods
+ *    https://en.wikipedia.org/wiki/Savitzky%E2%80%93Golay_filter
+ *     (TODO: WIP needs Tensor<T> and SVD implementation)
+ */
+template<typename T, InterpolationMethod Method = InterpolationMethod::NO_INTERPOLATION, std::size_t interpolationWindow = 16UZ>
+requires(std::is_arithmetic_v<T> or (UncertainValueLike<T> && std::is_arithmetic_v<meta::fundamental_base_value_type_t<T>>))
+struct SchmittTrigger {
+    static_assert(Method != InterpolationMethod::POLYNOMIAL_INTERPOLATION, "POLYNOMIAL_INTERPOLATION not implemented yet");
+    using value_t  = meta::fundamental_base_value_type_t<T>;
+    using EdgeType = UncertainValue<float>; // always float precision similar to `sample_rate` definition
+
+    value_t _threshold{1};
+    value_t _offset{0};
+    value_t _upperThreshold;
+    value_t _lowerThreshold;
+
+    bool _lastState{false}; // true if above upper threshold
+
+    HistoryBuffer<T, interpolationWindow> _historyBuffer;
+
+    // edge timing variables
+    EdgeDetection lastEdge = EdgeDetection::NONE;
+    std::int32_t  lastEdgeIdx{1};    /// relative index [-std::int32_t|_MAX,1[ of the last detected edge w.r.t. current sample
+    EdgeType      lastEdgeOffset{0}; /// relative sub-sample offset [0, 1[ of the last detected edge
+
+    std::size_t accumulatedSamples = 0UZ; // number of samples accumulated once threshold has been entered
+
+    constexpr explicit SchmittTrigger(value_t threshold = 1, value_t offset = 0) noexcept : _threshold(threshold), _offset(offset), _upperThreshold(_offset + _threshold), _lowerThreshold(_offset - _threshold) {}
+
+    constexpr void setThreshold(value_t threshold) {
+        _threshold      = threshold;
+        _upperThreshold = _offset + _threshold;
+        _lowerThreshold = _offset - _threshold;
+    }
+
+    constexpr void setOffset(value_t offset) {
+        _offset         = offset;
+        _upperThreshold = _offset + _threshold;
+        _lowerThreshold = _offset - _threshold;
+    }
+
+    constexpr void reset() {
+        accumulatedSamples = 0UZ;
+        lastEdge           = EdgeDetection::NONE;
+        lastEdgeIdx        = 1;
+        lastEdgeOffset     = 0.0f;
+    }
+
+    EdgeDetection processOne(T input) {
+        using enum InterpolationMethod;
+
+        if constexpr (Method == NO_INTERPOLATION) {
+            if (!_lastState && input >= _upperThreshold) { // rising edge detected
+                lastEdgeIdx = 0;
+                lastEdge    = EdgeDetection::RISING;
+                _lastState  = true;
+                return EdgeDetection::RISING;
+            }
+
+            if (_lastState && input <= _lowerThreshold) { // falling edge detected
+                lastEdgeIdx = 0;
+                lastEdge    = EdgeDetection::FALLING;
+                _lastState  = false;
+                return EdgeDetection::FALLING;
+            }
+            lastEdgeIdx = lastEdgeIdx > 0 ? 1 : lastEdgeIdx - 1;
+            lastEdgeIdx = lastEdgeIdx > 0 ? 1 : lastEdgeIdx - 1;
+            return EdgeDetection::NONE;
+        }
+
+        if constexpr (Method == BASIC_LINEAR_INTERPOLATION) {
+            _historyBuffer.push_back(input);
+            if (_historyBuffer.size() < 2) {
+                return EdgeDetection::NONE;
+            }
+
+            const T yPrev = _historyBuffer[1];
+            const T yCurr = _historyBuffer[0];
+
+            auto computeEdgePosition = [&](const EdgeType& y1, const EdgeType& y2) -> std::pair<std::int32_t, EdgeType> {
+                if (y1 == y2) {
+                    return {static_cast<std::int32_t>(0), static_cast<EdgeType>(0)};
+                }
+                const EdgeType offset   = (EdgeType(_offset) - y1) / (y2 - y1);
+                std::int32_t   intPart  = static_cast<std::int32_t>(std::floor(gr::value(offset)));
+                EdgeType       fracPart = offset - static_cast<float>(intPart);
+                return {intPart, fracPart};
+            };
+
+            if (!_lastState && input >= _upperThreshold) { // Rising edge detected
+                lastEdge                 = EdgeDetection::RISING;
+                auto [intPart, fracPart] = computeEdgePosition(yPrev, yCurr);
+                lastEdgeIdx              = -1 + intPart; // edge occurred intPart samples before the current sample
+                lastEdgeOffset           = fracPart;     // fractional part in [0, 1)
+                _lastState               = true;
+                return EdgeDetection::RISING;
+            }
+
+            if (_lastState && input <= _lowerThreshold) { // Falling edge detected
+                lastEdge                 = EdgeDetection::FALLING;
+                auto [intPart, fracPart] = computeEdgePosition(yPrev, yCurr);
+                lastEdgeIdx              = -1 + intPart; // edge occurred intPart samples before the current sample
+                lastEdgeOffset           = fracPart;     // fractional part in [0, 1)
+                _lastState               = false;
+                return EdgeDetection::FALLING;
+            }
+
+            lastEdgeIdx = lastEdgeIdx > 0 ? 1 : lastEdgeIdx - 1;
+            lastEdgeIdx = lastEdgeIdx > 0 ? 1 : lastEdgeIdx - 1;
+            return EdgeDetection::NONE;
+        }
+
+        if constexpr (Method == LINEAR_INTERPOLATION) {
+            _historyBuffer.push_back(input);
+
+            if (_historyBuffer.size() < 2) {
+                return EdgeDetection::NONE;
+            }
+
+            const T yPrev = _historyBuffer[1];
+            const T yCurr = _historyBuffer[0];
+
+            if (!_lastState && yPrev <= _lowerThreshold && yCurr > _lowerThreshold) { // detected rising edge -> start accumulating samples
+                accumulatedSamples = 1UZ;
+            }
+
+            if (_lastState && yPrev >= _upperThreshold && yCurr < _upperThreshold) { // detected falling edge -> start accumulating samples
+                accumulatedSamples = 1UZ;
+            }
+
+            if (accumulatedSamples > 0) {
+                accumulatedSamples++;
+
+                if ((!_lastState && yCurr >= _upperThreshold) || (_lastState && yCurr <= _lowerThreshold)) { // opposite threshold has been crossed
+                    EdgeDetection detectedEdge = (!_lastState && yCurr >= _upperThreshold) ? EdgeDetection::RISING : EdgeDetection::FALLING;
+
+                    // use all accumulated samples in regression
+                    size_t n        = std::min(accumulatedSamples, _historyBuffer.size());
+                    auto   crossing = findCrossingIndexLinearRegression(_historyBuffer, n, _offset);
+
+                    if (crossing) {
+                        const value_t relativeIndex = gr::value(*crossing) - static_cast<value_t>(n - 1);
+
+                        lastEdge    = detectedEdge;
+                        lastEdgeIdx = static_cast<std::int32_t>(std::floor(relativeIndex));
+                        if constexpr (UncertainValueLike<T>) {
+                            lastEdgeOffset = T{relativeIndex - static_cast<float>(gr::value(lastEdgeIdx)), static_cast<float>(gr::uncertainty(*crossing))};
+                        } else {
+                            lastEdgeOffset = EdgeType{relativeIndex - static_cast<float>(lastEdgeIdx)};
+                        }
+
+                        // update state and reset accumulation
+                        _lastState         = !_lastState;
+                        accumulatedSamples = 0UZ;
+                        return detectedEdge;
+                    }
+                } else {
+                    // reset accumulation if threshold zone is left without crossing the opposite threshold,
+                    if ((!_lastState && yCurr < _lowerThreshold) || (_lastState && yCurr > _upperThreshold)) {
+                        accumulatedSamples = 0UZ;
+                    }
+                }
+            }
+
+            return EdgeDetection::NONE;
+        }
+
+        if constexpr (Method == POLYNOMIAL_INTERPOLATION) {
+            static_assert(gr::meta::always_false<T>, "POLYNOMIAL_INTERPOLATION not implemented yet");
+        }
+
+        return EdgeDetection::NONE;
+    }
+
+    std::optional<T> findCrossingIndexLinearRegression(const auto& samples, std::size_t nSamples, value_t offset) {
+        if (nSamples < 2) { // not enough samples to perform linear regression
+            return std::nullopt;
+        }
+
+        const auto n_val = static_cast<value_t>(nSamples);
+        // sum of squares of the first (nSamples - 1) natural numbers
+        const value_t sumX2 = (n_val * (n_val - value_t(1)) * (value_t(2) * n_val - value_t(1))) / value_t(6);
+        const auto    meanX = value_t(0.5f) * (n_val - value_t(1));
+
+        value_t sumY  = 0;
+        value_t sumXY = 0;
+        for (std::size_t i = 0; i < nSamples; ++i) {
+            const auto xi = static_cast<value_t>(nSamples - 1 - i); // rationale: reversed indexing samples
+            const auto yi = gr::value(samples[i]);
+            sumY += yi;
+            sumXY += xi * yi;
+        }
+
+        const value_t meanY       = sumY / n_val;
+        const value_t numerator   = sumXY - n_val * meanX * meanY;
+        const value_t denominator = sumX2 - n_val * meanX * meanX;
+
+        if (denominator == 0.0f) {
+            return std::nullopt;
+        }
+
+        const value_t slope         = numerator / denominator; // slope of the regression line
+        const value_t intercept     = meanY - slope * meanX;   // intercept point of the regression line
+        const value_t crossingIndex = (offset - intercept) / slope;
+
+        if constexpr (UncertainValueLike<T>) {   // propagation of uncertainty
+            const value_t x_uncertainty = 1e-5f; // fixed uncertainty for x-axis for common ADC clock stability
+
+            value_t varianceY = 0.0f; // variance of the mean
+            for (std::size_t i = 0; i < nSamples; ++i) {
+                value_t u = gr::uncertainty(samples[i]);
+                varianceY += u * u;
+            }
+            varianceY /= (n_val * n_val);
+            varianceY += slope * slope * x_uncertainty * x_uncertainty;
+
+            // variance of slope (m) and intercept (b)
+            const value_t var_m = varianceY / denominator;
+            const value_t var_b = varianceY * sumX2 / (n_val * denominator);
+
+            // covariance between slope and intercept
+            value_t cov_mb = -varianceY * meanX / denominator;
+
+            // partial derivatives for crossing index = (offset - b) / m
+            // d(crossingIndex)/db = -1/m
+            // d(crossingIndex)/dm = -(offset - b)/m^2
+            value_t d_ci_db = -value_t(1) / slope;
+            value_t d_ci_dm = -(gr::value(offset) - intercept) / (slope * slope);
+
+            // error propagation
+            value_t var_ci = (d_ci_db * d_ci_db * var_b) + (d_ci_dm * d_ci_dm * var_m) + (value_t(2) * d_ci_db * d_ci_dm * cov_mb);
+
+            return T{crossingIndex, var_ci < 0 ? value_t(0) : std::sqrt(var_ci) /* uncertainty */};
+        } else { // fundamental type ->  no uncertainty
+            return std::make_optional(crossingIndex);
+        }
+    }
+};
+
+} // namespace gr::trigger
+
+#endif // SCHMITTTRIGGER_HPP

--- a/algorithm/test/CMakeLists.txt
+++ b/algorithm/test/CMakeLists.txt
@@ -1,9 +1,11 @@
 add_ut_test(qa_algorithm_fourier)
 add_ut_test(qa_FilterTool)
 add_ut_test(qa_ImChart)
+add_ut_test(qa_SchmittTrigger)
 target_link_libraries(qa_algorithm_fourier PRIVATE gnuradio-algorithm)
 target_link_libraries(qa_FilterTool PRIVATE gnuradio-algorithm)
 target_link_libraries(qa_ImChart PRIVATE gnuradio-algorithm)
+target_link_libraries(qa_SchmittTrigger PRIVATE gnuradio-algorithm)
 
 add_executable(example_ImChart example_ImChart.cpp)
 target_link_libraries(example_ImChart PRIVATE gnuradio-algorithm)

--- a/algorithm/test/qa_SchmittTrigger.cpp
+++ b/algorithm/test/qa_SchmittTrigger.cpp
@@ -1,0 +1,197 @@
+#include <boost/ut.hpp>
+
+#include <vector>
+
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+
+#include <gnuradio-4.0/algorithm/SchmittTrigger.hpp>
+#include <gnuradio-4.0/meta/UncertainValue.hpp>
+#include <gnuradio-4.0/meta/formatter.hpp>
+
+using namespace boost::ut;
+
+namespace {
+using namespace gr::trigger;
+
+template<typename T>
+std::vector<T> convert_signal(const std::vector<double>& input) {
+    using value_t = gr::meta::fundamental_base_value_type_t<T>;
+    std::vector<T> signal;
+    signal.reserve(input.size());
+    for (auto v : input) {
+        if constexpr (std::is_arithmetic_v<T>) {
+            signal.emplace_back(static_cast<T>(static_cast<value_t>(v)));
+        } else {
+            signal.emplace_back(gr::UncertainValue<value_t>(static_cast<value_t>(v), static_cast<value_t>(0.01))); // add some uncertainty
+        }
+    }
+    return signal;
+}
+
+template<typename T, gr::fixed_string testCaseName, typename Trigger, typename EdgeType = gr::UncertainValue<float>> // always float precision similar to `sample_rate` definition
+void test_schmitt_trigger_with_signal(Trigger& trigger, const std::vector<T>& signal, const std::vector<std::tuple<EdgeDetection, EdgeType>>& expected_edges) {
+    using enum gr::trigger::EdgeDetection;
+    using value_t                  = gr::meta::fundamental_base_value_type_t<T>;
+    const std::string fullTestName = fmt::format("{} - data: {}({})", testCaseName.c_str(), gr::meta::type_name<T>(), signal);
+
+    fmt::println("test: {}", fullTestName);
+    std::vector<std::tuple<EdgeDetection, EdgeType>> detected_edges;
+    std::ptrdiff_t                                   dataIndex = 0;
+    for (const auto& sample : signal) {
+        if (trigger.processOne(sample) != NONE) {
+            EdgeType sample_index = EdgeType{static_cast<float>(dataIndex + trigger.lastEdgeIdx)} + trigger.lastEdgeOffset;
+            detected_edges.emplace_back(trigger.lastEdge, sample_index);
+            fmt::println("   {:7} edge detected at sample index: {:.4f} (Idx: {}, Offset: {:.3f})", //
+                magic_enum::enum_name(trigger.lastEdge), sample_index, trigger.lastEdgeIdx, trigger.lastEdgeOffset);
+        }
+        dataIndex = dataIndex + 1;
+    }
+
+    expect(eq(detected_edges.size(), expected_edges.size())) << fmt::format("{}: n detected ({}) vs. expected ({}) edges does not match", fullTestName, detected_edges.size(), expected_edges.size());
+
+    for (std::size_t i = 0; i < expected_edges.size(); ++i) {
+        auto [expected_edge, expected_index] = expected_edges[i];
+        auto [detected_edge, detected_index] = detected_edges[i];
+
+        expect(detected_edge == expected_edge) << fmt::format("{}: detected {} edge type does not match expected {} at index {}\n", //
+            fullTestName, magic_enum::enum_name(detected_edge), magic_enum::enum_name(expected_edge), i);
+        expect(approx(gr::value(detected_index), gr::value(expected_index), std::is_floating_point_v<value_t> ? static_cast<value_t>(0.1f) : 0.1f)) //
+            << fmt::format("{}: detected edge ({}): is {} vs. expected {}\n", fullTestName, i, gr::value(detected_index), gr::value(expected_index));
+    }
+}
+} // namespace
+
+const suite<"SchmittTrigger"> SchmittTriggerTests = [] {
+    using namespace gr::trigger;
+    using enum gr::trigger::InterpolationMethod;
+    using enum gr::trigger::EdgeDetection;
+
+    // Test suite for different types
+    "SchmittTrigger w/ and w/o error propagation"_test = []<typename T>() {
+        using value_t = gr::meta::fundamental_base_value_type_t<T>;
+
+        "no interpolation"_test = [] {
+            SchmittTrigger<T> trigger(value_t(0.1f) /* threshold */, value_t(0.5f) /* offset */);
+
+            test_schmitt_trigger_with_signal<T, "slow rising edge (no interpolation)">(trigger,                                                                //
+                convert_signal<T>({0.3, 0.4, 0.45, 0.5, 0.55, 0.6 /* >= offset + threshold (RISING) */, 1.0, 1.0, 0.0 /* <= offset - threshold (FALLING) */}), //
+                {{RISING, 5}, {FALLING, 8}});
+
+            trigger.reset();
+            test_schmitt_trigger_with_signal<T, "slow falling edge (no interpolation)">(trigger,                                            //
+                convert_signal<T>({/* RISING */ 1.0, 0.9, 0.85, 0.8, 0.75, 0.7, 0.65, 0.6, 0.55, 0.5, 0.45, 0.4 /* FALLING */, 0.35, 0.3}), //
+                {{RISING, 0}, {FALLING, 11}});
+
+            trigger.reset();
+            test_schmitt_trigger_with_signal<T, "fast rising/falling edges (no interpolation)">(trigger,                                                            //
+                convert_signal<T>({0.0, 0.8 /* RISING */, 1.2, 0.9, 0.4 /* FALLING */, -0.2, -1.1, -0.5, 0.0, 1.1 /* RISING */, 1.1, 1.0, 0.0 /* FALLING */, 0.0}), //
+                {{RISING, 1}, {FALLING, 4}, {RISING, 9}, {FALLING, 12}});
+
+            trigger.reset();
+            test_schmitt_trigger_with_signal<T, "Dirac delta">(trigger,        //
+                convert_signal<T>({0.0, 1.0 /* RISING */, 0.0 /* FALLING */}), //
+                {{RISING, 1}, {FALLING, 2}});
+        };
+
+        "basic linear interpolation"_test = [] {
+            SchmittTrigger<T, BASIC_LINEAR_INTERPOLATION> trigger(value_t(0.1f) /* threshold */, value_t(0.5f) /* offset */);
+
+            test_schmitt_trigger_with_signal<T, "slow rising edge (basic)">(trigger,                                                             //
+                convert_signal<T>({0.3, 0.4, 0.45, 0.5 /* >= offset (int. RISING) */, 0.55, 0.6, 1.0, 1.0 /* <= offset (int. FALLING) */, 0.0}), //
+                {{RISING, 3}, {FALLING, 7.5f}});
+
+            trigger.reset();
+            test_schmitt_trigger_with_signal<T, "slow falling edge (basic)">(trigger,                                                       //
+                convert_signal<T>({/* RISING */ 1.0, 0.9, 0.85, 0.8, 0.75, 0.7, 0.65, 0.6, 0.55, 0.5 /* FALLING */, 0.45, 0.4, 0.35, 0.3}), //
+                {{RISING, -0.5}, {FALLING, 9.0}});
+
+            test_schmitt_trigger_with_signal<T, "fast rising/falling edges (basic)">(trigger,                                                                       //
+                convert_signal<T>({0.0 /* RISING */, 0.8, 1.2, 0.9 /* FALLING */, 0.4, -0.2, -1.1, -0.5, 0.0 /* RISING */, 1.1, 1.1, 1.0 /* FALLING */, 0.0, 0.0}), //
+                {{RISING, 0.625}, {FALLING, 3.8}, {RISING, 8.45455}, {FALLING, 11.5}});
+
+            trigger.reset();
+            test_schmitt_trigger_with_signal<T, "Dirac delta">(trigger,        //
+                convert_signal<T>({0.0, 1.0 /* RISING */, 0.0 /* FALLING */}), //
+                {{RISING, 0.5}, {FALLING, 1.5}});
+        };
+
+        "linear interpolation (large window)"_test = [] {
+            SchmittTrigger<T, LINEAR_INTERPOLATION, 12> trigger(value_t(0.1f) /* threshold */, value_t(0.5f) /* offset */);
+
+            test_schmitt_trigger_with_signal<T, "slow rising edge (large window)">(trigger,                    //
+                convert_signal<T>({0.3, 0.4, 0.45, 0.5 /* RISING */, 0.55, 0.6, 1.0, 1.0 /* FALLING */, 0.0}), //
+                {{RISING, 3}, {FALLING, 7.5f}});
+
+            trigger.reset();
+            test_schmitt_trigger_with_signal<T, "slow falling edge (large window)">(trigger,                                                //
+                convert_signal<T>({/* RISING */ 1.0, 0.9, 0.85, 0.8, 0.75, 0.7, 0.65, 0.6, 0.55, 0.5 /* FALLING */, 0.45, 0.4, 0.35, 0.3}), //
+                {{RISING, -0.5}, {FALLING, 9.0}});
+
+            trigger.reset();
+            test_schmitt_trigger_with_signal<T, "fast rising/falling edges">(trigger,                                                                               //
+                convert_signal<T>({0.0 /* RISING */, 0.8, 1.2, 0.9 /* FALLING */, 0.4, -0.2, -1.1, -0.5, 0.0 /* RISING */, 1.1, 1.1, 1.0 /* FALLING */, 0.0, 0.0}), //
+                {{RISING, 0.625}, {FALLING, 3.8}, {RISING, 8.45455}, {FALLING, 11.5}});
+
+            trigger.reset();
+            test_schmitt_trigger_with_signal<T, "Dirac delta">(trigger,        //
+                convert_signal<T>({0.0, 1.0 /* RISING */, 0.0 /* FALLING */}), //
+                {{RISING, 0.5}, {FALLING, 1.5}});
+        };
+
+        "linear interpolation (short window)"_test = [] {
+            SchmittTrigger<T, LINEAR_INTERPOLATION, 2> trigger(value_t(0.1f) /* threshold */, value_t(0.5f) /* offset */);
+
+            test_schmitt_trigger_with_signal<T, "slow rising edge (short window)">(trigger,                    //
+                convert_signal<T>({0.3, 0.4, 0.45, 0.5 /* RISING */, 0.55, 0.6, 1.0, 1.0 /* FALLING */, 0.0}), //
+                {{RISING, 3}, {FALLING, 7.5f}});
+
+            trigger.reset();
+            test_schmitt_trigger_with_signal<T, "slow falling edge (short window)">(trigger,                                                //
+                convert_signal<T>({/* RISING */ 1.0, 0.9, 0.85, 0.8, 0.75, 0.7, 0.65, 0.6, 0.55, 0.5 /* FALLING */, 0.45, 0.4, 0.35, 0.3}), //
+                {{RISING, -0.5}, {FALLING, 9.0}});
+
+            trigger.reset();
+            test_schmitt_trigger_with_signal<T, "fast rising/falling edges (short window)">(trigger,                                                                //
+                convert_signal<T>({0.0 /* RISING */, 0.8, 1.2, 0.9 /* FALLING */, 0.4, -0.2, -1.1, -0.5, 0.0 /* RISING */, 1.1, 1.1, 1.0 /* FALLING */, 0.0, 0.0}), //
+                {{RISING, 0.625}, {FALLING, 3.8}, {RISING, 8.45455}, {FALLING, 11.5}});
+
+            trigger.reset();
+            test_schmitt_trigger_with_signal<T, "Dirac delta">(trigger,        //
+                convert_signal<T>({0.0, 1.0 /* RISING */, 0.0 /* FALLING */}), //
+                {{RISING, 0.5}, {FALLING, 1.5}});
+        };
+    } | std::tuple<float, gr::UncertainValue<float>>{};
+
+    "SchmittTrigger (unsigned) integer values"_test = []<typename T>() {
+        using value_t = gr::meta::fundamental_base_value_type_t<T>;
+
+        "integer-type: no interpolation"_test = [] {
+            SchmittTrigger<T> trigger(value_t(1) /* threshold */, value_t(5) /* offset */);
+
+            test_schmitt_trigger_with_signal<T, "slow rising edge (no interpolation)">(trigger,                                      //
+                convert_signal<T>({0, 1, 5 /* RISING */, 7 /* >= offset + threshold */, 7, 7, 8, 0 /* <= offset - threshold */, 0}), //
+                {{RISING, 3}, {FALLING, 7}});
+
+            trigger.reset();
+            test_schmitt_trigger_with_signal<T, "fast rising/falling edges (no interpolation)">(trigger, //
+                convert_signal<T>({0, 10 /* RISING */, 0 /* FALLING */, 7 /* RISING */}),                //
+                {{RISING, 1}, {FALLING, 2}, {RISING, 3}});
+        };
+
+        "integer-type: basic interpolation"_test = [] {
+            SchmittTrigger<T, BASIC_LINEAR_INTERPOLATION> trigger(value_t(1) /* threshold */, value_t(5) /* offset */);
+
+            test_schmitt_trigger_with_signal<T, "slow rising edge (basic interpolation)">(trigger,                      //
+                convert_signal<T>({0, 1, 5 /* >= offset + threshold */, 7, 7, 7, 8 /* <= offset - threshold */, 0, 0}), //
+                {{RISING, 2}, {FALLING, 6.375f}});
+
+            trigger.reset();
+            test_schmitt_trigger_with_signal<T, "fast rising/falling edges (basic interpolation)">(trigger, //
+                convert_signal<T>({0 /* RISING */, 10 /* FALLING */, 0 /* RISING */, 8}),                   //
+                {{RISING, 0.5f}, {FALLING, 1.5f}, {RISING, 2.625f}});
+        };
+    } | std::tuple<uint8_t, int16_t>{};
+};
+
+int main() { /* not needed for UT */ }

--- a/blocks/basic/include/gnuradio-4.0/basic/ConverterBlocks.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/ConverterBlocks.hpp
@@ -252,6 +252,7 @@ For every pair of interleaved input items (real, imag), we produce one complex o
 
 /*
  TODO: temporarily disabled due to excessive compile-times on CI
+
 namespace gr::blocks::type::converter {
 using TSupportedTypes    = std::tuple<uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double>; // N.B. 10 base types
 using TComplexTypes      = std::tuple<std::complex<float>, std::complex<double>>;                                               // N.B. 2 (valid) complex types
@@ -276,5 +277,4 @@ const inline auto registerConverterBlocks =
 // clang-format on
 } // namespace gr::blocks::type::converter
 */
-
 #endif // CONVERTERBLOCKS_HPP

--- a/blocks/basic/include/gnuradio-4.0/basic/Trigger.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/Trigger.hpp
@@ -1,0 +1,160 @@
+#ifndef TRIGGER_HPP
+#define TRIGGER_HPP
+
+#include <gnuradio-4.0/Block.hpp>
+#include <gnuradio-4.0/BlockRegistry.hpp>
+#include <gnuradio-4.0/algorithm/SchmittTrigger.hpp>
+#include <gnuradio-4.0/meta/UncertainValue.hpp>
+
+namespace gr::blocks::basic {
+
+template<typename T, gr::trigger::InterpolationMethod Method>
+requires(std::is_arithmetic_v<T> or (UncertainValueLike<T> && std::is_arithmetic_v<meta::fundamental_base_value_type_t<T>>))
+struct SchmittTrigger : public gr::Block<SchmittTrigger<T, Method>, NoDefaultTagForwarding> {
+    using Description = Doc<R""(@brief Digital Schmitt trigger implementation with optional intersample interpolation
+
+@see https://en.wikipedia.org/wiki/Schmitt_trigger
+
+The following sub-sample interpolation methods are supported:
+  * NO_INTERPOLATION: nomen est omen
+  * BASIC_LINEAR_INTERPOLATION: basic linear interpolation based on the new and previous sample
+  * LINEAR_INTERPOLATION: interpolation via linear regression over the samples between when
+    the lower and upper threshold has been crossed and vice versa
+  * POLYNOMIAL_INTERPOLATION: Savitzky–Golay filter-based methods
+    https://en.wikipedia.org/wiki/Savitzky%E2%80%93Golay_filter
+    (TODO: WIP needs Tensor<T> and SVD implementation)
+
+The block generates the following optional trigger that are controlled by:
+ * trigger_name_rising_edge  -> trigger name that is used when a rising edge is detected
+ * trigger_name_falling_edge -> trigger name that is used when a falling edge is detected
+
+The trigger time and offset is calculated through sample counting from the last synchronising trigger.
+The information is stored (info only) in `trigger_name`, `trigger_time`, `trigger_offset`.
+)"">;
+    using enum gr::trigger::EdgeDetection;
+    using ClockSourceType = std::chrono::system_clock;
+    using value_t         = meta::fundamental_base_value_type_t<T>;
+
+    template<typename U, gr::meta::fixed_string description = "", typename... Arguments>
+    using A = gr::Annotated<U, description, Arguments...>;
+
+    constexpr static std::size_t N_HISTORY = 16UZ;
+
+    PortIn<T>  in;
+    PortOut<T> out;
+
+    A<value_t, "offset", Doc<"trigger offset">, Visible>                                                                         offset{value_t(0)};
+    A<value_t, "threshold", Doc<"trigger threshold">, Visible>                                                                   threshold{value_t(1)};
+    A<std::string, "rising trigger", Doc<"trigger name generated on detected rising edge (N.B. \"\" omits trigger)">, Visible>   trigger_name_rising_edge{magic_enum::enum_name(RISING)};
+    A<std::string, "falling trigger", Doc<"trigger name generated on detected falling edge (N.B. \"\" omits trigger)">, Visible> trigger_name_falling_edge{magic_enum::enum_name(FALLING)};
+    A<float, "avg. sample rate", Visible>                                                                                        sample_rate = 1.f;
+
+    A<bool, "forward tags ", Doc<"false: emit only tags for detected edges">>                                                  forward_tag{true};
+    A<std::string, "trigger name", Doc<"last trigger used to synchronise time">>                                               trigger_name = "";
+    A<std::uint64_t, "trigger time", Doc<"last trigger UTC time used for synchronisation (then sample counting)">, Unit<"ns">> trigger_time{0U};
+    A<float, "trigger offset", Doc<"last trigger offset time used for synchronisation (then sample counting)">, Unit<"s">>     trigger_offset{0.0f};
+    std::string                                                                                                                context = "";
+
+    GR_MAKE_REFLECTABLE(SchmittTrigger, in, out, offset, threshold, trigger_name_rising_edge, trigger_name_falling_edge, sample_rate, forward_tag, trigger_name, trigger_time, trigger_offset, context);
+
+    gr::trigger::SchmittTrigger<T, Method, N_HISTORY> _trigger{0, 1};
+    std::uint64_t                                     _period{1U};
+    std::uint64_t                                     _now{0U};
+
+    void settingsChanged(const gr::property_map& /*oldSettings*/, const gr::property_map& newSettings) {
+        if (newSettings.contains("sample_rate")) {
+            _period = static_cast<std::uint64_t>(1e6f / sample_rate);
+        }
+        if (newSettings.contains("trigger_time")) {
+            _now = trigger_time + static_cast<std::uint64_t>(1e6f * trigger_offset);
+        }
+
+        if (newSettings.contains("offset") || newSettings.contains("threshold")) {
+            _trigger.setOffset(offset);
+            _trigger.setThreshold(threshold);
+            _trigger.reset();
+        }
+    }
+
+    void start() { reset(); }
+
+    void reset() {
+        _trigger.reset();
+        _now         = static_cast<std::uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(ClockSourceType::now().time_since_epoch()).count());
+        trigger_time = _now;
+    }
+
+    gr::work::Status processBulk(InputSpanLike auto& inputSpan, OutputSpanLike auto& outputSpan) {
+        const std::optional<std::size_t> nextEoSTag = samples_to_eos_tag(in);
+        if (inputSpan.size() < N_HISTORY && nextEoSTag.value_or(0) >= N_HISTORY) {
+            return gr::work::Status::INSUFFICIENT_INPUT_ITEMS;
+        }
+        const std::size_t nProcess = inputSpan.size() - N_HISTORY * nextEoSTag.has_value(); // limit input data to have enough samples to back-date detected trigger if necessary
+
+        auto forwardTags = [&](std::size_t maxRelIndex) {
+            if (!forward_tag) {
+                return;
+            }
+            for (const auto& tag : inputSpan.rawTags) {
+                const auto relIndex = static_cast<std::ptrdiff_t>(tag.index) - static_cast<std::ptrdiff_t>(inputSpan.streamIndex);
+                if (relIndex >= 0 && static_cast<std::size_t>(relIndex) <= maxRelIndex) {
+                    outputSpan.publishTag(tag.map, static_cast<std::size_t>(relIndex));
+                }
+            }
+        };
+
+        auto publishEdge = [&](const std::string& triggerName, std::ptrdiff_t edgePosition) {
+            const std::size_t edgePosUnsigned = std::max(0UZ, static_cast<std::size_t>(edgePosition));
+
+            forwardTags(edgePosUnsigned);
+
+            const UncertainValue<float> edgeIdxOffset = UncertainValue<float>{static_cast<float>(_trigger.lastEdgeIdx)} + _trigger.lastEdgeOffset;
+            outputSpan.publishTag(
+                property_map{
+                    //
+                    {gr::tag::TRIGGER_NAME.shortKey(), triggerName},                                                      //
+                    {gr::tag::TRIGGER_TIME.shortKey(), static_cast<uint64_t>(_now - gr::value(edgeIdxOffset) * _period)}, //
+                    {"trigger_time_error", static_cast<uint64_t>(gr::uncertainty(edgeIdxOffset) * _period)},              //
+                    {gr::tag::TRIGGER_OFFSET.shortKey(), static_cast<float>(gr::value(edgeIdxOffset) * _period)},         //
+                    {gr::tag::CONTEXT.shortKey(), context}                                                                //
+                },
+                edgePosUnsigned);
+
+            // copy samples up to nPublish
+            std::copy_n(inputSpan.begin(), edgePosUnsigned, outputSpan.begin());
+            std::ignore = inputSpan.consume(edgePosUnsigned);
+            outputSpan.publish(edgePosUnsigned);
+            return gr::work::Status::OK;
+        };
+
+        for (std::size_t i = 0; i < nProcess; ++i) {
+            const T sample = inputSpan[i];
+            _now += _period;
+
+            if (_trigger.processOne(sample) != NONE) { // edge detected
+                const std::ptrdiff_t edgePosition = static_cast<std::ptrdiff_t>(i) + static_cast<std::ptrdiff_t>(gr::value(_trigger.lastEdgeIdx));
+
+                if (_trigger.lastEdge == RISING && !trigger_name_rising_edge.value.empty()) {
+                    return publishEdge(trigger_name_rising_edge, edgePosition);
+                }
+
+                if (_trigger.lastEdge == FALLING && !trigger_name_falling_edge.value.empty()) {
+                    return publishEdge(trigger_name_falling_edge, edgePosition);
+                }
+            }
+        }
+
+        // no trigger found - just copy samples & tags
+        std::copy_n(inputSpan.begin(), nProcess, outputSpan.begin());
+        forwardTags(nProcess - 1UZ);
+        return gr::work::Status::OK;
+    }
+};
+
+} // namespace gr::blocks::basic
+
+const inline auto registerTrigger = gr::registerBlock<gr::blocks::basic::SchmittTrigger, gr::trigger::InterpolationMethod::NO_INTERPOLATION, std::int16_t, std::int32_t, float, gr::UncertainValue<float>>(gr::globalBlockRegistry())             //
+                                    + gr::registerBlock<gr::blocks::basic::SchmittTrigger, gr::trigger::InterpolationMethod::BASIC_LINEAR_INTERPOLATION, std::int16_t, std::int32_t, float, gr::UncertainValue<float>>(gr::globalBlockRegistry()) //
+                                    + gr::registerBlock<gr::blocks::basic::SchmittTrigger, gr::trigger::InterpolationMethod::LINEAR_INTERPOLATION, std::int16_t, std::int32_t, float, gr::UncertainValue<float>>(gr::globalBlockRegistry());
+
+#endif // TRIGGER_HPP

--- a/blocks/basic/test/CMakeLists.txt
+++ b/blocks/basic/test/CMakeLists.txt
@@ -2,15 +2,17 @@ add_ut_test(qa_Converter)
 add_ut_test(qa_Selector)
 add_ut_test(qa_sources)
 add_ut_test(qa_DataSink)
+add_ut_test(qa_TriggerBlocks)
 
-if (ENABLE_BLOCK_REGISTRY AND ENABLE_BLOCK_PLUGINS)
-    add_ut_test(qa_BasicKnownBlocks)
-endif ()
+if(ENABLE_BLOCK_REGISTRY AND ENABLE_BLOCK_PLUGINS)
+  add_ut_test(qa_BasicKnownBlocks)
+endif()
 add_ut_test(qa_StreamToDataSet)
 add_ut_test(qa_SyncBlock)
 
 message(STATUS "###Python Include Dirs: ${Python3_INCLUDE_DIRS}")
-if (PYTHON_AVAILABL AND ENABLE_BLOCK_REGISTRY AND ENABLE_BLOCK_PLUGINS)
-    add_ut_test(qa_PythonBlock)
-endif ()
-
+if(PYTHON_AVAILABLE
+   AND ENABLE_BLOCK_REGISTRY
+   AND ENABLE_BLOCK_PLUGINS)
+  add_ut_test(qa_PythonBlock)
+endif()

--- a/blocks/basic/test/qa_TriggerBlocks.cpp
+++ b/blocks/basic/test/qa_TriggerBlocks.cpp
@@ -1,0 +1,137 @@
+#include <boost/ut.hpp>
+
+#include <gnuradio-4.0/Block.hpp>
+#include <gnuradio-4.0/Graph.hpp>
+#include <gnuradio-4.0/Scheduler.hpp>
+
+#include <gnuradio-4.0/basic/FunctionGenerator.hpp>
+#include <gnuradio-4.0/basic/Trigger.hpp>
+#include <gnuradio-4.0/basic/clock_source.hpp>
+#include <gnuradio-4.0/testing/ImChartMonitor.hpp>
+#include <gnuradio-4.0/testing/TagMonitors.hpp>
+
+using namespace boost::ut;
+
+const suite<"SchmittTrigger Block"> triggerTests = [] {
+    using namespace gr::basic;
+    using namespace gr::testing;
+
+    constexpr static float sample_rate       = 1000.f; // 100 Hz
+    bool                   enableVisualTests = false;
+    if (std::getenv("DISABLE_SENSITIVE_TESTS") == nullptr) {
+        // conditionally enable visual tests outside the CI
+        boost::ext::ut::cfg<override> = {.tag = std::vector<std::string_view>{"visual", "benchmarks"}};
+        enableVisualTests             = true;
+    }
+
+    using enum gr::trigger::InterpolationMethod;
+    "SchmittTrigger"_test =
+        [&enableVisualTests]<class Method> {
+            Graph graph;
+
+            // create blocks
+            auto& clockSrc = graph.emplaceBlock<gr::basic::ClockSource<float>>({//
+                {"sample_rate", sample_rate}, {"n_samples_max", 1000U}, {"name", "ClockSource"},
+                {"tag_times",
+                    std::vector<std::uint64_t>{
+                        0U,           // 0 ms - start - 50ms of bottom plateau
+                        100'000'000U, // 100 ms - start - ramp-up
+                        400'000'000U, // 300 ms - 50ms of bottom plateau
+                        500'000'000U, // 500 ms - start ramp-down
+                        800'000'000U  // 700 ms - 100ms of bottom plateau
+                    }},
+                {"tag_values",
+                    std::vector<std::string>{
+                        "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=0", //
+                        "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1", //
+                        "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2", //
+                        "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=3", //
+                        "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=4"  //
+                    }},
+                {"do_zero_order_hold", true}});
+
+            auto& funcGen = graph.emplaceBlock<FunctionGenerator<float>>({{"sample_rate", sample_rate}, {"name", "FunctionGenerator"}, {"start_value", 0.1f}});
+            using namespace function_generator;
+            expect(funcGen.settings().set(createConstPropertyMap(0.1f), SettingsCtx{.context = "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=0"}).empty());
+            expect(funcGen.settings().set(createParabolicRampPropertyMap(0.1f, 1.1f, .3f, 0.02f), SettingsCtx{.context = "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1"}).empty());
+            expect(funcGen.settings().set(createConstPropertyMap(1.1f), SettingsCtx{.context = "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2"}).empty());
+            expect(funcGen.settings().set(createParabolicRampPropertyMap(1.1f, 0.1f, .3f, 0.02f), SettingsCtx{.context = "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=3"}).empty());
+            expect(funcGen.settings().set(createConstPropertyMap(0.1f), SettingsCtx{.context = "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=4"}).empty());
+
+            auto& schmittTrigger = graph.emplaceBlock<gr::blocks::basic::SchmittTrigger<float, Method::value>>({
+                {"name", "SchmittTrigger"},                      //
+                {"threshold", .1f},                              //
+                {"offset", .6f},                                 //
+                {"trigger_name_rising_edge", "MY_RISING_EDGE"},  //
+                {"trigger_name_falling_edge", "MY_FALLING_EDGE"} //
+            });
+            auto& tagSink        = graph.emplaceBlock<TagSink<float, gr::testing::ProcessFunction::USE_PROCESS_ONE>>({{"name", "TagSink"}, {"log_tags", true}, {"log_samples", false}, {"verbose_console", false}});
+
+            // connect non-UI blocks
+            expect(eq(ConnectionResult::SUCCESS, graph.connect<"out">(clockSrc).to<"in">(funcGen))) << "connect clockSrc->funcGen";
+            expect(eq(ConnectionResult::SUCCESS, graph.connect<"out">(funcGen).to<"in">(schmittTrigger))) << "connect funcGen->schmittTrigger";
+            expect(eq(ConnectionResult::SUCCESS, graph.connect<"out">(schmittTrigger).template to<"in">(tagSink))) << "connect schmittTrigger->tagSink";
+
+            gr::scheduler::Simple sched{std::move(graph)}; // declared here to ensure life-time of graph and blocks inside.
+            if (enableVisualTests) {                       // execute UI-based tests
+                auto& uiSink1 = sched.graph().emplaceBlock<ImChartMonitor<float>>({{"name", "ImChartSink1"}});
+                auto& uiSink2 = sched.graph().emplaceBlock<ImChartMonitor<float>>({{"name", "ImChartSink2"}});
+                // connect UI blocks
+                expect(eq(ConnectionResult::SUCCESS, sched.graph().connect<"out">(funcGen).to<"in">(uiSink1))) << "connect funcGen->uiSink1";
+                expect(eq(ConnectionResult::SUCCESS, sched.graph().connect<"out">(schmittTrigger).template to<"in">(uiSink2))) << "connect schmittTrigger->uiSink2";
+
+                std::thread uiLoop([&uiSink1, &uiSink2]() {
+                    bool drawUI = true;
+                    while (drawUI) {
+                        using enum gr::work::Status;
+                        drawUI = false;
+                        drawUI |= uiSink1.draw({{"reset_view", true}}) != DONE;
+                        drawUI |= uiSink2.draw({}) != DONE;
+                        std::this_thread::sleep_for(std::chrono::milliseconds(40));
+                    }
+                    std::this_thread::sleep_for(std::chrono::seconds(1)); // wait before shutting down
+                });
+
+                expect(sched.runAndWait().has_value()) << "runAndWait";
+
+                uiLoop.join();
+                enableVisualTests = false; // only for first test
+            } else {
+                // non-UI test
+                expect(sched.runAndWait().has_value()) << "runAndWait";
+            }
+
+            expect(eq(tagSink._tags.size(), 7UZ)) << fmt::format("test {} : expected total number of tags", magic_enum::enum_name(Method::value));
+
+            // filter tags for those generated on rising and falling edges
+            std::vector<std::size_t> rising_edge_indices;
+            std::vector<std::size_t> falling_edge_indices;
+
+            for (const auto& tag : tagSink._tags) {
+                if (!tag.map.contains(std::string(gr::tag::TRIGGER_NAME.shortKey()))) {
+                    continue;
+                }
+                std::string trigger_name = std::get<std::string>(tag.map.at(std::string(gr::tag::TRIGGER_NAME.shortKey())));
+                if (trigger_name == "MY_RISING_EDGE") {
+                    rising_edge_indices.push_back(tag.index);
+                } else if (trigger_name == "MY_FALLING_EDGE") {
+                    falling_edge_indices.push_back(tag.index);
+                }
+            }
+            expect(eq(rising_edge_indices.size(), 1UZ)) << fmt::format("test {} : expected one rising edge", magic_enum::enum_name(Method::value));
+            expect(eq(falling_edge_indices.size(), 1UZ)) << fmt::format("test {} : expected one falling edge", magic_enum::enum_name(Method::value));
+
+            if (Method::value == NO_INTERPOLATION) { // edge position once crossing the threshold
+                expect(approx(rising_edge_indices[0], 278UZ, 2UZ)) << fmt::format("test {} : detected rising edge index", magic_enum::enum_name(Method::value));
+                expect(approx(falling_edge_indices[0], 678UZ, 2UZ)) << fmt::format("test {} : detected falling edge index", magic_enum::enum_name(Method::value));
+            } else { // exact edge position
+                expect(approx(rising_edge_indices[0], 250UZ, 2UZ)) << fmt::format("test {} : detected rising edge index", magic_enum::enum_name(Method::value));
+                expect(approx(falling_edge_indices[0], 650UZ, 2UZ)) << fmt::format("test {} : detected falling edge index", magic_enum::enum_name(Method::value));
+            }
+        } |
+        std::tuple<std::integral_constant<gr::trigger::InterpolationMethod, LINEAR_INTERPOLATION>, //
+            std::integral_constant<gr::trigger::InterpolationMethod, BASIC_LINEAR_INTERPOLATION>,  //
+            std::integral_constant<gr::trigger::InterpolationMethod, NO_INTERPOLATION>>{};
+};
+
+int main() { /* not needed for UT */ }

--- a/blocks/testing/include/gnuradio-4.0/testing/ImChartMonitor.hpp
+++ b/blocks/testing/include/gnuradio-4.0/testing/ImChartMonitor.hpp
@@ -71,9 +71,9 @@ struct ImChartMonitor : public Block<ImChartMonitor<T>, BlockingIO<false>, Drawa
             std::vector<T> reversedY(_historyBufferY.rbegin(), _historyBufferY.rend());
             std::vector<T> reversedTag(_historyBufferX.size());
             if constexpr (std::is_floating_point_v<T>) {
-                std::transform(_historyBufferTags.rbegin(), _historyBufferTags.rend(), _historyBufferY.rbegin(), reversedTag.begin(), [](const Tag& tag, const T& yValue) { return tag.index < 0 ? std::numeric_limits<T>::quiet_NaN() : yValue; });
+                std::transform(_historyBufferTags.rbegin(), _historyBufferTags.rend(), _historyBufferY.rbegin(), reversedTag.begin(), [](const Tag& tag, const T& yValue) { return tag.map.empty() ? std::numeric_limits<T>::quiet_NaN() : yValue; });
             } else {
-                std::transform(_historyBufferTags.rbegin(), _historyBufferTags.rend(), _historyBufferY.rbegin(), reversedTag.begin(), [](const Tag& tag, const T& yValue) { return tag.index < 0 ? std::numeric_limits<T>::lowest() : yValue; });
+                std::transform(_historyBufferTags.rbegin(), _historyBufferTags.rend(), _historyBufferY.rbegin(), reversedTag.begin(), [](const Tag& tag, const T& yValue) { return tag.map.empty() ? std::numeric_limits<T>::lowest() : yValue; });
             }
 
             auto adjustRange = [](T min, T max) {

--- a/meta/include/gnuradio-4.0/meta/formatter.hpp
+++ b/meta/include/gnuradio-4.0/meta/formatter.hpp
@@ -82,15 +82,19 @@ struct fmt::formatter<std::complex<T>> {
 // simplified formatter for UncertainValue
 template<gr::arithmetic_or_complex_like T>
 struct fmt::formatter<gr::UncertainValue<T>> {
-    constexpr auto parse(fmt::format_parse_context& ctx) const noexcept -> decltype(ctx.begin()) { return ctx.begin(); }
+    formatter<T> value_formatter;
+
+    constexpr auto parse(format_parse_context& ctx) { return value_formatter.parse(ctx); }
 
     template<typename FormatContext>
-    constexpr auto format(const gr::UncertainValue<T>& value, FormatContext& ctx) const noexcept {
-        if constexpr (gr::meta::complex_like<T>) {
-            return fmt::format_to(ctx.out(), "({} ± {})", value.value, value.uncertainty);
-        } else {
-            return fmt::format_to(ctx.out(), "({:G} ± {:G})", value.value, value.uncertainty);
-        }
+    auto format(const gr::UncertainValue<T>& uv, FormatContext& ctx) const {
+        auto out = ctx.out();
+        out      = fmt::format_to(out, "(");
+        out      = value_formatter.format(uv.value, ctx);
+        out      = fmt::format_to(out, " ± ");
+        out      = value_formatter.format(uv.uncertainty, ctx);
+        out      = fmt::format_to(out, ")");
+        return out;
     }
 };
 

--- a/meta/test/qa_formatter.cpp
+++ b/meta/test/qa_formatter.cpp
@@ -53,7 +53,7 @@ const boost::ut::suite uncertainValueFormatter = [] {
     using UncertainDouble  = gr::UncertainValue<double>;
     using UncertainComplex = gr::UncertainValue<std::complex<double>>;
 
-    "fmt::formatter<gr::meta::UncertainValue<T>>"_test = [] {
+    "fmt::formatter<gr::UncertainValue<T>>"_test = [] {
         // Test with UncertainValue<double>
         expect(eq("(1.23 ± 0.45)"s, fmt::format("{}", UncertainDouble{1.23, 0.45})));
         expect(eq("(3.14 ± 0.01)"s, fmt::format("{}", UncertainDouble{3.14, 0.01})));
@@ -63,6 +63,11 @@ const boost::ut::suite uncertainValueFormatter = [] {
         expect(eq("((1+2i) ± (0.1+0.2i))"s, fmt::format("{}", UncertainComplex{{1, 2}, {0.1, 0.2}})));
         expect(eq("((3.14+1.59i) ± (0.01+0.02i))"s, fmt::format("{}", UncertainComplex{{3.14, 1.59}, {0.01, 0.02}})));
         expect(eq("(0 ± 0)"s, fmt::format("{}", UncertainComplex{{0, 0}, {0, 0}})));
+
+        // Test with UncertainValue<double> and float number formatting
+        expect(eq("(1.230 ± 0.450)"s, fmt::format("{:1.3f}", UncertainDouble{1.23, 0.45})));
+        expect(eq("(3.140 ± 0.010)"s, fmt::format("{:1.3f}", UncertainDouble{3.14, 0.01})));
+        expect(eq("(0.000 ± 0.000)"s, fmt::format("{:1.3f}", UncertainDouble{0, 0})));
     };
 };
 


### PR DESCRIPTION
This PR introduces a new digitial `SchmittTrigger` block with configurable threshold and offset, as well as sub-sample edge timing interpolation options.

### Features

- **Edge Detection**: detects rising and falling edges based on user-defined `threshold` and `offset` values.
- **Uncertainty Support**: Propagates uncertainties and provides precise edge timing with associated errors.
- **Interpolation Methods**: Supports multiple methods for sub-sample precision:
  - `NO_INTERPOLATION`: basic detection without interpolation.
  - `BASIC_LINEAR_INTERPOLATION`: simple linear interpolation between adjacent samples.
  - `LINEAR_INTERPOLATION`: linear regression over the samples within the threshold window.
  - `POLYNOMIAL_INTERPOLATION`: (TODO) Placeholder for future implementation using Savitzky–Golay filters.
- **Trigger Generation**: Generates customizable triggers (`trigger_name_rising_edge`, `trigger_name_falling_edge`)

![image](https://github.com/user-attachments/assets/c1c981a7-204a-4b3e-9ce6-c277b2d5def7)

## FIXME and TODOs

- **FIXME**: In the `processBulk` method, there's a commented-out section related to input sample buffering and history. This needs to be revisited to ensure proper operation, especially when using interpolation methods that require a history buffer. The error seems to be unrelated to the underlying algorithm and probably also chosen block implementation (tbc.). To be followed up in the GR4 if that is the case.

- **TODO**: The `POLYNOMIAL_INTERPOLATION` method has not yet been implemented and requires the pending `Tensor<T>` and SVD implementations. This will be addressed in a future update.