### PR TITLE
ClockSource T -> std::uint8_t fix

### DIFF
--- a/blocks/basic/include/gnuradio-4.0/basic/FunctionGenerator.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/FunctionGenerator.hpp
@@ -115,7 +115,7 @@ auto addTimeTagEntry = []<typename T>(gr::basic::ClockSource<T>& clockSource, st
     clockSource.tag_values.value.push_back(value);
 };
 
-auto &clockSrc = testGraph.emplaceBlock<gr::basic::ClockSource<float>>({ gr::tag::SAMPLE_RATE(100.f), { "n_samples_max", 100 }, { "name", "ClockSource" } });
+auto &clockSrc = testGraph.emplaceBlock<gr::basic::ClockSource>({ gr::tag::SAMPLE_RATE(100.f), { "n_samples_max", 100 }, { "name", "ClockSource" } });
 addTimeTagEntry(1'000, "CMD_BP_START:FAIR.SELECTOR.C=1:S=1:P=1");
 addTimeTagEntry(10'000, "CMD_BP_START:FAIR.SELECTOR.C=1:S=1:P=2");
 addTimeTagEntry(30'000, "CMD_BP_START:FAIR.SELECTOR.C=1:S=1:P=3");
@@ -131,8 +131,8 @@ funcGen.settings().set(createConstPropertyMap(30.f), SettingsCtx{now, "CMD_BP_ST
 The parameters will automatically update when a Tag containing the "context" field arrives.
 )"">;
 
-    PortIn<T>  in; // ClockSource input
-    PortOut<T> out;
+    PortIn<std::uint8_t> in; // ClockSource input
+    PortOut<T>           out;
 
     // TODO: Example of type aliases for sample_rate, make global and for all default Tags
     using SampleRate       = Annotated<float, "sample_rate", Visible, Doc<"stream sampling rate in [Hz]">>;

--- a/blocks/basic/include/gnuradio-4.0/basic/SignalGenerator.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/SignalGenerator.hpp
@@ -61,8 +61,8 @@ s(t) = 2 * A * (t * f - floor(t * f + 0.5)) + O
 This waveform linearly increases from -amplitude to amplitude in the first half of its period and then decreases back to -amplitude in the second half, forming a triangle shape.
 s(t) = A * (4 * abs(t * f - floor(t * f + 0.75) + 0.25) - 1) + O
 )"">;
-    PortIn<T>  in; // ClockSource input
-    PortOut<T> out;
+    PortIn<std::uint8_t> in; // ClockSource input
+    PortOut<T>           out;
 
     Annotated<float, "sample_rate", Visible, Doc<"sample rate">>                      sample_rate = 1000.f;
     Annotated<std::string, "signal_type", Visible, Doc<"see signal_generator::Type">> signal_type = "Sin";

--- a/blocks/basic/include/gnuradio-4.0/basic/clock_source.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/clock_source.hpp
@@ -253,7 +253,7 @@ template<typename T>
 using DefaultClockSource = ClockSource<T, true, std::chrono::system_clock, true>;
 } // namespace gr::basic
 
-auto registerClockSource = gr::registerBlock<gr::basic::DefaultClockSource, std::uint8_t, std::uint32_t, std::int32_t, float, double>(gr::globalBlockRegistry());
-static_assert(gr::HasProcessBulkFunction<gr::basic::ClockSource<float>>);
+auto registerClockSource = gr::registerBlock<gr::basic::DefaultClockSource, std::uint8_t>(gr::globalBlockRegistry());
+static_assert(gr::HasProcessBulkFunction<gr::basic::ClockSource<std::uint8_t>>);
 
 #endif // GNURADIO_CLOCK_SOURCE_HPP

--- a/blocks/basic/test/qa_StreamToDataSet.cpp
+++ b/blocks/basic/test/qa_StreamToDataSet.cpp
@@ -33,7 +33,7 @@ const boost::ut::suite<"StreamToDataSet Block"> selectorTest = [] {
 
         // all times are in nanoseconds
         constexpr std::uint64_t ms       = 1'000'000; // ms -> ns conversion factor (wish we had a proper C++ units-lib integration)
-        auto&                   clockSrc = graph.emplaceBlock<gr::basic::ClockSource<float>>({
+        auto&                   clockSrc = graph.emplaceBlock<gr::basic::ClockSource<std::uint8_t>>({
             {"sample_rate", sample_rate},
             {"n_samples_max", kN_SAMPLES_MAX},
             {"name", "ClockSource"},                                                                                                           //

--- a/blocks/basic/test/qa_TriggerBlocks.cpp
+++ b/blocks/basic/test/qa_TriggerBlocks.cpp
@@ -30,7 +30,7 @@ const suite<"SchmittTrigger Block"> triggerTests = [] {
             Graph graph;
 
             // create blocks
-            auto& clockSrc = graph.emplaceBlock<gr::basic::ClockSource<float>>({//
+            auto& clockSrc = graph.emplaceBlock<gr::basic::ClockSource<std::uint8_t>>({//
                 {"sample_rate", sample_rate}, {"n_samples_max", 1000U}, {"name", "ClockSource"},
                 {"tag_times",
                     std::vector<std::uint64_t>{

--- a/blocks/basic/test/qa_sources.cpp
+++ b/blocks/basic/test/qa_sources.cpp
@@ -33,7 +33,7 @@ const boost::ut::suite TagTests = [] {
         constexpr gr::Size_t n_samples   = 1900;
         constexpr float      sample_rate = 2000.f;
         Graph                testGraph;
-        auto&                src = testGraph.emplaceBlock<gr::basic::ClockSource<float, useIoThreadPool>>({{"sample_rate", sample_rate}, {"n_samples_max", n_samples}, {"name", "ClockSource"}, {"verbose_console", verbose}});
+        auto&                src = testGraph.emplaceBlock<ClockSource<std::uint8_t, useIoThreadPool>>({{"sample_rate", sample_rate}, {"n_samples_max", n_samples}, {"name", "ClockSource"}, {"verbose_console", verbose}});
         src.tags                 = {
             {0, {{"key", "value@0"}}},       //
             {1, {{"key", "value@1"}}},       //
@@ -44,8 +44,8 @@ const boost::ut::suite TagTests = [] {
             {1002, {{"key", "value@1002"}}}, //
             {1023, {{"key", "value@1023"}}}  //
         };
-        auto& sink1 = testGraph.emplaceBlock<TagSink<float, ProcessFunction::USE_PROCESS_ONE>>({{"name", "TagSink1"}});
-        auto& sink2 = testGraph.emplaceBlock<TagSink<float, ProcessFunction::USE_PROCESS_BULK>>({{"name", "TagSink2"}});
+        auto& sink1 = testGraph.emplaceBlock<TagSink<std::uint8_t, ProcessFunction::USE_PROCESS_ONE>>({{"name", "TagSink1"}});
+        auto& sink2 = testGraph.emplaceBlock<TagSink<std::uint8_t, ProcessFunction::USE_PROCESS_BULK>>({{"name", "TagSink2"}});
         expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(src).template to<"in">(sink1)));
         expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(src).template to<"in">(sink2)));
 
@@ -113,7 +113,7 @@ const boost::ut::suite TagTests = [] {
         constexpr gr::Size_t n_samples   = 200;
         constexpr float      sample_rate = 1000.f;
         Graph                testGraph;
-        auto&                clockSrc  = testGraph.emplaceBlock<gr::basic::ClockSource<float>>({{"sample_rate", sample_rate}, {"n_samples_max", n_samples}, {"name", "ClockSource"}});
+        auto&                clockSrc  = testGraph.emplaceBlock<ClockSource<std::uint8_t>>({{"sample_rate", sample_rate}, {"n_samples_max", n_samples}, {"name", "ClockSource"}});
         auto&                signalGen = testGraph.emplaceBlock<SignalGenerator<float>>({{"sample_rate", sample_rate}, {"name", "SignalGenerator"}});
         auto&                sink      = testGraph.emplaceBlock<TagSink<float, ProcessFunction::USE_PROCESS_ONE>>({{"name", "TagSink"}, {"verbose_console", true}});
 
@@ -170,7 +170,7 @@ const boost::ut::suite TagTests = [] {
         constexpr std::uint32_t N           = 1000;
         constexpr float         sample_rate = 1000.f;
         Graph                   testGraph;
-        auto&                   clockSrc = testGraph.emplaceBlock<gr::basic::ClockSource<float>>({{"sample_rate", sample_rate}, {"n_samples_max", N}, {"name", "ClockSource"}});
+        auto&                   clockSrc = testGraph.emplaceBlock<ClockSource<std::uint8_t>>({{"sample_rate", sample_rate}, {"n_samples_max", N}, {"name", "ClockSource"}});
         const auto              now      = settings::convertTimePointToUint64Ns(std::chrono::system_clock::now());
 
         const auto createTriggerPropertyMap = [](const auto context) -> property_map {
@@ -232,10 +232,10 @@ const boost::ut::suite TagTests = [] {
         constexpr float         sample_rate   = 1'000.f;
 
         Graph      testGraph;
-        auto&      clockSrc = testGraph.emplaceBlock<gr::basic::ClockSource<float>>({{"sample_rate", sample_rate}, {"n_samples_max", N}, {"name", "ClockSource"}});
+        auto&      clockSrc = testGraph.emplaceBlock<ClockSource<std::uint8_t>>({{"sample_rate", sample_rate}, {"n_samples_max", N}, {"name", "ClockSource"}});
         const auto now      = settings::convertTimePointToUint64Ns(std::chrono::system_clock::now());
 
-        auto addTimeTagEntry = []<typename T>(gr::basic::ClockSource<T>& clockSource, std::uint64_t timeInNanoseconds, const std::string& value) {
+        auto addTimeTagEntry = []<typename T>(ClockSource<T>& clockSource, std::uint64_t timeInNanoseconds, const std::string& value) {
             clockSource.tag_times.value.push_back(timeInNanoseconds);
             clockSource.tag_values.value.push_back(value);
         };

--- a/blocks/testing/test/qa_UI_Integration.cpp
+++ b/blocks/testing/test/qa_UI_Integration.cpp
@@ -24,7 +24,7 @@ const boost::ut::suite TagTests = [] {
         constexpr float         sample_rate   = 1'000.f;
 
         Graph testGraph;
-        auto& clockSrc = testGraph.emplaceBlock<gr::basic::ClockSource<float>>({{"sample_rate", sample_rate}, {"n_samples_max", N}, {"name", "ClockSource"}, {"verbose_console", true}});
+        auto& clockSrc = testGraph.emplaceBlock<gr::basic::ClockSource<std::uint8_t>>({{"sample_rate", sample_rate}, {"n_samples_max", N}, {"name", "ClockSource"}, {"verbose_console", true}});
 
         auto addTimeTagEntry = []<typename T>(gr::basic::ClockSource<T>& clockSource, std::uint64_t timeInNanoseconds, const std::string& value) {
             clockSource.tag_times.value.push_back(timeInNanoseconds);


### PR DESCRIPTION
as discussed: changed ClockSource output port to always return 'std::uint8_t' as default data type for timing-only, clock-type and other usages where the vertical signal value is only of secondary importance.