### PR TITLE
XMas-Day-1: HistoryBuffer: added push_front method, iterator constraints, and resize

### DIFF
--- a/core/include/gnuradio-4.0/HistoryBuffer.hpp
+++ b/core/include/gnuradio-4.0/HistoryBuffer.hpp
@@ -132,7 +132,7 @@ public:
      */
     template<std::ranges::range Range>
     constexpr void push_back(const Range& range) noexcept {
-        push_back_bulk(range.cbegin(), range.cend());
+        push_back_bulk(std::ranges::begin(range), std::ranges::end(range));
     }
 
     template<std::ranges::range Range>
@@ -213,7 +213,7 @@ public:
      */
     template<std::ranges::range Range>
     constexpr void push_front(const Range& r) noexcept {
-        push_front(std::begin(r), std::end(r));
+        push_front(std::ranges::begin(r), std::ranges::end(r));
     }
 
     /**
@@ -277,7 +277,7 @@ public:
         std::copy(newBuf.begin(), newBuf.begin() + static_cast<std::ptrdiff_t>(copyCount), newBuf.begin() + static_cast<std::ptrdiff_t>(newCapacity)); // mirror second half
 
         // update members
-        _buffer         = std::move(newBuf); // destroys old buffer
+        std::swap(_buffer, newBuf);
         _capacity       = newCapacity;
         _size           = copyCount;
         _write_position = 0; // implementation choice


### PR DESCRIPTION
## On the first day of Christmas :christmas_tree: :angel: :one: :christmas_tree: , my code base gave to me...

*A ring buffer with push_front and pop—how jolly can that be?*

This PR **refines** the `HistoryBuffer` by introducing or improving:

1. **\`push_front(...)\`**: Lets you store elements so the *oldest* ends up at index \[0\].  
2. **\`pop_front()\` & \`pop_back()\`**: Remove elements from the logical front/back of the ring.  
3. **\`front()\` & \`back()\`**: Simple, direct access to the first/last elements in logical order.  
4. **\`resize(size_t)\`** (for dynamic-extent): Resize capacity while retaining existing items.  
5. **Documentation**: We’ve updated our doxygen comments to show how these new methods work, plus concise code examples illustrating “newest-at-\[0\]” vs. “oldest-at-\[0\].”

Along the way, we trimmed some unneeded modulo operations for single-step increments, simplified loops with `std::copy`, and tidied up our tests.

Feel free to test it out and give feedback.  
**Happy coding—and happy holidays!**

**Code Example**:
```cpp
gr::history_buffer<int, 5> hb_newest;   // Use push_back -> index[0] is newest
hb_newest.push_back(1); // [1]
hb_newest.push_back(2); // [2, 1]
hb_newest.push_back(3); // [3, 2, 1]
// => index[0] == 3, newest item

gr::history_buffer<int, 5> hb_oldest;   // Use push_front -> index[0] is oldest
hb_oldest.push_front(10); // [10]
hb_oldest.push_front(20); // [10, 20]
hb_oldest.push_front(30); // [10, 20, 30]
// => index[0] == 10, oldest item

hb_newest.pop_front();  // remove newest => now hb_newest: [2, 1]
hb_oldest.pop_front();  // remove oldest => now hb_oldest: [20, 30]

auto val = hb_newest.front();  // val == 2
auto last = hb_newest.back();  // last == 1
```