### PR TITLE
fixed FFT<T> block DataSet<T> output

### DIFF
--- a/algorithm/include/gnuradio-4.0/algorithm/ImChart.hpp
+++ b/algorithm/include/gnuradio-4.0/algorithm/ImChart.hpp
@@ -515,6 +515,10 @@ public:
                 _screen[cursorY][cursorX++] = datasetName[j];
             }
 
+            if (cursorX >= _screen_width) { // wrote till the end of the screen
+                return;
+            }
+
             _screen[cursorY][cursorX++] = ' '; // add a space separator between dataset names
         }
     }

--- a/algorithm/include/gnuradio-4.0/algorithm/dataset/DataSetMath.hpp
+++ b/algorithm/include/gnuradio-4.0/algorithm/dataset/DataSetMath.hpp
@@ -6,6 +6,7 @@
 
 #include <gnuradio-4.0/DataSet.hpp>
 #include <gnuradio-4.0/Message.hpp>
+#include <gnuradio-4.0/algorithm/filter/FilterTool.hpp>
 #include <gnuradio-4.0/meta/UncertainValue.hpp>
 
 #include "DataSetHelper.hpp"

--- a/algorithm/include/gnuradio-4.0/algorithm/dataset/DataSetTestFunctions.hpp
+++ b/algorithm/include/gnuradio-4.0/algorithm/dataset/DataSetTestFunctions.hpp
@@ -51,7 +51,7 @@ requires std::convertible_to<std::ranges::range_value_t<RangeValues>, TValue> &&
     ds.signal_values.resize(count);
     ds.meta_information.resize(1);
     ds.timing_events.resize(1);
-    ds.extents = {1, static_cast<std::int32_t>(count)};
+    ds.extents = {static_cast<std::int32_t>(count)};
 
     for (std::size_t i = 0; i < count; ++i) {
         ds.axis_values[0][i] = static_cast<TValue>(i);
@@ -85,7 +85,7 @@ template<typename T, typename TValue = gr::meta::fundamental_base_value_type_t<T
     ds.signal_values.resize(count);
     ds.meta_information.resize(1UZ);
     ds.timing_events.resize(1UZ);
-    ds.extents = {1, static_cast<std::int32_t>(count)};
+    ds.extents = {static_cast<std::int32_t>(count)};
 
     for (std::size_t i = 0UZ; i < count; ++i) {
         ds.axis_values[0][i] = static_cast<TValue>(i);
@@ -118,7 +118,7 @@ template<typename T, typename TValue = gr::meta::fundamental_base_value_type_t<T
     ds.signal_values.resize(count);
     ds.meta_information.resize(1UZ);
     ds.timing_events.resize(1UZ);
-    ds.extents = {1, static_cast<std::int32_t>(count)};
+    ds.extents = {static_cast<std::int32_t>(count)};
 
     for (std::size_t i = 0; i < count; i++) {
         ds.axis_values[0][i] = gr::cast<T>(i);
@@ -150,7 +150,7 @@ template<typename T, typename TValue = gr::meta::fundamental_base_value_type_t<T
     ds.signal_values.resize(count);
     ds.meta_information.resize(1UZ);
     ds.timing_events.resize(1UZ);
-    ds.extents = {1, static_cast<std::int32_t>(count)};
+    ds.extents = {static_cast<std::int32_t>(count)};
 
     auto gauss = [](U x, U mu, U sig) -> TValue { return std::exp(-std::pow((TValue(x) - TValue(mu)) / TValue(sig), 2) / U(2)) / (TValue(sig) * std::sqrt(TValue(2) * std::numbers::pi_v<TValue>)); };
 
@@ -186,7 +186,7 @@ template<typename T, typename TValue = gr::meta::fundamental_base_value_type_t<T
     ds.signal_values.resize(count);
     ds.meta_information.resize(1);
     ds.timing_events.resize(1);
-    ds.extents = {1, static_cast<std::int32_t>(count)};
+    ds.extents = {static_cast<std::int32_t>(count)};
 
     for (std::size_t i = 0; i < count; ++i) {
         ds.axis_values[0][i] = static_cast<TValue>(i);
@@ -216,7 +216,7 @@ template<typename T, typename TValue = gr::meta::fundamental_base_value_type_t<T
     ds.signal_values.resize(count);
     ds.meta_information.resize(1);
     ds.timing_events.resize(1);
-    ds.extents = {1, static_cast<std::int32_t>(count)};
+    ds.extents = {static_cast<std::int32_t>(count)};
 
     std::random_device                         rd;
     std::mt19937_64                            rng(seed == 0 ? rd() : seed);

--- a/blocks/basic/include/gnuradio-4.0/basic/StreamToDataSet.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/StreamToDataSet.hpp
@@ -282,7 +282,7 @@ If multiple 'start' or 'stop' Tags arrive in a single merged tag, only one DataS
             if (!_tempDataSets.empty() && !_accState.front().isActive) {
                 auto& ds = _tempDataSets.front();
                 assert(!ds.extents.empty());
-                ds.extents[1] = static_cast<std::int32_t>(ds.signal_values.size());
+                ds.extents[0UZ] = static_cast<std::int32_t>(ds.signal_values.size());
                 if (!ds.signal_values.empty()) { // TODO: do we need to publish empty  DataSet at all, empty DataSet can occur when n_max is set.
                     gr::dataset::updateMinMax(ds);
                 }
@@ -336,7 +336,6 @@ private:
         dataSet.axis_names.emplace_back("time");
         dataSet.axis_units.emplace_back("s");
         dataSet.axis_values.resize(1UZ);
-        dataSet.extents.emplace_back(1); // 1-dim data
         dataSet.extents.emplace_back(0); // size of 1-dim data
 
         dataSet.signal_names.emplace_back(signal_name);

--- a/blocks/basic/test/qa_StreamToDataSet.cpp
+++ b/blocks/basic/test/qa_StreamToDataSet.cpp
@@ -229,7 +229,9 @@ const boost::ut::suite<"StreamToDataSet test"> streamToDataSetTest = [] {
 
         expect(eq(dataSetSink._samples.size(), expectedValues.size()));
         for (std::size_t i = 0; i < dataSetSink._samples.size(); i++) {
-            const DataSet<float>& ds = dataSetSink._samples.at(i);
+            const DataSet<float>&          ds      = dataSetSink._samples.at(i);
+            std::expected<void, gr::Error> dsCheck = dataset::detail::checkDataSetConsistency(ds, "TestDataSet");
+            expect(dsCheck.has_value()) << [&] { return fmt::format("unexpected: {}", dsCheck.error()); } << fatal;
             expect(std::ranges::equal(ds.signal_values, expectedValues[i]));
 
             expect(fatal(eq(ds.timing_events.size(), 1UZ)));

--- a/blocks/testing/include/gnuradio-4.0/testing/ImChartMonitor.hpp
+++ b/blocks/testing/include/gnuradio-4.0/testing/ImChartMonitor.hpp
@@ -57,7 +57,7 @@ struct ImChartMonitor : public Block<ImChartMonitor<T>, BlockingIO<false>, Drawa
         }
     }
 
-    work::Status draw(const property_map& config = {}) noexcept {
+    work::Status draw(const property_map& config = {}, std::source_location location = std::source_location::current()) noexcept {
         [[maybe_unused]] const work::Status status = this->invokeWork(); // calls work(...) -> processOne(...) (all in the same thread as this 'draw()'
 
         if constexpr (std::is_arithmetic_v<T>) {
@@ -86,7 +86,7 @@ struct ImChartMonitor : public Block<ImChartMonitor<T>, BlockingIO<false>, Drawa
             if (_historyBufferY.empty()) {
                 return status;
             }
-            gr::dataset::draw(_historyBufferY[0], {.reset_view = config.contains("reset_view") ? graphs::ResetChartView::RESET : graphs::ResetChartView::KEEP});
+            gr::dataset::draw(_historyBufferY[0], {.reset_view = config.contains("reset_view") ? graphs::ResetChartView::RESET : graphs::ResetChartView::KEEP}, std::numeric_limits<std::size_t>::max(), location);
         }
 
         return status;

--- a/core/include/gnuradio-4.0/DataSet.hpp
+++ b/core/include/gnuradio-4.0/DataSet.hpp
@@ -100,14 +100,14 @@ struct DataSet {
     std::vector<std::vector<T>> axis_values{}; // explicit axis values
 
     // signal data layout:
-    std::vector<std::int32_t> extents{}; // extents[dim0_size, dim1_size, …]
+    std::vector<std::int32_t> extents{}; // extents[dim0_size, dim1_size, …] i.e. [axis_values[0].size(), axis_values[1].size(), …]
     tensor_layout_type        layout{};  // row-major, column-major, “special”
 
     // signal data storage:
-    std::vector<std::string> signal_names{};      // size = extents[0]
-    std::vector<std::string> signal_quantities{}; // size = extents[0]
-    std::vector<std::string> signal_units{};      // size = extents[0]
-    std::vector<T>           signal_values{};     // size = \PI_i extents[i]
+    std::vector<std::string> signal_names{};      // defines number of signals, i.e. 'this->size()'
+    std::vector<std::string> signal_quantities{}; // size = this->size()
+    std::vector<std::string> signal_units{};      // size = this->size()
+    std::vector<T>           signal_values{};     // size = this->size() × Π_i extents[i]
     std::vector<Range<T>>    signal_ranges{};     // [[min_0, max_0], [min_1, max_1], …] used for communicating, for example, HW limits
 
     // meta data
@@ -116,30 +116,35 @@ struct DataSet {
 
     GR_MAKE_REFLECTABLE(DataSet, timestamp, axis_names, axis_units, axis_values, extents, layout, signal_names, signal_quantities, signal_units, signal_values, signal_ranges, meta_information, timing_events);
 
+    [[nodiscard]] std::size_t nDimensions() const noexcept { return extents.size(); }
+
     [[nodiscard]] std::size_t        axisCount() const noexcept { return axis_names.size(); }
-    [[nodiscard]] std::string&       axisName(std::size_t i = 0UZ) { return axis_names[_axCheck(i)]; }
-    [[nodiscard]] std::string_view   axisName(std::size_t i = 0UZ) const { return axis_names[_axCheck(i)]; }
-    [[nodiscard]] std::string&       axisUnit(std::size_t i = 0UZ) { return axis_units[_axCheck(i)]; }
-    [[nodiscard]] std::string_view   axisUnit(std::size_t i = 0UZ) const { return axis_units[_axCheck(i)]; }
-    [[nodiscard]] std::span<T>       axisValues(std::size_t i = 0UZ) { return axis_values[_axCheck(i)]; }
-    [[nodiscard]] std::span<const T> axisValues(std::size_t i = 0UZ) const { return axis_values[_axCheck(i)]; }
+    [[nodiscard]] std::string&       axisName(std::size_t axisIdx = 0UZ) { return axis_names[_axCheck(axisIdx)]; }
+    [[nodiscard]] std::string_view   axisName(std::size_t axisIdx = 0UZ) const { return axis_names[_axCheck(axisIdx)]; }
+    [[nodiscard]] std::string&       axisUnit(std::size_t axisIdx = 0UZ) { return axis_units[_axCheck(axisIdx)]; }
+    [[nodiscard]] std::string_view   axisUnit(std::size_t axisIdx = 0UZ) const { return axis_units[_axCheck(axisIdx)]; }
+    [[nodiscard]] std::span<T>       axisValues(std::size_t axisIdx = 0UZ) { return axis_values[_axCheck(axisIdx)]; }
+    [[nodiscard]] std::span<const T> axisValues(std::size_t axisIdx = 0UZ) const { return axis_values[_axCheck(axisIdx)]; }
 
     [[nodiscard]] constexpr std::size_t size() const noexcept { return signal_names.size(); }
-    [[nodiscard]] std::string&          signalName(std::size_t i = 0UZ) { return signal_names[_idxCheck(i)]; }
-    [[nodiscard]] std::string_view      signalName(std::size_t i = 0UZ) const { return signal_names[_idxCheck(i)]; }
-    [[nodiscard]] std::string&          signalQuantity(std::size_t i = 0UZ) { return signal_quantities[_idxCheck(i)]; }
-    [[nodiscard]] std::string_view      signalQuantity(std::size_t i = 0UZ) const { return signal_quantities[_idxCheck(i)]; }
-    [[nodiscard]] std::string&          signalUnit(std::size_t i = 0UZ) { return signal_units[_idxCheck(i)]; }
-    [[nodiscard]] std::string_view      signalUnit(std::size_t i = 0UZ) const { return signal_units[_idxCheck(i)]; }
-    [[nodiscard]] std::span<T>          signalValues(std::size_t i = 0UZ) { return {std::next(signal_values.data(), _idxCheckS(i) * _valsPerSigS()), _valsPerSig()}; }
-    [[nodiscard]] std::span<const T>    signalValues(std::size_t i = 0UZ) const { return {std::next(signal_values.data(), _idxCheckS(i) * _valsPerSigS()), _valsPerSig()}; }
-    [[nodiscard]] Range<T>&             signalRange(std::size_t i = 0UZ) { return signal_ranges[_idxCheck(i)]; }
-    [[nodiscard]] const Range<T>&       signalRange(std::size_t i = 0UZ) const { return signal_ranges[_idxCheck(i)]; }
+    [[nodiscard]] std::string&          signalName(std::size_t signalIdx = 0UZ) { return signal_names[_idxCheck(signalIdx)]; }
+    [[nodiscard]] std::string_view      signalName(std::size_t signalIdx = 0UZ) const { return signal_names[_idxCheck(signalIdx)]; }
+    [[nodiscard]] std::string&          signalQuantity(std::size_t signalIdx = 0UZ) { return signal_quantities[_idxCheck(signalIdx)]; }
+    [[nodiscard]] std::string_view      signalQuantity(std::size_t signalIdx = 0UZ) const { return signal_quantities[_idxCheck(signalIdx)]; }
+    [[nodiscard]] std::string&          signalUnit(std::size_t signalIdx = 0UZ) { return signal_units[_idxCheck(signalIdx)]; }
+    [[nodiscard]] std::string_view      signalUnit(std::size_t signalIdx = 0UZ) const { return signal_units[_idxCheck(signalIdx)]; }
+    [[nodiscard]] std::span<T>          signalValues(std::size_t signalIdx = 0UZ) { return {std::next(signal_values.data(), _idxCheckS(signalIdx) * _valsPerSigS()), _valsPerSig()}; }
+    [[nodiscard]] std::span<const T>    signalValues(std::size_t signalIdx = 0UZ) const { return {std::next(signal_values.data(), _idxCheckS(signalIdx) * _valsPerSigS()), _valsPerSig()}; }
+    [[nodiscard]] Range<T>&             signalRange(std::size_t signalIdx = 0UZ) { return signal_ranges[_idxCheck(signalIdx)]; }
+    [[nodiscard]] const Range<T>&       signalRange(std::size_t signalIdx = 0UZ) const { return signal_ranges[_idxCheck(signalIdx)]; }
 
 private:
     [[nodiscard]] std::size_t _axCheck(std::size_t i, std::source_location loc = std::source_location::current()) const {
         if (i >= axis_names.size()) {
-            throw gr::exception(fmt::format("{} axis out of range: i={} >= [0, {}]", loc.function_name(), i, axis_names.size()), loc);
+            throw gr::exception(fmt::format("{} axis out of range: i={} >= axis_name [0, {}]", loc.function_name(), i, axis_names.size()), loc);
+        }
+        if (i >= axis_values.size()) {
+            throw gr::exception(fmt::format("{} axis out of range: i={} >= axis_values [0, {}]", loc.function_name(), i, axis_values.size()), loc);
         }
         return i;
     }

--- a/meta/include/gnuradio-4.0/meta/UnitTestHelper.hpp
+++ b/meta/include/gnuradio-4.0/meta/UnitTestHelper.hpp
@@ -1,0 +1,104 @@
+#ifndef UNITTESTHELPER_HPP
+#define UNITTESTHELPER_HPP
+
+#include <boost/ut.hpp>
+#include <concepts>
+#include <cstddef>
+#include <fmt/format.h>
+#include <ranges>
+
+#include "formatter.hpp"
+
+namespace gr::test {
+using namespace boost::ut;
+
+template<typename T>
+concept HasSize = requires(const T c) {
+    { c.size() } -> std::convertible_to<std::size_t>;
+};
+
+template<typename T>
+concept Collection = std::ranges::range<T> && HasSize<T>;
+
+struct eq_collection_result {
+    bool                 success{};
+    std::string          message{};
+    std::source_location location = std::source_location::current();
+
+    operator bool() const { return success; }
+    friend std::ostream& operator<<(std::ostream& os, const eq_collection_result& r) { return os << r.message; }
+};
+
+template<Collection RangeLHS, Collection RangeRHS>
+requires std::is_same_v<std::ranges::range_value_t<RangeLHS>, std::ranges::range_value_t<RangeRHS>>
+auto eq_collections(const RangeLHS& LHS, const RangeRHS& RHS, std::size_t contextWindow = 3, std::source_location location = std::source_location::current()) -> eq_collection_result {
+    const auto sizeLHS = LHS.size();
+    const auto sizeRHS = RHS.size();
+    if (sizeLHS != sizeRHS) {
+        return {false, fmt::format("Collections size mismatch: LHS.size()={}, RHS.size()={}", sizeLHS, sizeRHS), location};
+    }
+
+    auto firstMismatch = std::ranges::mismatch(LHS, RHS);
+    if (firstMismatch.in1 == LHS.end()) { // ferfect match
+        return {true, fmt::format("Collections match ({} elements)", sizeLHS), location};
+    }
+
+    // define context window around first mismatched value
+    const std::ptrdiff_t idx         = std::distance(LHS.begin(), firstMismatch.in1);
+    const std::ptrdiff_t ctxStartIdx = idx < static_cast<std::ptrdiff_t>(contextWindow) ? 0 : (idx - static_cast<std::ptrdiff_t>(contextWindow));
+    const std::ptrdiff_t ctxStopIdx  = std::min<std::ptrdiff_t>(static_cast<std::ptrdiff_t>(sizeLHS), idx + static_cast<std::ptrdiff_t>(contextWindow) + 1);
+
+    std::ostringstream ctxLHS, ctxRHS;
+    for (auto i = ctxStartIdx; i < ctxStopIdx; ++i) {
+        ctxLHS << *std::next(LHS.begin(), i) << ' ';
+        ctxRHS << *std::next(RHS.begin(), i) << ' ';
+    }
+
+    return {false,
+        fmt::format("Collections differ at index={idx}; LHS[{idx}]={lhs} vs RHS[{idx}]={rhs}\nContext window [{ctx_start}, {ctx_end}]:\n  left:  {lhs_context}\n  right: {rhs_context}", //
+            fmt::arg("idx", idx), fmt::arg("lhs", *firstMismatch.in1), fmt::arg("rhs", *firstMismatch.in2),                                                                              //
+            fmt::arg("ctx_start", ctxStartIdx), fmt::arg("ctx_end", ctxStopIdx - 1), fmt::arg("lhs_context", ctxLHS.str()), fmt::arg("rhs_context", ctxRHS.str())),
+        location};
+}
+
+template<Collection RangeLHS, Collection RangeRHS, typename T = std::ranges::range_value_t<RangeRHS>>
+requires std::is_same_v<std::ranges::range_value_t<RangeLHS>, std::ranges::range_value_t<RangeRHS>>
+auto approx_collections(const RangeLHS& LHS, const RangeRHS& RHS, T tolerance, std::size_t contextWindow = 3, std::source_location location = std::source_location::current()) -> eq_collection_result {
+    const auto sizeLHS = LHS.size();
+    const auto sizeRHS = RHS.size();
+    if (sizeLHS != sizeRHS) {
+        return {false, fmt::format("Collections size mismatch: LHS.size()={}, RHS.size()={}", sizeLHS, sizeRHS), location};
+    }
+
+    const auto pred = [tolerance](auto const& lhsValue, auto const& rhsValue) noexcept {
+        auto diff = (lhsValue > rhsValue) ? lhsValue - rhsValue : rhsValue - lhsValue;
+        return diff <= tolerance;
+    };
+
+    // define context window around first mismatched value with custom predicate
+    auto firstMismatch = std::ranges::mismatch(LHS, RHS, pred);
+    if (firstMismatch.in1 == LHS.end()) {
+        return {true, fmt::format("Collections approx match ({} elements) within tolerance={}", sizeLHS, tolerance), location};
+    }
+
+    // define context window around first mismatched value
+    const std::ptrdiff_t idx         = std::distance(LHS.begin(), firstMismatch.in1);
+    const std::ptrdiff_t ctxStartIdx = idx < static_cast<std::ptrdiff_t>(contextWindow) ? 0 : (idx - static_cast<std::ptrdiff_t>(contextWindow));
+    const std::ptrdiff_t ctxStopIdx  = std::min<std::ptrdiff_t>(static_cast<std::ptrdiff_t>(sizeLHS), idx + static_cast<std::ptrdiff_t>(contextWindow) + 1);
+
+    std::ostringstream ctxLHS, ctxRHS;
+    for (auto i = ctxStartIdx; i < ctxStopIdx; ++i) {
+        ctxLHS << *std::next(LHS.begin(), i) << ' ';
+        ctxRHS << *std::next(RHS.begin(), i) << ' ';
+    }
+
+    return {false,
+        fmt::format("Collections differ (approx) at index={idx}; LHS[{idx}]={lhs} vs RHS[{idx}]={rhs} (tolerance={tol})\nContext window [{ctx_start}, {ctx_end}]:\n  left:  {lhs_context}\n  right: {rhs_context}", //
+            fmt::arg("idx", idx), fmt::arg("lhs", *firstMismatch.in1), fmt::arg("rhs", *firstMismatch.in2), fmt::arg("tol", tolerance),                                                                             //
+            fmt::arg("ctx_start", ctxStartIdx), fmt::arg("ctx_end", ctxStopIdx - 1), fmt::arg("lhs_context", ctxLHS.str()), fmt::arg("rhs_context", ctxRHS.str())),
+        location};
+}
+
+} // namespace gr::test
+
+#endif // UNITTESTHELPER_HPP


### PR DESCRIPTION
 * added missing fields/init/defs for axis, meta-information, timing-events
 * added 'checkDataSetConsistency(..)' helper functions
 * added unit-test helper `[eq, approx]_collections` compatible with UT framework
 * cleaned-up/simplified unit-test
 * added visual representation
 * renamed DataSet parameter idx names (should make the semantic more 'nomen-est-omen' for users of that API)
 * changed from ramp to sine test-signal to better identify frequency mapping
 * fixed complex-value FFT ordering (shift was missing)
   - related: added optional boolean `shiftSpectrum` parameter to `compute[Magnitude, Phase]Spectrum(..)`

 Additional minor fixes:
  * ImChart: clamp DataSet signal names to chart width
  * ImChart: add additional selected signal parameter (default: draw all)
  * DataSetMath: added missing include
  * DataSetTestFunctions: fixed extends (needed to be 1D)
  * StreamToDataSet: fixed extends (needed to be 1D)
  
Visual examples:
  
![image](https://github.com/user-attachments/assets/3fdc391b-9281-4761-aa52-f9551d1385fc)

![image](https://github.com/user-attachments/assets/aa097ea5-73a4-43ff-a7f4-1d84ea2bc2f7)
