### PR TITLE
fixed FunctionGenerator

### DIFF
--- a/blocks/basic/include/gnuradio-4.0/basic/FunctionGenerator.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/FunctionGenerator.hpp
@@ -165,19 +165,27 @@ The parameters will automatically update when a Tag containing the 'context' fie
     function_generator::SignalType _signalType = function_generator::parse<function_generator::SignalType>(signal_type);
     T                              _timeTick   = T(1.) / static_cast<T>(sample_rate);
 
-    void settingsChanged(const property_map& /*old_settings*/, const property_map& new_settings) {
-        if (new_settings.contains(function_generator::toString(function_generator::signal_type))) {
+    void settingsChanged(const property_map& oldSettings, const property_map& newSettings) {
+        if (newSettings.contains(function_generator::toString(function_generator::signal_type))) {
             if (signal_trigger.value.empty()) {
                 _currentTime = T(0.);
-            } else if (new_settings.contains(gr::tag::TRIGGER_NAME.shortKey())) {
-                std::string newTrigger = std::get<std::string>(new_settings.at(gr::tag::TRIGGER_NAME.shortKey()));
+                _signalType  = function_generator::parse<function_generator::SignalType>(signal_type);
+            } else if (newSettings.contains(gr::tag::TRIGGER_NAME.shortKey())) {
+                std::string newTrigger = std::get<std::string>(newSettings.at(gr::tag::TRIGGER_NAME.shortKey()));
                 if (newTrigger == signal_trigger.value) {
                     _currentTime = T(0.);
+                    _signalType  = function_generator::parse<function_generator::SignalType>(signal_type);
                 } else {
-                    // trigger does not match required signal_trigger
+                    // trigger does not match required signal_trigger -- revert signal_type and others to previous ones
+                    signal_type    = function_generator::toString(_signalType);
+                    start_value    = std::get<T>(oldSettings.at("start_value"));
+                    final_value    = std::get<T>(oldSettings.at("final_value"));
+                    duration       = std::get<T>(oldSettings.at("duration"));
+                    round_off_time = std::get<T>(oldSettings.at("round_off_time"));
+                    impulse_time0  = std::get<T>(oldSettings.at("impulse_time0"));
+                    impulse_time1  = std::get<T>(oldSettings.at("impulse_time1"));
                 }
             }
-            _signalType = function_generator::parse<function_generator::SignalType>(signal_type);
         }
         _timeTick = T(1.) / static_cast<T>(sample_rate);
     }

--- a/blocks/basic/test/qa_StreamToDataSet.cpp
+++ b/blocks/basic/test/qa_StreamToDataSet.cpp
@@ -36,14 +36,14 @@ const boost::ut::suite<"StreamToDataSet Block"> selectorTest = [] {
         auto&                   clockSrc = graph.emplaceBlock<gr::basic::ClockSource<std::uint8_t>>({
             {"sample_rate", sample_rate},
             {"n_samples_max", kN_SAMPLES_MAX},
-            {"name", "ClockSource"},                                                                                                           //
-            {"tag_times", std::vector<std::uint64_t>{10 * ms, 90 * ms, 100 * ms, 300 * ms, 350 * ms, 550 * ms, 650 * ms, 800 * ms, 850 * ms}}, //
-            {"tag_values", std::vector<std::string>{"CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1", "CMD_DIAG_TRIGGER1", "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2", "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=3", "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=4", "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=5", "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=6", "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=7", "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=8"}},
+            {"name", "ClockSource"},                                                                                                                     //
+            {"tag_times", std::vector<std::uint64_t>{10 * ms, 90 * ms, 100 * ms, 300 * ms, 350 * ms, 400 * ms, 550 * ms, 650 * ms, 800 * ms, 850 * ms}}, //
+            {"tag_values", std::vector<std::string>{"CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1", "CMD_DIAG_TRIGGER1", "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2", "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=3", "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=4", "CMD_DIAG_TRIGGER2", "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=5", "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=6", "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=7", "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=8"}},
             {"repeat_period", 1000 * ms},
             {"do_zero_order_hold", true},
         });
 
-        auto& funcGen = graph.emplaceBlock<FunctionGenerator<float>>({{"sample_rate", sample_rate}, {"name", "FunctionGenerator"}});
+        auto& funcGen = graph.emplaceBlock<FunctionGenerator<float>>({{"sample_rate", sample_rate}, {"signal_trigger", "CMD_BP_START"}, {"name", "FunctionGenerator"}});
 
         using gr::tag::TRIGGER_NAME;
         using gr::tag::CONTEXT;

--- a/core/include/gnuradio-4.0/Settings.hpp
+++ b/core/include/gnuradio-4.0/Settings.hpp
@@ -871,6 +871,8 @@ public:
                 }
             }
 
+            updateActiveParametersImpl();
+
             if (_stagedParameters.contains(gr::tag::STORE_DEFAULTS)) {
                 storeDefaults();
             }


### PR DESCRIPTION
-- non matching trigger should not trigger a function parameter change.

This is a workaround. We may need to look into a user-definable settings pre-condition check that are used to reject settings changes based on -- for example -- required trigger, internal block state, ctx etc.