### PR TITLE
New GR4 Block Registry & Plugin System -- PART I

### DIFF
--- a/blocks/basic/include/gnuradio-4.0/basic/ConverterBlocks.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/ConverterBlocks.hpp
@@ -10,9 +10,11 @@
 
 namespace gr::blocks::type::converter {
 
+GR_REGISTER_BLOCK(gr::blocks::type::converter::Convert, [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double ], [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double ])
+
 template<typename T, typename R>
 requires std::is_arithmetic_v<T> && std::is_arithmetic_v<R>
-struct Convert : public gr::Block<Convert<T, R>> {
+struct Convert : Block<Convert<T, R>> {
     using Description = Doc<"(@brief basic block to perform a input to output data type conversion (N.B. w/o scaling))">;
     PortIn<T>  in;
     PortOut<R> out;
@@ -30,9 +32,11 @@ struct Convert : public gr::Block<Convert<T, R>> {
     }
 };
 
+GR_REGISTER_BLOCK(gr::blocks::type::converter::ScalingConvert, [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double ], [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double ])
+
 template<typename T, typename R>
 requires std::is_arithmetic_v<T> && std::is_arithmetic_v<R>
-struct ScalingConvert : public gr::Block<ScalingConvert<T, R>> {
+struct ScalingConvert : Block<ScalingConvert<T, R>> {
     using Description = Doc<R""(@brief basic block to perform a input to output data type conversion
 
 Performs scaling, i.e. 'R output = R(input * scale)'
@@ -54,9 +58,11 @@ Performs scaling, i.e. 'R output = R(input * scale)'
     }
 };
 
+GR_REGISTER_BLOCK(gr::blocks::type::converter::Abs, [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, std::complex<float>, std::complex<double> ])
+
 template<typename T>
 requires std::is_arithmetic_v<T> || meta::complex_like<T>
-struct Abs : public gr::Block<Abs<T>> {
+struct Abs : Block<Abs<T>> {
     using R           = meta::fundamental_base_value_type_t<T>;
     using Description = Doc<"@brief basic block to calculate the absolute (magnitude) value of a complex or arithmetic input stream">;
     PortIn<T>  in;
@@ -74,9 +80,11 @@ struct Abs : public gr::Block<Abs<T>> {
     }
 };
 
+GR_REGISTER_BLOCK(gr::blocks::type::converter::Imag, [ std::complex<float>, std::complex<double> ])
+
 template<typename T>
 requires std::is_arithmetic_v<T> || meta::complex_like<T>
-struct Imag : public gr::Block<Imag<T>> {
+struct Imag : Block<Imag<T>> {
     using R           = meta::fundamental_base_value_type_t<T>;
     using Description = Doc<"@brief basic block to the imaginary component of a complex input stream">;
     PortIn<T>  in;
@@ -87,9 +95,11 @@ struct Imag : public gr::Block<Imag<T>> {
     [[nodiscard]] constexpr R processOne(T input) const noexcept { return std::imag(input); }
 };
 
+GR_REGISTER_BLOCK(gr::blocks::type::converter::Real, [ std::complex<float>, std::complex<double> ])
+
 template<typename T>
 requires std::is_arithmetic_v<T> || meta::complex_like<T>
-struct Real : public gr::Block<Real<T>> {
+struct Real : Block<Real<T>> {
     using R           = meta::fundamental_base_value_type_t<T>;
     using Description = Doc<"@brief basic block to the real component of a complex input stream">;
     PortIn<T>  in;
@@ -100,9 +110,11 @@ struct Real : public gr::Block<Real<T>> {
     [[nodiscard]] constexpr R processOne(T input) const noexcept { return std::real(input); }
 };
 
+GR_REGISTER_BLOCK(gr::blocks::type::converter::Arg, [ std::complex<float>, std::complex<double> ])
+
 template<typename T>
 requires std::is_arithmetic_v<T> || meta::complex_like<T>
-struct Arg : public gr::Block<Arg<T>> {
+struct Arg : Block<Arg<T>> {
     using R           = meta::fundamental_base_value_type_t<T>;
     using Description = Doc<"@brief basic block to calculate the argument (phase angle, [radians]) of a complex input stream">;
     PortIn<T>  in;
@@ -113,8 +125,10 @@ struct Arg : public gr::Block<Arg<T>> {
     [[nodiscard]] constexpr R processOne(T input) const noexcept { return std::arg(input); }
 };
 
+GR_REGISTER_BLOCK(gr::blocks::type::converter::RadiansToDegree, [ float, double ])
+
 template<std::floating_point T>
-struct RadiansToDegree : public gr::Block<RadiansToDegree<T>> {
+struct RadiansToDegree : Block<RadiansToDegree<T>> {
     using R           = meta::fundamental_base_value_type_t<T>;
     using Description = Doc<"@brief convert radians to degree">;
     PortIn<T>  rad;
@@ -128,8 +142,10 @@ struct RadiansToDegree : public gr::Block<RadiansToDegree<T>> {
     }
 };
 
+GR_REGISTER_BLOCK(gr::blocks::type::converter::DegreeToRadians, [ float, double ])
+
 template<std::floating_point T>
-struct DegreeToRadians : public gr::Block<DegreeToRadians<T>> {
+struct DegreeToRadians : Block<DegreeToRadians<T>> {
     using R           = meta::fundamental_base_value_type_t<T>;
     using Description = Doc<"@brief convert radians to degree">;
     PortIn<T>  deg;
@@ -143,9 +159,11 @@ struct DegreeToRadians : public gr::Block<DegreeToRadians<T>> {
     }
 };
 
+GR_REGISTER_BLOCK(gr::blocks::type::converter::ToRealImag, [ std::complex<float>, std::complex<double> ])
+
 template<typename T>
 requires std::is_arithmetic_v<T> || meta::complex_like<T>
-struct ToRealImag : public gr::Block<ToRealImag<T>> {
+struct ToRealImag : Block<ToRealImag<T>> {
     using R           = meta::fundamental_base_value_type_t<T>;
     using Description = Doc<"(@brief decompose complex (or arithmetic) numbers their real and imaginary component">;
     PortIn<T>  in;
@@ -159,8 +177,10 @@ struct ToRealImag : public gr::Block<ToRealImag<T>> {
     }
 };
 
+GR_REGISTER_BLOCK(gr::blocks::type::converter::ToRealImag, [ float, double ])
+
 template<std::floating_point T>
-struct RealImagToComplex : public gr::Block<RealImagToComplex<T>> {
+struct RealImagToComplex : Block<RealImagToComplex<T>> {
     using R           = std::complex<T>;
     using Description = Doc<"(@brief compose complex (or arithmetic) numbers from their real and imaginary component">;
     PortIn<T>  real;
@@ -174,9 +194,11 @@ struct RealImagToComplex : public gr::Block<RealImagToComplex<T>> {
     }
 };
 
+GR_REGISTER_BLOCK(gr::blocks::type::converter::ToRealImag, [ std::complex<float>, std::complex<double> ])
+
 template<typename T>
 requires std::is_arithmetic_v<T> || meta::complex_like<T>
-struct ToMagPhase : public gr::Block<ToMagPhase<T>> {
+struct ToMagPhase : Block<ToMagPhase<T>> {
     using R           = meta::fundamental_base_value_type_t<T>;
     using Description = Doc<"(@brief decompose complex (or arithmetic) numbers their magnitude (abs) and phase (arg, [rad]) component">;
     PortIn<T>  in;
@@ -189,6 +211,8 @@ struct ToMagPhase : public gr::Block<ToMagPhase<T>> {
         return {static_cast<R>(std::abs(complexIn)), static_cast<R>(std::arg(complexIn))};
     }
 };
+
+GR_REGISTER_BLOCK(gr::blocks::type::converter::ToRealImag, [ float, double ])
 
 template<typename T>
 requires std::is_arithmetic_v<T>
@@ -206,9 +230,11 @@ struct MagPhaseToComplex : public gr::Block<MagPhaseToComplex<T>> {
     }
 };
 
+GR_REGISTER_BLOCK(gr::blocks::type::converter::ComplexToInterleaved, [ std::complex<float>, std::complex<double> ])
+
 template<typename T, typename R>
 requires meta::complex_like<T> && (std::floating_point<R> || std::is_same_v<R, std::int8_t> || std::is_same_v<R, std::int16_t>)
-struct ComplexToInterleaved : public gr::Block<ComplexToInterleaved<T, R>, Resampling<1UZ, 2UZ, true>> {
+struct ComplexToInterleaved : Block<ComplexToInterleaved<T, R>, Resampling<1UZ, 2UZ, true>> {
     using Description = Doc<R""(@brief convert stream of complex to a stream of interleaved specified type.
 
 The output stream contains twice as many output items as input items.
@@ -226,6 +252,8 @@ For every complex input item, we produce two output items that alternate between
         return work::Status::OK;
     }
 };
+
+GR_REGISTER_BLOCK(gr::blocks::type::converter::InterleavedToComplex, [ int8_t, int16_t, float, double ])
 
 template<typename T, typename R>
 requires(std::floating_point<T> || std::is_same_v<T, std::int8_t> || std::is_same_v<T, std::int16_t>) && meta::complex_like<R>
@@ -250,31 +278,4 @@ For every pair of interleaved input items (real, imag), we produce one complex o
 
 } // namespace gr::blocks::type::converter
 
-/*
- TODO: temporarily disabled due to excessive compile-times on CI
-
-namespace gr::blocks::type::converter {
-using TSupportedTypes    = std::tuple<uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double>; // N.B. 10 base types
-using TComplexTypes      = std::tuple<std::complex<float>, std::complex<double>>;                                               // N.B. 2 (valid) complex types
-using TCommonRawSDRTypes = std::tuple<int8_t, int16_t, float, double>;
-
-// clang-format off
-const inline auto registerConverterBlocks =
-    gr::registerBlockTT<Convert, TSupportedTypes, TSupportedTypes>(gr::globalBlockRegistry()) // N.B. source of long compile-times: 10 x 10 type instantiations
-  | gr::registerBlockTT<ScalingConvert, TSupportedTypes, TSupportedTypes>(gr::globalBlockRegistry()) // N.B. source of long compile-times: 10 x 10 type instantiations
-  | gr::registerBlock<Abs, uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, std::complex<float>, std::complex<double>>(gr::globalBlockRegistry())
-  | gr::registerBlock<Imag, std::complex<float>, std::complex<double>>(gr::globalBlockRegistry())
-  | gr::registerBlock<Real, std::complex<float>, std::complex<double>>(gr::globalBlockRegistry())
-  | gr::registerBlock<Arg, std::complex<float>, std::complex<double>>(gr::globalBlockRegistry())
-  | gr::registerBlock<RadiansToDegree, float, double>(gr::globalBlockRegistry())
-  | gr::registerBlock<DegreeToRadians, float, double>(gr::globalBlockRegistry())
-  | gr::registerBlock<ToRealImag, std::complex<float>, std::complex<double>>(gr::globalBlockRegistry())
-  | gr::registerBlock<RealImagToComplex, float, double>(gr::globalBlockRegistry())
-  | gr::registerBlock<ToMagPhase, std::complex<float>, std::complex<double>>(gr::globalBlockRegistry())
-  | gr::registerBlock<MagPhaseToComplex, float, double>(gr::globalBlockRegistry())
-  | gr::registerBlockTT<ComplexToInterleaved, TComplexTypes, TCommonRawSDRTypes>(gr::globalBlockRegistry())
-  | gr::registerBlockTT<InterleavedToComplex, TCommonRawSDRTypes, TComplexTypes>(gr::globalBlockRegistry());
-// clang-format on
-} // namespace gr::blocks::type::converter
-*/
 #endif // CONVERTERBLOCKS_HPP

--- a/blocks/basic/include/gnuradio-4.0/basic/DataSink.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/DataSink.hpp
@@ -407,6 +407,7 @@ template<typename T>
 
 } // namespace detail
 
+GR_REGISTER_BLOCK(gr::basic::DataSink, [ float, double ])
 /**
  * @brief generic data sink for exporting streams to non-GR C++ APIs.
  *
@@ -993,6 +994,7 @@ private:
     };
 };
 
+GR_REGISTER_BLOCK(gr::basic::DataSetSink, [ float, double ])
 /**
  * @brief data sink for exporting data set streams to non-GR C++ APIs.
  *
@@ -1152,8 +1154,5 @@ private:
 };
 
 } // namespace gr::basic
-
-auto registerDataSink    = gr::registerBlock<gr::basic::DataSink, float, double>(gr::globalBlockRegistry());
-auto registerDataSetSink = gr::registerBlock<gr::basic::DataSetSink, float, double>(gr::globalBlockRegistry());
 
 #endif

--- a/blocks/basic/include/gnuradio-4.0/basic/FunctionGenerator.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/FunctionGenerator.hpp
@@ -74,9 +74,11 @@ template<typename T>
 
 } // namespace function_generator
 
+GR_REGISTER_BLOCK(gr::basic::FunctionGenerator, [ float, double ])
+
 template<typename T>
 requires(std::floating_point<T>)
-struct FunctionGenerator : public gr::Block<FunctionGenerator<T>, BlockingIO<true>> {
+struct FunctionGenerator : Block<FunctionGenerator<T>, BlockingIO<true>> {
     using Description = Doc<R""(@brief The `FunctionGenerator` class generates a variety of functions and their combinations.
 It supports multiple function types, including Constant, Linear Ramp, Parabolic Ramp, Cubic Spline, and Impulse Response.
 Each function type is configurable with specific parameters, enabling precise tailoring to meet the user's requirements.
@@ -230,7 +232,5 @@ private:
 };
 
 } // namespace gr::basic
-
-auto registerFunctionGenerator = gr::registerBlock<gr::basic::FunctionGenerator, float, double>(gr::globalBlockRegistry());
 
 #endif // GNURADIO_FUNCTION_GENERATOR_HPP

--- a/blocks/basic/include/gnuradio-4.0/basic/PythonBlock.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/PythonBlock.hpp
@@ -14,9 +14,11 @@ namespace gr::basic {
 
 using namespace gr;
 
+GR_REGISTER_BLOCK(gr::basic::PythonBlock, [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double ])
+
 template<typename T>
 requires std::is_arithmetic_v<T> /* || std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>> */
-struct PythonBlock : public Block<PythonBlock<T>> {
+struct PythonBlock : Block<PythonBlock<T>> {
     using Description = Doc<R""(@brief PythonBlock enabling Python scripts to be executed in GR flow-graphs.
 
 This Block encapsulates Python-based scripts that can be executed within the GR flow-graph.

--- a/blocks/basic/include/gnuradio-4.0/basic/Selector.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/Selector.hpp
@@ -9,6 +9,8 @@
 namespace gr::basic {
 using namespace gr;
 
+GR_REGISTER_BLOCK(gr::basic::Selector, [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double ])
+
 template<typename T>
 struct Selector : Block<Selector<T>, NoDefaultTagForwarding> {
     using Description = Doc<R""(@brief basic multiplexing class to route arbitrary inputs to outputs
@@ -249,8 +251,5 @@ you can set the `backPressure` property to false.
     }
 };
 } // namespace gr::basic
-
-inline static auto registerSelector = gr::registerBlock<gr::basic::Selector, float, double>(gr::globalBlockRegistry());
-static_assert(gr::HasProcessBulkFunction<gr::basic::Selector<double>>);
 
 #endif // include guard

--- a/blocks/basic/include/gnuradio-4.0/basic/SignalGenerator.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/SignalGenerator.hpp
@@ -26,10 +26,11 @@ constexpr Type parse(std::string_view name) {
 
 } // namespace signal_generator
 
+GR_REGISTER_BLOCK(gr::basic::SignalGenerator, [ float, double ])
+
 template<std::floating_point T>
-struct SignalGenerator : public gr::Block<SignalGenerator<T>, BlockingIO<true>> {
-    using Description = Doc<R""(
-@brief The SignalGenerator class generates various types of signal waveforms, including sine, cosine, square, constant, saw, and triangle signals.
+struct SignalGenerator : Block<SignalGenerator<T>, BlockingIO<true>> {
+    using Description = Doc<R""(@brief The SignalGenerator class generates various types of signal waveforms, including sine, cosine, square, constant, saw, and triangle signals.
 Users can set parameters such as amplitude, frequency, offset, and phase for the desired waveform.
 Note that not all parameters are supported for all signals.
 
@@ -116,7 +117,5 @@ s(t) = A * (4 * abs(t * f - floor(t * f + 0.75) + 0.25) - 1) + O
 };
 
 } // namespace gr::basic
-
-auto registerSignalGenerator = gr::registerBlock<gr::basic::SignalGenerator, double, float>(gr::globalBlockRegistry());
 
 #endif // GNURADIO_SIGNAL_GENERATOR_HPP

--- a/blocks/basic/include/gnuradio-4.0/basic/StreamToDataSet.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/StreamToDataSet.hpp
@@ -10,11 +10,13 @@
 
 namespace gr::basic {
 
+GR_REGISTER_BLOCK("gr::basic::StreamToDataSet", gr::basic::StreamFilterImpl, (<T>, false), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, std::complex<float>, std::complex<double> ]);
+GR_REGISTER_BLOCK("gr::basic::StreamFilter", gr::basic::StreamFilterImpl, (<T>, true), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, std::complex<float>, std::complex<double> ]);
+
 template<typename T, bool streamOut = false, trigger::Matcher TMatcher = trigger::BasicTriggerNameCtxMatcher::Filter>
 requires(std::is_arithmetic_v<T> || gr::meta::complex_like<T>)
 struct StreamFilterImpl : Block<StreamFilterImpl<T, streamOut, TMatcher>> {
-    using Description = Doc<R"(
-@brief Converts stream of input data into chunked discrete DataSet<T> based on tag-based pre- / post-conditions
+    using Description = Doc<R"(@brief Converts stream of input data into chunked discrete DataSet<T> based on tag-based pre- / post-conditions
 Notes:
 * n_pre must be less than the size of the output port's CircularBuffer. The block waits until all n_pre samples can be written to the output in a single iteration.
 * In stream-to-stream mode, the 'stop' Tag is not included in the output stream.
@@ -358,10 +360,5 @@ template<typename T>
 using StreamFilter = StreamFilterImpl<T, true>;
 
 } // namespace gr::basic
-
-static_assert(gr::HasProcessBulkFunction<gr::basic::StreamFilterImpl<float>>);
-
-inline static auto registerStreamFilters = gr::registerBlock<"gr::basic::StreamToDataSet", gr::basic::StreamToDataSet, uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, std::complex<float>, std::complex<double>>(gr::globalBlockRegistry()) //
-                                           | gr::registerBlock<"gr::basic::StreamFilter", gr::basic::StreamFilter, uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, std::complex<float>, std::complex<double>>(gr::globalBlockRegistry());
 
 #endif // GNURADIO_STREAMTODATASET_HPP

--- a/blocks/basic/include/gnuradio-4.0/basic/SyncBlock.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/SyncBlock.hpp
@@ -7,12 +7,15 @@ namespace gr::basic {
 
 using namespace gr;
 
-using SyncBlockDoc = Doc<R""(
+GR_REGISTER_BLOCK(gr::basic::SyncBlock, [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, std::complex<float>, std::complex<double> ])
 
-The SyncBlock synchronizes data streams across multiple inputs.
-It addresses key scenarios including initial time shifts, clock drift, and significant delays.
-The SyncBlock synchronises input samples based on synchronization tags and
-publishes desynchronization tags with information about number of samples that were dropped.
+template<typename T>
+struct SyncBlock : Block<SyncBlock<T>, NoDefaultTagForwarding> {
+    using Description = Doc<R""(@brief SyncBlock synchronises data streams across multiple inputs.
+
+The SyncBlock addresses key scenarios including initial time shifts, clock drift, and significant delays.
+It synchronises input samples based on synchronization tags and publishes desynchronization tags with
+information about number of samples that were dropped.
 
 ### Important Prerequisites
 The sample rate must be the same across all input ports.
@@ -117,8 +120,6 @@ New synchronization occurs with `s8`, prior samples (`s6-s7`) are NOT included t
 Note: We assume that desynchronization should not exceed the buffer size of the SyncBlock; if it does, the samples will be dropped.
 )"">;
 
-template<typename T>
-struct SyncBlock : public gr::Block<SyncBlock<T>, NoDefaultTagForwarding, SyncBlockDoc> {
     std::vector<gr::PortIn<T, gr::Async>> inputs;
     std::vector<gr::PortOut<T>>           outputs;
 

--- a/blocks/basic/include/gnuradio-4.0/basic/Trigger.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/Trigger.hpp
@@ -8,6 +8,10 @@
 
 namespace gr::blocks::basic {
 
+GR_REGISTER_BLOCK("gr::blocks::basic::SchmittTriggerNoInterpolation", gr::blocks::basic::SchmittTrigger, ([T], gr::trigger::InterpolationMethod::NO_INTERPOLATION), [ std::int16_t, std::int32_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double> ])
+GR_REGISTER_BLOCK("gr::blocks::basic::SchmittTriggerBasic", gr::blocks::basic::SchmittTrigger, ([T], gr::trigger::InterpolationMethod::BASIC_LINEAR_INTERPOLATION), [ std::int16_t, std::int32_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double> ])
+GR_REGISTER_BLOCK("gr::blocks::basic::SchmittTrigger", gr::blocks::basic::SchmittTrigger, ([T], gr::trigger::InterpolationMethod::LINEAR_INTERPOLATION), [ std::int16_t, std::int32_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double> ])
+
 template<typename T, gr::trigger::InterpolationMethod Method>
 requires(std::is_arithmetic_v<T> or (UncertainValueLike<T> && std::is_arithmetic_v<meta::fundamental_base_value_type_t<T>>))
 struct SchmittTrigger : public gr::Block<SchmittTrigger<T, Method>, NoDefaultTagForwarding> {
@@ -155,9 +159,5 @@ The information is stored (info only) in `trigger_name`, `trigger_time`, `trigge
 };
 
 } // namespace gr::blocks::basic
-
-const inline auto registerTrigger = gr::registerBlock<gr::blocks::basic::SchmittTrigger, gr::trigger::InterpolationMethod::NO_INTERPOLATION, std::int16_t, std::int32_t, float, gr::UncertainValue<float>>(gr::globalBlockRegistry())             //
-                                    + gr::registerBlock<gr::blocks::basic::SchmittTrigger, gr::trigger::InterpolationMethod::BASIC_LINEAR_INTERPOLATION, std::int16_t, std::int32_t, float, gr::UncertainValue<float>>(gr::globalBlockRegistry()) //
-                                    + gr::registerBlock<gr::blocks::basic::SchmittTrigger, gr::trigger::InterpolationMethod::LINEAR_INTERPOLATION, std::int16_t, std::int32_t, float, gr::UncertainValue<float>>(gr::globalBlockRegistry());
 
 #endif // TRIGGER_HPP

--- a/blocks/basic/include/gnuradio-4.0/basic/clock_source.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/clock_source.hpp
@@ -29,8 +29,11 @@ template<typename T, gr::meta::fixed_string description = "", typename... Argume
 using A = gr::Annotated<T, description, Arguments...>;
 using namespace gr;
 
+GR_REGISTER_BLOCK("gr::basic::SystemClockSource", gr::basic::ClockSource < std::uint8_t, true, std::chrono::system_clock, true)
+GR_REGISTER_BLOCK("gr::basic::SystemClockSourceNonBlocking", gr::basic::ClockSource < std::uint8_t, false, std::chrono::system_clock, true)
+
 template<typename T, bool useIoThread = true, typename ClockSourceType = std::chrono::system_clock, bool basicPeriodAlgorithm = true>
-struct ClockSource : public gr::Block<ClockSource<T, useIoThread, ClockSourceType>, BlockingIO<useIoThread>> {
+struct ClockSource : Block<ClockSource<T, useIoThread, ClockSourceType>, BlockingIO<useIoThread>> {
     using Description = Doc<R""(A source block that generates clock signals with specified timing intervals.
 This block can generate periodic signals based on a system clock and allows for customization of the sample rate and chunk size.
 The 'tag_times[ns]:tag_value(string)' vectors control the emission of tags with a single 'context' keys at specified times after the block started.)"">;
@@ -256,7 +259,6 @@ template<typename T>
 using DefaultClockSource = ClockSource<T, true, std::chrono::system_clock, true>;
 } // namespace gr::basic
 
-inline auto registerClockSource = gr::registerBlock<"gr::basic::DefaultClockSource", gr::basic::DefaultClockSource, std::uint8_t>(gr::globalBlockRegistry());
 static_assert(gr::HasProcessBulkFunction<gr::basic::ClockSource<std::uint8_t>>);
 
 #endif // GNURADIO_CLOCK_SOURCE_HPP

--- a/blocks/basic/include/gnuradio-4.0/basic/common_blocks.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/common_blocks.hpp
@@ -14,9 +14,10 @@
 #include <gnuradio-4.0/Graph.hpp>
 #include <gnuradio-4.0/meta/reflection.hpp>
 
+GR_REGISTER_BLOCK(builtin_multiply, [ double, float ])
+
 template<typename T>
-class builtin_multiply : public gr::Block<builtin_multiply<T>> {
-public:
+struct builtin_multiply : gr::Block<builtin_multiply<T>> {
     T factor = static_cast<T>(1.0f);
 
     gr::PortIn<T>  in;
@@ -36,9 +37,10 @@ public:
     [[nodiscard]] constexpr auto processOne(T a) const noexcept { return a * factor; }
 };
 
+GR_REGISTER_BLOCK(builtin_counter, [ double, float ])
+
 template<typename T>
-class builtin_counter : public gr::Block<builtin_counter<T>> {
-public:
+struct builtin_counter : gr::Block<builtin_counter<T>> {
     static gr::Size_t s_event_count;
 
     gr::PortIn<T>  in;
@@ -97,8 +99,5 @@ struct MultiAdder : public gr::Block<MultiAdder<T>> {
     }
 };
 static_assert(gr::HasProcessBulkFunction<MultiAdder<float>>);
-
-auto registerMultiply = gr::registerBlock<builtin_multiply, double, float>(gr::globalBlockRegistry());
-auto registerCounter  = gr::registerBlock<builtin_counter, double, float>(gr::globalBlockRegistry());
 
 #endif // include guard

--- a/blocks/basic/test/qa_BasicKnownBlocks.cpp
+++ b/blocks/basic/test/qa_BasicKnownBlocks.cpp
@@ -4,8 +4,15 @@
 #include <gnuradio-4.0/basic/FunctionGenerator.hpp>
 #include <gnuradio-4.0/basic/Selector.hpp>
 #include <gnuradio-4.0/basic/SignalGenerator.hpp>
-#include <gnuradio-4.0/basic/clock_source.hpp>
 #include <gnuradio-4.0/basic/common_blocks.hpp>
+
+auto registerMultiply          = gr::registerBlock<builtin_multiply, double, float>(gr::globalBlockRegistry());
+auto registerCounter           = gr::registerBlock<builtin_counter, double, float>(gr::globalBlockRegistry());
+auto registerDataSink          = gr::registerBlock<gr::basic::DataSink, float, double>(gr::globalBlockRegistry());
+auto registerDataSetSink       = gr::registerBlock<gr::basic::DataSetSink, float, double>(gr::globalBlockRegistry());
+auto registerFunctionGenerator = gr::registerBlock<gr::basic::FunctionGenerator, float, double>(gr::globalBlockRegistry());
+auto registerSelector          = gr::registerBlock<gr::basic::Selector, float, double>(gr::globalBlockRegistry());
+auto registerSignalGenerator   = gr::registerBlock<gr::basic::SignalGenerator, double, float>(gr::globalBlockRegistry());
 
 const boost::ut::suite KnownBlockTests = [] {
     using namespace boost::ut;

--- a/blocks/electrical/test/qa_PowerEstimators.cpp
+++ b/blocks/electrical/test/qa_PowerEstimators.cpp
@@ -12,6 +12,15 @@
 #include <gnuradio-4.0/electrical/PowerEstimators.hpp>
 #include <gnuradio-4.0/meta/UncertainValue.hpp>
 
+namespace gr::electrical {
+static_assert(BlockLike<ThreePhasePowerMetrics<float>>, "block constraints not satisfied");
+static_assert(BlockLike<ThreePhasePowerMetrics<UncertainValue<float>>>, "block constraints not satisfied");
+static_assert(gr::HasProcessBulkFunction<ThreePhasePowerMetrics<float>>);
+static_assert(gr::HasProcessBulkFunction<ThreePhasePowerMetrics<UncertainValue<float>>>);
+
+static_assert(BlockLike<SinglePhasePowerMetrics<float>>, "block constraints not satisfied");
+} // namespace gr::electrical
+
 const boost::ut::suite<"Power Metrics Estimators"> powerEstimatorTests = [] {
     using namespace boost::ut;
     using namespace gr::electrical;

--- a/blocks/fileio/include/gnuradio-4.0/fileio/BasicFileIo.hpp
+++ b/blocks/fileio/include/gnuradio-4.0/fileio/BasicFileIo.hpp
@@ -61,8 +61,10 @@ inline std::vector<std::filesystem::path> getSortedFilesContaining(const std::st
 
 enum class Mode { overwrite, append, multi };
 
+GR_REGISTER_BLOCK(gr::blocks::fileio::BasicFileSink, [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ])
+
 template<typename T>
-struct BasicFileSink : public gr::Block<BasicFileSink<T>> {
+struct BasicFileSink : Block<BasicFileSink<T>> {
     using Description = Doc<R""(A sink block for writing a stream to a binary file.
 The file can be played back using a 'BasicFileSource' or read by any program that supports binary files (e.g. Python, C, C++, MATLAB).
 For complex types, the binary file contains [float, double]s in IQIQIQ order. No metadata is included with the binary data.)
@@ -167,8 +169,10 @@ private:
     }
 };
 
+GR_REGISTER_BLOCK(gr::blocks::fileio::BasicFileSource, [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ])
+
 template<typename T>
-struct BasicFileSource : public gr::Block<BasicFileSource<T>> {
+struct BasicFileSource : Block<BasicFileSource<T>> {
     using Description = Doc<R""(A source block for reading a binary file and outputting the data.
 This source is the counterpart to 'BasicFileSink'.
 For complex types, the binary file contains [float, double]s in IQIQIQ order. No metadata is expected in the binary data.
@@ -295,8 +299,5 @@ private:
 };
 
 } // namespace gr::blocks::fileio
-
-const inline auto registerBasicFileIo = gr::registerBlock<gr::blocks::fileio::BasicFileSink, uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double>>(gr::globalBlockRegistry()) //
-                                        | gr::registerBlock<gr::blocks::fileio::BasicFileSource, uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double>>(gr::globalBlockRegistry());
 
 #endif // BASICFILEIO_HPP

--- a/blocks/filter/include/gnuradio-4.0/filter/FrequencyEstimator.hpp
+++ b/blocks/filter/include/gnuradio-4.0/filter/FrequencyEstimator.hpp
@@ -20,6 +20,9 @@
 
 namespace gr::filter {
 
+GR_REGISTER_BLOCK("gr::filter::FrequencyEstimatorTimeDomain", gr::filter::FrequencyEstimatorTimeDomain, [ float, double ])
+GR_REGISTER_BLOCK("gr::filter::FrequencyEstimatorTimeDomainDecimating", gr::filter::FrequencyEstimatorTimeDomain, ([T], Resampling<10U>), [ float, double ])
+
 template<typename T, typename... Args>
 requires std::floating_point<T>
 struct FrequencyEstimatorTimeDomain : Block<FrequencyEstimatorTimeDomain<T, Args...>, Args...> {
@@ -172,6 +175,9 @@ private:
 
 template<typename T>
 using FrequencyEstimatorTimeDomainDecimating = FrequencyEstimatorTimeDomain<T, Resampling<10U>>;
+
+GR_REGISTER_BLOCK("gr::filter::FrequencyEstimatorFrequencyDomain", gr::filter::FrequencyEstimatorFrequencyDomain, [ float, double ])
+GR_REGISTER_BLOCK("gr::filter::FrequencyEstimatorFrequencyDomainDecimating", gr::filter::FrequencyEstimatorFrequencyDomain, ([T], Resampling<10U>), [ float, double ])
 
 template<typename T, typename... Args>
 requires std::floating_point<T>
@@ -346,10 +352,5 @@ template<typename T>
 using FrequencyEstimatorFrequencyDomainDecimating = FrequencyEstimatorFrequencyDomain<T, Resampling<1U>, Stride<0U>>;
 
 } // namespace gr::filter
-
-inline static auto registerFrequencyEstimators = gr::registerBlock<gr::filter::FrequencyEstimatorTimeDomain, float, double>(gr::globalBlockRegistry())             //
-                                                 + gr::registerBlock<gr::filter::FrequencyEstimatorTimeDomainDecimating, float, double>(gr::globalBlockRegistry()) //
-                                                 + gr::registerBlock<gr::filter::FrequencyEstimatorFrequencyDomain, float, double>(gr::globalBlockRegistry())      //
-                                                 + gr::registerBlock<gr::filter::FrequencyEstimatorFrequencyDomainDecimating, float, double>(gr::globalBlockRegistry());
 
 #endif // FREQUENCY_ESTIMATOR_HPP

--- a/blocks/filter/include/gnuradio-4.0/filter/time_domain_filter.hpp
+++ b/blocks/filter/include/gnuradio-4.0/filter/time_domain_filter.hpp
@@ -18,11 +18,12 @@ namespace gr::filter {
 
 using namespace gr;
 
+GR_REGISTER_BLOCK(gr::filter::fir_filter, [ float, double ])
+
 template<typename T>
 requires std::floating_point<T>
 struct fir_filter : Block<fir_filter<T>> {
-    using Description = Doc<R""(
-@brief Finite Impulse Response (FIR) filter class
+    using Description = Doc<R""(@brief Finite Impulse Response (FIR) filter class
 
 The transfer function of an FIR filter is given by:
 H(z) = b[0] + b[1]*z^-1 + b[2]*z^-2 + ... + b[N]*z^-N
@@ -53,6 +54,11 @@ enum class IIRForm {
     DF_I_TRANSPOSED,
     DF_II_TRANSPOSED,
 };
+
+GR_REGISTER_BLOCK(gr::filter::iir_filter, ([T], gr::filter::IIRForm::DF_I), [ float, double ])
+GR_REGISTER_BLOCK(gr::filter::iir_filter, ([T], gr::filter::IIRForm::DF_II), [ float, double ])
+GR_REGISTER_BLOCK(gr::filter::iir_filter, ([T], gr::filter::IIRForm::DF_I_TRANSPOSED), [ float, double ])
+GR_REGISTER_BLOCK(gr::filter::iir_filter, ([T], gr::filter::IIRForm::DF_II_TRANSPOSED), [ float, double ])
 
 template<typename T, IIRForm form = std::is_floating_point_v<T> ? IIRForm::DF_II : IIRForm::DF_I>
 requires std::floating_point<T>
@@ -115,6 +121,9 @@ a are the feedback coefficients
         }
     }
 };
+
+GR_REGISTER_BLOCK(gr::filter::BasicFilter, ([T]), [ double, float, gr::UncertainValue<float>, gr::UncertainValue<double> ])
+GR_REGISTER_BLOCK(gr::filter::BasicDecimatingFilter, ([T], Resampling<1UZ, 1UZ, false>), [ double, float, gr::UncertainValue<float>, gr::UncertainValue<double> ])
 
 template<typename T, typename... Args>
 requires(std::floating_point<T> or std::is_arithmetic_v<meta::fundamental_base_value_type_t<T>>)
@@ -221,6 +230,8 @@ using BasicFilter = BasicFilterProto<T>;
 template<typename T>
 using BasicDecimatingFilter = BasicFilterProto<T, Resampling<1UZ, 1UZ, false>>;
 
+GR_REGISTER_BLOCK(gr::filter::Decimator, ([T], gr::filter::IIRForm::DF_I_TRANSPOSED), [ uint8_t, int8_t, uint16_t, int16_t, uint32_t, int32_t, uint64_t, int64_t, float, double, std::complex<float>, std::complex<double>, gr::UncertainValue<float>, gr::UncertainValue<double> ])
+
 template<typename T>
 struct Decimator : Block<Decimator<T>, Resampling<1UZ, 1UZ, false>> {
     using TParent     = Block<Decimator<T>, Resampling<1UZ, 1UZ, false>>;
@@ -254,13 +265,5 @@ aliasing and sub-sampling related effects.
 };
 
 } // namespace gr::filter
-
-inline static auto registerFilter = gr::registerBlock<gr::filter::fir_filter, double, float>(gr::globalBlockRegistry())                                                                                                                                                                      //
-                                    + gr::registerBlock<gr::filter::iir_filter, gr::filter::IIRForm::DF_I, double, float>(gr::globalBlockRegistry())                                                                                                                                         //
-                                    + gr::registerBlock<gr::filter::iir_filter, gr::filter::IIRForm::DF_II, double, float>(gr::globalBlockRegistry())                                                                                                                                        //
-                                    + gr::registerBlock<gr::filter::iir_filter, gr::filter::IIRForm::DF_I_TRANSPOSED, double, float>(gr::globalBlockRegistry()) + gr::registerBlock<gr::filter::iir_filter, gr::filter::IIRForm::DF_II_TRANSPOSED, double, float>(gr::globalBlockRegistry()) //
-                                    + gr::registerBlock<gr::filter::BasicFilter, double, float, gr::UncertainValue<float>, gr::UncertainValue<double>>(gr::globalBlockRegistry())                                                                                                            //
-                                    + gr::registerBlock<gr::filter::BasicDecimatingFilter, double, float, gr::UncertainValue<float>, gr::UncertainValue<double>>(gr::globalBlockRegistry())                                                                                                  //
-                                    + gr::registerBlock<gr::filter::Decimator, uint8_t, int8_t, uint16_t, int16_t, uint32_t, int32_t, uint64_t, int64_t, float, double, std::complex<float>, std::complex<double>, gr::UncertainValue<float>, gr::UncertainValue<double>>(gr::globalBlockRegistry());
 
 #endif // GNURADIO_TIME_DOMAIN_FILTER_HPP

--- a/blocks/fourier/include/gnuradio-4.0/fourier/fft.hpp
+++ b/blocks/fourier/include/gnuradio-4.0/fourier/fft.hpp
@@ -27,11 +27,13 @@ struct OutputDataSet<T> {
     using type = DataSet<typename T::value_type>;
 };
 
+GR_REGISTER_BLOCK("gr::blocks::FFT", gr::blocks::FFT, [ float, double ])
+GR_REGISTER_BLOCK("gr::blocks::FFTw", gr::blocks::FFT, ([T], typename OutputDataSet<[T]>::type >, gr::algorithm::FFTw), [ float, double ])
+
 template<typename T, typename U = OutputDataSet<T>::type, template<typename, typename> typename FourierAlgorithm = gr::algorithm::FFT>
 requires((gr::meta::complex_like<T> || std::floating_point<T>) && (std::is_same_v<U, DataSet<float>> || std::is_same_v<U, DataSet<double>>))
-struct FFT : public Block<FFT<T, U, FourierAlgorithm>, Resampling<1024LU, 1LU>> {
-    using Description = Doc<R""(
-@brief Performs a (Fast) Fourier Transform (FFT) on the given input data.
+struct FFT : Block<FFT<T, U, FourierAlgorithm>, Resampling<1024LU, 1LU>> {
+    using Description = Doc<R""(@brief Performs a (Fast) Fourier Transform (FFT) on the given input data.
 
 The FFT block is capable of performing Fourier Transform computations on real or complex data,
 and populates a DataSet with the results, including real, imaginary, magnitude, and phase
@@ -214,7 +216,5 @@ template<typename T>
 using DefaultFFT = FFT<T, typename OutputDataSet<T>::type, gr::algorithm::FFT>;
 
 } // namespace gr::blocks::fft
-
-auto registerFFT = gr::registerBlock<"gr::blocks::fft::DefaultFFT", gr::blocks::fft::DefaultFFT, float, double>(gr::globalBlockRegistry());
 
 #endif // GNURADIO_FFT_HPP

--- a/blocks/http/test/qa_HttpBlock.cpp
+++ b/blocks/http/test/qa_HttpBlock.cpp
@@ -13,6 +13,8 @@
 
 #include <gnuradio-4.0/http/HttpBlock.hpp>
 
+static_assert(gr::BlockLike<http::HttpBlock<uint8_t>>);
+
 template<typename T>
 class FixedSource : public gr::Block<FixedSource<T>> {
     using super_t = gr::Block<FixedSource<T>>;

--- a/blocks/math/include/gnuradio-4.0/math/ExpressionBlocks.hpp
+++ b/blocks/math/include/gnuradio-4.0/math/ExpressionBlocks.hpp
@@ -62,6 +62,8 @@ struct vector_access_rtc : public exprtk::vector_access_runtime_check {
 
 } // namespace detail
 
+GR_REGISTER_BLOCK(gr::blocks::math::ExpressionSISO, [ float, double ]);
+
 template<typename T>
 requires std::floating_point<T>
 struct ExpressionSISO : Block<ExpressionSISO<T>> {
@@ -136,7 +138,8 @@ For full syntax, conditionals, loops, and advanced features:
         return _out;
     }
 };
-static_assert(std::is_constructible_v<ExpressionSISO<float>, property_map>, "Block type ExpressionSISO must be constructible from property_map");
+
+GR_REGISTER_BLOCK(gr::blocks::math::ExpressionDISO, [ float, double ]);
 
 template<typename T>
 requires std::floating_point<T>
@@ -217,7 +220,8 @@ For full syntax, conditionals, loops, and advanced features:
         return _out;
     }
 };
-static_assert(std::is_constructible_v<ExpressionDISO<float>, property_map>, "Block type ExpressionDISO must be constructible from property_map");
+
+GR_REGISTER_BLOCK(gr::blocks::math::ExpressionBulk, [ float, double ]);
 
 template<typename T>
 requires std::floating_point<T>
@@ -341,12 +345,7 @@ For full syntax, conditionals, loops, and advanced features:
         return work::Status::OK;
     }
 };
-static_assert(std::is_constructible_v<ExpressionBulk<float>, property_map>, "Block type ExpressionBulk must be constructible from property_map");
 
 } // namespace gr::blocks::math
-
-const inline static auto registerConstMath = gr::registerBlock<gr::blocks::math::ExpressionSISO, float, double>(gr::globalBlockRegistry())   //
-                                             + gr::registerBlock<gr::blocks::math::ExpressionDISO, float, double>(gr::globalBlockRegistry()) //
-                                             + gr::registerBlock<gr::blocks::math::ExpressionBulk, float, double>(gr::globalBlockRegistry());
 
 #endif // EXPRESSIONBLOCKS_HPP

--- a/blocks/math/include/gnuradio-4.0/math/Math.hpp
+++ b/blocks/math/include/gnuradio-4.0/math/Math.hpp
@@ -21,8 +21,13 @@ T defaultValue() noexcept {
 }
 } // namespace detail
 
+GR_REGISTER_BLOCK("gr::blocks::math::AddConst", gr::blocks::math::MathOpImpl, ([T], '+'), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ])
+GR_REGISTER_BLOCK("gr::blocks::math::SubtractConst", gr::blocks::math::MathOpImpl, ([T], '-'), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ])
+GR_REGISTER_BLOCK("gr::blocks::math::MultiplyConst", gr::blocks::math::MathOpImpl, ([T], '*'), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ])
+GR_REGISTER_BLOCK("gr::blocks::math::DivideConst", gr::blocks::math::MathOpImpl, ([T], '/'), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ])
+
 template<typename T, typename op>
-struct MathOpImpl : gr::Block<MathOpImpl<T, op>> {
+struct MathOpImpl : Block<MathOpImpl<T, op>> {
     PortIn<T>  in{};
     PortOut<T> out{};
     T          value = detail::defaultValue<T>();
@@ -59,11 +64,15 @@ using MultiplyConst = MathOpImpl<T, std::multiplies<T>>;
 template<typename T>
 using DivideConst = MathOpImpl<T, std::divides<T>>;
 
+GR_REGISTER_BLOCK("gr::blocks::math::Add", gr::blocks::math::MathOpImpl, ([T], std::plus<[T]>), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ])
+GR_REGISTER_BLOCK("gr::blocks::math::Subtract", gr::blocks::math::MathOpImpl, ([T], std::minus<[T]>), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ])
+GR_REGISTER_BLOCK("gr::blocks::math::Multiply", gr::blocks::math::MathOpImpl, ([T], std::multiplies<[T]>), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ])
+GR_REGISTER_BLOCK("gr::blocks::math::Divide", gr::blocks::math::MathOpImpl, ([T], std::divides<[T]>), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ])
+
 template<typename T, typename op>
 requires(std::is_arithmetic_v<T>)
-struct MathOpMultiPortImpl : public gr::Block<MathOpMultiPortImpl<T, op>> {
-    using Description = Doc<R""(
-    @brief Math block combining multiple inputs into a single output with a given operation
+struct MathOpMultiPortImpl : Block<MathOpMultiPortImpl<T, op>> {
+    using Description = Doc<R""(@brief Math block combining multiple inputs into a single output with a given operation
 
     Depending on the operator op this block computes:
     - Multiply: out = in_1 * in_2 * in_3 * ...
@@ -107,16 +116,5 @@ template<typename T>
 using Divide = MathOpMultiPortImpl<T, std::divides<T>>;
 
 } // namespace gr::blocks::math
-
-// clang-format off
-const inline auto registerConstMath = gr::registerBlock<"gr::blocks::math::AddConst", gr::blocks::math::AddConst,      uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double /*, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double>, std::string, gr::Packet<float>, gr::Packet<double>, gr::Tensor<float>, gr::Tensor<double>, gr::DataSet<float>, gr::DataSet<double> */>(gr::globalBlockRegistry())
-                                    | gr::registerBlock<"gr::blocks::math::SubtractConst", gr::blocks::math::SubtractConst, uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double /*, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double>, std::string, gr::Packet<float>, gr::Packet<double>, gr::Tensor<float>, gr::Tensor<double>, gr::DataSet<float>, gr::DataSet<double> */>(gr::globalBlockRegistry())
-                                    | gr::registerBlock<"gr::blocks::math::MultiplyConst", gr::blocks::math::MultiplyConst, uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double /*, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double>, std::string, gr::Packet<float>, gr::Packet<double>, gr::Tensor<float>, gr::Tensor<double>, gr::DataSet<float>, gr::DataSet<double> */>(gr::globalBlockRegistry())
-                                    | gr::registerBlock<"gr::blocks::math::DivideConst", gr::blocks::math::DivideConst,   uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double /*, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double>, std::string, gr::Packet<float>, gr::Packet<double>, gr::Tensor<float>, gr::Tensor<double>, gr::DataSet<float>, gr::DataSet<double> */>(gr::globalBlockRegistry());
-const inline auto registerMultiMath = gr::registerBlock<"gr::blocks::math::Add", gr::blocks::math::Add,      uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double /*, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double>, std::string, gr::Packet<float>, gr::Packet<double>, gr::Tensor<float>, gr::Tensor<double>, gr::DataSet<float>, gr::DataSet<double> */>(gr::globalBlockRegistry())
-                                    | gr::registerBlock<"gr::blocks::math::Subtract", gr::blocks::math::Subtract, uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double /*, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double>, std::string, gr::Packet<float>, gr::Packet<double>, gr::Tensor<float>, gr::Tensor<double>, gr::DataSet<float>, gr::DataSet<double> */>(gr::globalBlockRegistry())
-                                    | gr::registerBlock<"gr::blocks::math::Multiply", gr::blocks::math::Multiply, uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double /*, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double>, std::string, gr::Packet<float>, gr::Packet<double>, gr::Tensor<float>, gr::Tensor<double>, gr::DataSet<float>, gr::DataSet<double> */>(gr::globalBlockRegistry())
-                                    | gr::registerBlock<"gr::blocks::math::Divide", gr::blocks::math::Divide,   uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double /*, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double>, std::string, gr::Packet<float>, gr::Packet<double>, gr::Tensor<float>, gr::Tensor<double>, gr::DataSet<float>, gr::DataSet<double> */>(gr::globalBlockRegistry());
-// clang-format on
 
 #endif // GNURADIO_MATH_HPP

--- a/blocks/math/include/gnuradio-4.0/math/Rotator.hpp
+++ b/blocks/math/include/gnuradio-4.0/math/Rotator.hpp
@@ -12,6 +12,8 @@
 
 namespace gr::blocks::math {
 
+GR_REGISTER_BLOCK(gr::blocks::math::Rotator, [ std::complex<float>, std::complex<double> ])
+
 template<pmtv::Complex T>
 struct Rotator : gr::Block<Rotator<T>> {
     using value_type  = typename T::value_type;
@@ -60,7 +62,5 @@ given 'sample_rate' in Hz (N.B sample_rate is normalised to '1' by default).
 };
 
 } // namespace gr::blocks::math
-
-inline static auto registerRotator = gr::registerBlock<gr::blocks::math::Rotator, std::complex<float>, std::complex<double>>(gr::globalBlockRegistry());
 
 #endif // GNURADIO_ROTATOR_HPP

--- a/blocks/math/test/qa_ExpressionBlocks.cpp
+++ b/blocks/math/test/qa_ExpressionBlocks.cpp
@@ -7,6 +7,12 @@
 #include <gnuradio-4.0/testing/NullSources.hpp>
 #include <gnuradio-4.0/testing/TagMonitors.hpp>
 
+namespace gr::blocks::math {
+static_assert(std::is_constructible_v<ExpressionSISO<float>, property_map>, "Block type ExpressionSISO must be constructible from property_map");
+static_assert(std::is_constructible_v<ExpressionDISO<float>, property_map>, "Block type ExpressionDISO must be constructible from property_map");
+static_assert(std::is_constructible_v<ExpressionBulk<float>, property_map>, "Block type ExpressionBulk must be constructible from property_map");
+} // namespace gr::blocks::math
+
 const boost::ut::suite<"basic expression block tests"> basicMath = [] {
     using namespace boost::ut;
     using namespace gr;

--- a/blocks/soapy/include/gnuradio-4.0/soapy/Soapy.hpp
+++ b/blocks/soapy/include/gnuradio-4.0/soapy/Soapy.hpp
@@ -23,6 +23,9 @@ inline bool equalWithinOnePercent(const std::vector<double>& a, const std::vecto
 }
 } // namespace detail
 
+GR_REGISTER_BLOCK("gr::blocks::soapy::SoapySimpleSource", gr::blocks::soapy::SoapySimpleSource, ([T], 1UZ), [ uint8_t, int16_t, std::complex<float> ])
+GR_REGISTER_BLOCK("gr::blocks::soapy::SoapyDualSimpleSource", gr::blocks::soapy::SoapySimpleSource, ([T], 2UZ), [ uint8_t, int16_t, std::complex<float> ])
+
 template<typename T, std::size_t nPorts = std::dynamic_extent>
 struct SoapyBlock : public Block<SoapyBlock<T, nPorts> /*, BlockingIO<false>*/> {
     using Description = Doc<R""(A Soapy source block that interfaces with SDR hardware using the SoapySDR library.
@@ -271,12 +274,6 @@ using SoapySimpleSource = SoapyBlock<T, 1UZ>;
 template<typename T>
 using SoapyDualSimpleSource = SoapyBlock<T, 2UZ>;
 
-static_assert(std::is_constructible_v<SoapyBlock<std::complex<float>>, gr::property_map>, "SoapyBlock not default constructible w/ property_map");
-static_assert(std::is_constructible_v<SoapySimpleSource<std::complex<float>>, gr::property_map>, "SoapyBlock not default constructible w/ property_map");
-
 } // namespace gr::blocks::soapy
-
-const inline auto registerSoapy = gr::registerBlock<"gr::blocks::soapy::SoapySimpleSource", gr::blocks::soapy::SoapySimpleSource, uint8_t, int16_t, std::complex<float>>(gr::globalBlockRegistry()) //
-                                  | gr::registerBlock<"gr::blocks::soapy::SoapyDualSimpleSource", gr::blocks::soapy::SoapyDualSimpleSource, uint8_t, int16_t, std::complex<float>>(gr::globalBlockRegistry());
 
 #endif // SOAPY_HPP

--- a/blocks/soapy/test/qa_Soapy.cpp
+++ b/blocks/soapy/test/qa_Soapy.cpp
@@ -16,6 +16,11 @@
 #include <gnuradio-4.0/soapy/Soapy.hpp>
 #include <gnuradio-4.0/testing/NullSources.hpp>
 
+namespace gr::blocks::soapy {
+static_assert(std::is_constructible_v<SoapyBlock<std::complex<float>>, gr::property_map>, "SoapyBlock not default constructible w/ property_map");
+static_assert(std::is_constructible_v<SoapySimpleSource<std::complex<float>>, gr::property_map>, "SoapyBlock not default constructible w/ property_map");
+} // namespace gr::blocks::soapy
+
 const boost::ut::suite<"basic SoapySDR API "> basicSoapyAPI = [] {
     using namespace boost::ut;
     using namespace gr;

--- a/blocks/testing/include/gnuradio-4.0/testing/Delay.hpp
+++ b/blocks/testing/include/gnuradio-4.0/testing/Delay.hpp
@@ -8,8 +8,10 @@
 
 namespace gr::testing {
 
+GR_REGISTER_BLOCK(gr::testing::Delay, [float double])
+
 template<typename T>
-struct Delay : public gr::Block<Delay<T>> {
+struct Delay : Block<Delay<T>> {
     using clock = std::chrono::steady_clock;
 
     PortIn<T>  in;
@@ -45,7 +47,5 @@ struct Delay : public gr::Block<Delay<T>> {
 };
 
 } // namespace gr::testing
-
-auto registerTestingDelay = gr::registerBlock<gr::testing::Delay, float, double>(gr::globalBlockRegistry());
 
 #endif // GNURADIO_TESTING_DELAY_HPP

--- a/blocks/testing/include/gnuradio-4.0/testing/ImChartMonitor.hpp
+++ b/blocks/testing/include/gnuradio-4.0/testing/ImChartMonitor.hpp
@@ -14,6 +14,8 @@
 
 namespace gr::testing {
 
+GR_REGISTER_BLOCK(gr::testing::ImChartMonitor, [ float, double, gr::DataSet<float>, gr::DataSet<double> ])
+
 template<typename T>
 requires(std::is_arithmetic_v<T> || gr::DataSetLike<T>)
 struct ImChartMonitor : public Block<ImChartMonitor<T>, BlockingIO<false>, Drawable<UICategory::ChartPane, "console">> {
@@ -92,7 +94,5 @@ struct ImChartMonitor : public Block<ImChartMonitor<T>, BlockingIO<false>, Drawa
 };
 
 } // namespace gr::testing
-
-inline const auto registerImChartMonitor = gr::registerBlock<gr::testing::ImChartMonitor, float, double, gr::DataSet<float>, gr::DataSet<double>>(gr::globalBlockRegistry());
 
 #endif // GNURADIO_IMCHARTMONITOR_HPP

--- a/blocks/testing/include/gnuradio-4.0/testing/NullSources.hpp
+++ b/blocks/testing/include/gnuradio-4.0/testing/NullSources.hpp
@@ -8,8 +8,10 @@
 
 namespace gr::testing {
 
+GR_REGISTER_BLOCK(gr::testing::NullSource, [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, std::complex<float>, std::complex<double>, std::string, gr::Packet<float>, gr::Packet<double>, gr::Tensor<float>, gr::Tensor<double>, gr::DataSet<float>, gr::DataSet<double> ])
+
 template<typename T>
-struct NullSource : public gr::Block<NullSource<T>> {
+struct NullSource : Block<NullSource<T>> {
     using Description = Doc<R""(A source block that emits zeros or type-specified default value continuously.
 Used mainly for testing and benchmarking where a consistent and predictable output is essential.
 Ideal for scenarios that require a simple, low-overhead source of consistent values.)"">;
@@ -23,8 +25,10 @@ Ideal for scenarios that require a simple, low-overhead source of consistent val
 
 static_assert(gr::BlockLike<NullSource<float>>);
 
+GR_REGISTER_BLOCK(gr::testing::ConstantSource, [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, std::complex<float>, std::complex<double>, std::string, gr::Packet<float>, gr::Packet<double>, gr::Tensor<float>, gr::Tensor<double>, gr::DataSet<float>, gr::DataSet<double> ])
+
 template<typename T>
-struct ConstantSource : public gr::Block<ConstantSource<T>> {
+struct ConstantSource : Block<ConstantSource<T>> {
     using value_t     = std::conditional_t<std::is_same_v<T, std::string>, std::string, meta::fundamental_base_value_type_t<T>>; // use base-type for types not supported by settings
     using Description = Doc<R""(A source block that emits a constant default value for each output sample.
 This block counts the number of samples emitted and optionally halts after reaching a specified maximum.
@@ -51,8 +55,10 @@ Commonly used for testing and simulations where consistent output and finite exe
 
 static_assert(gr::BlockLike<ConstantSource<float>>);
 
+GR_REGISTER_BLOCK(gr::testing::SlowSource, [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, std::complex<float>, std::complex<double>, std::string, gr::Packet<float>, gr::Packet<double>, gr::Tensor<float>, gr::Tensor<double>, gr::DataSet<float>, gr::DataSet<double> ])
+
 template<typename T>
-struct SlowSource : public gr::Block<SlowSource<T>> {
+struct SlowSource : Block<SlowSource<T>> {
     using value_t     = std::conditional_t<std::is_same_v<T, std::string>, std::string, meta::fundamental_base_value_type_t<T>>; // use base-type for types not supported by settings
     using Description = Doc<R""(A source block that emits a constant default value every n miliseconds)"">;
 
@@ -78,11 +84,11 @@ struct SlowSource : public gr::Block<SlowSource<T>> {
     }
 };
 
-static_assert(gr::BlockLike<SlowSource<float>>);
+GR_REGISTER_BLOCK(gr::testing::CountingSource, [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, std::complex<float>, std::complex<double>, std::string, gr::Packet<float>, gr::Packet<double>, gr::Tensor<float>, gr::Tensor<double>, gr::DataSet<float>, gr::DataSet<double> ])
 
 template<typename T>
 requires(std::is_arithmetic_v<T>)
-struct CountingSource : public gr::Block<CountingSource<T>> {
+struct CountingSource : Block<CountingSource<T>> {
     using Description = Doc<R""(A source block that emits an increasing sequence starting from a specified default value.
 This block counts the number of samples emitted and optionally halts after reaching a specified maximum.
 Commonly used for testing and simulations where consistent output and finite execution are required.)"">;
@@ -106,10 +112,10 @@ Commonly used for testing and simulations where consistent output and finite exe
     }
 };
 
-static_assert(gr::BlockLike<CountingSource<float>>);
+GR_REGISTER_BLOCK(gr::testing::Copy, [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, std::complex<float>, std::complex<double>, std::string, gr::Packet<float>, gr::Packet<double>, gr::Tensor<float>, gr::Tensor<double>, gr::DataSet<float>, gr::DataSet<double> ])
 
 template<typename T>
-struct Copy : public gr::Block<Copy<T>> {
+struct Copy : Block<Copy<T>> {
     using Description = Doc<R""(A block that passes/copies input samples directly to its output without modification.
 Commonly used used to isolate parts of a flowgraph, manage buffer sizes, or simply duplicate the signal path.)"">;
 
@@ -124,10 +130,10 @@ Commonly used used to isolate parts of a flowgraph, manage buffer sizes, or simp
     }
 };
 
-static_assert(gr::BlockLike<Copy<float>>);
+GR_REGISTER_BLOCK(gr::testing::HeadBlock, [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, std::complex<float>, std::complex<double>, std::string, gr::Packet<float>, gr::Packet<double>, gr::Tensor<float>, gr::Tensor<double>, gr::DataSet<float>, gr::DataSet<double> ])
 
 template<typename T>
-struct HeadBlock : public gr::Block<HeadBlock<T>> { // TODO confirm naming: while known in GR3, the semantic name seems to be odd. (Maybe add an alias?!)
+struct HeadBlock : Block<HeadBlock<T>> { // TODO confirm naming: while known in GR3, the semantic name seems to be odd. (Maybe add an alias?!)
     using Description = Doc<R""(Limits the number of output samples by copying the first N items from the input to the output and then signaling completion.
 Commonly used to control data flow in systems where precise sample counts are critical, such as in file recording or when executing flow graphs without a GUI.)"">;
 
@@ -150,10 +156,10 @@ Commonly used to control data flow in systems where precise sample counts are cr
     }
 };
 
-static_assert(gr::BlockLike<HeadBlock<float>>);
+GR_REGISTER_BLOCK(gr::testing::NullSink, [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, std::complex<float>, std::complex<double>, std::string, gr::Packet<float>, gr::Packet<double>, gr::Tensor<float>, gr::Tensor<double>, gr::DataSet<float>, gr::DataSet<double> ])
 
 template<typename T>
-struct NullSink : public gr::Block<NullSink<T>> {
+struct NullSink : Block<NullSink<T>> {
     using Description = Doc<R""(A sink block that consumes and discards all input samples without producing any output.
 Used primarily for absorbing data in a flow graph where output processing is unnecessary.
 Commonly used for testing, performance benchmarking, and in scenarios where signal flow needs to be terminated without external effects.)"">;
@@ -165,10 +171,10 @@ Commonly used for testing, performance benchmarking, and in scenarios where sign
     void processOne(V) const noexcept {}
 };
 
-static_assert(gr::BlockLike<NullSink<float>>);
+GR_REGISTER_BLOCK(gr::testing::CountingSink, [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, std::complex<float>, std::complex<double>, std::string, gr::Packet<float>, gr::Packet<double>, gr::Tensor<float>, gr::Tensor<double>, gr::DataSet<float>, gr::DataSet<double> ])
 
 template<typename T>
-struct CountingSink : public gr::Block<CountingSink<T>> {
+struct CountingSink : Block<CountingSink<T>> {
     using Description = Doc<R""(A sink block that consumes and discards a fixed number of input samples, after which it signals the flow graph to halt.
 This block is used to control execution in systems requiring precise input processing without data output, similar to how a 'HeadBlock' manages output samples.
 Commonly used for testing scenarios and signal termination where output is unnecessary but precise input count control is needed.)"">;
@@ -190,11 +196,6 @@ Commonly used for testing scenarios and signal termination where output is unnec
     }
 };
 
-static_assert(gr::BlockLike<CountingSink<float>>);
-
 } // namespace gr::testing
-
-const inline auto registerNullSources = gr::registerBlock<gr::testing::NullSource, uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, std::complex<float>, std::complex<double>, std::string, gr::Packet<float>, gr::Packet<double>, gr::Tensor<float>, gr::Tensor<double>, gr::DataSet<float>, gr::DataSet<double>>(gr::globalBlockRegistry()) | gr::registerBlock<gr::testing::ConstantSource, uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, std::complex<float>, std::complex<double>, std::string, gr::Packet<float>, gr::Packet<double>, gr::Tensor<float>, gr::Tensor<double>, gr::DataSet<float>, gr::DataSet<double>>(gr::globalBlockRegistry()) | gr::registerBlock<gr::testing::CountingSource, uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double>(gr::globalBlockRegistry()) | gr::registerBlock<gr::testing::Copy, uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, std::complex<float>, std::complex<double>, std::string, gr::Packet<float>, gr::Packet<double>, gr::Tensor<float>, gr::Tensor<double>, gr::DataSet<float>, gr::DataSet<double>>(gr::globalBlockRegistry()) | gr::registerBlock<gr::testing::HeadBlock, uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, std::complex<float>, std::complex<double>, std::string, gr::Packet<float>, gr::Packet<double>, gr::Tensor<float>, gr::Tensor<double>, gr::DataSet<float>, gr::DataSet<double>>(gr::globalBlockRegistry()) | gr::registerBlock<gr::testing::NullSink, uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, std::complex<float>, std::complex<double>, std::string, gr::Packet<float>, gr::Packet<double>, gr::Tensor<float>, gr::Tensor<double>, gr::DataSet<float>, gr::DataSet<double>>(gr::globalBlockRegistry()) |
-                                        gr::registerBlock<gr::testing::CountingSink, uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, std::complex<float>, std::complex<double>, std::string, gr::Packet<float>, gr::Packet<double>, gr::Tensor<float>, gr::Tensor<double>, gr::DataSet<float>, gr::DataSet<double>>(gr::globalBlockRegistry());
 
 #endif // GNURADIO_NULLSOURCES_HPP

--- a/blocks/testing/include/gnuradio-4.0/testing/PerformanceMonitor.hpp
+++ b/blocks/testing/include/gnuradio-4.0/testing/PerformanceMonitor.hpp
@@ -57,8 +57,10 @@ std::string to_si_prefix(T value_base, std::string_view unit = "s", std::size_t 
 }
 } // namespace details
 
+GR_REGISTER_BLOCK(gr::testing::PerformanceMonitor, [ float, double ])
+
 template<typename T>
-struct PerformanceMonitor : public Block<PerformanceMonitor<T>> {
+struct PerformanceMonitor : Block<PerformanceMonitor<T>> {
     using Description = Doc<R""(The `PerformanceMonitor` block is used to track and report on performance metrics.
 Specifically, it monitors memory usage, including resident and virtual memory, as well as the sample rate.
 The results of this monitoring can be printed to the console or saved to a CSV file for further analysis.
@@ -181,7 +183,5 @@ private:
 };
 
 } // namespace gr::testing
-
-auto registerPerformanceMonitor = gr::registerBlock<gr::testing::PerformanceMonitor, float, double>(gr::globalBlockRegistry());
 
 #endif // GNURADIO_PERFORMANCEMONITOR_HPP

--- a/blocks/testing/include/gnuradio-4.0/testing/SettingsChangeRecorder.hpp
+++ b/blocks/testing/include/gnuradio-4.0/testing/SettingsChangeRecorder.hpp
@@ -52,12 +52,12 @@ void printChanges(const property_map& oldMap, const property_map& newMap) noexce
 };
 } // namespace utils
 
+GR_REGISTER_BLOCK(gr::testing::SettingsChangeRecorder, [ int32_t, float, double, gr::DataSetLike<T>, gr::DataSet<T> ])
+
 template<typename T>
 // struct SettingsChangeRecorder : public Block<SettingsChangeRecorder<T>, BlockingIO<true>, SupportedTypes<float, double>> { // TODO: reenable BlockingIO
-struct SettingsChangeRecorder : public Block<SettingsChangeRecorder<T>, SupportedTypes<float, double>> {
-    using Description = Doc<R""(
-some test doc documentation
-)"">;
+struct SettingsChangeRecorder : Block<SettingsChangeRecorder<T>> {
+    using Description = Doc<R""(some test doc documentation)"">;
     PortIn<T>  in{};
     PortOut<T> out{};
 
@@ -101,8 +101,5 @@ some test doc documentation
     }
 };
 
-static_assert(BlockLike<SettingsChangeRecorder<int>>);
-static_assert(BlockLike<SettingsChangeRecorder<float>>);
-static_assert(BlockLike<SettingsChangeRecorder<double>>);
 } // namespace gr::testing
-#endif // include guard
+#endif // GNURADIO_TESTING_SETTINGS_CHANGE_RECORDER_H

--- a/blocks/testing/include/gnuradio-4.0/testing/TagMonitors.hpp
+++ b/blocks/testing/include/gnuradio-4.0/testing/TagMonitors.hpp
@@ -84,8 +84,10 @@ inline constexpr bool equal_tag_lists(const std::vector<Tag>& tags1, const std::
     return true;
 }
 
+GR_REGISTER_BLOCK("gr::testing::TagSource", gr::testing::TagSource, ([T], ProcessFunction::USE_PROCESS_ONE), [ float, double ])
+
 template<typename T, ProcessFunction UseProcessVariant = ProcessFunction::USE_PROCESS_BULK>
-struct TagSource : public Block<TagSource<T, UseProcessVariant>> {
+struct TagSource : Block<TagSource<T, UseProcessVariant>> {
     PortOut<T> out;
 
     // settings
@@ -231,6 +233,8 @@ private:
     [[nodiscard]] bool isInfinite() const { return n_samples_max == 0U; }
 };
 
+GR_REGISTER_BLOCK("gr::testing::TagMonitor", gr::testing::TagMonitor, ([T], ProcessFunction::USE_PROCESS_ONE), [ float, double ])
+
 template<typename T, ProcessFunction UseProcessVariant>
 struct TagMonitor : public Block<TagMonitor<T, UseProcessVariant>> {
     PortIn<T>  in;
@@ -303,6 +307,8 @@ struct TagMonitor : public Block<TagMonitor<T, UseProcessVariant>> {
         return work::Status::OK;
     }
 };
+
+GR_REGISTER_BLOCK("gr::testing::TagSink", gr::testing::TagSink, ([T], ProcessFunction::USE_PROCESS_ONE), [ float, double ])
 
 template<typename T, ProcessFunction UseProcessVariant>
 struct TagSink : public Block<TagSink<T, UseProcessVariant>> {
@@ -383,9 +389,5 @@ struct TagSink : public Block<TagSink<T, UseProcessVariant>> {
 };
 
 } // namespace gr::testing
-
-auto registerTagSource  = gr::registerBlock<gr::testing::TagSource, gr::testing::ProcessFunction::USE_PROCESS_ONE, float, double>(gr::globalBlockRegistry()) | gr::registerBlock<gr::testing::TagSource, gr::testing::ProcessFunction::USE_PROCESS_BULK, float, double>(gr::globalBlockRegistry());
-auto registerTagMonitor = gr::registerBlock<gr::testing::TagMonitor, gr::testing::ProcessFunction::USE_PROCESS_ONE, float, double>(gr::globalBlockRegistry()) | gr::registerBlock<gr::testing::TagMonitor, gr::testing::ProcessFunction::USE_PROCESS_BULK, float, double>(gr::globalBlockRegistry());
-auto registerTagSink    = gr::registerBlock<gr::testing::TagSink, gr::testing::ProcessFunction::USE_PROCESS_ONE, float, double>(gr::globalBlockRegistry()) | gr::registerBlock<gr::testing::TagSink, gr::testing::ProcessFunction::USE_PROCESS_BULK, float, double>(gr::globalBlockRegistry());
 
 #endif // GNURADIO_TAGMONITORS_HPP

--- a/core/include/gnuradio-4.0/BlockRegistry.hpp
+++ b/core/include/gnuradio-4.0/BlockRegistry.hpp
@@ -10,6 +10,28 @@
 
 #include "BlockModel.hpp"
 
+/**
+ *  namespace gr {
+ *  template<typename T> struct AlgoImpl1 {};
+ *  template<typename T> struct AlgoImpl2 {};
+ *
+ *  // register block with arbitrary NTTPs (here: 3UZ) and expand T in [float,double], U in [short, int, long, long long]
+ *  GR_REGISTER_BLOCK(gr::basic::BlockN, ([T], [U], 3UZ), [ float, double ], [ short, int, long, long long ])
+ *  // register block with arbitrary NTTPs (here: 4UZ) and expand T for [short], U for [short] only
+ *  GR_REGISTER_BLOCK("CustomBlockNameN", gr::basic::BlockN, ([T], [U], 4UZ, gr::basic::AlgoImpl2<[T]>), [ short ], [ short ])
+ *
+ *  template<typename T, typename U, std::size_t N, typename Alog = AlgoImpl1<T>>
+ *  struct BlockN : public gr::IBlock { ... };
+ *
+ *  } // namespace gr::basic
+ *
+ * other macro variants options:
+ * GR_REGISTER_BLOCK("MyBlockName", gr::basic::Block1, ([T], [U]), [ float, double ], [int])
+ * GR_REGISTER_BLOCK(gr::basic::Block0)
+ * GR_REGISTER_BLOCK("blockN.hpp", gr::basic::BlockN, ([T],[U],3UZ,SomeAlgo<[T]>), [ short, int], [double])
+ */
+#define GR_REGISTER_BLOCK(...) /* Marker macro for parse_registrations */
+
 namespace gr {
 
 using namespace std::string_literals;

--- a/core/test/qa_GraphMessages.cpp
+++ b/core/test/qa_GraphMessages.cpp
@@ -1,30 +1,18 @@
 #include <boost/ut.hpp>
 
-#include <gnuradio-4.0/Block.hpp>
-#include <gnuradio-4.0/Message.hpp>
-#include <gnuradio-4.0/Scheduler.hpp>
-#include <gnuradio-4.0/basic/clock_source.hpp>
 #include <gnuradio-4.0/testing/NullSources.hpp>
-#include <gnuradio-4.0/testing/TagMonitors.hpp>
 
-#include <magic_enum.hpp>
-#include <magic_enum_utility.hpp>
+#include <gnuradio-4.0/Scheduler.hpp>
 
 #include "message_utils.hpp"
 
 using namespace std::chrono_literals;
 using namespace std::string_literals;
 
-using namespace gr::message;
-
-namespace gr::testing {
-
-using namespace boost::ut;
-using namespace gr;
-
 const boost::ut::suite<"Graph Formatter Tests"> graphFormatterTests = [] {
     using namespace boost::ut;
     using namespace gr;
+    using namespace gr::testing;
 
     "Edge formatter tests"_test = [] {
         Graph                  graph;
@@ -59,7 +47,15 @@ const boost::ut::suite NonRunningGraphTests = [] {
     using namespace std::string_literals;
     using namespace boost::ut;
     using namespace gr;
+    using namespace gr::testing;
     using enum gr::message::Command;
+
+    [[maybe_unused]] auto registerCopyBlock = gr::registerBlock<gr::testing::Copy, float, double>(gr::globalPluginLoader().registry());
+    expect(fatal(gt(gr::globalPluginLoader().registry().knownBlocks().size(), 0UZ))) << "didn't register any blocks";
+    fmt::println("registered blocks:");
+    for (const auto& blockName : gr::globalPluginLoader().registry().knownBlocks()) {
+        fmt::println("    block: {}", blockName);
+    }
 
     "Block addition tests"_test = [] {
         gr::MsgPortOut toGraph;
@@ -302,6 +298,7 @@ const boost::ut::suite RunningGraphTests = [] {
     using namespace std::string_literals;
     using namespace boost::ut;
     using namespace gr;
+    using namespace gr::testing;
     using enum gr::message::Command;
 
     gr::scheduler::Simple scheduler{gr::Graph()};
@@ -404,7 +401,5 @@ const boost::ut::suite RunningGraphTests = [] {
         expect(false) << fmt::format("scheduler.runAndWait() failed:\n{}\n", schedulerRet.error());
     }
 };
-
-} // namespace gr::testing
 
 int main() { /* tests are statically executed */ }


### PR DESCRIPTION
This is the first of two steps: https://github.com/fair-acc/gnuradio4/issues/517

Based on a minimal proof-of-concept prototype for building GR4 module plugin-registry t here: https://github.com/fair-acc/gr4-blocklib-build-concept

```cpp
template<typename T> struct AlgoImpl1 {};
template<typename T> struct AlgoImpl2 {};

// register block with arbitrary NTTPs (here: 3UZ) and expand T in [ float, double ], U in [short, int, long, long long]
GR_REGISTER_BLOCK(gr::basic::BlockN, ([T], [U], 3UZ), [ float, double ], [ short, int, long, long long ])
// register block with arbitrary NTTPs (here: 4UZ) and expand T for [short], U for [short] only
GR_REGISTER_BLOCK("CustomBlockNameN", gr::basic::BlockN, ([T], [U], 4UZ, gr::basic::AlgoImpl2<[T]>), [ short ], [ short ])
  
template<typename T, typename U, std::size_t N, typename Alog = AlgoImpl1<T>>
struct BlockN : public gr::IBlock { /* .. */  };

} // namespace gr::basic
  
/** other macro variants options:
 * A) non-tempalted or fully specialised blocks:
 *     GR_REGISTER_BLOCK(gr::basic::Block0)
 * B) providing a dedicated name (e.g. generates 'MyBlockName<float>', 'MyBlockName<double>'
 *     GR_REGISTER_BLOCK("MyBlockName", gr::basic::Block1, ([T], [U]), [ float, double ], [int])
 * C) providing a dedicated name and providing/absorbing template NTTP/Type specialisation not critical to the user
 *     GR_REGISTER_BLOCK("SimplerBlockName", gr::basic::BlockN, ([T],[U],3UZ,SomeAlgo<[T]>), [ short, int], [double])
 *
 *  N.B. Name specialisations should be used exceptionally and limited to cases when the automatic C++-type to block
 * name generation would yield unwieldy names (e.g. due to NTTPs and other dependent types).  
 * Otherwise please follow a 'nomen-est-omen' and C++ is the single source of truth paradigm
 */
```

### Timing

On my local notebook (i7-8565U CPU @ 1.80GHz):
```bash
time make -j
[..]
real    30m44.366s
user    150m52.563s
sys     20m14.971s
```

GitHub CI:

![image](https://github.com/user-attachments/assets/36cfc9b5-4ed7-4fa1-9921-11686f317d88)

