### PR TITLE
DataSink: Create consistent DataSet for Trigger, Multiplexed and Snap…

### DIFF
--- a/algorithm/include/gnuradio-4.0/algorithm/dataset/DataSetEstimators.hpp
+++ b/algorithm/include/gnuradio-4.0/algorithm/dataset/DataSetEstimators.hpp
@@ -492,8 +492,10 @@ struct StepStartDetectionResult {
 template<MetaInfo mode = MetaInfo::Apply, DataSetLike D, typename T = typename std::remove_cvref_t<D>::value_type, typename TValue = gr::meta::fundamental_base_value_type_t<T>>
 std::optional<StepStartDetectionResult<T>> detectStepStart(D& ds, TValue threshold = TValue(0.5), std::size_t indexMin = 0UZ, std::size_t indexMax = max_size_t, std::size_t signalIndex = 0UZ, std::source_location location = std::source_location::current()) {
     constexpr bool isConstDataSet = std::is_const_v<std::remove_reference_t<D>>;
-    if (!gr::dataset::verify<true>(ds)) {
-        throw gr::exception("Invalid DataSet for step/pulse start detection.");
+
+    std::expected<void, gr::Error> dsCheck = gr::dataset::checkConsistency(ds, "", location);
+    if (!dsCheck.has_value()) {
+        throw gr::exception(fmt::format("Invalid DataSet for step/pulse start detection: {}", dsCheck.error()), location);
     }
     indexMax = detail::checkIndexRange(ds, indexMin, indexMax, signalIndex, location);
 

--- a/algorithm/include/gnuradio-4.0/algorithm/dataset/DataSetUtils.hpp
+++ b/algorithm/include/gnuradio-4.0/algorithm/dataset/DataSetUtils.hpp
@@ -26,7 +26,7 @@ template<DataSetLike TDataSet>
         return false;
     }
 
-    std::expected<void, gr::Error> dsCheck = dataset::detail::checkDataSetConsistency(dataSet);
+    std::expected<void, gr::Error> dsCheck = dataset::checkConsistency(dataSet);
     if (!dsCheck) {
         throw gr::exception(fmt::format("draw(const DataSet&, ...) - DataSet is not consistent - Error:\n{}", dsCheck.error().message), location);
     }

--- a/algorithm/test/qa_DataSetEstimators.cpp
+++ b/algorithm/test/qa_DataSetEstimators.cpp
@@ -37,7 +37,8 @@ const boost::ut::suite<"DataSet<T> visual test functions"> _DataSetTestFcuntions
         gr::DataSet<T> ds = generate::triangular<T>("triagonal", nSamples);
         gr::dataset::draw(ds);
 
-        expect(gr::dataset::verify<true>(ds));
+        std::expected<void, gr::Error> dsCheck = gr::dataset::checkConsistency(ds);
+        expect(dsCheck.has_value()) << [&] { return fmt::format("unexpected: {}", dsCheck.error()); } << fatal;
 
         gr::DataSet<T> ds1 = generate::triangular<double>("triagonal - odd", 11);
         fmt::println("\"{:20}\": {}", ds1.signalName(0UZ), ds1.signal_values);
@@ -51,8 +52,9 @@ const boost::ut::suite<"DataSet<T> visual test functions"> _DataSetTestFcuntions
     };
 
     "ramp DataSet"_test = []<typename T = double> {
-        gr::DataSet<T> ds = generate::ramp<T>("ramp", nSamples);
-        expect(gr::dataset::verify<true>(ds));
+        gr::DataSet<T>                 ds      = generate::ramp<T>("ramp", nSamples);
+        std::expected<void, gr::Error> dsCheck = gr::dataset::checkConsistency(ds);
+        expect(dsCheck.has_value()) << [&] { return fmt::format("unexpected: {}", dsCheck.error()); } << fatal;
         gr::dataset::draw(ds);
     };
 
@@ -61,8 +63,9 @@ const boost::ut::suite<"DataSet<T> visual test functions"> _DataSetTestFcuntions
         constexpr T sigma         = T(nSamples) / T(10);
         const T     normalisation = sigma * gr::math::sqrt(T(2) * std::numbers::pi_v<T>);
 
-        gr::DataSet<T> ds = generate::gaussFunction<T>("gaussFunction", nSamples, mean, sigma, T(0), normalisation);
-        expect(gr::dataset::verify<true>(ds));
+        gr::DataSet<T>                 ds      = generate::gaussFunction<T>("gaussFunction", nSamples, mean, sigma, T(0), normalisation);
+        std::expected<void, gr::Error> dsCheck = gr::dataset::checkConsistency(ds);
+        expect(dsCheck.has_value()) << [&] { return fmt::format("unexpected: {}", dsCheck.error()); } << fatal;
         gr::dataset::draw(ds);
     };
 
@@ -76,13 +79,15 @@ const boost::ut::suite<"DataSet<T> visual test functions"> _DataSetTestFcuntions
         gr::DataSet<T> ds2 = generate::gaussFunction<T>("gaussFunction", nSamples, mean, sigma, T(0), normalisation);
         gr::DataSet<T> ds  = addFunction(ds1, ds2);
 
-        expect(gr::dataset::verify<true>(ds));
+        std::expected<void, gr::Error> dsCheck = gr::dataset::checkConsistency(ds);
+        expect(dsCheck.has_value()) << [&] { return fmt::format("unexpected: {}", dsCheck.error()); } << fatal;
         gr::dataset::draw(ds);
     };
 
     "randomStepFunction DataSet"_test = []<typename T = double> {
-        gr::DataSet<T> ds = generate::randomStepFunction<T>("randomStepFunction", nSamples);
-        expect(gr::dataset::verify<true>(ds));
+        gr::DataSet<T>                 ds      = generate::randomStepFunction<T>("randomStepFunction", nSamples);
+        std::expected<void, gr::Error> dsCheck = gr::dataset::checkConsistency(ds);
+        expect(dsCheck.has_value()) << [&] { return fmt::format("unexpected: {}", dsCheck.error()); } << fatal;
         gr::dataset::draw(ds);
     };
 };

--- a/blocks/basic/test/qa_DataSink.cpp
+++ b/blocks/basic/test/qa_DataSink.cpp
@@ -10,6 +10,7 @@
 #include <gnuradio-4.0/Buffer.hpp>
 #include <gnuradio-4.0/Graph.hpp>
 #include <gnuradio-4.0/Scheduler.hpp>
+#include <gnuradio-4.0/meta/UnitTestHelper.hpp>
 #include <gnuradio-4.0/meta/reflection.hpp>
 
 #include <gnuradio-4.0/basic/DataSink.hpp>
@@ -243,26 +244,6 @@ bool spinUntil(std::chrono::milliseconds timeout, auto fnc) {
     return false;
 }
 
-template<typename T>
-void testBasicsDataSet(const DataSet<T>& ds, std::source_location location = std::source_location::current()) {
-    using namespace boost::ut;
-
-    expect(eq(ds.extents.size(), 1UZ)) << fmt::format("Error line: {}\n", location.line());
-    if (ds.extents.size() >= 1) {
-        expect(eq(static_cast<std::size_t>(ds.extents[0]), ds.signal_values.size())) << fmt::format("Error line: {}\n", location.line());
-    }
-    expect(eq(ds.axis_values.size(), 1UZ));
-    if (ds.axis_values.size() >= 1) {
-        expect(eq(ds.axis_values[0].size(), ds.signal_values.size())) << fmt::format("Error line: {}\n", location.line());
-        expect(std::ranges::is_sorted(ds.axis_values[0])) << fmt::format("Error line: {}\n", location.line());
-    }
-
-    std::expected<void, gr::Error> dsCheck = dataset::detail::checkDataSetConsistency(ds);
-    if (!dsCheck) {
-        expect(false) << fmt::format("DataSet is not consistent - Error line: {}, Error:\n{}", location.line(), dsCheck.error().message);
-    }
-}
-
 } // namespace gr::basic::data_sink_test
 
 template<typename T>
@@ -285,6 +266,7 @@ const boost::ut::suite DataSinkTests = [] {
     using namespace gr::basic;
     using namespace gr::basic::data_sink_test;
     using namespace std::string_literals;
+    using namespace gr::test;
 
     "callback continuous mode"_test = [] {
         constexpr gr::Size_t  kSamples   = 200005;
@@ -466,7 +448,7 @@ const boost::ut::suite DataSinkTests = [] {
         expect(eq(nonMetadataTags.size(), tags.size()));
         expect(eq(indexesMatch(nonMetadataTags, tags), true)) << fmt::format("{} != {}", formatList(nonMetadataTags), formatList(tags));
         expect(eq(metadataTags.size(), 1UZ));
-        expect(eq(metadataTags[0].index, 0UZ));
+        expect(eq(metadataTags[0UZ].index, 0UZ));
         const auto metadata = latestMetadata(metadataTags);
         expect(eq(metadata.signal_name.value_or("<unset>"), "test signal"s));
         expect(eq(metadata.signal_unit.value_or("<unset>"), "test unit"s));
@@ -509,18 +491,17 @@ const boost::ut::suite DataSinkTests = [] {
                 [[maybe_unused]] auto r = poller->process([&receivedData, &receivedTags](const auto& datasets) {
                     for (const auto& dataset : datasets) {
                         receivedData.insert(receivedData.end(), dataset.signal_values.begin(), dataset.signal_values.end());
+                        std::expected<void, gr::Error> dsCheck = dataset::checkConsistency(dataset, "dataset - blocking polling trigger mode non-overlapping");
+                        expect(dsCheck.has_value()) << [&] { return fmt::format("unexpected: {}", dsCheck.error()); } << fatal;
+                        expect(eq(dataset.size(), 1UZ)) << "DataSink supports only 1 signal per DataSet<T> (for the time being)";
+
                         // signal info from sink settings
-                        expect(eq(dataset.signal_names.size(), 1u));
-                        expect(eq(dataset.signal_units.size(), 1u));
-                        expect(eq(dataset.signal_ranges.size(), 1u));
-                        expect(eq(dataset.timing_events.size(), 1u));
-                        expect(eq(dataset.signal_names[0], "test signal"s));
-                        expect(eq(dataset.signal_units[0], "none"s));
-                        expect(eq(dataset.signal_ranges[0], gr::Range<std::int32_t>{-2, +2}));
-                        expect(eq(dataset.timing_events[0].size(), 1u));
-                        expect(eq(dataset.timing_events[0][0].first, 3));
-                        receivedTags.insert(receivedTags.end(), dataset.timing_events[0].begin(), dataset.timing_events[0].end());
-                        testBasicsDataSet(dataset);
+                        expect(eq(dataset.signalName(0UZ), "test signal"s));
+                        expect(eq(dataset.signalUnit(0UZ), "none"s));
+                        expect(eq(dataset.signalRange(0UZ), gr::Range<std::int32_t>{-2, +2}));
+                        expect(eq(dataset.timingEvents(0UZ).size(), 1UZ));
+                        expect(eq(dataset.timingEvents(0UZ)[0UZ].first, 3));
+                        receivedTags.insert(receivedTags.end(), dataset.timingEvents(0UZ).begin(), dataset.timingEvents(0UZ).end());
                     }
                 });
             }
@@ -531,7 +512,7 @@ const boost::ut::suite DataSinkTests = [] {
         expect(sched.runAndWait().has_value());
 
         const auto& [poller, receivedData, receivedTags] = polling.get();
-        const auto expected_tags                         = {tags[0], tags[2]}; // triggers-only
+        const auto expected_tags                         = {tags[0UZ], tags[2UZ]}; // triggers-only
 
         expect(eq(receivedData.size(), 10UZ));
         expect(eq(receivedData, std::vector<int32_t>{2997, 2998, 2999, 3000, 3001, 179997, 179998, 179999, 180000, 180001}));
@@ -577,18 +558,17 @@ const boost::ut::suite DataSinkTests = [] {
                 [[maybe_unused]] auto r = poller->process([&receivedData, &receivedTags](const auto& datasets) {
                     for (const auto& dataset : datasets) {
                         receivedData.insert(receivedData.end(), dataset.signal_values.begin(), dataset.signal_values.end());
+                        std::expected<void, gr::Error> dsCheck = dataset::checkConsistency(dataset, "DataSet");
+                        expect(dsCheck.has_value()) << [&] { return fmt::format("unexpected: {}", dsCheck.error()); } << fatal;
+                        expect(eq(dataset.size(), 1UZ)) << "DataSink supports only 1 signal per DataSet<T> (for the time being)";
+
                         // signal info from sink settings
-                        expect(eq(dataset.signal_names.size(), 1u));
-                        expect(eq(dataset.signal_units.size(), 1u));
-                        expect(eq(dataset.signal_ranges.size(), 1u));
-                        expect(eq(dataset.timing_events.size(), 1u));
-                        expect(eq(dataset.signal_names[0], "test signal"s));
-                        expect(eq(dataset.signal_units[0], "no unit"s));
-                        expect(eq(dataset.signal_ranges[0], gr::Range<std::int32_t>{-2, +2}));
-                        expect(eq(dataset.timing_events[0].size(), 1UZ));
-                        expect(eq(dataset.timing_events[0][0].first, 0));
-                        receivedTags.insert(receivedTags.end(), dataset.timing_events[0].begin(), dataset.timing_events[0].end());
-                        testBasicsDataSet(dataset);
+                        expect(eq(dataset.signalName(0UZ), "test signal"s));
+                        expect(eq(dataset.signalUnit(0UZ), "no unit"s));
+                        expect(eq(dataset.signalRange(0UZ), gr::Range<std::int32_t>{-2, +2}));
+                        expect(eq(dataset.timingEvents(0UZ).size(), 1UZ));
+                        expect(eq(dataset.timingEvents(0UZ)[0UZ].first, 0));
+                        receivedTags.insert(receivedTags.end(), dataset.timingEvents(0UZ).begin(), dataset.timingEvents(0UZ).end());
                     }
                 });
             }
@@ -641,18 +621,16 @@ const boost::ut::suite DataSinkTests = [] {
                 seenFinished            = poller->finished;
                 [[maybe_unused]] auto r = poller->process([&receivedData](const auto& datasets) {
                     for (const auto& dataset : datasets) {
+                        std::expected<void, gr::Error> dsCheck = dataset::checkConsistency(dataset, "dataset blocking snapshot mode");
+                        expect(dsCheck.has_value()) << [&] { return fmt::format("unexpected: {}", dsCheck.error()); } << fatal;
+                        expect(eq(dataset.size(), 1UZ)) << "DataSink supports only 1 signal per DataSet<T> (for the time being)";
+
                         // signal info propagated from source to sink
-                        expect(eq(dataset.signal_names.size(), 1u));
-                        expect(eq(dataset.signal_units.size(), 1u));
-                        expect(eq(dataset.signal_ranges.size(), 1u));
-                        expect(eq(dataset.timing_events.size(), 1u));
-                        expect(eq(dataset.signal_names[0], "test signal"s));
-                        expect(eq(dataset.signal_units[0], "none"s));
-                        expect(eq(dataset.signal_ranges[0], gr::Range<int32_t>{0, kSamples - 1}));
-                        expect(eq(dataset.timing_events[0].size(), 1u));
-                        expect(eq(dataset.timing_events[0][0].first, -5000));
+                        expect(eq(dataset.signalName(0UZ), "test signal"s));
+                        expect(eq(dataset.signalUnit(0UZ), "none"s));
+                        expect(eq(dataset.signalRange(0UZ), gr::Range<int32_t>{0, kSamples - 1}));
+                        expect(eq(dataset.timingEvents(0UZ)[0UZ].first, -5000));
                         receivedData.insert(receivedData.end(), dataset.signal_values.begin(), dataset.signal_values.end());
-                        testBasicsDataSet(dataset);
                     }
                 });
             }
@@ -733,15 +711,15 @@ const boost::ut::suite DataSinkTests = [] {
                     seenFinished = poller->finished.load();
                     while (poller->process([&ranges](const auto& datasets) {
                         for (const auto& dataset : datasets) {
+                            std::expected<void, gr::Error> dsCheck = dataset::checkConsistency(dataset, "dataset - blocking multiplexed mode");
+                            expect(dsCheck.has_value()) << [&] { return fmt::format("unexpected: {}", dsCheck.error()); } << fatal;
+                            expect(eq(dataset.size(), 1UZ)) << "DataSink supports only 1 signal per DataSet<T> (for the time being)";
+
                             // default signal info, we didn't set anything
-                            expect(eq(dataset.signal_names.size(), 1u));
-                            expect(eq(dataset.signal_units.size(), 1u));
-                            expect(eq(dataset.timing_events.size(), 1u));
-                            expect(eq(dataset.signal_names[0], "test signal"s));
-                            expect(eq(dataset.signal_units[0], "a.u."s));
+                            expect(eq(dataset.signalName(0UZ), "test signal"s));
+                            expect(eq(dataset.signalUnit(0UZ), "a.u."s));
                             ranges.push_back(dataset.signal_values.front());
                             ranges.push_back(dataset.signal_values.back());
-                            testBasicsDataSet(dataset);
                         }
                     })) {
                     }
@@ -796,15 +774,17 @@ const boost::ut::suite DataSinkTests = [] {
                 seenFinished = poller->finished.load();
                 while (poller->process([&receivedData, &receivedTags](const auto& datasets) {
                     for (const auto& dataset : datasets) {
+                        std::expected<void, gr::Error> dsCheck = dataset::checkConsistency(dataset, "dataset - blocking polling trigger mode overlapping");
+                        expect(dsCheck.has_value()) << [&] { return fmt::format("unexpected: {}", dsCheck.error()); } << fatal;
+                        expect(eq(dataset.size(), 1UZ)) << "DataSink supports only 1 signal per DataSet<T> (for the time being)";
+
                         expect(eq(dataset.signal_values.size(), 5000u) >> fatal);
                         receivedData.push_back(dataset.signal_values.front());
                         receivedData.push_back(dataset.signal_values.back());
-                        expect(eq(dataset.timing_events.size(), 1u));
-                        expect(eq(dataset.timing_events[0].size(), 1u));
-                        expect(eq(dataset.timing_events[0][0].first, 3000));
-                        auto absolute = dataset.timing_events[0] | std::views::transform([&receivedData](const auto& t) { return gr::Tag{checkedSum(receivedData.size(), t.first), t.second}; });
+                        expect(eq(dataset.timingEvents(0UZ).size(), 1UZ));
+                        expect(eq(dataset.timingEvents(0UZ)[0UZ].first, 3000));
+                        auto absolute = dataset.timingEvents(0UZ) | std::views::transform([&receivedData](const auto& t) { return gr::Tag{checkedSum(receivedData.size(), t.first), t.second}; });
                         receivedTags.insert(receivedTags.end(), absolute.begin(), absolute.end());
-                        testBasicsDataSet(dataset);
                     }
                 })) {
                 }
@@ -948,15 +928,17 @@ const boost::ut::suite DataSinkTests = [] {
 
         const auto& [poller, receivedDataSets] = polling.get();
         expect(eq(receivedDataSets.size(), 2UZ));
-        expect(eq(receivedDataSets[0].signal_values, getIota(300, 300.f)));
-        expect(eq(receivedDataSets[0].signal_names, std::vector{"test signal"s}));
-        expect(eq(receivedDataSets[0].signal_units, std::vector{"test unit"s}));
-        expect(eq(receivedDataSets[0].timing_events.size(), 1UZ));
-        expect(eq(receivedDataSets[0].timing_events[0].size(), 0UZ));
-        expect(eq(receivedDataSets[1].signal_values, getIota(300, 700.f)));
-        expect(eq(receivedDataSets[1].signal_names, std::vector{"test signal"s}));
-        expect(eq(receivedDataSets[1].signal_units, std::vector{"test unit"s}));
-        testBasicsDataSet(receivedDataSets[1]);
+        std::expected<void, gr::Error> dsCheck = dataset::checkConsistency(receivedDataSets[1UZ], "receivedDataSets[1UZ]");
+        expect(dsCheck.has_value()) << [&] { return fmt::format("unexpected: {}", dsCheck.error()); } << fatal;
+        expect(eq(receivedDataSets[1UZ].size(), 1UZ)) << "DataSink supports only 1 signal per DataSet<T> (for the time being)";
+
+        expect(eq_collections(receivedDataSets[0UZ].signalValues(0UZ), getIota(300, 300.f)));
+        expect(eq(receivedDataSets[0UZ].signalName(0UZ), "test signal"s));
+        expect(eq(receivedDataSets[0UZ].signalUnit(0UZ), "test unit"s));
+        expect(eq(receivedDataSets[0UZ].timingEvents(0UZ).size(), 0UZ));
+        expect(eq_collections(receivedDataSets[1UZ].signalValues(0UZ), getIota(300, 700.f)));
+        expect(eq(receivedDataSets[1UZ].signalName(0UZ), "test signal"s));
+        expect(eq(receivedDataSets[1UZ].signalUnit(0UZ), "test unit"s));
     };
 
     "data set callback"_test = [] {
@@ -990,15 +972,17 @@ const boost::ut::suite DataSinkTests = [] {
         registerThread.join();
 
         expect(eq(receivedDataSets.size(), 2UZ));
-        expect(eq(receivedDataSets[0].signal_values, getIota(300, 300.f)));
-        expect(eq(receivedDataSets[0].signal_names, std::vector{"test signal"s}));
-        expect(eq(receivedDataSets[0].signal_units, std::vector{"test unit"s}));
-        expect(eq(receivedDataSets[0].timing_events.size(), 1UZ));
-        expect(eq(receivedDataSets[0].timing_events[0].size(), 0UZ));
-        expect(eq(receivedDataSets[1].signal_values, getIota(300, 700.f)));
-        expect(eq(receivedDataSets[1].signal_names, std::vector{"test signal"s}));
-        expect(eq(receivedDataSets[1].signal_units, std::vector{"test unit"s}));
-        testBasicsDataSet(receivedDataSets[1]);
+        std::expected<void, gr::Error> dsCheck = dataset::checkConsistency(receivedDataSets[1UZ], "receivedDataSets[1UZ]");
+        expect(dsCheck.has_value()) << [&] { return fmt::format("unexpected: {}", dsCheck.error()); } << fatal;
+        expect(eq(receivedDataSets[1UZ].size(), 1UZ)) << "DataSink supports only 1 signal per DataSet<T> (for the time being)";
+
+        expect(eq_collections(receivedDataSets[0UZ].signalValues(0UZ), getIota(300, 300.f)));
+        expect(eq(receivedDataSets[0UZ].signalName(0UZ), "test signal"s));
+        expect(eq(receivedDataSets[0UZ].signalUnit(0UZ), "test unit"s));
+        expect(eq(receivedDataSets[0UZ].timingEvents(0UZ).size(), 0UZ));
+        expect(eq_collections(receivedDataSets[1UZ].signalValues(0UZ), getIota(300, 700.f)));
+        expect(eq(receivedDataSets[1UZ].signalName(0UZ), "test signal"s));
+        expect(eq(receivedDataSets[1UZ].signalUnit(0UZ), "test unit"s));
     };
 };
 

--- a/blocks/basic/test/qa_StreamToDataSet.cpp
+++ b/blocks/basic/test/qa_StreamToDataSet.cpp
@@ -230,7 +230,7 @@ const boost::ut::suite<"StreamToDataSet test"> streamToDataSetTest = [] {
         expect(eq(dataSetSink._samples.size(), expectedValues.size()));
         for (std::size_t i = 0; i < dataSetSink._samples.size(); i++) {
             const DataSet<float>&          ds      = dataSetSink._samples.at(i);
-            std::expected<void, gr::Error> dsCheck = dataset::detail::checkDataSetConsistency(ds, "TestDataSet");
+            std::expected<void, gr::Error> dsCheck = dataset::checkConsistency(ds, "TestDataSet");
             expect(dsCheck.has_value()) << [&] { return fmt::format("unexpected: {}", dsCheck.error()); } << fatal;
             expect(std::ranges::equal(ds.signal_values, expectedValues[i]));
 

--- a/blocks/fourier/test/qa_fourier.cpp
+++ b/blocks/fourier/test/qa_fourier.cpp
@@ -69,7 +69,7 @@ const boost::ut::suite<"Fourier Transforms"> fftTests = [] {
         std::span<OutType>   outSpan(v);
 
         expect(gr::work::Status::OK == fftBlock.processBulk(signal, outSpan));
-        std::expected<void, gr::Error> dsCheck = dataset::detail::checkDataSetConsistency(v[0], fmt::format("TestDataSet({} -> {})", gr::meta::type_name<InType>(), gr::meta::type_name<OutType>()));
+        std::expected<void, gr::Error> dsCheck = dataset::checkConsistency(v[0], fmt::format("TestDataSet({} -> {})", gr::meta::type_name<InType>(), gr::meta::type_name<OutType>()));
         expect(dsCheck.has_value()) << [&] { return fmt::format("unexpected: {}", dsCheck.error()); } << fatal;
 
         // check for DataSet equality

--- a/core/include/gnuradio-4.0/DataSet.hpp
+++ b/core/include/gnuradio-4.0/DataSet.hpp
@@ -91,6 +91,7 @@ struct DataSet {
     using value_type           = T;
     using tensor_layout_type   = std::variant<LayoutRight, LayoutLeft, std::string>;
     using pmt_map              = pmtv::map_t;
+    using idx_pmt_map          = std::pair<std::ptrdiff_t, pmt_map>;
     T            default_value = T(); // default value for padding, ZOH etc.
     std::int64_t timestamp     = 0;   // UTC timestamp [ns]
 
@@ -111,8 +112,8 @@ struct DataSet {
     std::vector<Range<T>>    signal_ranges{};     // [[min_0, max_0], [min_1, max_1], …] used for communicating, for example, HW limits
 
     // meta data
-    std::vector<pmt_map>                                                  meta_information{};
-    std::vector<std::vector<std::pair<std::ptrdiff_t, gr::property_map>>> timing_events{};
+    std::vector<pmt_map>                  meta_information{};
+    std::vector<std::vector<idx_pmt_map>> timing_events{};
 
     GR_MAKE_REFLECTABLE(DataSet, timestamp, axis_names, axis_units, axis_values, extents, layout, signal_names, signal_quantities, signal_units, signal_values, signal_ranges, meta_information, timing_events);
 
@@ -137,6 +138,11 @@ struct DataSet {
     [[nodiscard]] std::span<const T>    signalValues(std::size_t signalIdx = 0UZ) const { return {std::next(signal_values.data(), _idxCheckS(signalIdx) * _valsPerSigS()), _valsPerSig()}; }
     [[nodiscard]] Range<T>&             signalRange(std::size_t signalIdx = 0UZ) { return signal_ranges[_idxCheck(signalIdx)]; }
     [[nodiscard]] const Range<T>&       signalRange(std::size_t signalIdx = 0UZ) const { return signal_ranges[_idxCheck(signalIdx)]; }
+
+    [[nodiscard]] pmt_map&                     metaInformation(std::size_t signalIdx = 0UZ) { return meta_information[_idxCheck(signalIdx)]; }
+    [[nodiscard]] const pmt_map&               metaInformation(std::size_t signalIdx = 0UZ) const { return meta_information[_idxCheck(signalIdx)]; }
+    [[nodiscard]] std::span<idx_pmt_map>       timingEvents(std::size_t signalIdx = 0UZ) { return timing_events[_idxCheck(signalIdx)]; }
+    [[nodiscard]] std::span<const idx_pmt_map> timingEvents(std::size_t signalIdx = 0UZ) const { return timing_events[_idxCheck(signalIdx)]; }
 
 private:
     [[nodiscard]] std::size_t _axCheck(std::size_t i, std::source_location loc = std::source_location::current()) const {


### PR DESCRIPTION
Ensure a consistent `DataSet` structure for `Trigger`, `Multiplexed`, and `Snapshot` modes.

- `DataSet::axis_values` and `DataSet::extents` are now correctly initialized.
- Additional tests were implemented.