### PR TITLE
Fix formatters build on F41, make fmt11-proof

### DIFF
--- a/blocks/soapy/test/qa_Soapy.cpp
+++ b/blocks/soapy/test/qa_Soapy.cpp
@@ -25,6 +25,7 @@ const boost::ut::suite<"basic SoapySDR API "> basicSoapyAPI = [] {
     using namespace boost::ut;
     using namespace gr;
     using namespace gr::blocks::soapy;
+    using gr::blocks::soapy::Range;
 
     "helper functions"_test = [] { "range printer"_test = [] { expect(eq(fmt::format("{}", gr::blocks::soapy::Range{1.0, 10.0, 0.5}), std::string("Range{min: 1, max: 10, step: 0.5}"))); }; };
 

--- a/meta/include/gnuradio-4.0/meta/formatter.hpp
+++ b/meta/include/gnuradio-4.0/meta/formatter.hpp
@@ -126,7 +126,7 @@ struct formatter<gr::Range<T>> {
     constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
 
     template<typename FormatContext>
-    auto format(const gr::Range<T>& range, FormatContext& ctx) {
+    auto format(const gr::Range<T>& range, FormatContext& ctx) const {
         return fmt::format_to(ctx.out(), "[min: {}, max: {}]", range.min, range.max);
     }
 };

--- a/meta/include/gnuradio-4.0/meta/formatter.hpp
+++ b/meta/include/gnuradio-4.0/meta/formatter.hpp
@@ -268,6 +268,8 @@ struct fmt::formatter<std::vector<bool>> {
     }
 };
 
+#if FMT_VERSION < 110000
+/* fmt introduces a std::expected formatter with version 11.0.0 */
 template<typename Value, typename Error>
 struct fmt::formatter<std::expected<Value, Error>> {
     constexpr auto parse(format_parse_context& ctx) const noexcept -> decltype(ctx.begin()) { return ctx.begin(); }
@@ -281,5 +283,5 @@ struct fmt::formatter<std::expected<Value, Error>> {
         }
     }
 };
-
+#endif
 #endif // GNURADIO_FORMATTER_HPP

--- a/meta/test/qa_formatter.cpp
+++ b/meta/test/qa_formatter.cpp
@@ -108,11 +108,16 @@ const boost::ut::suite expectedFormatter = [] {
 
     auto value = fmt::format("{}", Expected(5));
     fmt::println("expected formatter test: {}", value);
-    expect(eq(value, "<std::expected-value: 5>"s));
 
     auto error = fmt::format("{}", Expected(std::unexpected("Error")));
     fmt::println("expected formatter test: {}", error);
+#if FMT_VERSION < 110000
+    expect(eq(value, "<std::expected-value: 5>"s));
     expect(eq(error, "<std::unexpected: Error>"s));
+#else
+    expect(eq(value, "expected(5)"s));
+    expect(eq(error, "unexpected(\"Error\")"s));
+#endif
 };
 
 const boost::ut::suite<"Range<T> formatter"> _rangeFormatter = [] {


### PR DESCRIPTION
- **soapy QA: make Range unambiguous**
- **formatters: Range format() should be const**
- **formatters: only implement std::expected formatter if fmt < 11.0.0**

The build of qa_formatters failed for reasons of lacking constness; so fixed that.

While I was at it, fixed related alias resolution ambiguity making soapy stuff ftb.

And since at that point it was worth trying: with this changeset, GR4 also builds with fmt 11, not only 10.
