### PR TITLE
Updates in DataSetSink

### DIFF
--- a/blocks/basic/include/gnuradio-4.0/basic/StreamToDataSet.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/StreamToDataSet.hpp
@@ -10,7 +10,7 @@
 
 namespace gr::basic {
 
-template<typename T, bool streamOut = true, trigger::Matcher TMatcher = trigger::BasicTriggerNameCtxMatcher::Filter>
+template<typename T, bool streamOut = false, trigger::Matcher TMatcher = trigger::BasicTriggerNameCtxMatcher::Filter>
 requires(std::is_arithmetic_v<T> || gr::meta::complex_like<T>)
 struct StreamFilterImpl : Block<StreamFilterImpl<T, streamOut, TMatcher>> {
     using Description = Doc<R"(
@@ -361,6 +361,7 @@ using StreamFilter = StreamFilterImpl<T, true>;
 
 static_assert(gr::HasProcessBulkFunction<gr::basic::StreamFilterImpl<float>>);
 
-inline static auto registerStreamFilters = gr::registerBlock<gr::basic::StreamToDataSet, uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, std::complex<float>, std::complex<double>>(gr::globalBlockRegistry()) | gr::registerBlock<gr::basic::StreamFilter, uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, std::complex<float>, std::complex<double>>(gr::globalBlockRegistry());
+inline static auto registerStreamFilters = gr::registerBlock<gr::basic::StreamToDataSet, uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, std::complex<float>, std::complex<double>>(gr::globalBlockRegistry()) //
+                                           | gr::registerBlock<gr::basic::StreamFilter, uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, std::complex<float>, std::complex<double>>(gr::globalBlockRegistry());
 
 #endif // GNURADIO_STREAMTODATASET_HPP


### PR DESCRIPTION
This PR includes the following changes:
- Sets `DataSet` output as the default for the `StreamToDataSet` block.
- Updates `DataSetSink` to process the entire `DataSet` based on `signal_name`.