### PR TITLE
refactored sub-components to be statically compiled & linked

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,49 +1,53 @@
-add_library(
-  gnuradio-core
-  INTERFACE
-  include/gnuradio-4.0/Settings.hpp
-  include/gnuradio-4.0/annotated.hpp
-  include/gnuradio-4.0/AtomicBitset.hpp
-  include/gnuradio-4.0/Block.hpp
-  include/gnuradio-4.0/BlockModel.hpp
-  include/gnuradio-4.0/BlockRegistry.hpp
-  include/gnuradio-4.0/BlockTraits.hpp
-  include/gnuradio-4.0/Buffer.hpp
-  include/gnuradio-4.0/BufferSkeleton.hpp
-  include/gnuradio-4.0/CircularBuffer.hpp
-  include/gnuradio-4.0/ClaimStrategy.hpp
-  include/gnuradio-4.0/DataSet.hpp
-  include/gnuradio-4.0/Graph_yaml_importer.hpp
-  include/gnuradio-4.0/Graph.hpp
-  include/gnuradio-4.0/HistoryBuffer.hpp
-  include/gnuradio-4.0/LifeCycle.hpp
-  include/gnuradio-4.0/Message.hpp
-  include/gnuradio-4.0/plugin.hpp
-  include/gnuradio-4.0/PluginLoader.hpp
-  include/gnuradio-4.0/Port.hpp
-  include/gnuradio-4.0/PortTraits.hpp
-  include/gnuradio-4.0/Profiler.hpp
-  include/gnuradio-4.0/reader_writer_lock.hpp
-  include/gnuradio-4.0/Scheduler.hpp
-  include/gnuradio-4.0/Sequence.hpp
-  include/gnuradio-4.0/Settings.hpp
-  include/gnuradio-4.0/Tag.hpp
-  include/gnuradio-4.0/TriggerMatcher.hpp
-  include/gnuradio-4.0/WaitStrategy.hpp
-  include/gnuradio-4.0/YamlPmt.hpp)
+add_library(gnuradio-core STATIC src/PmtTypeHelpers.cpp src/Settings.cpp)
+
+set(public_headers
+    include/gnuradio-4.0/annotated.hpp
+    include/gnuradio-4.0/AtomicBitset.hpp
+    include/gnuradio-4.0/Block.hpp
+    include/gnuradio-4.0/BlockModel.hpp
+    include/gnuradio-4.0/BlockRegistry.hpp
+    include/gnuradio-4.0/BlockTraits.hpp
+    include/gnuradio-4.0/Buffer.hpp
+    include/gnuradio-4.0/BufferSkeleton.hpp
+    include/gnuradio-4.0/CircularBuffer.hpp
+    include/gnuradio-4.0/ClaimStrategy.hpp
+    include/gnuradio-4.0/DataSet.hpp
+    include/gnuradio-4.0/Graph_yaml_importer.hpp
+    include/gnuradio-4.0/Graph.hpp
+    include/gnuradio-4.0/HistoryBuffer.hpp
+    include/gnuradio-4.0/LifeCycle.hpp
+    include/gnuradio-4.0/Message.hpp
+    include/gnuradio-4.0/plugin.hpp
+    include/gnuradio-4.0/PluginLoader.hpp
+    include/gnuradio-4.0/Port.hpp
+    include/gnuradio-4.0/PortTraits.hpp
+    include/gnuradio-4.0/Profiler.hpp
+    include/gnuradio-4.0/reader_writer_lock.hpp
+    include/gnuradio-4.0/Scheduler.hpp
+    include/gnuradio-4.0/Sequence.hpp
+    include/gnuradio-4.0/Settings.hpp
+    include/gnuradio-4.0/Tag.hpp
+    include/gnuradio-4.0/TriggerMatcher.hpp
+    include/gnuradio-4.0/WaitStrategy.hpp
+    include/gnuradio-4.0/YamlPmt.hpp)
+
+set_target_properties(gnuradio-core PROPERTIES PUBLIC_HEADER "${public_headers}")
+
 target_include_directories(
   gnuradio-core
-  INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
-            $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src>
-            $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
-            $<INSTALL_INTERFACE:include/>)
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
+         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src>
+         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
+         $<INSTALL_INTERFACE:include/>)
+
 target_link_libraries(
   gnuradio-core
-  INTERFACE gnuradio-options
-            gnuradio-meta
-            magic_enum
-            pmtv
-            vir)
+  PUBLIC fmt
+         gnuradio-options
+         gnuradio-meta
+         magic_enum
+         pmtv
+         vir)
 
 # configure a header file to pass the CMake settings to the source code
 configure_file("${PROJECT_SOURCE_DIR}/cmake/config.hpp.in"

--- a/core/include/gnuradio-4.0/Block.hpp
+++ b/core/include/gnuradio-4.0/Block.hpp
@@ -1914,7 +1914,7 @@ constexpr std::string_view shortTypeName() {
 } // namespace detail
 
 template<typename TBlock, typename TDecayedBlock>
-inline void checkBlockContracts() {
+void checkBlockContracts() {
     // N.B. some checks could be evaluated during compile time but the expressed intent is to do this during runtime to allow
     // for more verbose feedback on method signatures etc.
     if constexpr (refl::reflectable<TDecayedBlock>) {
@@ -1927,7 +1927,7 @@ inline void checkBlockContracts() {
                     constexpr bool isAnnotated = !std::is_same_v<RawType, Type>;
                     // N.B. this function is compile-time ready but static_assert does not allow for configurable error
                     // messages
-                    if constexpr (!gr::settings::isSupportedType<Type>() && !traits::port::AnyPort<Type>) {
+                    if constexpr (!gr::settings::isReadableMember<Type>() && !traits::port::AnyPort<Type>) {
                         throw std::invalid_argument(fmt::format("block {} {}member '{}' has unsupported setting type '{}'", //
                             gr::meta::type_name<TDecayedBlock>(), isAnnotated ? "" : "annotated ", refl::data_member_name<TDecayedBlock, Idxs>.view(), detail::shortTypeName<Type>()));
                     }
@@ -2077,8 +2077,8 @@ struct BlockParameters : meta::typelist<Types...> {
     static constexpr /*meta::constexpr_string*/ auto toString() { return detail::encodeListOfTypes<Types...>(); }
 };
 
-template<typename TBlock>
-inline int registerBlock(auto& registerInstance) {
+template<typename TBlock, fixed_string Name = "">
+int registerBlock(auto& registerInstance) {
     using namespace vir::literals;
     constexpr auto name     = refl::class_name<TBlock>;
     constexpr auto longname = refl::type_name<TBlock>;
@@ -2092,7 +2092,7 @@ inline int registerBlock(auto& registerInstance) {
 }
 
 template<typename TBlock0, typename TBlock1, typename... More>
-inline int registerBlock(auto& registerInstance) {
+int registerBlock(auto& registerInstance) {
     registerBlock<TBlock0>(registerInstance);
     return registerBlock<TBlock1, More...>(registerInstance);
 }

--- a/core/include/gnuradio-4.0/BlockModel.hpp
+++ b/core/include/gnuradio-4.0/BlockModel.hpp
@@ -126,12 +126,26 @@ public:
 
     using DynamicPortOrCollection = std::variant<gr::DynamicPort, NamedPortCollection>;
     using DynamicPorts            = std::vector<DynamicPortOrCollection>;
+    using FuncPtr                 = void (*)();
 
 protected:
-    bool                  _dynamicPortsLoaded = false;
-    std::function<void()> _dynamicPortsLoader;
-    DynamicPorts          _dynamicInputPorts;
-    DynamicPorts          _dynamicOutputPorts;
+    struct DynamicPortsLoader {
+        using LoaderFn = void (*)(BlockModel*);
+
+        LoaderFn    fn       = nullptr;
+        BlockModel* instance = nullptr;
+
+        void operator()() const {
+            if (instance) {
+                fn(instance);
+            }
+        }
+    };
+
+    bool               _dynamicPortsLoaded = false;
+    DynamicPortsLoader _dynamicPortsLoader;
+    DynamicPorts       _dynamicInputPorts;
+    DynamicPorts       _dynamicOutputPorts;
 
     BlockModel() = default;
 
@@ -468,11 +482,17 @@ protected:
         _dynamicPortsLoaded = true;
     }
 
+    static void blockWrapperDynamicPortsLoader(BlockModel* base) {
+        auto* wrapper = static_cast<BlockWrapper*>(base);
+        wrapper->dynamicPortsLoader();
+    }
+
 public:
     BlockWrapper() : BlockWrapper(gr::property_map()) {}
     explicit BlockWrapper(gr::property_map initParameter) : _block(std::move(initParameter)) {
         initMessagePorts();
-        _dynamicPortsLoader = [this] { this->dynamicPortsLoader(); };
+        _dynamicPortsLoader.fn       = &BlockWrapper::blockWrapperDynamicPortsLoader;
+        _dynamicPortsLoader.instance = this;
     }
 
     BlockWrapper(const BlockWrapper& other)            = delete;

--- a/core/include/gnuradio-4.0/BlockModel.hpp
+++ b/core/include/gnuradio-4.0/BlockModel.hpp
@@ -126,7 +126,6 @@ public:
 
     using DynamicPortOrCollection = std::variant<gr::DynamicPort, NamedPortCollection>;
     using DynamicPorts            = std::vector<DynamicPortOrCollection>;
-    using FuncPtr                 = void (*)();
 
 protected:
     struct DynamicPortsLoader {

--- a/core/include/gnuradio-4.0/Graph.hpp
+++ b/core/include/gnuradio-4.0/Graph.hpp
@@ -75,7 +75,7 @@ public:
     GraphWrapper() {
         // We need to make sure nobody touches our dynamic ports
         // as this class will handle them
-        this->_dynamicPortsLoader = [] {};
+        this->_dynamicPortsLoader.instance = nullptr;
 
         this->_block.propertyCallbacks[graph::property::kSubgraphExportPort] = [this](auto& /*self*/, std::string_view /*property*/, Message message) -> std::optional<Message> {
             const auto&        data            = message.data.value();

--- a/core/include/gnuradio-4.0/PmtTypeHelpers.hpp
+++ b/core/include/gnuradio-4.0/PmtTypeHelpers.hpp
@@ -1,17 +1,24 @@
 #ifndef PMTTYPEHELPERS_HPP
 #define PMTTYPEHELPERS_HPP
 
+#include <algorithm>
 #include <bit>
 #include <charconv>
 #include <cmath>
+#include <complex>
+#include <cstdint>
 #include <expected>
 #include <limits>
 #include <ranges>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <variant>
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
+
+#include <pmtv/pmt.hpp>
 
 #ifdef __GNUC__
 // ignore warning from external libraries we don't control
@@ -40,7 +47,15 @@ struct is_complex<std::complex<T>> : std::true_type {};
 template<typename T>
 inline constexpr bool is_complex_v = is_complex<T>::value;
 
-template<class Variant, class T>
+template<typename T>
+concept VariantLike = requires(T v) {
+    { std::variant_size_v<T> } -> std::convertible_to<std::size_t>;
+    {
+        std::visit([](auto&&) {}, v)
+    };
+};
+
+template<class, class>
 struct variant_contains : std::false_type {};
 
 template<class T, class... Ts>
@@ -122,11 +137,8 @@ static std::expected<T, std::string> parseStringToFloat(std::string_view trimmed
 
 } // namespace detail
 
-template<class T, bool strictCheck = false, class... Ts>
-[[nodiscard]] std::expected<T, std::string> convert_safely(const std::variant<Ts...>& v);
-
-template<class T, bool strictCheck, class... Ts>
-[[nodiscard]] std::expected<T, std::string> convert_safely(const std::variant<Ts...>& v) {
+template<class T, bool strictCheck = false, detail::VariantLike TVariant>
+[[nodiscard]] constexpr std::expected<T, std::string> convert_safely(const TVariant& v) {
     using namespace std::string_literals;
     return std::visit(
         [&](auto&& srcValue) -> std::expected<T, std::string> {
@@ -473,6 +485,41 @@ template<typename TMinimalNumericVariant, typename R = std::expected<TMinimalNum
         }
     }
 }
+
+// forward-declare helper functions -> implemented in the corresponding .cpp file.
+
+// ---- fundamental types ----
+extern template std::expected<bool, std::string>                 convert_safely<bool, false, pmt>(const pmt&);
+extern template std::expected<std::int8_t, std::string>          convert_safely<std::int8_t, false, pmt>(const pmt&);
+extern template std::expected<std::uint8_t, std::string>         convert_safely<std::uint8_t, false, pmt>(const pmt&);
+extern template std::expected<std::int16_t, std::string>         convert_safely<std::int16_t, false, pmt>(const pmt&);
+extern template std::expected<std::uint16_t, std::string>        convert_safely<std::uint16_t, false, pmt>(const pmt&);
+extern template std::expected<std::int32_t, std::string>         convert_safely<std::int32_t, false, pmt>(const pmt&);
+extern template std::expected<std::uint32_t, std::string>        convert_safely<std::uint32_t, false, pmt>(const pmt&);
+extern template std::expected<std::int64_t, std::string>         convert_safely<std::int64_t, false, pmt>(const pmt&);
+extern template std::expected<std::uint64_t, std::string>        convert_safely<std::uint64_t, false, pmt>(const pmt&);
+extern template std::expected<float, std::string>                convert_safely<float, false, pmt>(const pmt&);
+extern template std::expected<double, std::string>               convert_safely<double, false, pmt>(const pmt&);
+extern template std::expected<std::complex<float>, std::string>  convert_safely<std::complex<float>, false, pmt>(const pmt&);
+extern template std::expected<std::complex<double>, std::string> convert_safely<std::complex<double>, false, pmt>(const pmt&);
+extern template std::expected<std::string, std::string>          convert_safely<std::string, false, pmt>(const pmt&);
+
+// ---- vector-of-fundamentals ----
+extern template std::expected<std::vector<bool>, std::string>                 convert_safely<std::vector<bool>, false, pmt>(const pmt&);
+extern template std::expected<std::vector<std::int8_t>, std::string>          convert_safely<std::vector<std::int8_t>, false, pmt>(const pmt&);
+extern template std::expected<std::vector<std::uint8_t>, std::string>         convert_safely<std::vector<std::uint8_t>, false, pmt>(const pmt&);
+extern template std::expected<std::vector<std::int16_t>, std::string>         convert_safely<std::vector<std::int16_t>, false, pmt>(const pmt&);
+extern template std::expected<std::vector<std::uint16_t>, std::string>        convert_safely<std::vector<std::uint16_t>, false, pmt>(const pmt&);
+extern template std::expected<std::vector<std::int32_t>, std::string>         convert_safely<std::vector<std::int32_t>, false, pmt>(const pmt&);
+extern template std::expected<std::vector<std::uint32_t>, std::string>        convert_safely<std::vector<std::uint32_t>, false, pmt>(const pmt&);
+extern template std::expected<std::vector<std::int64_t>, std::string>         convert_safely<std::vector<std::int64_t>, false, pmt>(const pmt&);
+extern template std::expected<std::vector<std::uint64_t>, std::string>        convert_safely<std::vector<std::uint64_t>, false, pmt>(const pmt&);
+extern template std::expected<std::vector<float>, std::string>                convert_safely<std::vector<float>, false, pmt>(const pmt&);
+extern template std::expected<std::vector<double>, std::string>               convert_safely<std::vector<double>, false, pmt>(const pmt&);
+extern template std::expected<std::vector<std::complex<float>>, std::string>  convert_safely<std::vector<std::complex<float>>, false, pmt>(const pmt&);
+extern template std::expected<std::vector<std::complex<double>>, std::string> convert_safely<std::vector<std::complex<double>>, false, pmt>(const pmt&);
+extern template std::expected<std::vector<std::string>, std::string>          convert_safely<std::vector<std::string>, false, pmt>(const pmt&);
+extern template std::expected<map_t, std::string>                             convert_safely<map_t, false, pmt>(const pmt&);
 
 } // namespace pmtv
 

--- a/core/include/gnuradio-4.0/Settings.hpp
+++ b/core/include/gnuradio-4.0/Settings.hpp
@@ -40,7 +40,7 @@ namespace gr {
 namespace settings {
 
 template<typename T>
-inline constexpr static bool isSupportedVectorType() {
+constexpr static bool isSupportedVectorType() {
     if constexpr (gr::meta::vector_type<T>) {
         return std::is_arithmetic_v<typename T::value_type> || std::is_same_v<typename T::value_type, std::string> //
                || std::is_same_v<typename T::value_type, std::complex<double>> || std::is_same_v<typename T::value_type, std::complex<float>>;
@@ -50,7 +50,7 @@ inline constexpr static bool isSupportedVectorType() {
 }
 
 template<typename T>
-inline constexpr static bool isSupportedType() {
+constexpr static bool isSupportedType() {
     return std::is_arithmetic_v<T> || std::is_same_v<T, std::string> || isSupportedVectorType<T>() || std::is_same_v<T, property_map> //
            || std::is_same_v<T, std::complex<double>> || std::is_same_v<T, std::complex<float>>;
 }
@@ -102,7 +102,7 @@ struct ApplyStagedParametersResult {
 
 namespace detail {
 template<class T>
-inline constexpr std::size_t hash_combine(std::size_t seed, const T& v) noexcept {
+constexpr std::size_t hash_combine(std::size_t seed, const T& v) noexcept {
     std::hash<T> hasher;
     seed ^= hasher(v) + 0x9e3779b9UZ + (seed << 6) + (seed >> 2);
     return seed;
@@ -200,6 +200,28 @@ template<typename TBlock>
 concept HasSettingsResetCallback = requires(TBlock* block) {
     { block->reset() };
 };
+
+namespace settings {
+/**
+ * @brief Convert the given `value` to type `T`. If conversion fails or return diagnostic text.
+ */
+template<typename T>
+[[nodiscard]] constexpr std::expected<T, std::string> convertParameter(std::string_view key, const pmtv::pmt& value) {
+    constexpr bool strictChecks = false;
+
+    std::expected<T, std::string> convertedValue = pmtv::convert_safely<T, strictChecks>(value);
+    if (!convertedValue) { // error
+        // Build the detailed error message that your original snippet used
+        const std::size_t actualIndex   = value.index();
+        const std::size_t requiredIndex = meta::to_typelist<pmtv::pmt>::index_of<T>();
+        return std::unexpected{fmt::format("value for key '{}' has a wrong or not safely convertible type or value {}.\n" //
+                                           "Index of actual type: {} ({}), Index of expected type: {} ({})",              //
+            key, convertedValue.error(), actualIndex, "<missing pmt type>", requiredIndex, gr::meta::type_name<T>())};
+    }
+
+    return convertedValue; // success
+}
+} // namespace settings
 
 struct SettingsBase {
     virtual ~SettingsBase() = default;
@@ -517,20 +539,14 @@ public:
                         if (fieldName != key) {
                             return;
                         }
-                        constexpr bool strictChecks = false;
-                        if (auto convertedValue = pmtv::convert_safely<Type, strictChecks>(value); convertedValue) [[likely]] {
+                        if (auto convertedValue = settings::convertParameter<Type>(key, value); convertedValue) [[likely]] {
                             if (currentAutoUpdateParameters.contains(key)) {
                                 currentAutoUpdateParameters.erase(key);
                             }
                             newParameters.insert_or_assign(key, convertedValue.value());
                             isSet = true;
                         } else {
-                            throw std::invalid_argument([&key, &value, &convertedValue] { // lazy evaluation
-                                const std::size_t actual_index   = value.index();
-                                const std::size_t required_index = meta::to_typelist<pmtv::pmt>::index_of<Type>();                                                                                // This too, as per your implementation.
-                                return fmt::format("value for key '{}' has a wrong or not safely convertible type or value {}.\n Index of actual type: {} ({}), Index of expected type: {} ({})", //
-                                    key, convertedValue.error(), actual_index, "<missing pmt type>", required_index, gr::meta::type_name<Type>());
-                            }());
+                            throw gr::exception(convertedValue.error());
                         }
                     }
                 });
@@ -1037,19 +1053,12 @@ private:
                         if (fieldName != key) {
                             return;
                         }
-                        constexpr bool strictChecks = false;
 
-                        if (auto convertedValue = pmtv::convert_safely<Type, strictChecks>(value); convertedValue) [[likely]] {
+                        if (auto convertedValue = settings::convertParameter<Type>(key, value); convertedValue) [[likely]] {
                             _stagedParameters.insert_or_assign(key, convertedValue.value());
                             isSet = true;
-                            isSet = true;
                         } else {
-                            throw std::invalid_argument([&key, &value, &convertedValue] { // lazy evaluation
-                                const std::size_t actual_index   = value.index();
-                                const std::size_t required_index = meta::to_typelist<pmtv::pmt>::index_of<Type>();                                                                                // This too, as per your implementation.
-                                return fmt::format("value for key '{}' has a wrong or not safely convertible type or value {}.\n Index of actual type: {} ({}), Index of expected type: {} ({})", //
-                                    key, convertedValue.error(), actual_index, "<missing pmt type>", required_index, gr::meta::type_name<Type>());
-                            }());
+                            throw gr::exception(convertedValue.error());
                         }
                     }
                 });
@@ -1181,6 +1190,53 @@ struct hash<gr::SettingsCtx> {
     [[nodiscard]] size_t operator()(const gr::SettingsCtx& ctx) const noexcept { return ctx.hash(); }
 };
 } // namespace std
+
+namespace gr {
+
+namespace detail {
+extern template std::size_t hash_combine<std::size_t>(std::size_t seed, std::size_t const& v) noexcept;
+
+}
+
+namespace settings {
+
+// specialisation for fundamental base-types
+extern template std::expected<bool, std::string>                 convertParameter<bool>(std::string_view key, const pmtv::pmt& value);
+extern template std::expected<std::int8_t, std::string>          convertParameter<std::int8_t>(std::string_view key, const pmtv::pmt& value);
+extern template std::expected<std::uint8_t, std::string>         convertParameter<std::uint8_t>(std::string_view key, const pmtv::pmt& value);
+extern template std::expected<std::int16_t, std::string>         convertParameter<std::int16_t>(std::string_view key, const pmtv::pmt& value);
+extern template std::expected<std::uint16_t, std::string>        convertParameter<std::uint16_t>(std::string_view key, const pmtv::pmt& value);
+extern template std::expected<std::int32_t, std::string>         convertParameter<std::int32_t>(std::string_view key, const pmtv::pmt& value);
+extern template std::expected<std::uint32_t, std::string>        convertParameter<std::uint32_t>(std::string_view key, const pmtv::pmt& value);
+extern template std::expected<std::int64_t, std::string>         convertParameter<std::int64_t>(std::string_view key, const pmtv::pmt& value);
+extern template std::expected<std::uint64_t, std::string>        convertParameter<std::uint64_t>(std::string_view key, const pmtv::pmt& value);
+extern template std::expected<float, std::string>                convertParameter<float>(std::string_view key, const pmtv::pmt& value);
+extern template std::expected<double, std::string>               convertParameter<double>(std::string_view key, const pmtv::pmt& value);
+extern template std::expected<std::complex<float>, std::string>  convertParameter<std::complex<float>>(std::string_view key, const pmtv::pmt& value);
+extern template std::expected<std::complex<double>, std::string> convertParameter<std::complex<double>>(std::string_view key, const pmtv::pmt& value);
+extern template std::expected<std::string, std::string>          convertParameter<std::string>(std::string_view key, const pmtv::pmt& value);
+
+// specialisation declarations for std::string and vectors
+extern template std::expected<std::string, std::string>                       convertParameter<std::string>(std::string_view key, const pmtv::pmt& value);
+extern template std::expected<std::vector<bool>, std::string>                 convertParameter<std::vector<bool>>(std::string_view key, const pmtv::pmt& value);
+extern template std::expected<std::vector<std::int8_t>, std::string>          convertParameter<std::vector<std::int8_t>>(std::string_view key, const pmtv::pmt& value);
+extern template std::expected<std::vector<std::uint8_t>, std::string>         convertParameter<std::vector<std::uint8_t>>(std::string_view key, const pmtv::pmt& value);
+extern template std::expected<std::vector<std::int16_t>, std::string>         convertParameter<std::vector<std::int16_t>>(std::string_view key, const pmtv::pmt& value);
+extern template std::expected<std::vector<std::uint16_t>, std::string>        convertParameter<std::vector<std::uint16_t>>(std::string_view key, const pmtv::pmt& value);
+extern template std::expected<std::vector<std::int32_t>, std::string>         convertParameter<std::vector<std::int32_t>>(std::string_view key, const pmtv::pmt& value);
+extern template std::expected<std::vector<std::uint32_t>, std::string>        convertParameter<std::vector<std::uint32_t>>(std::string_view key, const pmtv::pmt& value);
+extern template std::expected<std::vector<std::int64_t>, std::string>         convertParameter<std::vector<std::int64_t>>(std::string_view key, const pmtv::pmt& value);
+extern template std::expected<std::vector<std::uint64_t>, std::string>        convertParameter<std::vector<std::uint64_t>>(std::string_view key, const pmtv::pmt& value);
+extern template std::expected<std::vector<float>, std::string>                convertParameter<std::vector<float>>(std::string_view key, const pmtv::pmt& value);
+extern template std::expected<std::vector<double>, std::string>               convertParameter<std::vector<double>>(std::string_view key, const pmtv::pmt& value);
+extern template std::expected<std::vector<std::complex<float>>, std::string>  convertParameter<std::vector<std::complex<float>>>(std::string_view key, const pmtv::pmt& value);
+extern template std::expected<std::vector<std::complex<double>>, std::string> convertParameter<std::vector<std::complex<double>>>(std::string_view key, const pmtv::pmt& value);
+extern template std::expected<std::vector<std::string>, std::string>          convertParameter<std::vector<std::string>>(std::string_view key, const pmtv::pmt& value);
+
+extern template std::expected<property_map, std::string> convertParameter<property_map>(std::string_view key, const pmtv::pmt& value);
+
+} // namespace settings
+} // namespace gr
 
 #undef NO_INLINE
 

--- a/core/src/PmtTypeHelpers.cpp
+++ b/core/src/PmtTypeHelpers.cpp
@@ -1,0 +1,40 @@
+#include <gnuradio-4.0/PmtTypeHelpers.hpp>
+
+namespace pmtv {
+
+// implement/instantiate helper functions for the given specific types
+
+// ---- fundamental types ----
+template std::expected<bool, std::string>                 convert_safely<bool, false, pmt>(const pmt&);
+template std::expected<std::int8_t, std::string>          convert_safely<std::int8_t, false, pmt>(const pmt&);
+template std::expected<std::uint8_t, std::string>         convert_safely<std::uint8_t, false, pmt>(const pmt&);
+template std::expected<std::int16_t, std::string>         convert_safely<std::int16_t, false, pmt>(const pmt&);
+template std::expected<std::uint16_t, std::string>        convert_safely<std::uint16_t, false, pmt>(const pmt&);
+template std::expected<std::int32_t, std::string>         convert_safely<std::int32_t, false, pmt>(const pmt&);
+template std::expected<std::uint32_t, std::string>        convert_safely<std::uint32_t, false, pmt>(const pmt&);
+template std::expected<std::int64_t, std::string>         convert_safely<std::int64_t, false, pmt>(const pmt&);
+template std::expected<std::uint64_t, std::string>        convert_safely<std::uint64_t, false, pmt>(const pmt&);
+template std::expected<float, std::string>                convert_safely<float, false, pmt>(const pmt&);
+template std::expected<double, std::string>               convert_safely<double, false, pmt>(const pmt&);
+template std::expected<std::complex<float>, std::string>  convert_safely<std::complex<float>, false, pmt>(const pmt&);
+template std::expected<std::complex<double>, std::string> convert_safely<std::complex<double>, false, pmt>(const pmt&);
+template std::expected<std::string, std::string>          convert_safely<std::string, false, pmt>(const pmt&);
+
+// ---- vector-of-fundamentals ----
+template std::expected<std::vector<bool>, std::string>                 convert_safely<std::vector<bool>, false, pmt>(const pmt&);
+template std::expected<std::vector<std::int8_t>, std::string>          convert_safely<std::vector<std::int8_t>, false, pmt>(const pmt&);
+template std::expected<std::vector<std::uint8_t>, std::string>         convert_safely<std::vector<std::uint8_t>, false, pmt>(const pmt&);
+template std::expected<std::vector<std::int16_t>, std::string>         convert_safely<std::vector<std::int16_t>, false, pmt>(const pmt&);
+template std::expected<std::vector<std::uint16_t>, std::string>        convert_safely<std::vector<std::uint16_t>, false, pmt>(const pmt&);
+template std::expected<std::vector<std::int32_t>, std::string>         convert_safely<std::vector<std::int32_t>, false, pmt>(const pmt&);
+template std::expected<std::vector<std::uint32_t>, std::string>        convert_safely<std::vector<std::uint32_t>, false, pmt>(const pmt&);
+template std::expected<std::vector<std::int64_t>, std::string>         convert_safely<std::vector<std::int64_t>, false, pmt>(const pmt&);
+template std::expected<std::vector<std::uint64_t>, std::string>        convert_safely<std::vector<std::uint64_t>, false, pmt>(const pmt&);
+template std::expected<std::vector<float>, std::string>                convert_safely<std::vector<float>, false, pmt>(const pmt&);
+template std::expected<std::vector<double>, std::string>               convert_safely<std::vector<double>, false, pmt>(const pmt&);
+template std::expected<std::vector<std::complex<float>>, std::string>  convert_safely<std::vector<std::complex<float>>, false, pmt>(const pmt&);
+template std::expected<std::vector<std::complex<double>>, std::string> convert_safely<std::vector<std::complex<double>>, false, pmt>(const pmt&);
+template std::expected<std::vector<std::string>, std::string>          convert_safely<std::vector<std::string>, false, pmt>(const pmt&);
+template std::expected<map_t, std::string>                             convert_safely<map_t, false, pmt>(const pmt&);
+
+} // namespace pmtv

--- a/core/src/Settings.cpp
+++ b/core/src/Settings.cpp
@@ -1,0 +1,46 @@
+#include <gnuradio-4.0/Settings.hpp>
+
+namespace gr {
+
+namespace detail {
+template std::size_t hash_combine<std::size_t>(std::size_t seed, std::size_t const& v) noexcept;
+}
+
+namespace settings {
+
+template std::expected<bool, std::string>                 convertParameter<bool>(std::string_view key, const pmtv::pmt& value);
+template std::expected<std::int8_t, std::string>          convertParameter<std::int8_t>(std::string_view key, const pmtv::pmt& value);
+template std::expected<std::uint8_t, std::string>         convertParameter<std::uint8_t>(std::string_view key, const pmtv::pmt& value);
+template std::expected<std::int16_t, std::string>         convertParameter<std::int16_t>(std::string_view key, const pmtv::pmt& value);
+template std::expected<std::uint16_t, std::string>        convertParameter<std::uint16_t>(std::string_view key, const pmtv::pmt& value);
+template std::expected<std::int32_t, std::string>         convertParameter<std::int32_t>(std::string_view key, const pmtv::pmt& value);
+template std::expected<std::uint32_t, std::string>        convertParameter<std::uint32_t>(std::string_view key, const pmtv::pmt& value);
+template std::expected<std::int64_t, std::string>         convertParameter<std::int64_t>(std::string_view key, const pmtv::pmt& value);
+template std::expected<std::uint64_t, std::string>        convertParameter<std::uint64_t>(std::string_view key, const pmtv::pmt& value);
+template std::expected<float, std::string>                convertParameter<float>(std::string_view key, const pmtv::pmt& value);
+template std::expected<double, std::string>               convertParameter<double>(std::string_view key, const pmtv::pmt& value);
+template std::expected<std::complex<float>, std::string>  convertParameter<std::complex<float>>(std::string_view key, const pmtv::pmt& value);
+template std::expected<std::complex<double>, std::string> convertParameter<std::complex<double>>(std::string_view key, const pmtv::pmt& value);
+template std::expected<std::string, std::string>          convertParameter<std::string>(std::string_view key, const pmtv::pmt& value);
+
+// Specialisation declarations for std::string and vectors
+template std::expected<std::vector<bool>, std::string>                 convertParameter<std::vector<bool>>(std::string_view key, const pmtv::pmt& value);
+template std::expected<std::vector<std::int8_t>, std::string>          convertParameter<std::vector<std::int8_t>>(std::string_view key, const pmtv::pmt& value);
+template std::expected<std::vector<std::uint8_t>, std::string>         convertParameter<std::vector<std::uint8_t>>(std::string_view key, const pmtv::pmt& value);
+template std::expected<std::vector<std::int16_t>, std::string>         convertParameter<std::vector<std::int16_t>>(std::string_view key, const pmtv::pmt& value);
+template std::expected<std::vector<std::uint16_t>, std::string>        convertParameter<std::vector<std::uint16_t>>(std::string_view key, const pmtv::pmt& value);
+template std::expected<std::vector<std::int32_t>, std::string>         convertParameter<std::vector<std::int32_t>>(std::string_view key, const pmtv::pmt& value);
+template std::expected<std::vector<std::uint32_t>, std::string>        convertParameter<std::vector<std::uint32_t>>(std::string_view key, const pmtv::pmt& value);
+template std::expected<std::vector<std::int64_t>, std::string>         convertParameter<std::vector<std::int64_t>>(std::string_view key, const pmtv::pmt& value);
+template std::expected<std::vector<std::uint64_t>, std::string>        convertParameter<std::vector<std::uint64_t>>(std::string_view key, const pmtv::pmt& value);
+template std::expected<std::vector<float>, std::string>                convertParameter<std::vector<float>>(std::string_view key, const pmtv::pmt& value);
+template std::expected<std::vector<double>, std::string>               convertParameter<std::vector<double>>(std::string_view key, const pmtv::pmt& value);
+template std::expected<std::vector<std::complex<float>>, std::string>  convertParameter<std::vector<std::complex<float>>>(std::string_view key, const pmtv::pmt& value);
+template std::expected<std::vector<std::complex<double>>, std::string> convertParameter<std::vector<std::complex<double>>>(std::string_view key, const pmtv::pmt& value);
+template std::expected<std::vector<std::string>, std::string>          convertParameter<std::vector<std::string>>(std::string_view key, const pmtv::pmt& value);
+
+template std::expected<property_map, std::string> convertParameter<property_map>(std::string_view key, const pmtv::pmt& value);
+
+} // namespace settings
+
+} // namespace gr

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -39,7 +39,7 @@ endfunction()
 function(add_app_test TEST_NAME)
   add_executable(${TEST_NAME} ${TEST_NAME}.cpp)
   setup_test(${TEST_NAME})
-  target_link_libraries(${TEST_NAME} PRIVATE gnuradio-plugin)
+  target_link_libraries(${TEST_NAME} PRIVATE gnuradio-core gnuradio-plugin)
   add_dependencies(
     ${TEST_NAME}
     good_math_plugin


### PR DESCRIPTION
## Main changes:
 * pre-instantiate settings `convert_safely<..>` handler for common types and push implementation into static lib
 * replaced `std::function<(lambda ...>>` in 'BlockModel' with more basic member function pointers.
  ... should help improve the overall and per-unit compilation time

### Local build difference (for qa_Converter unit-test):

```markdown
| Configuration       |   Parsing (frontend) [s] |   Codegen & opts (backend) [s] 
|:--------------------|-------------------------:|-------------------------------:|
| before: w/o plugins |                     69.4 |                          135.2 |
| before: w/ plugins  |                    540.8 |                          813.9 |
| after: w/o plugins  |                     54.5 |                          130.8 |
| after: w/ plugins   |                    388.5 |                          715.1 |
```
relative compile-time difference: w/o plugins ~10% and w/ plugins ~20%

**Clang's `-ftime-trace` analysis**:
* before - w/o plugins (74 block instantiations): [qa_Converter_wo_plugin_before.txt](https://github.com/user-attachments/files/18659315/qa_Converter_wo_plugin_before.txt)
* before - w/ plugins (226 block instantiations): [qa_Converter_w_plugin_before.txt](https://github.com/user-attachments/files/18659314/qa_Converter_w_plugin_before.txt)
* after - w/o plugins (74 block instantiations): [qa_Converter_wo_plugin_after.txt](https://github.com/user-attachments/files/18659571/qa_Converter_wo_plugin_after.txt)
* after - w/ plugins (226 block instantiations): [qa_Converter_w_plugin_after.txt](https://github.com/user-attachments/files/18659570/qa_Converter_w_plugin_after.txt)


### CI build differences:
*N.B. numbers to be interpreted with care... non-exclusive use of the GH runner*

<table>
  <tr>
    <td valign="top"><b>Before</b>: <img src="https://github.com/user-attachments/assets/f3df0adb-7738-4cba-9fb8-626027aae424" width="350"></td>
    <td valign="top"><b>After</b>: <img src="https://github.com/user-attachments/assets/a61e180a-3c3e-41b2-812b-5b2bbad320b8" width="350"></td>
  </tr>
</table>