### PR TITLE
YamlPmt improvements, safe type conversions, and lenient numeric parser

### DIFF
--- a/core/include/gnuradio-4.0/PmtTypeHelpers.hpp
+++ b/core/include/gnuradio-4.0/PmtTypeHelpers.hpp
@@ -1,0 +1,479 @@
+#ifndef PMTTYPEHELPERS_HPP
+#define PMTTYPEHELPERS_HPP
+
+#include <bit>
+#include <charconv>
+#include <cmath>
+#include <expected>
+#include <limits>
+#include <ranges>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+#include <fmt/format.h>
+
+#ifdef __GNUC__
+// ignore warning from external libraries we don't control
+#pragma GCC diagnostic push
+#ifndef __clang__
+#pragma GCC diagnostic ignored "-Wuseless-cast"
+#endif
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
+#include <magic_enum.hpp>
+#include <magic_enum_utility.hpp>
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
+namespace pmtv {
+
+namespace detail {
+
+template<typename T>
+struct is_complex : std::false_type {};
+
+template<typename T>
+struct is_complex<std::complex<T>> : std::true_type {};
+
+template<typename T>
+inline constexpr bool is_complex_v = is_complex<T>::value;
+
+template<class Variant, class T>
+struct variant_contains : std::false_type {};
+
+template<class T, class... Ts>
+struct variant_contains<std::variant<Ts...>, T> : std::bool_constant<(std::is_same_v<T, Ts> || ...)> {};
+
+template<class Variant, class T>
+inline constexpr bool variant_contains_v = variant_contains<Variant, T>::value;
+
+template<typename T>
+[[nodiscard]] constexpr bool inRange(std::int64_t val);
+
+template<std::signed_integral T>
+[[nodiscard]] constexpr bool inRange(std::int64_t val) {
+    return val >= static_cast<std::int64_t>(std::numeric_limits<T>::min()) && val <= static_cast<std::int64_t>(std::numeric_limits<T>::max());
+}
+template<std::unsigned_integral T>
+[[nodiscard]] constexpr bool inRange(std::int64_t val) {
+    return val < 0 ? false : static_cast<unsigned long long>(val) <= static_cast<std::uint64_t>(std::numeric_limits<T>::max());
+}
+
+constexpr std::string_view trimAndCutComment(std::string_view input) {
+    constexpr auto is_space = [](unsigned char ch) { return std::isspace(ch); };
+
+    // remove leading whitespace
+    input.remove_prefix(static_cast<std::size_t>(std::ranges::find_if_not(input, is_space) - input.begin()));
+
+    // cut off at `#` if present
+    if (auto pos = input.find('#'); pos != std::string_view::npos) {
+        input = input.substr(0, pos);
+    }
+
+    // remove trailing whitespace
+    input.remove_suffix(static_cast<std::size_t>(input.end() - std::ranges::find_if_not(input | std::views::reverse, is_space).base()));
+
+    return input;
+}
+
+template<typename T>
+requires(std::is_floating_point_v<T>)
+static std::expected<T, std::string> parseStringToFloat(std::string_view trimmed) {
+    using namespace std::string_literals;
+#if defined(__clang__)
+    // Fallback to std::strtof / strtod for Clang versions prior to 20
+    if constexpr (std::is_same_v<T, float>) {
+        char* endPtr = nullptr;
+        float valF   = std::strtof(trimmed.data(), &endPtr);
+        if (endPtr == trimmed.data() + trimmed.size() && !std::isinf(valF)) {
+            return valF;
+        }
+        if (std::isinf(valF)) {
+            return std::unexpected("float parse out-of-range"s);
+        }
+        return std::unexpected("invalid float parse"s);
+    } else {
+        // double
+        char*  endPtr = nullptr;
+        double valD   = std::strtod(trimmed.data(), &endPtr);
+        if (endPtr == trimmed.data() + trimmed.size() && !std::isinf(valD)) {
+            return static_cast<T>(valD);
+        }
+        if (std::isinf(valD)) {
+            return std::unexpected("double parse out-of-range"s);
+        }
+        return std::unexpected("invalid double parse"s);
+    }
+#else
+    // Use std::from_chars for supported compilers
+    T parsedVal{};
+    auto [p, errorCode] = std::from_chars(trimmed.data(), trimmed.data() + trimmed.size(), parsedVal, std::chars_format::general);
+    if (errorCode == std::errc() && p == trimmed.data() + trimmed.size()) {
+        return parsedVal;
+    }
+    if (errorCode == std::errc::result_out_of_range) {
+        return std::unexpected("floating-point out-of-range");
+    }
+    return std::unexpected("invalid floating-point parse");
+#endif
+}
+
+} // namespace detail
+
+template<class T, bool strictCheck = false, class... Ts>
+[[nodiscard]] std::expected<T, std::string> convert_safely(const std::variant<Ts...>& v);
+
+template<class T, bool strictCheck, class... Ts>
+[[nodiscard]] std::expected<T, std::string> convert_safely(const std::variant<Ts...>& v) {
+    using namespace std::string_literals;
+    return std::visit(
+        [&](auto&& srcValue) -> std::expected<T, std::string> {
+            using S = std::decay_t<decltype(srcValue)>;
+
+            // 1) same type => trivial
+            if constexpr (std::is_same_v<S, T>) {
+                return srcValue;
+            }
+
+            if constexpr (strictCheck) {
+                return std::unexpected(fmt::format("strict-check enabled: source {} and target {} type do not match", typeid(S).name(), typeid(T).name()));
+            }
+
+            // 2) source is bool (special case, needed to be treated first because of overlapping with integral)
+            else if constexpr (std::is_same_v<S, bool>) {
+                if constexpr (std::is_same_v<T, std::string>) {
+                    return srcValue ? "true" : "false";
+                } else if constexpr (std::is_integral_v<T>) {
+                    return std::unexpected("unsupported bool to integer conversion"s);
+                } else if constexpr (std::is_floating_point_v<T>) {
+                    return std::unexpected("unsupported bool to floating-point conversion"s);
+                }
+            }
+
+            // 3) source is integral
+            else if constexpr (std::is_integral_v<S>) {
+                // 3a) target is integral
+                if constexpr (std::is_integral_v<T>) {
+                    if constexpr (std::is_unsigned_v<T> && std::is_signed_v<S>) {
+                        if (srcValue < 0) {
+                            return std::unexpected(fmt::format("negative integer {} cannot be converted to unsigned type", srcValue));
+                        }
+                    }
+                    constexpr auto digitsS = std::numeric_limits<S>::digits;
+                    constexpr auto digitsT = std::numeric_limits<T>::digits;
+                    if constexpr (digitsS <= digitsT) {
+                        return static_cast<T>(srcValue); // always safe
+                    } else {                             // range check
+                        if (static_cast<std::int64_t>(srcValue) >= std::numeric_limits<T>::lowest() && static_cast<std::int64_t>(srcValue) <= std::numeric_limits<T>::max()) {
+                            return static_cast<T>(srcValue);
+                        }
+                        return std::unexpected(fmt::format("out-of-range integer conversion: {} not in [{}..{}]", srcValue, std::numeric_limits<T>::lowest(), std::numeric_limits<T>::max()));
+                    }
+                }
+                // 3b) target is floating‐point
+                else if constexpr (std::is_floating_point_v<T>) {
+                    // integer->float
+                    constexpr auto digitsS = std::numeric_limits<S>::digits;
+                    constexpr auto digitsT = std::numeric_limits<T>::digits;
+                    if constexpr (digitsS <= digitsT) {
+                        return static_cast<T>(srcValue);
+                    } else {
+                        using WideType         = std::conditional_t<(sizeof(S) < sizeof(long long)), long long, S>;
+                        const WideType wideVal = static_cast<WideType>(srcValue);
+                        if (wideVal == std::numeric_limits<WideType>::min()) {
+                            return std::unexpected(fmt::format("cannot handle integer min()={} when checking bit width", wideVal));
+                        }
+                        const auto magnitude = (wideVal < 0) ? -wideVal : wideVal;
+                        const auto bitWidth  = std::bit_width(static_cast<std::make_unsigned_t<WideType>>(magnitude));
+                        if (bitWidth <= digitsT) {
+                            return static_cast<T>(srcValue);
+                        }
+                        return std::unexpected(fmt::format("integer bit_width({})={} > floating-point mantissa={}", srcValue, bitWidth, digitsT));
+                    }
+                }
+                // 3c) target is std::complex<T>
+                else if constexpr (detail::is_complex_v<T>) { // value becomes real-part
+                    auto conv = convert_safely<typename T::value_type>(v);
+                    if (conv.has_value()) {
+                        return T{conv.value()};
+                    }
+                    return std::unexpected(fmt::format("unsupported complex conversion {}", conv.error()));
+                }
+                // 3d) no match
+                else {
+                    return std::unexpected(fmt::format("no valid safe conversion for <integral {}> -> <{}>", typeid(S).name(), typeid(T).name()));
+                }
+            }
+
+            // 4) source is floating-point
+            else if constexpr (std::is_floating_point_v<S>) {
+                // 4a) target is integral
+                if constexpr (std::is_integral_v<T>) {
+                    if (!std::isfinite(srcValue)) {
+                        return std::unexpected(fmt::format("floating-point value {} is not finite (NaN/inf)", srcValue));
+                    }
+                    if (srcValue < static_cast<S>(std::numeric_limits<T>::lowest()) || srcValue > static_cast<S>(std::numeric_limits<T>::max())) {
+                        return std::unexpected(fmt::format("floating-point value {} is outside [{}, {}]", srcValue, std::numeric_limits<T>::lowest(), std::numeric_limits<T>::max()));
+                    }
+                    if (srcValue != std::nearbyint(srcValue)) {
+                        return std::unexpected(fmt::format("floating-point value {} is not an integer", srcValue));
+                    }
+                    return static_cast<T>(srcValue);
+                }
+                // 4b) target is floating‐point
+                else if constexpr (std::is_floating_point_v<T>) {
+                    if (static_cast<long double>(srcValue) >= static_cast<long double>(std::numeric_limits<T>::lowest()) && static_cast<long double>(srcValue) <= static_cast<long double>(std::numeric_limits<T>::max())) {
+                        return static_cast<T>(srcValue);
+                    }
+                    return std::unexpected(fmt::format("floating-point conversion from {} is outside [{}, {}]", srcValue, std::numeric_limits<T>::lowest(), std::numeric_limits<T>::max()));
+                }
+                // 4c) target is std::complex<T>
+                else if constexpr (detail::is_complex_v<T>) { // value becomes real-part
+                    auto conv = convert_safely<typename T::value_type>(v);
+                    if (conv.has_value()) {
+                        return T{conv.value()};
+                    }
+                    return std::unexpected(fmt::format("unsupported complex conversion {}", conv.error()));
+                }
+                // 4d) no match
+                else {
+                    return std::unexpected(fmt::format("no valid safe conversion for <float {}> src = {} -> <{}>", typeid(S).name(), srcValue, typeid(T).name()));
+                }
+            }
+
+            // 5) source is complex
+            else if constexpr (detail::is_complex_v<S>) {
+                // 5a) complex->complex
+                if constexpr (detail::is_complex_v<T>) {
+                    using RealS = typename S::value_type;
+                    using RealT = typename T::value_type;
+                    if constexpr (std::is_same_v<S, T>) {
+                        return srcValue; // trivial
+                    } else {
+                        // Must convert real/imag individually
+                        auto realPart = convert_safely<RealT>(std::variant<RealS>{srcValue.real()});
+                        if (!realPart) {
+                            return std::unexpected(realPart.error());
+                        }
+                        auto imagPart = convert_safely<RealT>(std::variant<RealS>{srcValue.imag()});
+                        if (!imagPart) {
+                            return std::unexpected(imagPart.error());
+                        }
+                        return T{*realPart, *imagPart};
+                    }
+                }
+                // 5b) complex->integral or float (only for real-valued complex)
+                else if constexpr (std::is_arithmetic_v<T>) {
+                    if (std::imag(srcValue) != 0) {
+                        return std::unexpected(fmt::format("cannot convert non-real-valued std:complex<{}> src= {} +{}i -> <{}>", //
+                            typeid(T).name(), std::real(srcValue), std::imag(srcValue), typeid(T).name()));
+                    }
+                    auto conv = convert_safely<T>(std::variant<typename S::value_type>{srcValue.real()});
+                    if (conv.has_value()) {
+                        return conv.value();
+                    }
+                    return std::unexpected(fmt::format("cannot convert non-real-valued std:complex<{}> src= {} +{}i -> <{}> reason: {}", //
+                        typeid(T).name(), std::real(srcValue), std::imag(srcValue), typeid(T).name(), conv.error()));
+                }
+
+                return std::unexpected(fmt::format("no valid safe conversion for std:complex<{}> src= {} +{}i -> <{}>", //
+                    typeid(T).name(), std::real(srcValue), std::imag(srcValue), typeid(T).name()));
+            }
+
+            // 6) source is string
+            else if constexpr (std::is_same_v<S, std::string>) {
+                // 6a) string->enum
+                if constexpr (std::is_enum_v<T>) {
+                    if (auto maybeEnum = magic_enum::enum_cast<T>(srcValue)) {
+                        return *maybeEnum;
+                    }
+                    auto possibleEnumValues = []<typename U>(const U&) -> std::string {
+                        constexpr auto vals  = magic_enum::enum_values<U>();
+                        auto           names = vals | std::views::transform(magic_enum::enum_name<U>);
+                        return fmt::format("{}", fmt::join(names, ", "));
+                    };
+                    return std::unexpected(fmt::format("'{}' is not a valid enum '{}' value: [{}]", srcValue, magic_enum::enum_type_name<T>(), possibleEnumValues(T{})));
+                }
+                // 6b) string->integral (excluding bool)
+                else if constexpr (std::is_integral_v<T> && !std::is_same_v<T, bool>) {
+                    const auto trimmed = detail::trimAndCutComment(srcValue);
+                    T          parsedVal{};
+                    auto [p, errorCode] = std::from_chars(trimmed.data(), trimmed.data() + trimmed.size(), parsedVal, 10);
+                    if (errorCode == std::errc::invalid_argument || p != trimmed.data() + trimmed.size()) {
+                        return std::unexpected(fmt::format("cannot parse '{}' as an integer", srcValue));
+                    }
+                    if (errorCode == std::errc::result_out_of_range) {
+                        return std::unexpected(fmt::format("integer out-of-range: '{}'", srcValue));
+                    }
+                    return parsedVal;
+                }
+                // 6c) string->float
+                else if constexpr (std::is_floating_point_v<T>) {
+                    const auto trimmed = detail::trimAndCutComment(srcValue);
+                    auto       result  = detail::parseStringToFloat<T>(trimmed);
+                    if (!result) {
+                        return std::unexpected(fmt::format("cannot parse '{}' as floating-point: {}", srcValue, result.error()));
+                    }
+                    return *result;
+                }
+                // 6d) string->bool
+                else if constexpr (std::is_same_v<T, bool>) {
+                    std::string s = srcValue;
+                    std::ranges::transform(s, s.begin(), [](unsigned char c) { return std::tolower(c); });
+                    if (s == "true" || s == "1") {
+                        return true;
+                    } else if (s == "false" || s == "0") {
+                        return false;
+                    }
+                    return std::unexpected(fmt::format("cannot parse '{}' as bool", srcValue));
+                }
+                // fallback
+                else {
+                    return std::unexpected(fmt::format("no safe conversion for std::string src = {} -> <{}>", srcValue, typeid(T).name()));
+                }
+            }
+
+            // 7) source is enum
+            else if constexpr (std::is_enum_v<S>) {
+                if constexpr (std::is_same_v<T, std::string>) {
+                    return std::string(magic_enum::enum_name(srcValue));
+                }
+                return std::unexpected(fmt::format("no safe conversion for {} src = {} -> <{}>", magic_enum::enum_type_name<S>(), magic_enum::enum_name(srcValue), typeid(T).name()));
+            }
+
+            // fallback
+            return std::unexpected(fmt::format("no safe conversion for <{}> -> <{}>", typeid(S).name(), typeid(T).name()));
+        },
+        v);
+}
+
+template<typename TMinimalNumericVariant, typename R = std::expected<TMinimalNumericVariant, std::string>>
+[[nodiscard]] constexpr R parseToMinimalNumeric(std::string_view numericString) {
+    const std::string_view str = detail::trimAndCutComment(numericString);
+    if (str.empty()) {
+        return std::unexpected(fmt::format("empty or comment-only string: '{}'", numericString));
+    }
+
+    const bool mightBeFloat = (str.find('.') != std::string_view::npos) || (str.find('e') != std::string_view::npos) || (str.find('E') != std::string_view::npos);
+
+    if (!mightBeFloat) { // attempt to parse as signed or unsigned integral
+        const bool isNegative = (!str.empty() && str.front() == '-');
+
+        if (isNegative) { // needs to be 64-bit signed integer
+            std::int64_t val{};
+
+            const auto [p, errorCode] = std::from_chars(str.data(), str.data() + str.size(), val, 10);
+            if (errorCode == std::errc::invalid_argument || p != str.data() + str.size()) {
+                return std::unexpected(fmt::format("invalid integer - cannot parse '{}'", str));
+            } else if (errorCode == std::errc::result_out_of_range) {
+                return std::unexpected(fmt::format("out-of-range for signed 64-bit - cannot parse '{}'", str));
+            }
+
+            // check smallest signed-integer type that can hold `val`
+            if constexpr (detail::variant_contains_v<TMinimalNumericVariant, std::int8_t>) {
+                if (detail::inRange<std::int8_t>(val)) {
+                    return TMinimalNumericVariant(static_cast<std::int8_t>(val));
+                }
+            }
+            if constexpr (detail::variant_contains_v<TMinimalNumericVariant, std::int16_t>) {
+                if (detail::inRange<std::int16_t>(val)) {
+                    return TMinimalNumericVariant(static_cast<std::int16_t>(val));
+                }
+            }
+            if constexpr (detail::variant_contains_v<TMinimalNumericVariant, std::int32_t>) {
+                if (detail::inRange<std::int32_t>(val)) {
+                    return TMinimalNumericVariant(static_cast<std::int32_t>(val));
+                }
+            }
+            if constexpr (detail::variant_contains_v<TMinimalNumericVariant, std::int64_t>) {
+                return TMinimalNumericVariant(val);
+            }
+
+            return std::unexpected(fmt::format("no suitable integral type available (negative) for: {}", val));
+        } else { // needs to be 64-bit unsigned integer
+            std::uint64_t valU{};
+            auto [p, errorCode] = std::from_chars(str.data(), str.data() + str.size(), valU, 10);
+            if (errorCode == std::errc::invalid_argument || p != str.data() + str.size()) {
+                return std::unexpected(fmt::format("invalid integer - cannot parse '{}'", str));
+            } else if (errorCode == std::errc::result_out_of_range) {
+                return std::unexpected(fmt::format("out-of-range for unsigned 64-bit - cannot parse '{}'", str));
+            }
+
+            // check smallest integer type that can hold `val` with preference to signed-types
+            if constexpr (detail::variant_contains_v<TMinimalNumericVariant, std::int8_t>) {
+                if (valU <= static_cast<unsigned long long>(std::numeric_limits<std::int8_t>::max())) {
+                    return TMinimalNumericVariant(static_cast<std::int8_t>(valU));
+                }
+            }
+            if constexpr (detail::variant_contains_v<TMinimalNumericVariant, std::uint8_t>) {
+                if (valU <= std::numeric_limits<std::uint8_t>::max()) {
+                    return TMinimalNumericVariant(static_cast<std::uint8_t>(valU));
+                }
+            }
+            if constexpr (detail::variant_contains_v<TMinimalNumericVariant, std::int16_t>) {
+                if (valU <= static_cast<unsigned long long>(std::numeric_limits<std::int16_t>::max())) {
+                    return TMinimalNumericVariant(static_cast<std::int16_t>(valU));
+                }
+            }
+            if constexpr (detail::variant_contains_v<TMinimalNumericVariant, std::uint16_t>) {
+                if (valU <= std::numeric_limits<std::uint16_t>::max()) {
+                    return TMinimalNumericVariant(static_cast<std::uint16_t>(valU));
+                }
+            }
+            if constexpr (detail::variant_contains_v<TMinimalNumericVariant, std::int32_t>) {
+                if (valU <= static_cast<unsigned long long>(std::numeric_limits<std::int32_t>::max())) {
+                    return TMinimalNumericVariant(static_cast<std::int32_t>(valU));
+                }
+            }
+            if constexpr (detail::variant_contains_v<TMinimalNumericVariant, std::uint32_t>) {
+                if (valU <= std::numeric_limits<std::uint32_t>::max()) {
+                    return TMinimalNumericVariant(static_cast<std::uint32_t>(valU));
+                }
+            }
+            if constexpr (detail::variant_contains_v<TMinimalNumericVariant, std::int64_t>) {
+                if (valU <= static_cast<unsigned long long>(std::numeric_limits<std::int64_t>::max())) {
+                    return TMinimalNumericVariant(static_cast<std::int64_t>(valU));
+                }
+            }
+            if constexpr (detail::variant_contains_v<TMinimalNumericVariant, std::uint64_t>) {
+                if (valU <= std::numeric_limits<std::uint64_t>::max()) {
+                    return TMinimalNumericVariant(static_cast<std::uint64_t>(valU));
+                }
+            }
+
+            return std::unexpected(fmt::format("no suitable integral type available (non-negative) for: {}", valU));
+        }
+    } else { // mightBeFloat - prefer float if in the variant, fallback to double
+        if constexpr (detail::variant_contains_v<TMinimalNumericVariant, float>) {
+            if (std::expected<float, std::string> tryFloat = convert_safely<float>(std::variant<std::string>{std::string(str)}); tryFloat) { // successfully parsed as float
+                return TMinimalNumericVariant(*tryFloat);
+            } else { // attempt conversion to double
+                if constexpr (detail::variant_contains_v<TMinimalNumericVariant, double>) {
+                    if (std::expected<double, std::string> tryDouble = convert_safely<double>(std::variant<std::string>{std::string(str)}); tryDouble) {
+                        return TMinimalNumericVariant(*tryDouble);
+                    } else {
+                        return std::unexpected(tryDouble.error());
+                    }
+                }
+                // no double in variant => fail with float's error
+                return std::unexpected(tryFloat.error());
+            }
+        } else if constexpr (detail::variant_contains_v<TMinimalNumericVariant, double>) {
+            // we don't have float, but we do have double in the variant
+            std::expected<double, std::string> tryDouble = convert_safely<double>(std::variant<std::string>{std::string(str)});
+            if (tryDouble) {
+                return TMinimalNumericVariant(*tryDouble);
+            }
+            return std::unexpected(tryDouble.error());
+        } else {
+            // no float or double in the variant => cannot parse a float number
+            return std::unexpected("no float/double in the variant => cannot parse");
+        }
+    }
+}
+
+} // namespace pmtv
+
+#endif // PMTTYPEHELPERS_HPP

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -67,6 +67,7 @@ add_ut_test(qa_thread_affinity)
 add_ut_test(qa_thread_pool)
 add_ut_test(qa_PerformanceMonitor)
 add_ut_test(qa_YamlPmt)
+add_ut_test(qa_PmtTypeHelpers)
 
 if(ENABLE_BLOCK_REGISTRY AND ENABLE_BLOCK_PLUGINS)
   add_app_test(qa_grc)

--- a/core/test/qa_PmtTypeHelpers.cpp
+++ b/core/test/qa_PmtTypeHelpers.cpp
@@ -1,0 +1,402 @@
+#include <boost/ut.hpp>
+#include <complex>
+#include <cstdint>
+#include <fmt/format.h>
+#include <string>
+#include <variant>
+
+#include <gnuradio-4.0/PmtTypeHelpers.hpp>
+
+#include <gnuradio-4.0/meta/formatter.hpp>
+
+namespace test {
+enum class Colour { Red, Green, Blue };
+}
+
+using TestVariant = std::variant<bool, std::int8_t, std::int16_t, std::int32_t, std::int64_t, std::uint8_t, std::uint16_t, std::uint32_t, std::uint64_t, //
+    float, double, std::complex<float>, std::complex<double>, std::string, test::Colour>;
+
+const boost::ut::suite<"pmt safe conversion tests"> _conversionTests = [] {
+    using namespace boost::ut;
+    using namespace std::string_literals;
+
+    constexpr static auto unexpected = [](auto& exp) { return exp.has_value() ? fmt::format("unexpected value return: {}", exp.value()) : fmt::format("unexpected error return: {}", exp.error()); };
+
+    "integral->integral (in-range)"_test = [] {
+        TestVariant v   = 42;
+        auto        res = pmtv::convert_safely<std::int64_t>(v);
+        expect(res.has_value()) << unexpected(res);
+        if (res) {
+            expect(*res == 42_ll) << fmt::format("wrong value, got: {}", res.value());
+        }
+    };
+
+    "integral->integral (out-of-range)"_test = [] {
+        TestVariant v   = 1'000'000LL;
+        auto        res = pmtv::convert_safely<std::int16_t>(v);
+        expect(!res.has_value()) << unexpected(res);
+    };
+
+    "signed->unsigned (negative)"_test = [] {
+        TestVariant v   = -1;
+        auto        res = pmtv::convert_safely<std::uint32_t>(v);
+        expect(!res.has_value()) << unexpected(res);
+    };
+
+    "integral->float (within mantissa)"_test = [] {
+        // 2^24 = 16777216 is the approximate integer limit for exact float
+        TestVariant v   = (1 << 24) - 1;
+        auto        res = pmtv::convert_safely<float>(v);
+        expect(res.has_value()) << unexpected(res);
+        if (res) {
+            expect(*res == static_cast<float>((1 << 24) - 1)) << fmt::format("wrong value, got: {}", *res);
+        }
+    };
+
+    "integral->float (bit_width check, out-of-range for float mantissa)"_test = [] {
+        // 2^24 = 16777216 is the approximate integer limit for exact float
+        TestVariant v   = (1 << 24) + 1;
+        auto        res = pmtv::convert_safely<float>(v);
+        expect(!res.has_value()) << unexpected(res);
+    };
+
+    "float->integral (exact integer)"_test = [] {
+        TestVariant v   = 42.0f;
+        auto        res = pmtv::convert_safely<std::int32_t>(v);
+        expect(res.has_value()) << unexpected(res);
+        if (res) {
+            expect(*res == 42);
+        }
+    };
+
+    "float->integral (not exact integer)"_test = [] {
+        TestVariant v   = 42.1f;
+        auto        res = pmtv::convert_safely<std::int32_t>(v);
+        expect(!res.has_value()) << unexpected(res);
+    };
+
+    "float->integral (out-of-range)"_test = [] {
+        TestVariant v   = 3e9f; // 3,000,000,000 outside 32-bit int range
+        auto        res = pmtv::convert_safely<std::int32_t>(v);
+        expect(!res.has_value()) << unexpected(res);
+    };
+
+    "float->double (valid)"_test = [] {
+        TestVariant v   = 1.2345f;
+        auto        res = pmtv::convert_safely<double>(v);
+        expect(res.has_value()) << unexpected(res);
+    };
+
+    "double->float (in-range)"_test = [] {
+        TestVariant v   = 123.456;
+        auto        res = pmtv::convert_safely<float>(v);
+        expect(res.has_value()) << unexpected(res);
+    };
+
+    "double->float (out-of-range)"_test = [] {
+        TestVariant v   = 1e40; // outside of float max ~3.4e38
+        auto        res = pmtv::convert_safely<float>(v);
+        expect(!res.has_value()) << unexpected(res);
+    };
+
+    "string->integral (valid)"_test = [] {
+        TestVariant v   = "  123  # trailing comment"s;
+        auto        res = pmtv::convert_safely<std::int32_t>(v);
+        expect(res.has_value()) << unexpected(res);
+        ;
+        if (res) {
+            expect(*res == 123) << fmt::format("wrong parsed value, got: {}", *res);
+        }
+    };
+
+    "string->integral (invalid)"_test = [] {
+        TestVariant v   = "12.3"s;
+        auto        res = pmtv::convert_safely<std::int32_t>(v);
+        expect(!res.has_value()) << unexpected(res);
+    };
+
+    "string->integral (out-of-range)"_test = [] {
+        TestVariant v   = "999999999999"s; // too big
+        auto        res = pmtv::convert_safely<std::int32_t>(v);
+        expect(!res.has_value()) << unexpected(res);
+    };
+
+    "string->float (valid)"_test = [] {
+        TestVariant v   = " 3.14159 #some comment"s;
+        auto        res = pmtv::convert_safely<float>(v);
+        expect(res.has_value()) << unexpected(res);
+    };
+
+    "string->float (invalid)"_test = [] {
+        TestVariant v   = "not_a_float"s;
+        auto        res = pmtv::convert_safely<double>(v);
+        expect(!res.has_value()) << unexpected(res);
+    };
+
+    "string->float (out-of-range)"_test = [] {
+        // Something bigger than double can hold
+        TestVariant v   = "1e9999"s;
+        auto        res = pmtv::convert_safely<double>(v);
+        expect(!res.has_value()) << unexpected(res);
+    };
+
+    "string->bool (valid, true)"_test = [] {
+        TestVariant v   = "TRUE"s;
+        auto        res = pmtv::convert_safely<bool>(v);
+        expect(res.has_value()) << unexpected(res);
+        if (res) {
+            expect(*res == true);
+        }
+    };
+
+    "string->bool (valid, false)"_test = [] {
+        TestVariant v   = "False"s;
+        auto        res = pmtv::convert_safely<bool>(v);
+        expect(res.has_value()) << unexpected(res);
+        if (res) {
+            expect(*res == false);
+        }
+    };
+
+    "string->bool (invalid)"_test = [] {
+        TestVariant v   = "notABool"s;
+        auto        res = pmtv::convert_safely<bool>(v);
+        expect(!res.has_value()) << unexpected(res);
+    };
+
+    "bool->string (valid, true)"_test = [] {
+        TestVariant v   = true;
+        auto        res = pmtv::convert_safely<std::string>(v);
+        expect(res.has_value()) << unexpected(res);
+        if (res) {
+            expect(*res == "true"s);
+        }
+    };
+
+    "bool->string (valid, false)"_test = [] {
+        TestVariant v   = false;
+        auto        res = pmtv::convert_safely<std::string>(v);
+        expect(res.has_value()) << unexpected(res);
+        if (res) {
+            expect(*res == "false"s);
+        }
+    };
+
+    "enum->string"_test = [] {
+        TestVariant v   = test::Colour::Blue;
+        auto        res = pmtv::convert_safely<std::string>(v);
+        expect(res.has_value()) << unexpected(res);
+        if (res) {
+            expect(*res == "Blue"s);
+        }
+    };
+
+    "enum->float (invalid)"_test = [] {
+        TestVariant v   = test::Colour::Blue;
+        auto        res = pmtv::convert_safely<float>(v);
+        expect(!res.has_value()) << unexpected(res);
+    };
+
+    "string->enum (valid)"_test = [] {
+        TestVariant v   = "Green"s;
+        auto        res = pmtv::convert_safely<test::Colour>(v);
+        expect(res.has_value()) << (res.has_value() ? "" : res.error());
+        if (res) {
+            expect(*res == test::Colour::Green);
+        }
+    };
+
+    "string->enum (invalid)"_test = [] {
+        TestVariant v   = "Magenta"s;
+        auto        res = pmtv::convert_safely<test::Colour>(v);
+        expect(!res.has_value()) << (res.has_value() ? "unexpected success, value is present" : fmt::format("Should fail invalid enum, got: {}", res.error()));
+    };
+
+    "complex<float> -> complex<double>"_test = [] {
+        TestVariant v   = std::complex<float>(1.25f, -2.5f);
+        auto        res = pmtv::convert_safely<std::complex<double>>(v);
+        expect(res.has_value()) << (res.has_value() ? "" : "should succeed: complex<float> -> complex<double>");
+        if (res) {
+            expect(res->real() == 1.25) << "wrong real part";
+            expect(res->imag() == -2.5) << "wrong imag part";
+        }
+    };
+
+    "complex<double> -> complex<float>"_test = [] {
+        TestVariant v   = std::complex<double>(3.32, -1.2345);
+        auto        res = pmtv::convert_safely<std::complex<float>>(v);
+        expect(res.has_value()) << (res.has_value() ? "" : "should succeed: complex<double> -> complex<float>");
+        if (res) {
+            expect(approx(res->real(), 3.32f, 1e-5f)) << "real part mismatch";
+            expect(approx(res->imag(), -1.2345f, 1e-5f)) << "imag part mismatch";
+        }
+    };
+
+    "integral -> complex<float>"_test = [] {
+        TestVariant v   = std::int32_t{42};
+        auto        res = pmtv::convert_safely<std::complex<float>>(v);
+        expect(res.has_value()) << (res.has_value() ? "" : "should succeed: int -> complex<float>");
+        if (res) {
+            expect(res->real() == 42.0f) << "wrong real part";
+            expect(res->imag() == 0.0f) << "imag should be 0";
+        }
+    };
+
+    "double -> complex<double>"_test = [] {
+        TestVariant v   = 123.456;
+        auto        res = pmtv::convert_safely<std::complex<double>>(v);
+        expect(res.has_value()) << (res.has_value() ? "" : "should succeed: double -> complex<double>");
+        if (res) {
+            expect(res->real() == 123.456) << "wrong real part";
+            expect(res->imag() == 0.0) << "imag should be 0";
+        }
+    };
+
+    "bool -> complex<float> (should fail)"_test = [] {
+        TestVariant v   = true;
+        auto        res = pmtv::convert_safely<std::complex<float>>(v);
+        expect(!res.has_value()) << (res.has_value() ? "unexpected success, value is present" : fmt::format("should fail, got: {}", res.error()));
+    };
+
+    "complex<float> -> integral (not implemented)"_test = [] {
+        TestVariant v   = std::complex<float>(1.0f, 2.0f);
+        auto        res = pmtv::convert_safely<int>(v);
+        expect(!res.has_value()) << (res.has_value() ? "unexpected success, value is present" : fmt::format("should fail, got: {}", res.error()));
+    };
+
+    "complex<double> (non-real-only) -> float"_test = [] {
+        TestVariant v   = std::complex<double>(1.0, -3.32);
+        auto        res = pmtv::convert_safely<float>(v);
+        expect(!res.has_value()) << (res.has_value() ? "unexpected success, value is present" : fmt::format("should fail, got: {}", res.error()));
+    };
+
+    "complex<double> (real-only) -> floating-point"_test = []<typename T> {
+        TestVariant v   = std::complex<T>(T(1), 0);
+        auto        res = pmtv::convert_safely<float>(v);
+        expect(res.has_value()) << unexpected(res);
+        expect(eq(res.value(), 1.0f));
+    } | std::tuple<double, float>{};
+
+    "string -> complex<float> (not implemented)"_test = [] {
+        TestVariant v   = "1.0, 2.0"s;
+        auto        res = pmtv::convert_safely<std::complex<float>>(v);
+        expect(!res.has_value()) << (res.has_value() ? "unexpected success, value is present" : fmt::format("should fail, got: {}", res.error()));
+    };
+};
+
+const boost::ut::suite<"parse to minmal numeric type"> _parseToMinimalNumericType = [] {
+    using namespace boost::ut;
+
+    using MinimalNumericVariant = std::variant<std::int8_t, std::int16_t, std::int32_t, std::int64_t, std::uint8_t, float, double>;
+
+    constexpr static auto variantToString = [](const MinimalNumericVariant& v) { return std::visit([](auto val) { return fmt::format("{} (type={})", val, typeid(val).name()); }, v); };
+
+    "empty or comment only"_test = [] {
+        "empty_string"_test = [] {
+            auto res = pmtv::parseToMinimalNumeric<MinimalNumericVariant>("");
+            expect(!res.has_value());
+        };
+        "comment only"_test = [] {
+            auto res = pmtv::parseToMinimalNumeric<MinimalNumericVariant>("# comment");
+            expect(!res.has_value());
+        };
+    };
+
+    "integral fits int8_t"_test = [] {
+        const auto res = pmtv::parseToMinimalNumeric<MinimalNumericVariant>("127");
+        expect(res.has_value()) << "should parse successfully";
+        if (res) {
+            // check the variant holds int8_t
+            expect(std::holds_alternative<std::int8_t>(*res)) << fmt::format("wrong type => got {}", variantToString(*res));
+            expect(std::get<std::int8_t>(*res) == 127) << "wrong value for int8_t";
+        }
+    };
+
+    "integral fits uint8_t"_test = [] {
+        const auto res = pmtv::parseToMinimalNumeric<MinimalNumericVariant>("255");
+        expect(res.has_value()) << "should parse successfully";
+        if (res) {
+            // because 255 is non-negative and fits in uint8_t
+            expect(std::holds_alternative<std::uint8_t>(*res)) << fmt::format("wrong type => got {}", variantToString(*res));
+            expect(std::get<std::uint8_t>(*res) == 255) << "wrong value for uint8_t";
+        }
+    };
+
+    "negative integral no unsigned check"_test = [] {
+        // -1 => should prefer int8_t if in range
+        const auto res = pmtv::parseToMinimalNumeric<MinimalNumericVariant>("-1");
+        expect(res.has_value()) << "should parse successfully";
+        if (res) {
+            // with the smallest signed type that can hold -1 => int8_t
+            expect(std::holds_alternative<std::int8_t>(*res)) << fmt::format("wrong type => got {}", variantToString(*res));
+            expect(std::get<std::int8_t>(*res) == -1) << "wrong value for int8_t";
+        }
+    };
+
+    "integral fits int16_t"_test = [] {
+        const auto res = pmtv::parseToMinimalNumeric<MinimalNumericVariant>("300");
+        expect(res.has_value());
+        if (res) {
+            expect(std::holds_alternative<std::int16_t>(*res)) << fmt::format("wrong type => got {}", variantToString(*res));
+            expect(std::get<std::int16_t>(*res) == 300);
+        }
+    };
+
+    "integral fits int32_t"_test = [] {
+        const auto res = pmtv::parseToMinimalNumeric<MinimalNumericVariant>("40000");
+        expect(res.has_value());
+        if (res) {
+            expect(std::holds_alternative<std::int32_t>(*res)) << fmt::format("wrong type => got {}", variantToString(*res));
+            expect(std::get<std::int32_t>(*res) == 40000);
+        }
+    };
+
+    "integral fits int64_t"_test = [] {
+        // bigger than 2^31-1
+        const auto res = pmtv::parseToMinimalNumeric<MinimalNumericVariant>("9999999999");
+        expect(res.has_value());
+        if (res) {
+            expect(std::holds_alternative<std::int64_t>(*res)) << fmt::format("wrong type => got {}", variantToString(*res));
+            expect(std::get<std::int64_t>(*res) == 9999999999LL);
+        }
+    };
+
+    "integral parse error"_test = [] {
+        const auto res = pmtv::parseToMinimalNumeric<MinimalNumericVariant>("42abc");
+        expect(!res.has_value()) << "should fail parse => leftover 'abc'";
+    };
+
+    "integral out-of-range for 64-bit"_test = [] {
+        const auto res = pmtv::parseToMinimalNumeric<MinimalNumericVariant>("999999999999999999999999999");
+        expect(!res.has_value()) << "should fail => out-of-range for 64-bit";
+    };
+
+    "float => float"_test = [] {
+        const auto res = pmtv::parseToMinimalNumeric<MinimalNumericVariant>("3.14159");
+        expect(res.has_value());
+        if (res) {
+            expect(std::holds_alternative<float>(*res)) << fmt::format("wrong type => got {}", variantToString(*res));
+        }
+    };
+
+    "float parse => double fallback"_test = [] {
+        // ~3.4e38 is float max, let's try something bigger => fallback to double
+        const auto res = pmtv::parseToMinimalNumeric<MinimalNumericVariant>("9.999999e39");
+        expect(res.has_value()) << "should parse as double fallback if out-of-range for float";
+        if (res) {
+            expect(std::holds_alternative<double>(*res)) << fmt::format("wrong type => got {}", variantToString(*res));
+        }
+    };
+
+    "invalid float parse"_test = [] {
+        const auto res = pmtv::parseToMinimalNumeric<MinimalNumericVariant>("not_a_number");
+        expect(!res.has_value()) << "should fail invalid float parse";
+    };
+
+    "double out-of-range"_test = [] {
+        const auto res = pmtv::parseToMinimalNumeric<MinimalNumericVariant>("1e999999");
+        expect(!res.has_value()) << "should fail => double parse out-of-range";
+    };
+};
+
+int main() { /* tests are statically executed */ }


### PR DESCRIPTION
**Summary of Changes:**
1. **YamlPmt improvements (first commit)**  
   - Replaced overly broad use of `auto` with explicit types for clarity and safer conversions.  
   - Fixed lifetime issues with `string_view::data()` by constructing proper `std::string` copies where needed.  
   - Ensured correct usage of `std::iscntrl`, `std::isspace`, etc. by casting to `unsigned char`, as required by the C++ standard to avoid undefined behaviour.  
   - Added a new helper function `formatAsLines(...)` to annotate lines and columns for YAML syntax errors, simplifying debugging.

   ```cpp
   // example snippet showing the new usage of formatAsLines:
   auto errorMsg = pmtv::yaml::formatAsLines(yamlInput, parseError);
   std::cerr << "Parse error:\n" << errorMsg << std::endl;
   ```
    **Example output:**

    ```text
    Unexpected exception with message:
    Could not parse yaml: 
     0:│⏎
     1:│blocks:⏎
     2:│  - name: main_source⏎
     3:│    id: good::fixed_source⏎
     4:│    parameters:⏎
     5:│      event_count: !!uint32 100
     6:│      unknown_property: !!int32_t aa⏎
                    Invalid value for type^
        
     7:│  - name: multiplier⏎
     8:│    id: good::multiply⏎
     9:│  - name: counter⏎
    10:│    id: builtin_counter⏎
    11:│  - name: sink⏎
    12:│    id: good::cout_sink⏎
    13:│    parameters:⏎
    14:│      total_count: 100
    15:│      unknown_property: 42⏎
    16:│⏎
    17:│connections:⏎
    18:│  - [main_source, 0, multiplier, 0]⏎
    19:│  - [multiplier, 0, counter, 0]⏎
    20:│  - [counter, 0, sink, 0]⏎
    21:│⏎
     at /home/rstein/git/graph-prototype/core/test/qa_grc.cpp:199
    ```
   
2. **Safe type conversions and parse-to-minimal-numeric utilities (second commit)**  
   - Introduced `convert_safely<T>(variant)`, which provides range-checked conversions among integrals, floats, enums, and partial support for complex types. Returns a `std::expected<T, std::string>` on success/failure.  
   - Added `parseToMinimalNumeric<Variant>(string_view)`, which reads a string, detects integer vs. float, and picks the smallest type in your `Variant` that can hold the parsed value. Negative integers skip unsigned checks; extremely large integers parse as `uint64_t` if it’s in the variant.  
   - Includes unit-tests (Boost.UT) to ensure correct behaviour for typical scenarios.

   ```cpp
   // snippet: safely_convert
   std::variant<int, float> var = 123;
   auto res = pmtv::convert_safely<float>(var);
   if (res) {
       // success: we have float(123.0f)
   } else {
       // error details: res.error()
   }

   // snippet: parseToMinimalNumeric
   using MyVariant = std::variant<int8_t, int64_t, float, double>;
   auto parsed = pmtv::parseToMinimalNumeric<MyVariant>("255");
   if (parsed) {
       // if MyVariant includes uint8_t, will store 255 as uint8_t
   }
   ```

3. **Lenient conversions in Settings (third commit)**  
   - Updated `Settings.hpp` to use `convert_safely` for type-safe and lenient assignment from PMT values to block parameters.  
   - Falls back to an exception if the provided value cannot be safely converted.  
   - Inlines a small code snippet:

   ```cpp
   if (auto convertedValue = pmtv::convert_safely<Type, strictConversion>(value); convertedValue) {
       newParameters.insert_or_assign(key, convertedValue.value());
   } else {
       throw std::invalid_argument(
           fmt::format("key '{}': cannot convert '{}': {}",
                       key, value.index(), convertedValue.error()));
   }
   ```

**Rationale:**
- Improves human readability and enforces explicit types, reducing hidden conversions.
- Fixes potential undefined behaviour in `std::isspace`/`std::isprint` calls.
- Allows easier debugging of YAML parse errors with line/column formatting.
- Strengthens type-safety through compile-time and runtime checks in the new “safe conversion” infrastructure.