### PR TITLE
HistoryBuffer<T> flipped push_back<->push_front naming

### DIFF
--- a/algorithm/include/gnuradio-4.0/algorithm/SchmittTrigger.hpp
+++ b/algorithm/include/gnuradio-4.0/algorithm/SchmittTrigger.hpp
@@ -103,7 +103,7 @@ struct SchmittTrigger {
         }
 
         if constexpr (Method == BASIC_LINEAR_INTERPOLATION) {
-            _historyBuffer.push_back(input);
+            _historyBuffer.push_front(input);
             if (_historyBuffer.size() < 2) {
                 return EdgeDetection::NONE;
             }
@@ -113,7 +113,7 @@ struct SchmittTrigger {
 
             auto computeEdgePosition = [&](const EdgeType& y1, const EdgeType& y2) -> std::pair<std::int32_t, EdgeType> {
                 if (y1 == y2) {
-                    return {static_cast<std::int32_t>(0), static_cast<EdgeType>(0)};
+                    return {static_cast<std::int32_t>(0U), static_cast<EdgeType>(0)};
                 }
                 const EdgeType offset   = (EdgeType(_offset) - y1) / (y2 - y1);
                 std::int32_t   intPart  = static_cast<std::int32_t>(std::floor(gr::value(offset)));
@@ -145,7 +145,7 @@ struct SchmittTrigger {
         }
 
         if constexpr (Method == LINEAR_INTERPOLATION) {
-            _historyBuffer.push_back(input);
+            _historyBuffer.push_front(input);
 
             if (_historyBuffer.size() < 2) {
                 return EdgeDetection::NONE;

--- a/algorithm/test/qa_FilterTool.cpp
+++ b/algorithm/test/qa_FilterTool.cpp
@@ -839,7 +839,7 @@ const boost::ut::suite<"IIR & FIR Benchmarks"> filterBenchmarks = [] {
             gr::HistoryBuffer<T, 8> buffer;
             ::benchmark::benchmark<10>(fmt::format("HistoryBuffer<{}>", gr::meta::type_name<T>()), nSamples) = [&actualGain, &buffer, &yValues] {
                 for (auto& yValue : yValues) {
-                    buffer.push_back(yValue);
+                    buffer.push_front(yValue);
                     actualGain = std::max(actualGain, buffer[0]);
                 }
             };

--- a/blocks/basic/include/gnuradio-4.0/basic/DataSink.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/DataSink.hpp
@@ -591,7 +591,7 @@ public:
                 listener->process(historyView, inData, tagData);
             }
             if (_history) {
-                _history->push_back_bulk(inData.begin(), inData.end());
+                _history->push_front(inData);
             }
         }
         return work::Status::OK;
@@ -609,7 +609,7 @@ private:
 
         auto new_history = gr::HistoryBuffer<T>(new_size);
         if (_history) {
-            new_history.push_back_bulk(_history->begin(), _history->end());
+            new_history.push_front(_history->begin(), _history->end());
         }
         _history = std::move(new_history);
     }

--- a/blocks/basic/include/gnuradio-4.0/basic/StreamToDataSet.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/StreamToDataSet.hpp
@@ -124,9 +124,7 @@ If multiple 'start' or 'stop' Tags arrive in a single merged tag, only one DataS
                     throw gr::exception("n_pre must be <= output port CircularBuffer size");
                 }
             }
-            auto newBuffer = HistoryBuffer<T>(MIN_BUFFER_SIZE + std::get<gr::Size_t>(newSettings.at("n_pre")));
-            newBuffer.push_back_bulk(_history);
-            _history = std::move(newBuffer);
+            _history.resize(MIN_BUFFER_SIZE + std::get<gr::Size_t>(newSettings.at("n_pre")));
         }
 
         if constexpr (!streamOut) {
@@ -321,7 +319,7 @@ private:
     void copyInputSamplesToHistory(InputSpanLike auto& inSamples, std::size_t maxSamplesToCopy) {
         if (n_pre > 0) {
             const auto samplesToCopy = std::min(maxSamplesToCopy, inSamples.size());
-            _history.push_back_bulk(inSamples.begin(), std::next(inSamples.begin(), static_cast<std::ptrdiff_t>(samplesToCopy)));
+            _history.push_front(inSamples.begin(), std::next(inSamples.begin(), static_cast<std::ptrdiff_t>(samplesToCopy)));
         }
     }
 

--- a/blocks/basic/include/gnuradio-4.0/basic/SyncBlock.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/SyncBlock.hpp
@@ -2,7 +2,6 @@
 #define GNURADIO_SYNC_BLOCK_HPP
 
 #include <gnuradio-4.0/Block.hpp>
-#include <gnuradio-4.0/HistoryBuffer.hpp>
 
 namespace gr::basic {
 

--- a/blocks/electrical/include/gnuradio-4.0/electrical/PowerEstimators.hpp
+++ b/blocks/electrical/include/gnuradio-4.0/electrical/PowerEstimators.hpp
@@ -9,7 +9,6 @@
 #include <gnuradio-4.0/Block.hpp>
 #include <gnuradio-4.0/BlockRegistry.hpp>
 
-#include <gnuradio-4.0/HistoryBuffer.hpp>
 #include <gnuradio-4.0/algorithm/filter/FilterTool.hpp>
 #include <gnuradio-4.0/meta/UncertainValue.hpp>
 

--- a/blocks/filter/include/gnuradio-4.0/filter/FrequencyEstimator.hpp
+++ b/blocks/filter/include/gnuradio-4.0/filter/FrequencyEstimator.hpp
@@ -83,10 +83,10 @@ This block estimates the frequency of a signal using the time-domain algorithm d
     requires(TParent::ResamplingControl::kIsConst)
     {
         // process input sample through the IIR filter
-        _inputHistory.push_back(input);
+        _inputHistory.push_front(input);
         const T output = std::inner_product(_singleFilterSection.b.cbegin(), _singleFilterSection.b.cend(), _inputHistory.cbegin(), static_cast<T>(0))         // feed-forward
                          - std::inner_product(_singleFilterSection.a.cbegin() + 1, _singleFilterSection.a.cend(), _outputHistory.cbegin(), static_cast<T>(0)); // feed-back
-        _outputHistory.push_back(output);
+        _outputHistory.push_front(output);
         _prevFrequency = estimateFrequency();
         return _prevFrequency;
     }
@@ -106,12 +106,12 @@ This block estimates the frequency of a signal using the time-domain algorithm d
 
             for (const T& sample : chunk) {
                 // process input sample through the IIR filter
-                _inputHistory.push_back(sample);
+                _inputHistory.push_front(sample);
 
                 const T output_sample = std::inner_product(_singleFilterSection.b.cbegin(), _singleFilterSection.b.cend(), _inputHistory.cbegin(), static_cast<T>(0))         // feed-forward
                                         - std::inner_product(_singleFilterSection.a.cbegin() + 1, _singleFilterSection.a.cend(), _outputHistory.cbegin(), static_cast<T>(0)); // feed-back
 
-                _outputHistory.push_back(output_sample);
+                _outputHistory.push_front(output_sample);
             }
 
             _prevFrequency = estimateFrequency();
@@ -241,7 +241,7 @@ This block estimates the frequency of a signal using the frequency-domain algori
     [[nodiscard]] T processOne(T input) noexcept
     requires(TParent::ResamplingControl::kIsConst)
     {
-        _inputHistory.push_back(input);
+        _inputHistory.push_front(input);
         _prevFrequency = estimateFrequencyFFT();
         return _prevFrequency;
     }
@@ -260,7 +260,7 @@ This block estimates the frequency of a signal using the frequency-domain algori
             std::span<const T> chunk  = input.subspan(offset, this->input_chunk_size);
 
             for (const T& sample : chunk) {
-                _inputHistory.push_back(sample);
+                _inputHistory.push_front(sample);
             }
 
             _prevFrequency = estimateFrequencyFFT();

--- a/core/benchmarks/bm_HistoryBuffer.cpp
+++ b/core/benchmarks/bm_HistoryBuffer.cpp
@@ -91,11 +91,21 @@ inline const boost::ut::suite _buffer_tests = [] {
     {
         HistoryBuffer<int> buffer(32);
 
-        "history_buffer<int>(32)"_benchmark.repeat<n_repetitions>(samples) = [&buffer] {
+        "history_buffer<int>(32) - push_front"_benchmark.repeat<n_repetitions>(samples) = [&buffer] {
+            static int counter = 0;
+            for (std::size_t i = 0; i < samples; i++) {
+                buffer.push_front(counter);
+                if (const auto data = buffer[0] != counter) {
+                    throw std::runtime_error(fmt::format("write {} read {} mismatch", counter, data));
+                }
+                counter++;
+            }
+        };
+        "history_buffer<int>(32) - push_back"_benchmark.repeat<n_repetitions>(samples) = [&buffer] {
             static int counter = 0;
             for (std::size_t i = 0; i < samples; i++) {
                 buffer.push_back(counter);
-                if (const auto data = buffer[0] != counter) {
+                if (const auto data = buffer[buffer.size() - 1UZ] != counter) {
                     throw std::runtime_error(fmt::format("write {} read {} mismatch", counter, data));
                 }
                 counter++;
@@ -105,11 +115,22 @@ inline const boost::ut::suite _buffer_tests = [] {
     {
         HistoryBuffer<int> buffer(32);
 
-        "history_buffer<int, 32>"_benchmark.repeat<n_repetitions>(samples) = [&buffer] {
+        "history_buffer<int, 32> - push_front"_benchmark.repeat<n_repetitions>(samples) = [&buffer] {
+            static int counter = 0;
+            for (std::size_t i = 0; i < samples; i++) {
+                buffer.push_front(counter);
+                if (const auto data = buffer[0] != counter) {
+                    throw std::runtime_error(fmt::format("write {} read {} mismatch", counter, data));
+                }
+                counter++;
+            }
+        };
+
+        "history_buffer<int, 32> - push_back"_benchmark.repeat<n_repetitions>(samples) = [&buffer] {
             static int counter = 0;
             for (std::size_t i = 0; i < samples; i++) {
                 buffer.push_back(counter);
-                if (const auto data = buffer[0] != counter) {
+                if (const auto data = buffer[buffer.size() - 1UZ] != counter) {
                     throw std::runtime_error(fmt::format("write {} read {} mismatch", counter, data));
                 }
                 counter++;
@@ -140,7 +161,16 @@ inline const boost::ut::suite _buffer_tests = [] {
     {
         HistoryBuffer<int, 32> buffer;
 
-        "history_buffer<int, 32>  - no checks"_benchmark.repeat<n_repetitions>(samples) = [&buffer] {
+        "history_buffer<int, 32>  - no checks - push_front"_benchmark.repeat<n_repetitions>(samples) = [&buffer] {
+            static int counter = 0;
+            for (std::size_t i = 0; i < samples; i++) {
+                buffer.push_front(counter);
+                [[maybe_unused]] const auto data = buffer[0];
+                counter++;
+            }
+        };
+
+        "history_buffer<int, 32>  - no checks - push_back"_benchmark.repeat<n_repetitions>(samples) = [&buffer] {
             static int counter = 0;
             for (std::size_t i = 0; i < samples; i++) {
                 buffer.push_back(counter);
@@ -152,7 +182,16 @@ inline const boost::ut::suite _buffer_tests = [] {
     {
         HistoryBuffer<int> buffer(32);
 
-        "history_buffer<int>(32)  - no checks"_benchmark.repeat<n_repetitions>(samples) = [&buffer] {
+        "history_buffer<int>(32)  - no checks - push_front"_benchmark.repeat<n_repetitions>(samples) = [&buffer] {
+            static int counter = 0;
+            for (std::size_t i = 0; i < samples; i++) {
+                buffer.push_front(counter);
+                [[maybe_unused]] const auto data = buffer[0];
+                counter++;
+            }
+        };
+
+        "history_buffer<int>(32)  - no checks - push_back"_benchmark.repeat<n_repetitions>(samples) = [&buffer] {
             static int counter = 0;
             for (std::size_t i = 0; i < samples; i++) {
                 buffer.push_back(counter);

--- a/core/include/gnuradio-4.0/Scheduler.hpp
+++ b/core/include/gnuradio-4.0/Scheduler.hpp
@@ -446,7 +446,7 @@ private:
         std::lock_guard lock(base_t::_jobListsMutex);
 
         std::size_t blockCount = 0UZ;
-        this->forAllUnmanagedBlocks([&blockCount](auto&& block) { blockCount++; });
+        this->forAllUnmanagedBlocks([&blockCount](auto&& /*block*/) { blockCount++; });
         std::vector<BlockModel*> allBlocks;
         allBlocks.reserve(blockCount);
         this->forAllUnmanagedBlocks([&allBlocks](auto&& block) { allBlocks.push_back(block.get()); });

--- a/core/test/qa_buffer.cpp
+++ b/core/test/qa_buffer.cpp
@@ -707,7 +707,7 @@ const boost::ut::suite HistoryBufferTest = [] {
         expect(eq(hb.size(), 0UZ));
 
         for (std::size_t i = 1; i <= capacity + 1; ++i) {
-            hb.push_back(static_cast<int>(i));
+            hb.push_front(static_cast<int>(i));
         }
         expect(eq(hb.capacity(), capacity));
         expect(eq(hb.size(), capacity));
@@ -725,8 +725,8 @@ const boost::ut::suite HistoryBufferTest = [] {
 
     "HistoryBuffer - range tests"_test = [] {
         HistoryBuffer<int> hb(5);
-        hb.push_back_bulk(std::array{1, 2, 3});
-        hb.push_back_bulk(std::vector{4, 5, 6});
+        hb.push_front(std::array{1, 2, 3});
+        hb.push_front(std::vector{4, 5, 6});
         expect(eq(hb.capacity(), 5UZ));
         expect(eq(hb.size(), 5UZ));
 
@@ -761,8 +761,8 @@ const boost::ut::suite HistoryBufferTest = [] {
         HistoryBuffer<int, 8UZ> buffer8;
 
         for (std::size_t i = 0UZ; i <= buffer8.capacity(); ++i) {
-            buffer5.push_back(static_cast<int>(i));
-            buffer8.push_back(static_cast<int>(i));
+            buffer5.push_front(static_cast<int>(i));
+            buffer8.push_front(static_cast<int>(i));
         }
 
         expect(eq(buffer5[0], 8));
@@ -778,8 +778,8 @@ const boost::ut::suite HistoryBufferTest = [] {
         const auto&        const_hb_one = hb_one; // tests const access
         expect(eq(hb_one.capacity(), 1UZ));
         expect(eq(hb_one.size(), 0UZ));
-        hb_one.push_back(41);
-        hb_one.push_back(42);
+        hb_one.push_front(41);
+        hb_one.push_front(42);
         expect(eq(hb_one.capacity(), 1UZ));
         expect(eq(hb_one.size(), 1UZ));
         expect(eq(hb_one[0], 42));
@@ -790,17 +790,17 @@ const boost::ut::suite HistoryBufferTest = [] {
         // Push more elements than buffer size
         HistoryBuffer<int> hb_overflow(5);
         auto               in = std::vector{1, 2, 3, 4, 5, 6};
-        hb_overflow.push_back_bulk(in.begin(), in.end());
+        hb_overflow.push_front(in.begin(), in.end());
         expect(eq(hb_overflow[0], 6));
-        hb_overflow.push_back_bulk(std::vector{7, 8, 9, 10, 11, 12, 13, 14});
+        hb_overflow.push_front(std::vector{7, 8, 9, 10, 11, 12, 13, 14});
         expect(eq(hb_overflow[0], 14));
-        hb_overflow.push_back_bulk(std::array{15, 16, 17});
+        hb_overflow.push_front(std::array{15, 16, 17});
         expect(eq(hb_overflow[0], 17));
 
         // Test with different types, e.g., double
         HistoryBuffer<double> hb_double(5);
         for (int i = 0; i < 10; ++i) {
-            hb_double.push_back(i * 0.1);
+            hb_double.push_front(i * 0.1);
         }
         expect(eq(hb_double.capacity(), 5UZ));
         expect(eq(hb_double.size(), 5UZ));
@@ -823,13 +823,13 @@ const boost::ut::suite HistoryBufferTest = [] {
     };
 
     "HistoryBuffer - forward/reversed usage"_test = [] {
-        HistoryBuffer<int> forward(5);  // stores push_back(..) with forward[0] being newest sample
-        HistoryBuffer<int> backward(5); // stores push_front(..) with backward[0] being the oldest sample
+        HistoryBuffer<int> forward(5);  // stores push_front(..) with forward[0] being newest sample
+        HistoryBuffer<int> backward(5); // stores push_back(..) with backward[0] being the oldest sample
 
         // push {1,2,3,4,5,6} individually to both
         for (int i = 1; i <= 6; ++i) {
-            forward.push_back(i);
-            backward.push_front(i);
+            forward.push_front(i);
+            backward.push_back(i);
         }
 
         // expected content of forward:  [6,5,4,3,2]
@@ -848,7 +848,7 @@ const boost::ut::suite HistoryBufferTest = [] {
 
         // Bulk test:
         backward.reset();
-        backward.push_front(std::vector<int>{10, 11, 12, 13, 14, 15, 16}); // push more than capacity:
+        backward.push_back(std::vector<int>{10, 11, 12, 13, 14, 15, 16}); // push more than capacity:
         expect(eq(backward[0], 12));
         expect(eq(backward[4], 16));
 
@@ -862,7 +862,7 @@ const boost::ut::suite HistoryBufferTest = [] {
         // Only for dynamic-extent
         HistoryBuffer<int> hb(5);
         for (int i = 1; i <= 5; ++i) {
-            hb.push_back(i);
+            hb.push_front(i);
         }
         // now: [5,4,3,2,1]
         expect(eq(hb.size(), 5UZ));
@@ -876,7 +876,7 @@ const boost::ut::suite HistoryBufferTest = [] {
 
         // push more data
         for (int i = 6; i <= 10; ++i) {
-            hb.push_back(i); // if we keep pushing
+            hb.push_front(i); // if we keep pushing
         }
         expect(eq(hb.size(), 8UZ)); // now full at 8
         expect(eq(hb[0], 10));      // newest => 10
@@ -894,7 +894,7 @@ const boost::ut::suite HistoryBufferTest = [] {
         expect(eq(hb.empty(), true));
 
         for (int i = 1; i <= 6; ++i) {
-            hb.push_back(i);
+            hb.push_front(i);
         }
         // final ring => [6,5,4,3,2]
         expect(eq(hb.front(), 6)) << "front == [0] => newest sample in push_back orientation";
@@ -902,7 +902,7 @@ const boost::ut::suite HistoryBufferTest = [] {
 
         hb.reset();
         for (int i = 1; i <= 6; ++i) {
-            hb.push_front(i);
+            hb.push_back(i);
         }
         // final ring => [2,3,4,5,6] in logical terms
         expect(eq(hb.front(), 2)) << "front == [0] => oldest sample in push_front orientation";
@@ -915,7 +915,7 @@ const boost::ut::suite HistoryBufferTest = [] {
 
         HistoryBuffer<int> hb(5);
         for (int i = 1; i <= 5; ++i) { // push_back => newest @ [0]
-            hb.push_back(i);           // final ring => [5,4,3,2,1]
+            hb.push_front(i);          // final ring => [5,4,3,2,1]
         }
         expect(eq(hb.size(), 5UZ));
         expect(eq(hb[0], 5));
@@ -943,7 +943,7 @@ const boost::ut::suite HistoryBufferTest = [] {
         // test push_front orientation
         HistoryBuffer<int> hb2(5);
         for (int i = 1; i <= 5; ++i) {
-            hb2.push_front(i); // final ring => [1,2,3,4,5] logically
+            hb2.push_back(i); // final ring => [1,2,3,4,5] logically
         }
         expect(eq(hb2[0], 1));
         hb2.pop_front(); // remove '1'


### PR DESCRIPTION
should (hopefully) simplify and provide a more intuitive the naming.

### Storage
 - Dynamic (`N == std::dynamic_extent`): uses `std::vector<T>` (size = 2 * capacity).
 - Fixed (`N != std::dynamic_extent`): uses `std::array<T, N * 2>`.

### Key Operations
 - `push_front(const T&)`: Add new item, drop oldest if full, index `[0]` is newest.
 - `push_back(const T&)`: Add new item, drop oldest if full, index `[0]` is oldest.
 - `pop_front()`, `pop_back()`: Remove from logical front/back of the ring.
 - `front()`, `back()`: Returns the first/last item in logical order.
 - `operator[](i)`, `at(i)`: Unchecked/checked access.
 - `resize(...)` (dynamic-only): Adjust capacity, preserving existing data.
 - `get_span(...)`: Obtain a contiguous view across wrap boundaries.

 ### Code Examples
 ```cpp
 gr::history_buffer<int, 5> hb_newest;   // use push_front -> index[0] is newest
 hb_newest.push_front(1); // [1]
 hb_newest.push_front(2); // [2, 1]
 hb_newest.push_front(3); // [3, 2, 1]
 // => index[0] == 3, newest item

gr::history_buffer<int, 5> hb_oldest;   // use push_back -> index[0] is oldest
hb_oldest.push_back(10); // [10]
hb_oldest.push_back(20); // [10, 20]
hb_oldest.push_back(30); // [10, 20, 30]
// => index[0] == 10, oldest item

hb_newest.pop_front();  // remove newest => now hb_newest: [2, 1]
hb_oldest.pop_front();  // remove oldest => now hb_oldest: [20, 30]

auto val = hb_newest.front();  // val == 2
auto last = hb_newest.back();  // last == 1
 ```

 Also added/extended the `HistoryBuffer<T>` performance benchmark:
 
![image](https://github.com/user-attachments/assets/8e126728-5451-415e-8378-51b13d8b9e86)

*N.B. the performance for `push_front(..)` -- used by IIR, FIR filter etc. storing the newest sample in the first (`0`) index -- is slightly asymmetric and ~30% faster w.r.t. `push_back(..)` which stores the newest sample in the last `size() - 1UZ` index.*