### PR TITLE
Remove the publishEoS call for BlockingIO<false>

### DIFF
--- a/core/include/gnuradio-4.0/Block.hpp
+++ b/core/include/gnuradio-4.0/Block.hpp
@@ -1821,7 +1821,6 @@ public:
         if constexpr (!useIoThread) {
             const bool blockIsActive = lifecycle::isActive(this->state());
             if (!blockIsActive) {
-                publishEoS();
                 ioLastWorkStatus.exchange(work::Status::DONE, std::memory_order_relaxed);
             }
         }


### PR DESCRIPTION
Remove the `publishEoS` call for `BlockingIO<false>` because it introduces multi-threading issues.

- The `publishEoS` call was originally added as a safeguard to ensure the EOS tag is always published if someone implements their own `work()` method and forgets to publish `EoS` tag.
- However, this call is not thread-safe. Specifically, `publishEoS` does not publish immediately; it stores pending tags, and actual publishing happens later in the destructor when `workInternal()` finishes. This deferred mechanism can lead to race conditions in multi-threaded environments.
- If the user relies on the provided `invokeWork()` method rather than a custom `work() `method, EoS tag publication is already guaranteed. 
- Users implementing custom `work()` methods must ensure they handle EoS publication themselves.
