### PR TITLE
Fix DataSinkRegistry

### DIFF
--- a/blocks/basic/include/gnuradio-4.0/basic/DataSink.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/DataSink.hpp
@@ -133,15 +133,15 @@ public:
     }
 
     template<DataSinkOrDataSetSinkLike TSink>
-    void registerSink(TSink* sink) {
+    void registerSink(TSink* sink, std::source_location location = std::source_location::current()) {
         std::lock_guard lg{_mutex};
 
-        if (sink->signal_name == "") {
-            throw gr::exception("Failed to register sink. Sink signal_name is an empty string.");
+        if (sink->_registered || sink->signal_name.value.empty()) {
+            return;
         }
 
         if (_sink_by_signal_name.contains(sink->signal_name)) {
-            throw gr::exception(fmt::format("Failed to register sink. Sink with the name `{}` is already registered.", sink->signal_name));
+            throw gr::exception(fmt::format("Failed to register sink `{}`. Sink with the signal_name `{}` is already registered.", sink->name, sink->signal_name), location);
         }
 
         _sinks.push_back(sink);
@@ -161,15 +161,19 @@ public:
     }
 
     template<DataSinkOrDataSetSinkLike TSink>
-    void updateSignalName(TSink* sink, std::string_view oldName, std::string_view newName) {
+    void updateSignalName(TSink* sink, std::string_view oldName, std::string_view newName, std::source_location location = std::source_location::current()) {
         std::lock_guard lg{_mutex};
 
-        if (oldName == "" || newName == "") {
-            throw gr::exception("Failed to update the sink name. Either the old name or the new name is an empty string.");
+        if (oldName.empty()) {
+            throw gr::exception(fmt::format("Failed to update signal_name of sink `{}`. The old signal_name is an empty string.", sink->name), location);
+        }
+
+        if (newName.empty()) {
+            throw gr::exception(fmt::format("Failed to update signal_name of sink `{}`. The new signal_name is an empty string.", sink->name), location);
         }
 
         if (_sink_by_signal_name.contains(std::string{newName})) {
-            throw gr::exception(fmt::format("Failed to update sink name. Sink with the name `{}` is already registered.", newName));
+            throw gr::exception(fmt::format("Failed to update signal_name of sink `{}`. Sink with signal_name `{}` is already registered.", sink->name, newName), location);
         }
 
         _sink_by_signal_name.erase(std::string(oldName));
@@ -324,19 +328,6 @@ private:
 
 namespace detail {
 
-template<typename U>
-[[nodiscard]] constexpr inline std::optional<U> getProperty(const property_map& m, std::string_view key) {
-    const auto it = m.find(std::string(key));
-    if (it == m.end()) {
-        return std::nullopt;
-    }
-    try {
-        return std::get<U>(it->second);
-    } catch (const std::bad_variant_access&) {
-        return std::nullopt;
-    }
-};
-
 struct Metadata {
     float       sampleRate;
     std::string signalName;
@@ -461,7 +452,7 @@ public:
     PortIn<T, RequiredSamples<std::dynamic_extent, detail::data_sink_buffer_size>> in;
 
     Annotated<float, "sample rate", Doc<"signal sample rate">, Unit<"Hz">>           sample_rate = 1.f;
-    Annotated<std::string, "signal name", Visible>                                   signal_name = "unknown signal";
+    Annotated<std::string, "signal name", Visible>                                   signal_name = ""; // DataSink cannot be registered with an empty string; it must be set either by the user or via a tag.
     Annotated<std::string, "signal unit", Visible, Doc<"signal's physical SI unit">> signal_unit = "a.u.";
     Annotated<float, "signal min", Doc<"signal physical min. (e.g. DAQ) limit">>     signal_min  = -1.0f;
     Annotated<float, "signal max", Doc<"signal physical max. (e.g. DAQ) limit">>     signal_max  = +1.0f;
@@ -473,9 +464,13 @@ public:
     using Block<DataSink<T>>::Block; // needed to inherit mandatory base-class Block(property_map) constructor
 
     void settingsChanged(const property_map& oldSettings, const property_map& /*newSettings*/) {
-        const auto oldSignalName = detail::getProperty<std::string>(oldSettings, "signal_name");
-        if (oldSignalName != signal_name && _registered) {
-            DataSinkRegistry::instance().updateSignalName(this, oldSignalName.value_or(""), signal_name);
+        if (oldSettings.contains("signal_name")) {
+            const std::string oldSignalName = std::get<std::string>(oldSettings.at("signal_name"));
+            if (oldSignalName.empty()) {
+                DataSinkRegistry::instance().registerSink(this);
+            } else if (oldSignalName != signal_name && _registered) {
+                DataSinkRegistry::instance().updateSignalName(this, oldSignalName, signal_name);
+            }
         }
         std::lock_guard lg{_listener_mutex};
         for (auto& listener : _listeners) {
@@ -545,8 +540,6 @@ public:
         std::lock_guard lg(_listener_mutex);
         addListener(std::make_unique<SnapshotListener<Callback, M>>(std::forward<M>(matcher), delay, std::forward<Callback>(callback)), false);
     }
-
-    void start() noexcept { DataSinkRegistry::instance().registerSink(this); }
 
     void stop() noexcept {
         DataSinkRegistry::instance().unregisterSink(this);
@@ -983,7 +976,7 @@ class DataSetSink : public Block<DataSetSink<T>> {
 
 public:
     PortIn<DataSet<T>>                              in;
-    Annotated<std::string, "DataSet name", Visible> signal_name = "unknown DataSet";
+    Annotated<std::string, "DataSet name", Visible> signal_name = ""; // DataSetSink cannot be registered with an empty string; it must be set either by the user or via a tag.
 
     GR_MAKE_REFLECTABLE(DataSetSink, in, signal_name);
 
@@ -992,9 +985,13 @@ public:
     using Block<DataSetSink<T>>::Block; // needed to inherit mandatory base-class Block(property_map) constructor
 
     void settingsChanged(const property_map& oldSettings, const property_map& /*newSettings*/) {
-        const auto oldSignalName = detail::getProperty<std::string>(oldSettings, "signal_name");
-        if (oldSignalName != signal_name && _registered) {
-            DataSinkRegistry::instance().updateSignalName(this, oldSignalName.value_or(""), signal_name);
+        if (oldSettings.contains("signal_name")) {
+            const std::string oldSignalName = std::get<std::string>(oldSettings.at("signal_name"));
+            if (oldSignalName.empty()) {
+                DataSinkRegistry::instance().registerSink(this);
+            } else if (oldSignalName != signal_name && _registered) {
+                DataSinkRegistry::instance().updateSignalName(this, oldSignalName, signal_name);
+            }
         }
     }
 
@@ -1022,8 +1019,6 @@ public:
     void registerCallback(Callback&& callback) {
         registerCallback([](const auto&) { return true; }, std::forward<Callback>(callback));
     }
-
-    void start() noexcept { DataSinkRegistry::instance().registerSink(this); }
 
     void stop() noexcept {
         DataSinkRegistry::instance().unregisterSink(this);

--- a/blocks/basic/test/qa_DataSink.cpp
+++ b/blocks/basic/test/qa_DataSink.cpp
@@ -275,7 +275,7 @@ const boost::ut::suite DataSinkTests = [] {
         gr::Graph testGraph;
         auto&     src   = testGraph.emplaceBlock<gr::testing::TagSource<float>>({{"n_samples_max", kSamples}, {"mark_tag", false}, {"signal_name", "test source"}, {"signal_unit", "test unit"}, {"signal_min", -42.f}, {"signal_max", 42.f}});
         auto&     delay = testGraph.emplaceBlock<testing::Delay<float>>({{"delay_ms", kProcessingDelayMs}});
-        auto&     sink  = testGraph.emplaceBlock<DataSink<float>>({{"name", "test_sink"}});
+        auto&     sink  = testGraph.emplaceBlock<DataSink<float>>({{"name", "test_sink"}, {"signal_name", "test source"}});
         src._tags       = srcTags;
 
         expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(src).to<"in">(delay)));
@@ -373,7 +373,7 @@ const boost::ut::suite DataSinkTests = [] {
 
         gr::Graph  testGraph;
         const auto tags = makeTestTags(0, 1000);
-        auto&      src  = testGraph.emplaceBlock<gr::testing::TagSource<float>>({{"n_samples_max", kSamples}, {"mark_tag", false}, {"signal_name", "test source"}, {"signal_unit", "test unit"}, {"signal_min", -42.f}, {"signal_max", 42.f}});
+        auto&      src  = testGraph.emplaceBlock<gr::testing::TagSource<float>>({{"n_samples_max", kSamples}, {"mark_tag", false}, {"signal_name", "test signal"}, {"signal_unit", "test unit"}, {"signal_min", -42.f}, {"signal_max", 42.f}});
         src._tags       = tags;
         auto& delay     = testGraph.emplaceBlock<testing::Delay<float>>({{"delay_ms", kProcessingDelayMs}});
         auto& sink      = testGraph.emplaceBlock<DataSink<float>>({{"name", "test_sink"}, {"signal_name", "test signal"}});
@@ -527,7 +527,7 @@ const boost::ut::suite DataSinkTests = [] {
         const auto tags = std::vector<Tag>{{39000000, {{"TYPE", "TRIGGER"}}}};
         src._tags       = tags;
         auto& delay     = testGraph.emplaceBlock<testing::Delay<int32_t>>({{"delay_ms", kProcessingDelayMs}});
-        auto& sink      = testGraph.emplaceBlock<DataSink<int32_t>>();
+        auto& sink      = testGraph.emplaceBlock<DataSink<int32_t>>({{"signal_name", "test signal"}});
 
         expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(src).to<"in">(delay)));
         expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(delay).to<"in">(sink)));
@@ -587,7 +587,7 @@ const boost::ut::suite DataSinkTests = [] {
         auto&     src = testGraph.emplaceBlock<gr::testing::TagSource<int32_t>>({{"n_samples_max", kSamples}, {"mark_tag", false}, {"sample_rate", 10000.f}, {"signal_name", "test signal"}, {"signal_unit", "none"}, {"signal_min", 0.f}, {"signal_max", static_cast<float>(kSamples - 1)}});
         src._tags     = {{3000, {{"TYPE", "TRIGGER"}}}, {8000, {{"TYPE", "NO_TRIGGER"}}}, {180000, {{"TYPE", "TRIGGER"}}}};
         auto& delay   = testGraph.emplaceBlock<testing::Delay<int32_t>>({{"delay_ms", kProcessingDelayMs}});
-        auto& sink    = testGraph.emplaceBlock<DataSink<int32_t>>({{"name", "test_sink"}});
+        auto& sink    = testGraph.emplaceBlock<DataSink<int32_t>>({{"name", "test_sink"}, {"signal_name", "test signal"}});
 
         expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(src).to<"in">(delay)));
         expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(delay).to<"in">(sink)));
@@ -657,7 +657,7 @@ const boost::ut::suite DataSinkTests = [] {
         auto&            src = testGraph.emplaceBlock<gr::testing::TagSource<int32_t>>({{"n_samples_max", n_samples}, {"mark_tag", false}});
         src._tags            = tags;
         auto& delay          = testGraph.emplaceBlock<testing::Delay<int32_t>>({{"delay_ms", 2500u}});
-        auto& sink           = testGraph.emplaceBlock<DataSink<int32_t>>({{"name", "test_sink"}});
+        auto& sink           = testGraph.emplaceBlock<DataSink<int32_t>>({{"name", "test_sink"}, {"signal_name", "test signal"}});
 
         expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(src).to<"in">(delay)));
         expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(delay).to<"in">(sink)));
@@ -714,7 +714,7 @@ const boost::ut::suite DataSinkTests = [] {
                             expect(eq(dataset.signal_names.size(), 1u));
                             expect(eq(dataset.signal_units.size(), 1u));
                             expect(eq(dataset.timing_events.size(), 1u));
-                            expect(eq(dataset.signal_names[0], "unknown signal"s));
+                            expect(eq(dataset.signal_names[0], "test signal"s));
                             expect(eq(dataset.signal_units[0], "a.u."s));
                             ranges.push_back(dataset.signal_values.front());
                             ranges.push_back(dataset.signal_values.back());
@@ -749,7 +749,7 @@ const boost::ut::suite DataSinkTests = [] {
         }
 
         auto& delay = testGraph.emplaceBlock<testing::Delay<float>>({{"delay_ms", kProcessingDelayMs}});
-        auto& sink  = testGraph.emplaceBlock<DataSink<float>>({{"name", "test_sink"}});
+        auto& sink  = testGraph.emplaceBlock<DataSink<float>>({{"name", "test_sink"}, {"signal_name", "test signal"}});
 
         expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(src).to<"in">(delay)));
         expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(delay).to<"in">(sink)));
@@ -807,7 +807,7 @@ const boost::ut::suite DataSinkTests = [] {
         }
 
         auto& delay = testGraph.emplaceBlock<testing::Delay<float>>({{"delay_ms", kProcessingDelayMs}});
-        auto& sink  = testGraph.emplaceBlock<DataSink<float>>({{"name", "test_sink"}});
+        auto& sink  = testGraph.emplaceBlock<DataSink<float>>({{"name", "test_sink"}, {"signal_name", "test signal"}});
 
         expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(src).to<"in">(delay)));
         expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(delay).to<"in">(sink)));
@@ -844,7 +844,7 @@ const boost::ut::suite DataSinkTests = [] {
         gr::Graph testGraph;
         auto&     src   = testGraph.emplaceBlock<gr::testing::TagSource<float>>({{"n_samples_max", kSamples}, {"mark_tag", false}});
         auto&     delay = testGraph.emplaceBlock<testing::Delay<float>>({{"delay_ms", kProcessingDelayMs}});
-        auto&     sink  = testGraph.emplaceBlock<DataSink<float>>({{"name", "test_sink"}});
+        auto&     sink  = testGraph.emplaceBlock<DataSink<float>>({{"name", "test_sink"}, {"signal_name", "test signal"}});
 
         expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(src).to<"in">(delay)));
         expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(delay).to<"in">(sink)));
@@ -885,7 +885,7 @@ const boost::ut::suite DataSinkTests = [] {
         auto&     source          = testGraph.emplaceBlock<testing::TagSource<float, testing::ProcessFunction::USE_PROCESS_BULK>>({{"n_samples_max", static_cast<gr::Size_t>(1024)}, {"signal_name", "test signal"}, {"signal_unit", "test unit"}, {"mark_tag", false}});
         auto&     delay           = testGraph.emplaceBlock<testing::Delay<float>>({{"delay_ms", kProcessingDelayMs}});
         auto&     streamToDataSet = testGraph.emplaceBlock<StreamToDataSet<float>>({{"filter", "CMD_DIAG_TRIGGER1"}, {"n_pre", static_cast<gr::Size_t>(100)}, {"n_post", static_cast<gr::Size_t>(200)}});
-        auto&     sink            = testGraph.emplaceBlock<DataSetSink<float>>({{"name", "test_sink"}});
+        auto&     sink            = testGraph.emplaceBlock<DataSetSink<float>>({{"name", "test_sink"}, {"signal_name", "test signal"}});
         expect(eq(gr::ConnectionResult::SUCCESS, testGraph.connect<"out">(source).to<"in">(delay)));
         expect(eq(gr::ConnectionResult::SUCCESS, testGraph.connect<"out">(delay).to<"in">(streamToDataSet)));
         expect(eq(gr::ConnectionResult::SUCCESS, testGraph.connect<"out">(streamToDataSet).to<"in">(sink)));
@@ -934,7 +934,7 @@ const boost::ut::suite DataSinkTests = [] {
         auto&     source          = testGraph.emplaceBlock<testing::TagSource<float, testing::ProcessFunction::USE_PROCESS_BULK>>({{"n_samples_max", static_cast<gr::Size_t>(1024)}, {"signal_name", "test signal"}, {"signal_unit", "test unit"}, {"mark_tag", false}});
         auto&     delay           = testGraph.emplaceBlock<testing::Delay<float>>({{"delay_ms", kProcessingDelayMs}});
         auto&     streamToDataSet = testGraph.emplaceBlock<StreamToDataSet<float>>({{"filter", "CMD_DIAG_TRIGGER1"}, {"n_pre", static_cast<gr::Size_t>(100)}, {"n_post", static_cast<gr::Size_t>(200)}});
-        auto&     sink            = testGraph.emplaceBlock<DataSetSink<float>>({{"name", "test_sink"}});
+        auto&     sink            = testGraph.emplaceBlock<DataSetSink<float>>({{"name", "test_sink"}, {"signal_name", "test signal"}});
         expect(eq(gr::ConnectionResult::SUCCESS, testGraph.connect<"out">(source).to<"in">(delay)));
         expect(eq(gr::ConnectionResult::SUCCESS, testGraph.connect<"out">(delay).to<"in">(streamToDataSet)));
         expect(eq(gr::ConnectionResult::SUCCESS, testGraph.connect<"out">(streamToDataSet).to<"in">(sink)));


### PR DESCRIPTION
The PR includes the following changes:

- DataSink cannot be registered with an empty string; it must be set either by the user or via a tag.
- The registration with the same signal name is not allowed.
- Fix qa_DataSink
