### PR TITLE
fix/standardised CONTEXT position in tag property_map

### DIFF
--- a/blocks/basic/include/gnuradio-4.0/basic/clock_source.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/clock_source.hpp
@@ -43,7 +43,7 @@ The 'tag_times[ns]:tag_value(string)' vectors control the emission of tags with 
     A<float, "avg. sample rate", Visible>                                                                          sample_rate = 1000.f;
     A<gr::Size_t, "chunk_size", Visible, Doc<"number of samples per update">>                                      chunk_size  = 100;
     A<std::vector<std::uint64_t>, "tag times", Doc<"times when tags should be emitted [ns]">>                      tag_times;
-    A<std::vector<std::string>, "tag values", Doc<"list of '<trigger name>::<ctx>' formatted tags">>               tag_values;
+    A<std::vector<std::string>, "tag values", Doc<"list of '<trigger name>/<ctx>' formatted tags">>                tag_values;
     A<std::uint64_t, "repeat period", Visible, Doc<"if repeat_period > last tag_time -> restart tags, in [ns]">>   repeat_period{0U}; //
     A<bool, "perform zero-order-hold", Doc<"if tag_times>tag_values: true=publish last tag, false=publish empty">> do_zero_order_hold{false};
     A<bool, "verbose console">                                                                                     verbose_console = false;
@@ -156,12 +156,12 @@ The 'tag_times[ns]:tag_value(string)' vectors control the emission of tags with 
                 gr::basic::trigger::detail::parse(value, triggerName, triggerNameNegated, triggerContext, triggerContextNegated);
                 property_map triggerTag;
                 uint64_t     triggerTime = static_cast<std::uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch()).count());
-                triggerTime += static_cast<std::uint64_t>(samplesToNextTimeTag * 1e9f / sample_rate);
+                triggerTime += static_cast<std::uint64_t>(static_cast<float>(samplesToNextTimeTag) * 1e9f / sample_rate);
                 triggerTag[tag::TRIGGER_NAME.shortKey()]      = triggerName;
                 triggerTag[tag::TRIGGER_TIME.shortKey()]      = triggerTime;
                 triggerTag[tag::TRIGGER_OFFSET.shortKey()]    = 0.f;
                 triggerTag[tag::CONTEXT.shortKey()]           = triggerContext;
-                triggerTag[tag::TRIGGER_META_INFO.shortKey()] = property_map{{tag::CONTEXT.shortKey(), value}};
+                triggerTag[tag::TRIGGER_META_INFO.shortKey()] = property_map{};
                 if (verbose_console) {
                     fmt::println("{}::processBulk(...)\t publish tag-time at  {:6}, time:{}ns", this->name, samplesToNextTimeTag, tag_times.value[_nextTimeTag]);
                 }

--- a/blocks/basic/test/qa_DataSink.cpp
+++ b/blocks/basic/test/qa_DataSink.cpp
@@ -584,7 +584,7 @@ const boost::ut::suite DataSinkTests = [] {
         constexpr gr::Size_t kSamples = 200000;
 
         gr::Graph testGraph;
-        auto&     src = testGraph.emplaceBlock<gr::testing::TagSource<int32_t>>({{"n_samples_max", kSamples}, {"mark_tag", false}, {"sample_rate", 10000.f}, {"signal_name", "test signal"}, {"signal_unit", "none"}, {"signal_min", 0.f}, {"signal_max", static_cast<float>(kSamples - 1)}});
+        auto&     src = testGraph.emplaceBlock<gr::testing::TagSource<int32_t>>({{"n_samples_max", kSamples}, {"mark_tag", false}, {gr::tag::SAMPLE_RATE.shortKey(), 10000.f}, {"signal_name", "test signal"}, {"signal_unit", "none"}, {"signal_min", 0.f}, {"signal_max", static_cast<float>(kSamples - 1)}});
         src._tags     = {{3000, {{"TYPE", "TRIGGER"}}}, {8000, {{"TYPE", "NO_TRIGGER"}}}, {180000, {{"TYPE", "TRIGGER"}}}};
         auto& delay   = testGraph.emplaceBlock<testing::Delay<int32_t>>({{"delay_ms", kProcessingDelayMs}});
         auto& sink    = testGraph.emplaceBlock<DataSink<int32_t>>({{"name", "test_sink"}, {"signal_name", "test signal"}});
@@ -892,11 +892,12 @@ const boost::ut::suite DataSinkTests = [] {
 
         auto genTrigger = [](std::size_t index, std::string triggerName, std::string triggerCtx = {}) {
             return Tag{index, {{gr::tag::TRIGGER_NAME.shortKey(), triggerName}, {gr::tag::TRIGGER_TIME.shortKey(), std::uint64_t(0)}, {gr::tag::TRIGGER_OFFSET.shortKey(), 0.f}, //
-                                  {gr::tag::TRIGGER_META_INFO.shortKey(), gr::property_map{{gr::tag::CONTEXT.shortKey(), triggerCtx}}}}};
+                                  {gr::tag::CONTEXT.shortKey(), triggerCtx},                                                                                                     //
+                                  {gr::tag::TRIGGER_META_INFO.shortKey(), gr::property_map{}}}};
         };
 
-        source._tags.push_back(genTrigger(400, "CMD_DIAG_TRIGGER1", "CMD_DIAG_TRIGGER1"));
-        source._tags.push_back(genTrigger(800, "CMD_DIAG_TRIGGER1", "CMD_DIAG_TRIGGER1"));
+        source._tags.push_back(genTrigger(400, "CMD_DIAG_TRIGGER1", ""));
+        source._tags.push_back(genTrigger(800, "CMD_DIAG_TRIGGER1", ""));
 
         auto polling = std::async([] {
             std::shared_ptr<DataSetPoller<float>> poller;
@@ -941,11 +942,12 @@ const boost::ut::suite DataSinkTests = [] {
 
         auto genTrigger = [](std::size_t index, std::string triggerName, std::string triggerCtx = {}) {
             return Tag{index, {{gr::tag::TRIGGER_NAME.shortKey(), triggerName}, {gr::tag::TRIGGER_TIME.shortKey(), std::uint64_t(0)}, {gr::tag::TRIGGER_OFFSET.shortKey(), 0.f}, //
-                                  {gr::tag::TRIGGER_META_INFO.shortKey(), gr::property_map{{gr::tag::CONTEXT.shortKey(), triggerCtx}}}}};
+                                  {gr::tag::CONTEXT.shortKey(), triggerCtx},                                                                                                     //
+                                  {gr::tag::TRIGGER_META_INFO.shortKey(), gr::property_map{}}}};
         };
 
-        source._tags.push_back(genTrigger(400, "CMD_DIAG_TRIGGER1", "CMD_DIAG_TRIGGER1"));
-        source._tags.push_back(genTrigger(800, "CMD_DIAG_TRIGGER1", "CMD_DIAG_TRIGGER1"));
+        source._tags.push_back(genTrigger(400, "CMD_DIAG_TRIGGER1", ""));
+        source._tags.push_back(genTrigger(800, "CMD_DIAG_TRIGGER1", ""));
 
         std::vector<DataSet<float>> receivedDataSets;
         auto                        callback = [&receivedDataSets](const auto& ds) { receivedDataSets.push_back(ds); };

--- a/blocks/basic/test/qa_StreamToDataSet.cpp
+++ b/blocks/basic/test/qa_StreamToDataSet.cpp
@@ -49,14 +49,14 @@ const boost::ut::suite<"StreamToDataSet Block"> selectorTest = [] {
         using gr::tag::CONTEXT;
 
         const auto now = settings::convertTimePointToUint64Ns(std::chrono::system_clock::now());
-        expect(funcGen.settings().set(createConstPropertyMap(5.f), SettingsCtx{now, "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1"}).empty());
-        expect(funcGen.settings().set(createLinearRampPropertyMap(5.f, 30.f, .2f), SettingsCtx{now, "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2"}).empty());
-        expect(funcGen.settings().set(createConstPropertyMap(30.f), SettingsCtx{now, "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=3"}).empty());
-        expect(funcGen.settings().set(createParabolicRampPropertyMap(30.f, 20.f, .1f, 0.02f), SettingsCtx{now, "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=4"}).empty());
-        expect(funcGen.settings().set(createConstPropertyMap(20.f), SettingsCtx{now, "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=5"}).empty());
-        expect(funcGen.settings().set(createCubicSplinePropertyMap(20.f, 10.f, .1f), SettingsCtx{now, "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=6"}).empty());
-        expect(funcGen.settings().set(createConstPropertyMap(10.f), SettingsCtx{now, "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=7"}).empty());
-        expect(funcGen.settings().set(createImpulseResponsePropertyMap(10.f, 20.f, .02f, .06f), SettingsCtx{now, "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=8"}).empty());
+        expect(funcGen.settings().set(createConstPropertyMap("CMD_BP_START", 5.f), SettingsCtx{now, "FAIR.SELECTOR.C=1:S=1:P=1"}).empty());
+        expect(funcGen.settings().set(createLinearRampPropertyMap("CMD_BP_START", 5.f, 30.f, .2f), SettingsCtx{now, "FAIR.SELECTOR.C=1:S=1:P=2"}).empty());
+        expect(funcGen.settings().set(createConstPropertyMap("CMD_BP_START", 30.f), SettingsCtx{now, "FAIR.SELECTOR.C=1:S=1:P=3"}).empty());
+        expect(funcGen.settings().set(createParabolicRampPropertyMap("CMD_BP_START", 30.f, 20.f, .1f, 0.02f), SettingsCtx{now, "FAIR.SELECTOR.C=1:S=1:P=4"}).empty());
+        expect(funcGen.settings().set(createConstPropertyMap("CMD_BP_START", 20.f), SettingsCtx{now, "FAIR.SELECTOR.C=1:S=1:P=5"}).empty());
+        expect(funcGen.settings().set(createCubicSplinePropertyMap("CMD_BP_START", 20.f, 10.f, .1f), SettingsCtx{now, "FAIR.SELECTOR.C=1:S=1:P=6"}).empty());
+        expect(funcGen.settings().set(createConstPropertyMap("CMD_BP_START", 10.f), SettingsCtx{now, "FAIR.SELECTOR.C=1:S=1:P=7"}).empty());
+        expect(funcGen.settings().set(createImpulseResponsePropertyMap("CMD_BP_START", 10.f, 20.f, .02f, .06f), SettingsCtx{now, "FAIR.SELECTOR.C=1:S=1:P=8"}).empty());
 
         expect(eq(funcGen.settings().getNStoredParameters(), 9UZ));
 
@@ -115,7 +115,8 @@ const boost::ut::suite<"StreamToDataSet Block"> selectorTest = [] {
 
 gr::Tag genTrigger(std::size_t index, std::string triggerName, std::string triggerCtx = {}) {
     return {index, {{gr::tag::TRIGGER_NAME.shortKey(), triggerName}, {gr::tag::TRIGGER_TIME.shortKey(), std::uint64_t(0)}, {gr::tag::TRIGGER_OFFSET.shortKey(), 0.f}, //
-                       {gr::tag::TRIGGER_META_INFO.shortKey(), gr::property_map{{gr::tag::CONTEXT.shortKey(), triggerCtx}}}}};
+                       {gr::tag::CONTEXT.shortKey(), triggerCtx},                                                                                                     //
+                       {gr::tag::TRIGGER_META_INFO.shortKey(), gr::property_map{}}}};
 };
 
 const boost::ut::suite<"StreamToStream test"> streamToStreamTest = [] {
@@ -131,13 +132,13 @@ const boost::ut::suite<"StreamToStream test"> streamToStreamTest = [] {
         auto& tagSrc = graph.emplaceBlock<TagSource<float, ProcessFunction::USE_PROCESS_BULK>>({{"sample_rate", sample_rate}, //
             {"n_samples_max", nSamples}, {"name", "TagSource"}, {"verbose_console", false}, {"repeat_tags", false}, {"mark_tag", false}});
         tagSrc._tags = {
-            genTrigger(5, "CMD_BP_START", "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1"),  // start
-            genTrigger(8, "CMD_DIAG_TRIGGER1", "CMD_DIAG_TRIGGER1"),                  // it is also used to split samples processing into 2 iterations
-            genTrigger(10, "CMD_BP_START", "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2"), // stop
-            genTrigger(12, "CMD_DIAG_TRIGGER1", "CMD_DIAG_TRIGGER1"),                 // it is also used as end trigger for "including" mode
-            genTrigger(15, "CMD_BP_START", "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1"), // start
-            genTrigger(20, "CMD_BP_START", "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2"), // stop
-            genTrigger(22, "CMD_DIAG_TRIGGER1", "CMD_DIAG_TRIGGER1")                  // it is also used as end trigger for "including" mode
+            genTrigger(5, "CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=1"),  // start
+            genTrigger(8, "CMD_DIAG_TRIGGER1", ""),                      // it is also used to split samples processing into 2 iterations
+            genTrigger(10, "CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=2"), // stop
+            genTrigger(12, "CMD_DIAG_TRIGGER1", ""),                     // it is also used as end trigger for "including" mode
+            genTrigger(15, "CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=1"), // start
+            genTrigger(20, "CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=2"), // stop
+            genTrigger(22, "CMD_DIAG_TRIGGER1", "")                      // it is also used as end trigger for "including" mode
         };
 
         const property_map blockSettings        = {{"filter", filter}, {"n_pre", preSamples}, {"n_post", postSamples}};
@@ -199,16 +200,16 @@ const boost::ut::suite<"StreamToDataSet test"> streamToDataSetTest = [] {
         auto& tagSrc = graph.emplaceBlock<TagSource<float, ProcessFunction::USE_PROCESS_BULK>>({{"sample_rate", sample_rate}, //
             {"n_samples_max", nSamples}, {"name", "TagSource"}, {"verbose_console", false}, {"repeat_tags", false}, {"mark_tag", false}});
         tagSrc._tags = {
-            genTrigger(5, "CMD_BP_START", "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1"),  // start
-            genTrigger(8, "CMD_DIAG_TRIGGER1", "CMD_DIAG_TRIGGER1"),                  // it is also used to split samples processing into 2 iterations
-            genTrigger(10, "CMD_BP_START", "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2"), // stop
-            genTrigger(12, "CMD_DIAG_TRIGGER1", "CMD_DIAG_TRIGGER1"),                 // it is also used as end trigger for "including" mode
-            genTrigger(15, "CMD_BP_START", "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1"), // start
-            genTrigger(20, "CMD_BP_START", "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1"), // start
-            genTrigger(25, "CMD_BP_START", "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2"), // stop
-            genTrigger(27, "CMD_DIAG_TRIGGER1", "CMD_DIAG_TRIGGER1"),                 // it is also used as end trigger for "including" mode
-            genTrigger(30, "CMD_BP_START", "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2"), // stop
-            genTrigger(32, "CMD_DIAG_TRIGGER1", "CMD_DIAG_TRIGGER1")                  // it is also used as end trigger for "including" mode
+            genTrigger(5, "CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=1"),  // start
+            genTrigger(8, "CMD_DIAG_TRIGGER1", ""),                      // it is also used to split samples processing into 2 iterations
+            genTrigger(10, "CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=2"), // stop
+            genTrigger(12, "CMD_DIAG_TRIGGER1", ""),                     // it is also used as end trigger for "including" mode
+            genTrigger(15, "CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=1"), // start
+            genTrigger(20, "CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=1"), // start
+            genTrigger(25, "CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=2"), // stop
+            genTrigger(27, "CMD_DIAG_TRIGGER1", ""),                     // it is also used as end trigger for "including" mode
+            genTrigger(30, "CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=2"), // stop
+            genTrigger(32, "CMD_DIAG_TRIGGER1", "")                      // it is also used as end trigger for "including" mode
         };
 
         const property_map blockSettings         = {{"filter", filter}, {"n_pre", preSamples}, {"n_post", postSamples}, {"n_max", maxSamples}};

--- a/blocks/basic/test/qa_TriggerBlocks.cpp
+++ b/blocks/basic/test/qa_TriggerBlocks.cpp
@@ -52,11 +52,11 @@ const suite<"SchmittTrigger Block"> triggerTests = [] {
 
             auto& funcGen = graph.emplaceBlock<FunctionGenerator<float>>({{"sample_rate", sample_rate}, {"name", "FunctionGenerator"}, {"start_value", 0.1f}});
             using namespace function_generator;
-            expect(funcGen.settings().set(createConstPropertyMap(0.1f), SettingsCtx{.context = "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=0"}).empty());
-            expect(funcGen.settings().set(createParabolicRampPropertyMap(0.1f, 1.1f, .3f, 0.02f), SettingsCtx{.context = "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1"}).empty());
-            expect(funcGen.settings().set(createConstPropertyMap(1.1f), SettingsCtx{.context = "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2"}).empty());
-            expect(funcGen.settings().set(createParabolicRampPropertyMap(1.1f, 0.1f, .3f, 0.02f), SettingsCtx{.context = "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=3"}).empty());
-            expect(funcGen.settings().set(createConstPropertyMap(0.1f), SettingsCtx{.context = "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=4"}).empty());
+            expect(funcGen.settings().set(createConstPropertyMap("CMD_BP_START", 0.1f), SettingsCtx{.context = "FAIR.SELECTOR.C=1:S=1:P=0"}).empty());
+            expect(funcGen.settings().set(createParabolicRampPropertyMap("CMD_BP_START", 0.1f, 1.1f, .3f, 0.02f), SettingsCtx{.context = "FAIR.SELECTOR.C=1:S=1:P=1"}).empty());
+            expect(funcGen.settings().set(createConstPropertyMap("CMD_BP_START", 1.1f), SettingsCtx{.context = "FAIR.SELECTOR.C=1:S=1:P=2"}).empty());
+            expect(funcGen.settings().set(createParabolicRampPropertyMap("CMD_BP_START", 1.1f, 0.1f, .3f, 0.02f), SettingsCtx{.context = "FAIR.SELECTOR.C=1:S=1:P=3"}).empty());
+            expect(funcGen.settings().set(createConstPropertyMap("CMD_BP_START", 0.1f), SettingsCtx{.context = "FAIR.SELECTOR.C=1:S=1:P=4"}).empty());
 
             auto& schmittTrigger = graph.emplaceBlock<gr::blocks::basic::SchmittTrigger<float, Method::value>>({
                 {"name", "SchmittTrigger"},                      //

--- a/blocks/soapy/test/qa_Soapy.cpp
+++ b/blocks/soapy/test/qa_Soapy.cpp
@@ -21,7 +21,7 @@ const boost::ut::suite<"basic SoapySDR API "> basicSoapyAPI = [] {
     using namespace gr;
     using namespace gr::blocks::soapy;
 
-    "helper functions"_test = [] { "range printer"_test = [] { expect(eq(fmt::format("{}", Range{1.0, 10.0, 0.5}), std::string("Range{min: 1, max: 10, step: 0.5}"))); }; };
+    "helper functions"_test = [] { "range printer"_test = [] { expect(eq(fmt::format("{}", gr::blocks::soapy::Range{1.0, 10.0, 0.5}), std::string("Range{min: 1, max: 10, step: 0.5}"))); }; };
 
     "ModulesCheck"_test = [] {
         std::vector<std::string> modules = getSoapySDRModules();
@@ -157,8 +157,8 @@ const boost::ut::suite<"basic SoapySDR API "> basicSoapyAPI = [] {
             };
 
             "center RF frequency"_test = [&device] {
-                std::vector<Range> ranges          = device.getOverallFrequencyRange(SOAPY_SDR_RX, 0);
-                double             centerFrequency = device.getCenterFrequency(SOAPY_SDR_RX, 0);
+                std::vector<gr::blocks::soapy::Range> ranges          = device.getOverallFrequencyRange(SOAPY_SDR_RX, 0);
+                double                                centerFrequency = device.getCenterFrequency(SOAPY_SDR_RX, 0);
                 fmt::println("Rx freq ranges: [{}] - active: {} Hz", fmt::join(ranges, ", "), centerFrequency);
 
                 device.setCenterFrequency(SOAPY_SDR_RX, 0, 106e6);

--- a/blocks/testing/test/qa_UI_Integration.cpp
+++ b/blocks/testing/test/qa_UI_Integration.cpp
@@ -33,27 +33,27 @@ const boost::ut::suite TagTests = [] {
 
         // all times are in nanoseconds
         constexpr std::uint64_t ms = 1'000'000; // ms -> ns conversion factor (wish we had a proper C++ units-lib integration)
-        addTimeTagEntry(clockSrc, 10 * ms, "CMD_BP_START:FAIR.SELECTOR.C=1:S=1:P=1");
-        addTimeTagEntry(clockSrc, 100 * ms, "CMD_BP_START:FAIR.SELECTOR.C=1:S=1:P=2");
-        addTimeTagEntry(clockSrc, 300 * ms, "CMD_BP_START:FAIR.SELECTOR.C=1:S=1:P=3");
-        addTimeTagEntry(clockSrc, 350 * ms, "CMD_BP_START:FAIR.SELECTOR.C=1:S=1:P=4");
-        addTimeTagEntry(clockSrc, 550 * ms, "CMD_BP_START:FAIR.SELECTOR.C=1:S=1:P=5");
-        addTimeTagEntry(clockSrc, 650 * ms, "CMD_BP_START:FAIR.SELECTOR.C=1:S=1:P=6");
-        addTimeTagEntry(clockSrc, 800 * ms, "CMD_BP_START:FAIR.SELECTOR.C=1:S=1:P=7");
-        addTimeTagEntry(clockSrc, 850 * ms, "CMD_BP_START:FAIR.SELECTOR.C=1:S=1:P=8");
+        addTimeTagEntry(clockSrc, 10 * ms, "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1");
+        addTimeTagEntry(clockSrc, 100 * ms, "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2");
+        addTimeTagEntry(clockSrc, 300 * ms, "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=3");
+        addTimeTagEntry(clockSrc, 350 * ms, "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=4");
+        addTimeTagEntry(clockSrc, 550 * ms, "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=5");
+        addTimeTagEntry(clockSrc, 650 * ms, "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=6");
+        addTimeTagEntry(clockSrc, 800 * ms, "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=7");
+        addTimeTagEntry(clockSrc, 850 * ms, "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=8");
         clockSrc.repeat_period      = 1000 * ms;
         clockSrc.do_zero_order_hold = true;
 
         const auto now     = settings::convertTimePointToUint64Ns(std::chrono::system_clock::now());
         auto&      funcGen = testGraph.emplaceBlock<FunctionGenerator<float>>({{"sample_rate", sample_rate}, {"name", "FunctionGenerator"}});
-        expect(funcGen.settings().set(createConstPropertyMap(5.f), SettingsCtx{now, "CMD_BP_START:FAIR.SELECTOR.C=1:S=1:P=1"}).empty());
-        expect(funcGen.settings().set(createLinearRampPropertyMap(5.f, 30.f, .2f), SettingsCtx{now, "CMD_BP_START:FAIR.SELECTOR.C=1:S=1:P=2"}).empty());
-        expect(funcGen.settings().set(createConstPropertyMap(30.f), SettingsCtx{now, "CMD_BP_START:FAIR.SELECTOR.C=1:S=1:P=3"}).empty());
-        expect(funcGen.settings().set(createParabolicRampPropertyMap(30.f, 20.f, .1f, 0.02f), SettingsCtx{now, "CMD_BP_START:FAIR.SELECTOR.C=1:S=1:P=4"}).empty());
-        expect(funcGen.settings().set(createConstPropertyMap(20.f), SettingsCtx{now, "CMD_BP_START:FAIR.SELECTOR.C=1:S=1:P=5"}).empty());
-        expect(funcGen.settings().set(createCubicSplinePropertyMap(20.f, 10.f, .1f), SettingsCtx{now, "CMD_BP_START:FAIR.SELECTOR.C=1:S=1:P=6"}).empty());
-        expect(funcGen.settings().set(createConstPropertyMap(10.f), SettingsCtx{now, "CMD_BP_START:FAIR.SELECTOR.C=1:S=1:P=7"}).empty());
-        expect(funcGen.settings().set(createImpulseResponsePropertyMap(10.f, 20.f, .02f, .06f), SettingsCtx{now, "CMD_BP_START:FAIR.SELECTOR.C=1:S=1:P=8"}).empty());
+        expect(funcGen.settings().set(createConstPropertyMap("CMD_BP_START", 5.f), SettingsCtx{now, "FAIR.SELECTOR.C=1:S=1:P=1"}).empty());
+        expect(funcGen.settings().set(createLinearRampPropertyMap("CMD_BP_START", 5.f, 30.f, .2f), SettingsCtx{now, "FAIR.SELECTOR.C=1:S=1:P=2"}).empty());
+        expect(funcGen.settings().set(createConstPropertyMap("CMD_BP_START", 30.f), SettingsCtx{now, "FAIR.SELECTOR.C=1:S=1:P=3"}).empty());
+        expect(funcGen.settings().set(createParabolicRampPropertyMap("CMD_BP_START", 30.f, 20.f, .1f, 0.02f), SettingsCtx{now, "FAIR.SELECTOR.C=1:S=1:P=4"}).empty());
+        expect(funcGen.settings().set(createConstPropertyMap("CMD_BP_START", 20.f), SettingsCtx{now, "FAIR.SELECTOR.C=1:S=1:P=5"}).empty());
+        expect(funcGen.settings().set(createCubicSplinePropertyMap("CMD_BP_START", 20.f, 10.f, .1f), SettingsCtx{now, "FAIR.SELECTOR.C=1:S=1:P=6"}).empty());
+        expect(funcGen.settings().set(createConstPropertyMap("CMD_BP_START", 10.f), SettingsCtx{now, "FAIR.SELECTOR.C=1:S=1:P=7"}).empty());
+        expect(funcGen.settings().set(createImpulseResponsePropertyMap("CMD_BP_START", 10.f, 20.f, .02f, .06f), SettingsCtx{now, "FAIR.SELECTOR.C=1:S=1:P=8"}).empty());
 
         auto& sink = testGraph.emplaceBlock<TagSink<float, ProcessFunction::USE_PROCESS_ONE>>({{"name", "SampleGeneratorSink"}});
 

--- a/core/include/gnuradio-4.0/Block.hpp
+++ b/core/include/gnuradio-4.0/Block.hpp
@@ -1051,7 +1051,7 @@ protected:
             const auto& dataMap = message.data.value(); // Introduced const auto& dataMap
 
             std::string contextStr;
-            if (auto it = dataMap.find("context"); it != dataMap.end()) {
+            if (auto it = dataMap.find(gr::tag::CONTEXT.shortKey()); it != dataMap.end()) {
                 if (const auto stringPtr = std::get_if<std::string>(&it->second); stringPtr) {
                     contextStr = *stringPtr;
                 } else {
@@ -1062,7 +1062,7 @@ protected:
             }
 
             std::uint64_t time = 0;
-            if (auto it = dataMap.find("time"); it != dataMap.end()) {
+            if (auto it = dataMap.find(gr::tag::CONTEXT_TIME.shortKey()); it != dataMap.end()) {
                 if (const std::uint64_t* timePtr = std::get_if<std::uint64_t>(&it->second); timePtr) {
                     time = *timePtr;
                 }
@@ -1080,7 +1080,7 @@ protected:
 
         if (message.cmd == Get || message.cmd == Set) {
             const auto& ctx = settings().activeContext();
-            message.data    = {{"context", ctx.context}, {"time", ctx.time}};
+            message.data    = {{gr::tag::CONTEXT.shortKey(), ctx.context}, {gr::tag::CONTEXT_TIME.shortKey(), ctx.time}};
             return message;
         }
 
@@ -1098,7 +1098,7 @@ protected:
         const auto& dataMap = message.data.value(); // Introduced const auto& dataMap
 
         std::string contextStr;
-        if (auto it = dataMap.find("context"); it != dataMap.end()) {
+        if (auto it = dataMap.find(gr::tag::CONTEXT.shortKey()); it != dataMap.end()) {
             if (const auto stringPtr = std::get_if<std::string>(&it->second); stringPtr) {
                 contextStr = *stringPtr;
             } else {
@@ -1109,7 +1109,7 @@ protected:
         }
 
         std::uint64_t time = 0;
-        if (auto it = dataMap.find("time"); it != dataMap.end()) {
+        if (auto it = dataMap.find(gr::tag::CONTEXT_TIME.shortKey()); it != dataMap.end()) {
             if (const std::uint64_t* timePtr = std::get_if<std::uint64_t>(&it->second); timePtr) {
                 time = *timePtr;
             }

--- a/core/include/gnuradio-4.0/DataSet.hpp
+++ b/core/include/gnuradio-4.0/DataSet.hpp
@@ -88,10 +88,11 @@ concept DataSetLike = TensorLike<T> && requires(T t, const std::size_t n_items) 
 
 template<typename T>
 struct DataSet {
-    using value_type         = T;
-    using tensor_layout_type = std::variant<LayoutRight, LayoutLeft, std::string>;
-    using pmt_map            = std::map<std::string, pmtv::pmt>;
-    std::int64_t timestamp   = 0; // UTC timestamp [ns]
+    using value_type           = T;
+    using tensor_layout_type   = std::variant<LayoutRight, LayoutLeft, std::string>;
+    using pmt_map              = pmtv::map_t;
+    T            default_value = T(); // default value for padding, ZOH etc.
+    std::int64_t timestamp     = 0;   // UTC timestamp [ns]
 
     // axis layout:
     std::vector<std::string>    axis_names{};  // axis quantity, e.g. time, frequency, …
@@ -167,10 +168,11 @@ static_assert(DataSetLike<DataSet<double>>, "DataSet<double> concept conformity"
 
 template<typename T>
 struct Tensor {
-    using value_type         = T;
-    using tensor_layout_type = std::variant<LayoutRight, LayoutLeft, std::string>;
-    using pmt_map            = std::map<std::string, pmtv::pmt>;
-    std::int64_t timestamp   = 0; // UTC timestamp [ns]
+    using value_type           = T;
+    using tensor_layout_type   = std::variant<LayoutRight, LayoutLeft, std::string>;
+    using pmt_map              = pmtv::map_t;
+    T            default_value = T(); // default value for padding, ZOH etc.
+    std::int64_t timestamp     = 0;   // UTC timestamp [ns]
 
     std::vector<std::int32_t> extents{}; // extents[dim0_size, dim1_size, …]
     tensor_layout_type        layout{};  // row-major, column-major, “special”
@@ -190,7 +192,8 @@ static_assert(TensorLike<Tensor<double>>, "Tensor<std::byte> concept conformity"
 template<typename T>
 struct Packet {
     using value_type = T;
-    using pmt_map    = std::map<std::string, pmtv::pmt>;
+    using pmt_map    = pmtv::map_t;
+    T default_value  = T(); // default value for padding, ZOH etc.
 
     std::int64_t         timestamp = 0;   // UTC timestamp [ns]
     std::vector<T>       signal_values{}; // size = \PI_i extents[i

--- a/core/include/gnuradio-4.0/Graph_yaml_importer.hpp
+++ b/core/include/gnuradio-4.0/Graph_yaml_importer.hpp
@@ -67,8 +67,8 @@ inline void loadGraphFromMap(PluginLoader& loader, gr::Graph& resultGraph, gr::p
                 auto parametersCtx = std::get<std::vector<pmtv::pmt>>(it->second);
                 for (const auto& ctxPmt : parametersCtx) {
                     auto       ctxPar        = std::get<property_map>(ctxPmt);
-                    const auto ctxName       = std::get<std::string>(ctxPar["context"]);
-                    const auto ctxTime       = std::get<std::uint64_t>(ctxPar["time"]); // in ns
+                    const auto ctxName       = std::get<std::string>(ctxPar[gr::tag::CONTEXT.shortKey()]);
+                    const auto ctxTime       = std::get<std::uint64_t>(ctxPar[gr::tag::CONTEXT_TIME.shortKey()]); // in ns
                     const auto ctxParameters = std::get<property_map>(ctxPar["parameters"]);
 
                     currentBlock->settings().loadParametersFromPropertyMap(ctxParameters, SettingsCtx{ctxTime, ctxName});
@@ -198,9 +198,9 @@ inline gr::property_map saveGraphToMap(PluginLoader& loader, const gr::Graph& ro
                             },
                             ctxTime.context);
 
-                        ctxParam["context"]    = contextStr;
-                        ctxParam["time"]       = ctxTime.time;
-                        ctxParam["parameters"] = writeParameters(settingsMap);
+                        ctxParam[gr::tag::CONTEXT.shortKey()]      = contextStr;
+                        ctxParam[gr::tag::CONTEXT_TIME.shortKey()] = ctxTime.time;
+                        ctxParam["parameters"]                     = writeParameters(settingsMap);
                         ctxParamsSeq.emplace_back(std::move(ctxParam));
                     }
                 }

--- a/core/include/gnuradio-4.0/Port.hpp
+++ b/core/include/gnuradio-4.0/Port.hpp
@@ -189,13 +189,13 @@ Follows the ISO 80000-1:2022 Quantities and Units conventions:
     GR_MAKE_REFLECTABLE(PortMetaInfo, sample_rate, signal_name, signal_quantity, signal_unit, signal_min, signal_max);
 
     // controls automatic (if set) or manual update of above parameters
-    std::set<std::string, std::less<>> auto_update{"sample_rate", "signal_name", "signal_quantity", "signal_unit", "signal_min", "signal_max"};
+    std::set<std::string, std::less<>> auto_update{gr::tag::kDefaultTags.begin(), gr::tag::kDefaultTags.end()};
 
     constexpr PortMetaInfo() noexcept = default;
     explicit PortMetaInfo(std::initializer_list<std::pair<const std::string, pmtv::pmt>> initMetaInfo) noexcept(true) : PortMetaInfo(property_map{initMetaInfo.begin(), initMetaInfo.end()}) {}
     explicit PortMetaInfo(const property_map& metaInfo) noexcept(true) { update<true>(metaInfo); }
 
-    void reset() { auto_update = {"sample_rate", "signal_name", "signal_quantity", "signal_unit", "signal_min", "signal_max"}; }
+    void reset() { auto_update = {gr::tag::kDefaultTags.begin(), gr::tag::kDefaultTags.end()}; }
 
     template<bool isNoexcept = false>
     void update(const property_map& metaInfo) noexcept(isNoexcept) {
@@ -217,17 +217,17 @@ Follows the ISO 80000-1:2022 Quantities and Units conventions:
         };
 
         for (const auto& key : auto_update) {
-            if (key == "sample_rate") {
+            if (key == gr::tag::SAMPLE_RATE.shortKey()) {
                 updateValue(key, sample_rate);
-            } else if (key == "signal_name") {
+            } else if (key == gr::tag::SIGNAL_NAME.shortKey()) {
                 updateValue(key, signal_name);
-            } else if (key == "signal_quantity") {
+            } else if (key == gr::tag::SIGNAL_QUANTITY.shortKey()) {
                 updateValue(key, signal_quantity);
-            } else if (key == "signal_unit") {
+            } else if (key == gr::tag::SIGNAL_UNIT.shortKey()) {
                 updateValue(key, signal_unit);
-            } else if (key == "signal_min") {
+            } else if (key == gr::tag::SIGNAL_MIN.shortKey()) {
                 updateValue(key, signal_min);
-            } else if (key == "signal_max") {
+            } else if (key == gr::tag::SIGNAL_MAX.shortKey()) {
                 updateValue(key, signal_max);
             }
         }
@@ -235,12 +235,12 @@ Follows the ISO 80000-1:2022 Quantities and Units conventions:
 
     [[nodiscard]] property_map get() const noexcept {
         property_map metaInfo;
-        metaInfo["sample_rate"]     = sample_rate;
-        metaInfo["signal_name"]     = signal_name;
-        metaInfo["signal_quantity"] = signal_quantity;
-        metaInfo["signal_unit"]     = signal_unit;
-        metaInfo["signal_min"]      = signal_min;
-        metaInfo["signal_max"]      = signal_max;
+        metaInfo[gr::tag::SAMPLE_RATE.shortKey()]     = sample_rate;
+        metaInfo[gr::tag::SIGNAL_NAME.shortKey()]     = signal_name;
+        metaInfo[gr::tag::SIGNAL_QUANTITY.shortKey()] = signal_quantity;
+        metaInfo[gr::tag::SIGNAL_UNIT.shortKey()]     = signal_unit;
+        metaInfo[gr::tag::SIGNAL_MIN.shortKey()]      = signal_min;
+        metaInfo[gr::tag::SIGNAL_MAX.shortKey()]      = signal_max;
 
         return metaInfo;
     }

--- a/core/include/gnuradio-4.0/Tag.hpp
+++ b/core/include/gnuradio-4.0/Tag.hpp
@@ -177,11 +177,12 @@ inline EM_CONSTEXPR_STATIC DefaultTag<"trigger_time", uint64_t, "ns", "UTC-based
 inline EM_CONSTEXPR_STATIC DefaultTag<"trigger_offset", float, "s", "sample delay w.r.t. the trigger (e.g.compensating analog group delays)"> TRIGGER_OFFSET;
 inline EM_CONSTEXPR_STATIC DefaultTag<"trigger_meta_info", property_map, "", "maps containing additional trigger information"> TRIGGER_META_INFO;
 inline EM_CONSTEXPR_STATIC DefaultTag<"context", std::string, "", "multiplexing key to orchestrate node settings/behavioural changes"> CONTEXT;
+inline EM_CONSTEXPR_STATIC DefaultTag<"time", std::uint64_t, "", "multiplexing UTC-time in [ns] when ctx should be applied"> CONTEXT_TIME; // TODO: for backward compatibility -> rename to `ctx_time'
 inline EM_CONSTEXPR_STATIC DefaultTag<"reset_default", bool, "", "reset block state to stored default"> RESET_DEFAULTS;
 inline EM_CONSTEXPR_STATIC DefaultTag<"store_default", bool, "", "store block settings as default"> STORE_DEFAULTS;
 inline EM_CONSTEXPR_STATIC DefaultTag<"end_of_stream", bool, "", "end of stream, receiver should change to DONE state"> END_OF_STREAM;
 
-inline constexpr std::array<std::string_view, 15> kDefaultTags = {"sample_rate", "signal_name", "signal_quantity", "signal_unit", "signal_min", "signal_max", "n_dropped_samples", "trigger_name", "trigger_time", "trigger_offset", "trigger_meta_info", "context", "reset_default", "store_default", "end_of_stream"};
+inline constexpr std::array<std::string_view, 16> kDefaultTags = {"sample_rate", "signal_name", "signal_quantity", "signal_unit", "signal_min", "signal_max", "n_dropped_samples", "trigger_name", "trigger_time", "trigger_offset", "trigger_meta_info", "context", "time", "reset_default", "store_default", "end_of_stream"};
 
 } // namespace tag
 

--- a/core/include/gnuradio-4.0/TriggerMatcher.hpp
+++ b/core/include/gnuradio-4.0/TriggerMatcher.hpp
@@ -229,13 +229,11 @@ inline void verifyFilterState(std::string_view matchCriteria, property_map& stat
 
     std::string triggerName;
     std::string triggerCtx;
-    if (tag.map.contains(tag::TRIGGER_NAME.shortKey())) {
+    if (tag.map.contains(tag::TRIGGER_NAME.shortKey()) && std::holds_alternative<std::string>(tag.map.at(tag::TRIGGER_NAME.shortKey()))) {
         triggerName = std::get<std::string>(tag.map.at(tag::TRIGGER_NAME.shortKey()));
     }
-    if (tag.map.contains(tag::TRIGGER_META_INFO.shortKey())) {
-        if (auto meta = std::get_if<property_map>(&tag.map.at(tag::TRIGGER_META_INFO.shortKey())); meta && meta->contains(tag::CONTEXT.shortKey())) {
-            triggerCtx = std::get<std::string>(meta->at(tag::CONTEXT.shortKey()));
-        }
+    if (tag.map.contains(tag::CONTEXT.shortKey()) && std::holds_alternative<std::string>(tag.map.at(tag::CONTEXT.shortKey()))) {
+        triggerCtx = std::get<std::string>(tag.map.at(tag::CONTEXT.shortKey()));
     }
 
     if (isSingleTrigger(filterState)) {

--- a/core/test/qa_Block.cpp
+++ b/core/test/qa_Block.cpp
@@ -831,8 +831,8 @@ const boost::ut::suite<"Port MetaInfo Tests"> _portMetaInfoTests = [] {
 
     "constructor test"_test = [] {
         // Test the initializer list constructor
-        PortMetaInfo portMetaInfo({{"sample_rate", 48000.f}, //
-            {"signal_name", "TestSignal"}, {"signal_quantity", "voltage"}, {"signal_unit", "V"}, {"signal_min", -1.f}, {"signal_max", 1.f}});
+        PortMetaInfo portMetaInfo({{gr::tag::SAMPLE_RATE.shortKey(), 48000.f}, //
+            {gr::tag::SIGNAL_NAME.shortKey(), "TestSignal"}, {gr::tag::SIGNAL_QUANTITY.shortKey(), "voltage"}, {gr::tag::SIGNAL_UNIT.shortKey(), "V"}, {gr::tag::SIGNAL_MIN.shortKey(), -1.f}, {gr::tag::SIGNAL_MAX.shortKey(), 1.f}});
 
         expect(eq(48000.f, portMetaInfo.sample_rate.value));
         expect(eq("TestSignal"s, portMetaInfo.signal_name.value));
@@ -849,18 +849,18 @@ const boost::ut::suite<"Port MetaInfo Tests"> _portMetaInfoTests = [] {
 
         portMetaInfo.reset();
 
-        expect(portMetaInfo.auto_update.contains("sample_rate"));
-        expect(portMetaInfo.auto_update.contains("signal_name"));
-        expect(portMetaInfo.auto_update.contains("signal_quantity"));
-        expect(portMetaInfo.auto_update.contains("signal_unit"));
-        expect(portMetaInfo.auto_update.contains("signal_min"));
-        expect(portMetaInfo.auto_update.contains("signal_max"));
-        expect(eq(portMetaInfo.auto_update.size(), 6UZ));
+        expect(portMetaInfo.auto_update.contains(gr::tag::SAMPLE_RATE.shortKey()));
+        expect(portMetaInfo.auto_update.contains(gr::tag::SIGNAL_NAME.shortKey()));
+        expect(portMetaInfo.auto_update.contains(gr::tag::SIGNAL_QUANTITY.shortKey()));
+        expect(portMetaInfo.auto_update.contains(gr::tag::SIGNAL_UNIT.shortKey()));
+        expect(portMetaInfo.auto_update.contains(gr::tag::SIGNAL_MIN.shortKey()));
+        expect(portMetaInfo.auto_update.contains(gr::tag::SIGNAL_MAX.shortKey()));
+        expect(eq(portMetaInfo.auto_update.size(), 16UZ));
     };
 
     "update test"_test = [] {
         PortMetaInfo portMetaInfo;
-        property_map updateProps{{"sample_rate", 96000.f}, {"signal_name", "UpdatedSignal"}};
+        property_map updateProps{{gr::tag::SAMPLE_RATE.shortKey(), 96000.f}, {gr::tag::SIGNAL_NAME.shortKey(), "UpdatedSignal"}};
         portMetaInfo.update(updateProps);
 
         expect(eq(96000.f, portMetaInfo.sample_rate));
@@ -868,11 +868,11 @@ const boost::ut::suite<"Port MetaInfo Tests"> _portMetaInfoTests = [] {
     };
 
     "get test"_test = [] {
-        PortMetaInfo portMetaInfo({{"sample_rate", 48000.f}, {"signal_name", "TestSignal"}});
+        PortMetaInfo portMetaInfo({{gr::tag::SAMPLE_RATE.shortKey(), 48000.f}, {gr::tag::SIGNAL_NAME.shortKey(), "TestSignal"}});
         const auto   props = portMetaInfo.get();
 
-        expect(eq(48000.f, std::get<float>(props.at("sample_rate"))));
-        expect(eq("TestSignal"s, std::get<std::string>(props.at("signal_name"))));
+        expect(eq(48000.f, std::get<float>(props.at(gr::tag::SAMPLE_RATE.shortKey()))));
+        expect(eq("TestSignal"s, std::get<std::string>(props.at(gr::tag::SIGNAL_NAME.shortKey()))));
     };
 };
 
@@ -947,7 +947,7 @@ const boost::ut::suite<"BlockingIO Tests"> _blockingIOTests = [] {
 
         gr::Graph flow;
         // ClockSource has a BlockingIO attribute
-        auto& source  = flow.emplaceBlock<ClockSource<float>>({{"sample_rate", 10.f}, {"n_samples_max", gr::Size_t(0)}});
+        auto& source  = flow.emplaceBlock<ClockSource<float>>({{gr::tag::SAMPLE_RATE.shortKey(), 10.f}, {"n_samples_max", gr::Size_t(0)}});
         auto& monitor = flow.emplaceBlock<TagMonitor<float, ProcessFunction::USE_PROCESS_ONE>>({{"log_samples", false}});
         auto& sink    = flow.emplaceBlock<TagSink<float, ProcessFunction::USE_PROCESS_ONE>>({{"log_samples", false}});
         expect(eq(ConnectionResult::SUCCESS, flow.connect<"out">(source).to<"in">(monitor)));

--- a/core/test/qa_Messages.cpp
+++ b/core/test/qa_Messages.cpp
@@ -397,12 +397,12 @@ const boost::ut::suite MessagesTests = [] {
                 expect(eq(reply.clientRequestID, ""s));
                 expect(eq(reply.endpoint, std::string(block::property::kActiveContext)));
                 expect(reply.data.has_value());
-                expect(reply.data.value().contains("context"));
-                expect(eq(""s, std::get<std::string>(reply.data.value().at("context"))));
+                expect(reply.data.value().contains(gr::tag::CONTEXT.shortKey()));
+                expect(eq(""s, std::get<std::string>(reply.data.value().at(gr::tag::CONTEXT.shortKey()))));
             };
 
             "create active test_context - w/o explicit serviceName"_test = [&] {
-                sendMessage<Set>(toBlock, "" /* serviceName */, block::property::kSettingsCtx /* endpoint */, {{"context", "test_context"}, {"time", 1UZ}} /* data  */);
+                sendMessage<Set>(toBlock, "" /* serviceName */, block::property::kSettingsCtx /* endpoint */, {{gr::tag::CONTEXT.shortKey(), "test_context"}, {gr::tag::CONTEXT_TIME.shortKey(), 1UZ}} /* data  */);
                 expect(nothrow([&] { unitTestBlock.processScheduledMessages(); })) << "manually execute processing of messages";
 
                 expect(eq(fromBlock.streamReader().available(), 1UZ)) << "didn't receive reply message";
@@ -421,7 +421,7 @@ const boost::ut::suite MessagesTests = [] {
             };
 
             "create active new_context - w/o explicit serviceName"_test = [&] {
-                sendMessage<Set>(toBlock, "" /* serviceName */, block::property::kSettingsCtx /* endpoint */, {{"context", "new_context"}, {"time", 2UZ}} /* data  */);
+                sendMessage<Set>(toBlock, "" /* serviceName */, block::property::kSettingsCtx /* endpoint */, {{gr::tag::CONTEXT.shortKey(), "new_context"}, {gr::tag::CONTEXT_TIME.shortKey(), 2UZ}} /* data  */);
                 expect(nothrow([&] { unitTestBlock.processScheduledMessages(); })) << "manually execute processing of messages";
 
                 expect(eq(fromBlock.streamReader().available(), 1UZ)) << "didn't receive reply message";
@@ -440,7 +440,7 @@ const boost::ut::suite MessagesTests = [] {
             };
 
             "activate new_context - w/o explicit serviceName"_test = [&] {
-                sendMessage<Set>(toBlock, "" /* serviceName */, block::property::kActiveContext /* endpoint */, {{"context", "new_context"}, {"time", 2UZ}} /* data  */);
+                sendMessage<Set>(toBlock, "" /* serviceName */, block::property::kActiveContext /* endpoint */, {{gr::tag::CONTEXT.shortKey(), "new_context"}, {gr::tag::CONTEXT_TIME.shortKey(), 2UZ}} /* data  */);
                 expect(nothrow([&] { unitTestBlock.processScheduledMessages(); })) << "manually execute processing of messages";
 
                 expect(eq(fromBlock.streamReader().available(), 1UZ)) << "didn't receive reply message";
@@ -453,9 +453,9 @@ const boost::ut::suite MessagesTests = [] {
                 expect(eq(reply.clientRequestID, ""s));
                 expect(eq(reply.endpoint, std::string(block::property::kActiveContext)));
                 expect(reply.data.has_value());
-                expect(reply.data.value().contains("context"));
-                expect(reply.data.value().contains("time"));
-                expect(eq("new_context"s, std::get<std::string>(reply.data.value().at("context"))));
+                expect(reply.data.value().contains(gr::tag::CONTEXT.shortKey()));
+                expect(reply.data.value().contains(gr::tag::CONTEXT_TIME.shortKey()));
+                expect(eq("new_context"s, std::get<std::string>(reply.data.value().at(gr::tag::CONTEXT.shortKey()))));
             };
 
             "get active new_context - w/o explicit serviceName"_test = [&] {
@@ -469,9 +469,9 @@ const boost::ut::suite MessagesTests = [] {
                 expect(eq(reply.clientRequestID, ""s));
                 expect(eq(reply.endpoint, std::string(block::property::kActiveContext)));
                 expect(reply.data.has_value());
-                expect(reply.data.value().contains("context"));
-                expect(reply.data.value().contains("time"));
-                expect(eq("new_context"s, std::get<std::string>(reply.data.value().at("context"))));
+                expect(reply.data.value().contains(gr::tag::CONTEXT.shortKey()));
+                expect(reply.data.value().contains(gr::tag::CONTEXT_TIME.shortKey()));
+                expect(eq("new_context"s, std::get<std::string>(reply.data.value().at(gr::tag::CONTEXT.shortKey()))));
             };
 
             "get all contexts - w/o explicit serviceName"_test = [&] {
@@ -509,7 +509,7 @@ const boost::ut::suite MessagesTests = [] {
                 expect(eq(allStored.size(), 3UZ));
                 const std::uint64_t internalTimeForWasm = allStored.at("new_context")[0].first.time;
 
-                sendMessage<Disconnect>(toBlock, "" /* serviceName */, block::property::kSettingsCtx /* endpoint */, {{"context", "new_context"}, {"time", internalTimeForWasm}} /* data  */);
+                sendMessage<Disconnect>(toBlock, "" /* serviceName */, block::property::kSettingsCtx /* endpoint */, {{gr::tag::CONTEXT.shortKey(), "new_context"}, {gr::tag::CONTEXT_TIME.shortKey(), internalTimeForWasm}} /* data  */);
                 expect(nothrow([&] { unitTestBlock.processScheduledMessages(); })) << "manually execute processing of messages";
 
                 expect(eq(fromBlock.streamReader().available(), 1UZ)) << "didn't receive reply message";
@@ -529,8 +529,8 @@ const boost::ut::suite MessagesTests = [] {
                 expect(eq(reply.clientRequestID, ""s));
                 expect(eq(reply.endpoint, std::string(block::property::kActiveContext)));
                 expect(reply.data.has_value());
-                expect(reply.data.value().contains("context"));
-                expect(eq(""s, std::get<std::string>(reply.data.value().at("context"))));
+                expect(reply.data.value().contains(gr::tag::CONTEXT.shortKey()));
+                expect(eq(""s, std::get<std::string>(reply.data.value().at(gr::tag::CONTEXT.shortKey()))));
             };
         };
     };

--- a/core/test/qa_PerformanceMonitor.cpp
+++ b/core/test/qa_PerformanceMonitor.cpp
@@ -63,7 +63,7 @@ int main(int argc, char* argv[]) {
     // parameters of generated Tags
     std::size_t nSamplesPerTag    = 10000UZ;
     bool        tagWithAutoUpdate = false;
-    std::string tagName           = tagWithAutoUpdate ? "sample_rate" : "some_random_name_1234";
+    std::string tagName           = tagWithAutoUpdate ? gr::tag::SAMPLE_RATE.shortKey() : "some_random_name_1234";
     std::string outputCsvFilePath = "";
 
     if (outFilePath != "") {

--- a/core/test/qa_Tags.cpp
+++ b/core/test/qa_Tags.cpp
@@ -151,7 +151,7 @@ const boost::ut::suite TagPropagation = [] {
     auto runTest = []<auto srcType>(bool verbose = true) {
         gr::Size_t         n_samples = 1024;
         Graph              testGraph;
-        const property_map srcParameter = {{"n_samples_max", n_samples}, {"name", "TagSource"}, {"signal_name", "tagStream"}, {"verbose_console", true && verbose}};
+        const property_map srcParameter = {{"n_samples_max", n_samples}, {"name", "TagSource"}, {gr::tag::SIGNAL_NAME.shortKey(), "tagStream"}, {"verbose_console", true && verbose}};
         auto&              src          = testGraph.emplaceBlock<TagSource<float, srcType>>(srcParameter);
         src._tags                       = {
             // TODO: allow parameter settings to include maps?!?
@@ -199,7 +199,7 @@ const boost::ut::suite TagPropagation = [] {
         expect(!sinkBulk.log_samples || eq(sinkBulk._samples.size(), n_samples)) << "sinkBulk did not log enough input samples";
         expect(!sinkOne.log_samples || eq(sinkOne._samples.size(), n_samples)) << "sinkOne did not log enough input samples";
 
-        const std::vector<std::string> ignoreKeys = {"sample_rate", "signal_name"};
+        const std::vector<std::string> ignoreKeys = {gr::tag::SIGNAL_RATE.shortKey(), gr::tag::SIGNAL_NAME.shortKey()};
         expect(equal_tag_lists(src._tags, monitorBulk._tags, ignoreKeys)) << "monitorBulk did not receive the required tags";
         expect(equal_tag_lists(src._tags, monitorOne._tags, ignoreKeys)) << "monitorOne did not receive the required tags";
         expect(equal_tag_lists(src._tags, sinkBulk._tags, ignoreKeys)) << "sinkBulk did not receive the required tags";
@@ -213,7 +213,7 @@ const boost::ut::suite TagPropagation = [] {
     "CustomTagHandling"_test = []() {
         gr::Size_t         n_samples = 1024;
         Graph              testGraph;
-        const property_map srcParameter = {{"n_samples_max", n_samples}, {"name", "TagSource"}, {"signal_name", "tagStream"}, {"verbose_console", true}};
+        const property_map srcParameter = {{"n_samples_max", n_samples}, {"name", "TagSource"}, {gr::tag::SIGNAL_NAME.shortKey(), "tagStream"}, {"verbose_console", true}};
         auto&              src          = testGraph.emplaceBlock<TagSource<float, gr::testing::ProcessFunction::USE_PROCESS_BULK>>(srcParameter);
         src._tags                       = {
             {0, {{"key", "value@0"}, {"key0", "value@0"}}},          //

--- a/core/test/qa_TriggerMatcher.cpp
+++ b/core/test/qa_TriggerMatcher.cpp
@@ -63,10 +63,7 @@ const boost::ut::suite<"BasicTriggerNameCtxMatcher"> triggerTest = [] {
     "BasicTriggerNameCtxMatcher Tests"_test = [] {
         using namespace std::string_literals;
         using enum gr::trigger::MatchResult;
-        constexpr auto createTag = [](std::string triggerName, std::string cxt) noexcept {
-            auto meta = property_map{{tag::CONTEXT.shortKey(), cxt}};
-            return Tag(0, {{tag::TRIGGER_NAME.shortKey(), triggerName}, {tag::TRIGGER_META_INFO.shortKey(), meta}});
-        };
+        constexpr auto createTag = [](std::string triggerName, std::string cxt) noexcept { return Tag(0, {{tag::TRIGGER_NAME.shortKey(), triggerName}, {tag::CONTEXT.shortKey(), cxt}, {tag::TRIGGER_META_INFO.shortKey(), property_map{}}}); };
 
         "trigger on room1-room3 (exclusive)"_test = [&] {
             auto&          matcher = trigger::BasicTriggerNameCtxMatcher::filter;


### PR DESCRIPTION
  * CONTEXT needs to be always in the property-root, since this is also used outside the trigger logic. `TRIGGER_META_INFO` sub-property-map is kept (default: {}) for user-defined/hw-specific info.
  * replaced `"context"` and `"sample_rate"` with `CONTEXT` and `SAMPLE_RATE` definition -> should simplify later refactoring
  * FunctionGenerator block changes:
    * added additional `trigger_...`diagnostics property fields
    * added 'signal_trigger' parameter matcher/criteria
  * `Packet<T>`, `Tensor<T>`, `DataSet<T>` changes:
     *  changed to using straight `pmtv::map_t` type (easier move/copy operation)
     * added `default_value` field for ZOH, range padding, interpolation purposes etc.