### PR TITLE
Add Complex Conjugate  block with tests 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,7 +231,9 @@ endif()
 
 # include header-only libraries that have been inlined to simplify builds w/o requiring access to the internet
 if(NOT (TARGET magic_enum))
-  add_library(magic_enum INTERFACE)
+  add_library(magic_enum INTERFACE
+          blocks/basic/include/gnuradio-4.0/basic/ClockSource.hpp
+          blocks/basic/include/gnuradio-4.0/basic/ClockSource.hpp)
   target_include_directories(magic_enum ${CMAKE_EXT_DEP_WARNING_GUARD}
                              INTERFACE ${PROJECT_SOURCE_DIR}/third_party/magic_enum/)
 endif()
@@ -239,7 +241,10 @@ endif()
 # include exprtk header-only libraries available as a statically linked library to simplify/speed-up builds
 add_library(
   exprtk STATIC "${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk.hpp"
-                "${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk.cpp" # dummy source file
+                "${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk.cpp"
+        blocks/basic/include/gnuradio-4.0/basic/ClockSource.hpp
+        blocks/basic/include/gnuradio-4.0/basic/ClockSource.hpp
+        blocks/basic/include/gnuradio-4.0/basic/ClockSource.hpp # dummy source file
 )
 target_include_directories(exprtk PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/third_party"
                                          "${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk")
@@ -286,11 +291,15 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)") # WIP
   find_package(SoapySDR CONFIG)
 endif()
 
-add_library(pmtv INTERFACE)
+add_library(pmtv INTERFACE
+        blocks/basic/include/gnuradio-4.0/basic/ClockSource.hpp
+        blocks/basic/include/gnuradio-4.0/basic/ClockSource.hpp)
 target_include_directories(pmtv INTERFACE ${pmt_SOURCE_DIR}/include/)
 target_link_libraries(pmtv INTERFACE)
 
-add_library(vir INTERFACE)
+add_library(vir INTERFACE
+        blocks/basic/include/gnuradio-4.0/basic/ClockSource.hpp
+        blocks/basic/include/gnuradio-4.0/basic/ClockSource.hpp)
 target_include_directories(vir INTERFACE ${vir-simd_SOURCE_DIR}/)
 
 # FFTW3 is build 2 times for float and double precisions
@@ -371,7 +380,9 @@ ExternalProject_Add(
   INSTALL_COMMAND ""
   LOG_DOWNLOAD ON)
 
-add_library(fftw INTERFACE)
+add_library(fftw INTERFACE
+        blocks/basic/include/gnuradio-4.0/basic/ClockSource.hpp
+        blocks/basic/include/gnuradio-4.0/basic/ClockSource.hpp)
 target_link_libraries(
   fftw
   INTERFACE fftw3

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,15 +5,19 @@ set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
 
-add_library(gnuradio-options INTERFACE)
+# Mainly for FMT
+set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 
 if(CMAKE_CXX_COMPILER MATCHES "/em\\+\\+(-[a-zA-Z0-9.])?$") # if this hasn't been set before via e.g. emcmake
   message(" Transpiling to WASM: using: Emscripten (${CMAKE_CXX_COMPILER})")
   set(EMSCRIPTEN ON)
 endif()
 
-option(ENABLE_BLOCK_PLUGINS "Enable building the plugin system" ON)
-option(ENABLE_BLOCK_REGISTRY "Enable building the block registry" ON)
+# This option affects the GR build, as well as the behavior of BlockLib cmake functions that are used in out-of-tree
+# modules
+option(GR_ENABLE_BLOCK_REGISTRY "Enable building the block registry" ON)
+
+option(INTERNAL_ENABLE_BLOCK_PLUGINS "Enable building the plugin system" ON)
 option(EMBEDDED "Enable embedded mode" OFF)
 if(EMSCRIPTEN)
   option(WARNINGS_AS_ERRORS "Enable -Werror flags" OFF) # some ubiquous warnings in UT need to be fixed first.
@@ -26,15 +30,20 @@ option(UB_SANITIZER "Enable undefined behavior sanitizer" OFF)
 option(THREAD_SANITIZER "Enable thread sanitizer" OFF)
 option(ENABLE_TBB "Enable the TBB dependency for std::execution::par in gcc" OFF)
 
-if(EMSCRIPTEN)
-  set(ENABLE_BLOCK_PLUGINS OFF)
+if(EMSCRIPTEN OR NOT GR_ENABLE_BLOCK_REGISTRY)
+  set(INTERNAL_ENABLE_BLOCK_PLUGINS OFF)
 endif()
+
+# blocklib_generator is a build process dependency, add it before everything
+add_subdirectory(blocklib_generator)
+
+add_library(gnuradio-options INTERFACE)
 
 message(
   STATUS
-    "Is block registry enabled? (faster compile-times and when runtime or Python wrapping APIs are not required) ${ENABLE_BLOCK_REGISTRY}"
+    "Is block registry enabled? (faster compile-times and when runtime or Python wrapping APIs are not required) ${GR_ENABLE_BLOCK_REGISTRY}"
 )
-message(STATUS "Is plugin system enabled? ${ENABLE_BLOCK_PLUGINS}")
+message(STATUS "Is plugin system enabled? ${INTERNAL_ENABLE_BLOCK_PLUGINS}")
 
 # Determine if fmt is built as a subproject (using add_subdirectory) or if it is the master project.
 if(NOT DEFINED GR_TOPLEVEL_PROJECT)
@@ -205,9 +214,6 @@ if(INCLUDE_WHAT_YOU_USE_TOOL_PATH)
   set_property(GLOBAL PROPERTY CMAKE_CXX_INCLUDE_WHAT_YOU_USE ${INCLUDE_WHAT_YOU_USE_TOOL_PATH})
 endif()
 
-# Mainly for FMT
-set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
-
 include(cmake/CompilerWarnings.cmake)
 set_project_warnings(gnuradio-options)
 
@@ -231,9 +237,7 @@ endif()
 
 # include header-only libraries that have been inlined to simplify builds w/o requiring access to the internet
 if(NOT (TARGET magic_enum))
-  add_library(magic_enum INTERFACE
-          blocks/basic/include/gnuradio-4.0/basic/ClockSource.hpp
-          blocks/basic/include/gnuradio-4.0/basic/ClockSource.hpp)
+  add_library(magic_enum INTERFACE)
   target_include_directories(magic_enum ${CMAKE_EXT_DEP_WARNING_GUARD}
                              INTERFACE ${PROJECT_SOURCE_DIR}/third_party/magic_enum/)
 endif()
@@ -241,10 +245,7 @@ endif()
 # include exprtk header-only libraries available as a statically linked library to simplify/speed-up builds
 add_library(
   exprtk STATIC "${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk.hpp"
-                "${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk.cpp"
-        blocks/basic/include/gnuradio-4.0/basic/ClockSource.hpp
-        blocks/basic/include/gnuradio-4.0/basic/ClockSource.hpp
-        blocks/basic/include/gnuradio-4.0/basic/ClockSource.hpp # dummy source file
+                "${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk.cpp" # dummy source file
 )
 target_include_directories(exprtk PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/third_party"
                                          "${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk")
@@ -291,15 +292,11 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)") # WIP
   find_package(SoapySDR CONFIG)
 endif()
 
-add_library(pmtv INTERFACE
-        blocks/basic/include/gnuradio-4.0/basic/ClockSource.hpp
-        blocks/basic/include/gnuradio-4.0/basic/ClockSource.hpp)
+add_library(pmtv INTERFACE)
 target_include_directories(pmtv INTERFACE ${pmt_SOURCE_DIR}/include/)
 target_link_libraries(pmtv INTERFACE)
 
-add_library(vir INTERFACE
-        blocks/basic/include/gnuradio-4.0/basic/ClockSource.hpp
-        blocks/basic/include/gnuradio-4.0/basic/ClockSource.hpp)
+add_library(vir INTERFACE)
 target_include_directories(vir INTERFACE ${vir-simd_SOURCE_DIR}/)
 
 # FFTW3 is build 2 times for float and double precisions
@@ -380,9 +377,7 @@ ExternalProject_Add(
   INSTALL_COMMAND ""
   LOG_DOWNLOAD ON)
 
-add_library(fftw INTERFACE
-        blocks/basic/include/gnuradio-4.0/basic/ClockSource.hpp
-        blocks/basic/include/gnuradio-4.0/basic/ClockSource.hpp)
+add_library(fftw INTERFACE)
 target_link_libraries(
   fftw
   INTERFACE fftw3

--- a/blocks/math/include/gnuradio-4.0/math/Math.hpp
+++ b/blocks/math/include/gnuradio-4.0/math/Math.hpp
@@ -5,14 +5,8 @@
 #include <gnuradio-4.0/BlockRegistry.hpp>
 #include <gnuradio-4.0/DataSet.hpp>
 #include <gnuradio-4.0/meta/UncertainValue.hpp>
-#include <vector>
-#include <algorithm>
-#include <complex>
-#include <functional>
-#include <span>
-#include <volk/volk.h>
-namespace gr::blocks::math {
 
+namespace gr::blocks::math {
 
 namespace detail {
 template<typename T>
@@ -27,6 +21,10 @@ T defaultValue() noexcept {
 }
 } // namespace detail
 
+GR_REGISTER_BLOCK("gr::blocks::math::AddConst", gr::blocks::math::MathOpImpl, ([T], '+'), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ])
+GR_REGISTER_BLOCK("gr::blocks::math::SubtractConst", gr::blocks::math::MathOpImpl, ([T], '-'), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ])
+GR_REGISTER_BLOCK("gr::blocks::math::MultiplyConst", gr::blocks::math::MathOpImpl, ([T], '*'), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ])
+GR_REGISTER_BLOCK("gr::blocks::math::DivideConst", gr::blocks::math::MathOpImpl, ([T], '/'), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ])
 
 template<typename T, typename op>
 struct MathOpImpl : Block<MathOpImpl<T, op>> {
@@ -59,21 +57,17 @@ struct MathOpImpl : Block<MathOpImpl<T, op>> {
 
 template<typename T>
 using AddConst = MathOpImpl<T, std::plus<T>>;
-
 template<typename T>
 using SubtractConst = MathOpImpl<T, std::minus<T>>;
-
 template<typename T>
 using MultiplyConst = MathOpImpl<T, std::multiplies<T>>;
-
 template<typename T>
 using DivideConst = MathOpImpl<T, std::divides<T>>;
 
-// Macros for constant blocks registration
-GR_REGISTER_BLOCK("gr::blocks::math::AddConst", gr::blocks::math::MathOpImpl, ([T], '+'), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ])
-GR_REGISTER_BLOCK("gr::blocks::math::SubtractConst", gr::blocks::math::MathOpImpl, ([T], '-'), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ])
-GR_REGISTER_BLOCK("gr::blocks::math::MultiplyConst", gr::blocks::math::MathOpImpl, ([T], '*'), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ])
-GR_REGISTER_BLOCK("gr::blocks::math::DivideConst", gr::blocks::math::MathOpImpl, ([T], '/'), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ]);
+GR_REGISTER_BLOCK("gr::blocks::math::Add", gr::blocks::math::MathOpImpl, ([T], std::plus<[T]>), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ])
+GR_REGISTER_BLOCK("gr::blocks::math::Subtract", gr::blocks::math::MathOpImpl, ([T], std::minus<[T]>), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ])
+GR_REGISTER_BLOCK("gr::blocks::math::Multiply", gr::blocks::math::MathOpImpl, ([T], std::multiplies<[T]>), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ])
+GR_REGISTER_BLOCK("gr::blocks::math::Divide", gr::blocks::math::MathOpImpl, ([T], std::divides<[T]>), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ])
 
 template<typename T, typename op>
 requires(std::is_arithmetic_v<T>)
@@ -87,11 +81,11 @@ struct MathOpMultiPortImpl : Block<MathOpMultiPortImpl<T, op>> {
     - Subtract: out = in_1 - in_2 - in_3 - ...
     )"">;
 
-    // Ports
+    // ports
     std::vector<PortIn<T>> in;
     PortOut<T>             out;
 
-    // Settings
+    // settings
     Annotated<gr::Size_t, "n_inputs", Visible, Doc<"Number of inputs">, Limits<1U, 32U>> n_inputs = 0U;
 
     GR_MAKE_REFLECTABLE(MathOpMultiPortImpl, in, out, n_inputs);
@@ -104,9 +98,7 @@ struct MathOpMultiPortImpl : Block<MathOpMultiPortImpl<T, op>> {
 
     template<gr::InputSpanLike TInSpan>
     gr::work::Status processBulk(const std::span<TInSpan>& ins, gr::OutputSpanLike auto& sout) const {
-        // Initialize output with the first input stream.
         std::copy(ins[0].begin(), ins[0].end(), sout.begin());
-        // Apply the operator for every subsequent input stream.
         for (std::size_t n = 1; n < ins.size(); n++) {
             std::transform(sout.begin(), sout.end(), ins[n].begin(), sout.begin(), op{});
         }
@@ -116,26 +108,13 @@ struct MathOpMultiPortImpl : Block<MathOpMultiPortImpl<T, op>> {
 
 template<typename T>
 using Add = MathOpMultiPortImpl<T, std::plus<T>>;
-
 template<typename T>
 using Subtract = MathOpMultiPortImpl<T, std::minus<T>>;
-
 template<typename T>
 using Multiply = MathOpMultiPortImpl<T, std::multiplies<T>>;
-
 template<typename T>
 using Divide = MathOpMultiPortImpl<T, std::divides<T>>;
-
-// Registration macros for multiport math operations
-GR_REGISTER_BLOCK("gr::blocks::math::Add", gr::blocks::math::MathOpImpl, ([T], std::plus<[T]>), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ])
-GR_REGISTER_BLOCK("gr::blocks::math::Subtract", gr::blocks::math::MathOpImpl, ([T], std::minus<[T]>), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ])
-GR_REGISTER_BLOCK("gr::blocks::math::Multiply", gr::blocks::math::MathOpImpl, ([T], std::multiplies<[T]>), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ])
-GR_REGISTER_BLOCK("gr::blocks::math::Divide", gr::blocks::math::MathOpImpl, ([T], std::divides<[T]>), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ]);
-
-
-// Conjugate Block
-
-template<typename T>    // complex<float> complex<double>
+template<typename T>    // std::complex<float> or std::complex<double>
 struct ConjugateImpl : Block<ConjugateImpl<T>> {
     using Description = Doc<R"("@brief This block returns the conjugate by inverting the imaginary part of the input signal")">;
 
@@ -143,20 +122,15 @@ struct ConjugateImpl : Block<ConjugateImpl<T>> {
     PortIn<T> in{};
     PortOut<T> out{};
 
-    GR_MAKE_REFLECTABLE(ConjugateImpl, in, out);   // macros used for the reflection class 
-    
-    static std::shared_ptr<ConjugateImpl<T>> make() {     // returns a smart pointer to ConjugateImpl
-        return std::make_shared<ConjugateImpl<T>>();      // new instance of ConjugateImpl dynamically and wraps it ina shrared_ptr.
-    }
+    GR_MAKE_REFLECTABLE(ConjugateImpl, in, out);  
+
     T processOne(const T& input) const noexcept {
         if constexpr (std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>) {
             return std::conj(input);
+        }else{
+            return input;
         }
-        return input;
-    }  
+    }
 };
-GR_REGISTER_BLOCK("gr::blocks::math::Conjugate", gr::blocks::math::ConjugateImpl, std::tuple<std::complex<float>, std::complex<double>>);
-
 } // namespace gr::blocks::math
-
 #endif // GNURADIO_MATH_HPP

--- a/blocks/math/include/gnuradio-4.0/math/Math.hpp
+++ b/blocks/math/include/gnuradio-4.0/math/Math.hpp
@@ -5,9 +5,17 @@
 #include <gnuradio-4.0/BlockRegistry.hpp>
 #include <gnuradio-4.0/DataSet.hpp>
 #include <gnuradio-4.0/meta/UncertainValue.hpp>
-
+#include <vector>
+#include <algorithm>
+#include <complex>
+#include <functional>
+#include <span>
+#include <volk/volk.h>
 namespace gr::blocks::math {
 
+//------------------------------------------------------------------------------
+// Helper: defaultValue()
+//------------------------------------------------------------------------------
 namespace detail {
 template<typename T>
 T defaultValue() noexcept {
@@ -21,11 +29,10 @@ T defaultValue() noexcept {
 }
 } // namespace detail
 
-GR_REGISTER_BLOCK("gr::blocks::math::AddConst", gr::blocks::math::MathOpImpl, ([T], '+'), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ])
-GR_REGISTER_BLOCK("gr::blocks::math::SubtractConst", gr::blocks::math::MathOpImpl, ([T], '-'), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ])
-GR_REGISTER_BLOCK("gr::blocks::math::MultiplyConst", gr::blocks::math::MathOpImpl, ([T], '*'), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ])
-GR_REGISTER_BLOCK("gr::blocks::math::DivideConst", gr::blocks::math::MathOpImpl, ([T], '/'), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ])
-
+//------------------------------------------------------------------------------
+// Constant Math Operation Blocks
+// (AddConst, SubtractConst, MultiplyConst, DivideConst)
+//------------------------------------------------------------------------------
 template<typename T, typename op>
 struct MathOpImpl : Block<MathOpImpl<T, op>> {
     PortIn<T>  in{};
@@ -57,18 +64,26 @@ struct MathOpImpl : Block<MathOpImpl<T, op>> {
 
 template<typename T>
 using AddConst = MathOpImpl<T, std::plus<T>>;
+
 template<typename T>
 using SubtractConst = MathOpImpl<T, std::minus<T>>;
+
 template<typename T>
 using MultiplyConst = MathOpImpl<T, std::multiplies<T>>;
+
 template<typename T>
 using DivideConst = MathOpImpl<T, std::divides<T>>;
 
-GR_REGISTER_BLOCK("gr::blocks::math::Add", gr::blocks::math::MathOpImpl, ([T], std::plus<[T]>), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ])
-GR_REGISTER_BLOCK("gr::blocks::math::Subtract", gr::blocks::math::MathOpImpl, ([T], std::minus<[T]>), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ])
-GR_REGISTER_BLOCK("gr::blocks::math::Multiply", gr::blocks::math::MathOpImpl, ([T], std::multiplies<[T]>), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ])
-GR_REGISTER_BLOCK("gr::blocks::math::Divide", gr::blocks::math::MathOpImpl, ([T], std::divides<[T]>), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ])
+// Macros for constant blocks registration
+GR_REGISTER_BLOCK("gr::blocks::math::AddConst", gr::blocks::math::MathOpImpl, ([T], '+'), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ])
+GR_REGISTER_BLOCK("gr::blocks::math::SubtractConst", gr::blocks::math::MathOpImpl, ([T], '-'), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ])
+GR_REGISTER_BLOCK("gr::blocks::math::MultiplyConst", gr::blocks::math::MathOpImpl, ([T], '*'), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ])
+GR_REGISTER_BLOCK("gr::blocks::math::DivideConst", gr::blocks::math::MathOpImpl, ([T], '/'), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ]);
 
+//------------------------------------------------------------------------------
+// Multi-Port Math Operation Blocks
+// (Add, Subtract, Multiply, Divide)
+//------------------------------------------------------------------------------
 template<typename T, typename op>
 requires(std::is_arithmetic_v<T>)
 struct MathOpMultiPortImpl : Block<MathOpMultiPortImpl<T, op>> {
@@ -81,11 +96,11 @@ struct MathOpMultiPortImpl : Block<MathOpMultiPortImpl<T, op>> {
     - Subtract: out = in_1 - in_2 - in_3 - ...
     )"">;
 
-    // ports
+    // Ports
     std::vector<PortIn<T>> in;
     PortOut<T>             out;
 
-    // settings
+    // Settings
     Annotated<gr::Size_t, "n_inputs", Visible, Doc<"Number of inputs">, Limits<1U, 32U>> n_inputs = 0U;
 
     GR_MAKE_REFLECTABLE(MathOpMultiPortImpl, in, out, n_inputs);
@@ -98,7 +113,9 @@ struct MathOpMultiPortImpl : Block<MathOpMultiPortImpl<T, op>> {
 
     template<gr::InputSpanLike TInSpan>
     gr::work::Status processBulk(const std::span<TInSpan>& ins, gr::OutputSpanLike auto& sout) const {
+        // Initialize output with the first input stream.
         std::copy(ins[0].begin(), ins[0].end(), sout.begin());
+        // Apply the operator for every subsequent input stream.
         for (std::size_t n = 1; n < ins.size(); n++) {
             std::transform(sout.begin(), sout.end(), ins[n].begin(), sout.begin(), op{});
         }
@@ -108,12 +125,63 @@ struct MathOpMultiPortImpl : Block<MathOpMultiPortImpl<T, op>> {
 
 template<typename T>
 using Add = MathOpMultiPortImpl<T, std::plus<T>>;
+
 template<typename T>
 using Subtract = MathOpMultiPortImpl<T, std::minus<T>>;
+
 template<typename T>
 using Multiply = MathOpMultiPortImpl<T, std::multiplies<T>>;
+
 template<typename T>
 using Divide = MathOpMultiPortImpl<T, std::divides<T>>;
+
+// Registration macros for multiport math operations
+GR_REGISTER_BLOCK("gr::blocks::math::Add", gr::blocks::math::MathOpImpl, ([T], std::plus<[T]>), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ])
+GR_REGISTER_BLOCK("gr::blocks::math::Subtract", gr::blocks::math::MathOpImpl, ([T], std::minus<[T]>), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ])
+GR_REGISTER_BLOCK("gr::blocks::math::Multiply", gr::blocks::math::MathOpImpl, ([T], std::multiplies<[T]>), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ])
+GR_REGISTER_BLOCK("gr::blocks::math::Divide", gr::blocks::math::MathOpImpl, ([T], std::divides<[T]>), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ]);
+
+//------------------------------------------------------------------------------
+// Conjugate Block
+//------------------------------------------------------------------------------
+template<typename T>    // complex<float> complex<double>
+struct ConjugateImpl : Block<ConjugateImpl<T>> {
+    using Description = Doc<R"("@brief This block returns the conjugate by inverting the imaginary part of the input signal")">;
+
+    // Ports
+    PortIn<T> in{};
+    PortOut<T> out{};
+
+    GR_MAKE_REFLECTABLE(ConjugateImpl, in, out);   // macros used for the reflection class 
+    
+    static std::shared_ptr<ConjugateImpl<T>> make() {     // returns a smart pointer to ConjugateImpl
+        return std::make_shared<ConjugateImpl<T>>();      // new instance of ConjugateImpl dynamically and wraps it ina shrared_ptr.
+    }
+    
+    gr::work::Status processBulk(gr::InputSpanLike auto& input_span, gr::OutputSpanLike auto& output_span) const noexcept {
+        if (input_span.size() != output_span.size()) {
+            return gr::work::Status::ERROR;
+        }
+        
+        if constexpr (std::is_same_v<T, std::complex<float>>) {
+            volk_32fc_conjugate_32fc(
+                reinterpret_cast<std::complex<float>*>(output_span.data()),
+                reinterpret_cast<const std::complex<float>*>(input_span.data()),
+                static_cast<unsigned int>(input_span.size())
+            );            
+        }
+        else if constexpr (std::is_same_v<T, std::complex<double>>) {
+            std::transform(input_span.begin(), input_span.end(), output_span.begin(),
+                [](const std::complex<double>& z) {
+                    return std::conj(z);
+                });
+        }
+        return gr::work::Status::OK;
+    }
+};
+
+// Register the Conjugate block for the float and double complex types
+GR_REGISTER_BLOCK("gr::blocks::math::Conjugate", gr::blocks::math::ConjugateImpl, std::tuple<std::complex<float>, std::complex<double>>);
 
 } // namespace gr::blocks::math
 

--- a/blocks/math/include/gnuradio-4.0/math/Math.hpp
+++ b/blocks/math/include/gnuradio-4.0/math/Math.hpp
@@ -13,9 +13,7 @@
 #include <volk/volk.h>
 namespace gr::blocks::math {
 
-//------------------------------------------------------------------------------
-// Helper: defaultValue()
-//------------------------------------------------------------------------------
+
 namespace detail {
 template<typename T>
 T defaultValue() noexcept {
@@ -29,10 +27,7 @@ T defaultValue() noexcept {
 }
 } // namespace detail
 
-//------------------------------------------------------------------------------
-// Constant Math Operation Blocks
-// (AddConst, SubtractConst, MultiplyConst, DivideConst)
-//------------------------------------------------------------------------------
+
 template<typename T, typename op>
 struct MathOpImpl : Block<MathOpImpl<T, op>> {
     PortIn<T>  in{};
@@ -80,10 +75,6 @@ GR_REGISTER_BLOCK("gr::blocks::math::SubtractConst", gr::blocks::math::MathOpImp
 GR_REGISTER_BLOCK("gr::blocks::math::MultiplyConst", gr::blocks::math::MathOpImpl, ([T], '*'), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ])
 GR_REGISTER_BLOCK("gr::blocks::math::DivideConst", gr::blocks::math::MathOpImpl, ([T], '/'), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ]);
 
-//------------------------------------------------------------------------------
-// Multi-Port Math Operation Blocks
-// (Add, Subtract, Multiply, Divide)
-//------------------------------------------------------------------------------
 template<typename T, typename op>
 requires(std::is_arithmetic_v<T>)
 struct MathOpMultiPortImpl : Block<MathOpMultiPortImpl<T, op>> {
@@ -141,9 +132,9 @@ GR_REGISTER_BLOCK("gr::blocks::math::Subtract", gr::blocks::math::MathOpImpl, ([
 GR_REGISTER_BLOCK("gr::blocks::math::Multiply", gr::blocks::math::MathOpImpl, ([T], std::multiplies<[T]>), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ])
 GR_REGISTER_BLOCK("gr::blocks::math::Divide", gr::blocks::math::MathOpImpl, ([T], std::divides<[T]>), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ]);
 
-//------------------------------------------------------------------------------
+
 // Conjugate Block
-//------------------------------------------------------------------------------
+
 template<typename T>    // complex<float> complex<double>
 struct ConjugateImpl : Block<ConjugateImpl<T>> {
     using Description = Doc<R"("@brief This block returns the conjugate by inverting the imaginary part of the input signal")">;

--- a/blocks/math/include/gnuradio-4.0/math/Math.hpp
+++ b/blocks/math/include/gnuradio-4.0/math/Math.hpp
@@ -148,30 +148,13 @@ struct ConjugateImpl : Block<ConjugateImpl<T>> {
     static std::shared_ptr<ConjugateImpl<T>> make() {     // returns a smart pointer to ConjugateImpl
         return std::make_shared<ConjugateImpl<T>>();      // new instance of ConjugateImpl dynamically and wraps it ina shrared_ptr.
     }
-    
-    gr::work::Status processBulk(gr::InputSpanLike auto& input_span, gr::OutputSpanLike auto& output_span) const noexcept {
-        if (input_span.size() != output_span.size()) {
-            return gr::work::Status::ERROR;
+    T processOne(const T& input) const noexcept {
+        if constexpr (std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>) {
+            return std::conj(input);
         }
-        
-        if constexpr (std::is_same_v<T, std::complex<float>>) {
-            volk_32fc_conjugate_32fc(
-                reinterpret_cast<std::complex<float>*>(output_span.data()),
-                reinterpret_cast<const std::complex<float>*>(input_span.data()),
-                static_cast<unsigned int>(input_span.size())
-            );            
-        }
-        else if constexpr (std::is_same_v<T, std::complex<double>>) {
-            std::transform(input_span.begin(), input_span.end(), output_span.begin(),
-                [](const std::complex<double>& z) {
-                    return std::conj(z);
-                });
-        }
-        return gr::work::Status::OK;
-    }
+        return input;
+    }  
 };
-
-// Register the Conjugate block for the float and double complex types
 GR_REGISTER_BLOCK("gr::blocks::math::Conjugate", gr::blocks::math::ConjugateImpl, std::tuple<std::complex<float>, std::complex<double>>);
 
 } // namespace gr::blocks::math

--- a/blocks/math/test/CMakeLists.txt
+++ b/blocks/math/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-
 add_ut_test(qa_Math)
 add_ut_test(qa_ExpressionBlocks)
 add_ut_test(qa_Rotator)
+

--- a/blocks/math/test/CMakeLists.txt
+++ b/blocks/math/test/CMakeLists.txt
@@ -1,3 +1,14 @@
+
+find_package(Volk REQUIRED)
+find_package(Boost REQUIRED COMPONENTS unit_test_framework)
+
+# Debug VOLK detection
+message(STATUS "VOLK_FOUND: ${VOLK_FOUND}")
+message(STATUS "VOLK_LIBRARIES: ${VOLK_LIBRARIES}")
+
 add_ut_test(qa_Math)
 add_ut_test(qa_ExpressionBlocks)
 add_ut_test(qa_Rotator)
+
+# Link VOLK to qa_Math
+target_link_libraries(qa_Math PRIVATE ${VOLK_LIBRARIES})

--- a/blocks/math/test/CMakeLists.txt
+++ b/blocks/math/test/CMakeLists.txt
@@ -1,14 +1,4 @@
 
-find_package(Volk REQUIRED)
-find_package(Boost REQUIRED COMPONENTS unit_test_framework)
-
-# Debug VOLK detection
-message(STATUS "VOLK_FOUND: ${VOLK_FOUND}")
-message(STATUS "VOLK_LIBRARIES: ${VOLK_LIBRARIES}")
-
 add_ut_test(qa_Math)
 add_ut_test(qa_ExpressionBlocks)
 add_ut_test(qa_Rotator)
-
-# Link VOLK to qa_Math
-target_link_libraries(qa_Math PRIVATE ${VOLK_LIBRARIES})

--- a/blocks/math/test/qa_Math.cpp
+++ b/blocks/math/test/qa_Math.cpp
@@ -1,11 +1,12 @@
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wconversion"
 #include <boost/ut.hpp>
-
 #include <gnuradio-4.0/math/Math.hpp>
-
 #include <gnuradio-4.0/Block.hpp>
 #include <gnuradio-4.0/Graph.hpp>
 #include <gnuradio-4.0/Scheduler.hpp>
 #include <gnuradio-4.0/testing/TagMonitors.hpp>
+#include <volk/volk.h>
 
 template<typename T>
 struct TestParameters {
@@ -23,10 +24,14 @@ void test_block(const TestParameters<T> p) {
 
     // build test graph
     Graph graph;
-    auto& block = graph.emplaceBlock<BlockUnderTest>({{"n_inputs", n_inputs}});
+    //auto& block = graph.emplaceBlock<BlockUnderTest>({{"n_inputs", n_inputs}});
+    auto& block = std::is_same_v<BlockUnderTest,ConjugateImpl<T>>
+        ? graph.emplaceBlock<BlockUnderTest>()
+        : graph.emplaceBlock<BlockUnderTest>({{"n_inputs", n_inputs}});
     for (Size_t i = 0; i < n_inputs; ++i) {
         auto& src = graph.emplaceBlock<TagSource<T>>({{"values", p.inputs[i]}, {"n_samples_max", static_cast<Size_t>(p.inputs[i].size())}});
-        expect(eq(graph.connect(src, "out"s, block, "in#"s + std::to_string(i)), ConnectionResult::SUCCESS)) << fmt::format("Failed to connect output port of src {} to input port 'in#{}' of block", i, i);
+        std::string input_port=std::is_same_v<BlockUnderTest,ConjugateImpl<T>> ? "in"s : "in#" + std::to_string(i);
+        expect(eq(graph.connect(src, "out"s, block, input_port), ConnectionResult::SUCCESS)) << fmt::format("Failed to connect output port of src {} to input port {}", i, input_port);
     }
     auto& sink = graph.emplaceBlock<TagSink<T, ProcessFunction::USE_PROCESS_ONE>>();
     expect(eq(graph.connect<"out">(block).template to<"in">(sink), ConnectionResult::SUCCESS)) << "Failed to connect output port 'out' of block to input port of sink";
@@ -36,6 +41,7 @@ void test_block(const TestParameters<T> p) {
     expect(scheduler.runAndWait().has_value()) << "Failed to run graph: No value";
     expect(std::ranges::equal(sink._samples, p.output)) << fmt::format("Failed to validate block output: Expected {} but got {} for input {}", p.output, sink._samples, p.inputs);
 };
+
 
 const boost::ut::suite<"basic math tests"> basicMath = [] {
     using namespace boost::ut;
@@ -142,6 +148,36 @@ std::complex<float>, std::complex<double>*/>();
         block.init(block.progress, block.ioThreadPool);
         expect(eq(block.processOne(T(4)), T(4) / T(2))) << fmt::format("SubtractConst(2) test for type {}\n", meta::type_name<T>());
     } | kArithmeticTypes;
+   
+};
+
+using namespace boost::ut;
+using namespace gr;
+using namespace gr::testing;
+using namespace gr::blocks;
+using namespace gr::blocks::math;
+
+const boost::ut::suite<"complex conjugate math tests"> conjugateTests = [] {
+    "Conjugate"_test = []<typename T>(const T&) {
+        // Define test parameters:
+        // Input: vector of complex numbers.
+        // Expected output: each complex number with its imaginary part inverted.
+        TestParameters<T> params{
+            .inputs = {{
+                T(1.0,  2.0),    // Expected conjugate: (1.0, -2.0)
+                T(0.0, -3.0),    // Expected conjugate: (0.0,  3.0)
+                T(2.0,  3.0)     // Expected conjugate: (2.0, -3.0)
+            }},
+            .output = {
+                T(1.0, -2.0),
+                T(0.0,  3.0),
+                T(2.0, -3.0)
+            }
+        };
+
+        // Execute the test graph: instantiate the Conjugate block and check the output.
+        test_block<T, ConjugateImpl<T>>(params);
+    } | std::tuple<std::complex<float>, std::complex<double>>();
 };
 
 int main() { /* not needed for UT */ }

--- a/blocks/math/test/qa_Math.cpp
+++ b/blocks/math/test/qa_Math.cpp
@@ -147,10 +147,8 @@ std::complex<float>, std::complex<double>*/>();
         auto block = DivideConst<T>(property_map{{"value", T(2)}});
         block.init(block.progress, block.ioThreadPool);
         expect(eq(block.processOne(T(4)), T(4) / T(2))) << fmt::format("SubtractConst(2) test for type {}\n", meta::type_name<T>());
-    } | kArithmeticTypes;
-   
+    } | kArithmeticTypes; 
 };
-
 using namespace boost::ut;
 using namespace gr;
 using namespace gr::testing;

--- a/blocks/testing/include/gnuradio-4.0/testing/TagMonitors.hpp
+++ b/blocks/testing/include/gnuradio-4.0/testing/TagMonitors.hpp
@@ -84,7 +84,7 @@ inline constexpr bool equal_tag_lists(const std::vector<Tag>& tags1, const std::
     return true;
 }
 
-GR_REGISTER_BLOCK("gr::testing::TagSource", gr::testing::TagSource, ([T], ProcessFunction::USE_PROCESS_ONE), [ float, double ])
+GR_REGISTER_BLOCK("gr::testing::TagSource", gr::testing::TagSource, ([T], gr::testing::ProcessFunction::USE_PROCESS_ONE), [ float, double ])
 
 template<typename T, ProcessFunction UseProcessVariant = ProcessFunction::USE_PROCESS_BULK>
 struct TagSource : Block<TagSource<T, UseProcessVariant>> {
@@ -146,7 +146,7 @@ struct TagSource : Block<TagSource<T, UseProcessVariant>> {
             _valueIndex++;
             return currentValue;
         }
-        return mark_tag ? (tagGenerated ? static_cast<T>(1) : static_cast<T>(0)) : static_cast<T>(_nSamplesProduced);
+return mark_tag ? (tagGenerated ? static_cast<T>(1) : static_cast<T>(0)) : static_cast<T>(static_cast<float>(_nSamplesProduced));
     }
 
     work::Status processBulk(OutputSpanLike auto& outSpan) noexcept
@@ -187,8 +187,7 @@ struct TagSource : Block<TagSource<T, UseProcessVariant>> {
                 outSpan[0] = tagGenerated ? static_cast<T>(1) : static_cast<T>(0);
             } else {
                 for (std::size_t i = 0; i < nSamples; ++i) {
-                     outSpan[i] = static_cast<T>(_nSamplesProduced + i);
-                    //outSpan[i] = T(static_cast<typename T::value_type>(_nSamplesProduced + i), 0.0);
+                    outSpan[i] = static_cast<T>(_nSamplesProduced + i);
                 }
             }
         }
@@ -234,7 +233,7 @@ private:
     [[nodiscard]] bool isInfinite() const { return n_samples_max == 0U; }
 };
 
-GR_REGISTER_BLOCK("gr::testing::TagMonitor", gr::testing::TagMonitor, ([T], ProcessFunction::USE_PROCESS_ONE), [ float, double ])
+GR_REGISTER_BLOCK("gr::testing::TagMonitor", gr::testing::TagMonitor, ([T], gr::testing::ProcessFunction::USE_PROCESS_ONE), [ float, double ])
 
 template<typename T, ProcessFunction UseProcessVariant>
 struct TagMonitor : public Block<TagMonitor<T, UseProcessVariant>> {
@@ -309,7 +308,7 @@ struct TagMonitor : public Block<TagMonitor<T, UseProcessVariant>> {
     }
 };
 
-GR_REGISTER_BLOCK("gr::testing::TagSink", gr::testing::TagSink, ([T], ProcessFunction::USE_PROCESS_ONE), [ float, double ])
+GR_REGISTER_BLOCK("gr::testing::TagSink", gr::testing::TagSink, ([T], gr::testing::ProcessFunction::USE_PROCESS_ONE), [ float, double ])
 
 template<typename T, ProcessFunction UseProcessVariant>
 struct TagSink : public Block<TagSink<T, UseProcessVariant>> {

--- a/blocks/testing/include/gnuradio-4.0/testing/TagMonitors.hpp
+++ b/blocks/testing/include/gnuradio-4.0/testing/TagMonitors.hpp
@@ -187,7 +187,8 @@ struct TagSource : Block<TagSource<T, UseProcessVariant>> {
                 outSpan[0] = tagGenerated ? static_cast<T>(1) : static_cast<T>(0);
             } else {
                 for (std::size_t i = 0; i < nSamples; ++i) {
-                    outSpan[i] = static_cast<T>(_nSamplesProduced + i);
+                     outSpan[i] = static_cast<T>(_nSamplesProduced + i);
+                    //outSpan[i] = T(static_cast<typename T::value_type>(_nSamplesProduced + i), 0.0);
                 }
             }
         }


### PR DESCRIPTION
Refers #161 
This PR basically is meant for the implementation of Complex Conjugate Block Under Math. 

The Complex Conjugate block processes complex input signals, producing their conjugates by retaining the real part and inverting the sign of the imaginary part. For an input of the form x + yi, where x represents the real component and y the imaginary component, the output is x - yi. This operation is vital for complex signal manipulation in digital signal processing applications.

Changes Made:

1.  Implemented and tested the Complex Conjugate block locally to ensure correct functionality. 

2. Added comprehensive unit test cases in qa_Math.cpp to validate the block’s behavior for float and  double inputs.

3. Verified successful execution of all tests with make && ./qa_Math, confirming no regressions in existing math block tests.
 
### Test Case Example
![Screenshot From 2025-04-09 23-59-48](https://github.com/user-attachments/assets/c866fb54-99eb-4017-982e-8e57a8a09807)



