### PR TITLE
feat: Ported Boolean 'And' block (refs #536, EPIC #161)

### DIFF
--- a/blocks/basic/CMakeLists.txt
+++ b/blocks/basic/CMakeLists.txt
@@ -8,7 +8,8 @@ set(GrBasicBlocks_HDRS
     include/gnuradio-4.0/basic/SignalGenerator.hpp
     include/gnuradio-4.0/basic/StreamToDataSet.hpp
     include/gnuradio-4.0/basic/SyncBlock.hpp
-    include/gnuradio-4.0/basic/Trigger.hpp)
+    include/gnuradio-4.0/basic/Trigger.hpp
+    include/gnuradio-4.0/basic/And.hpp)
 
 set(GrBasicBlocks_LIBS gr-basic gr-testing)
 

--- a/blocks/basic/include/gnuradio-4.0/basic/And.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/And.hpp
@@ -1,0 +1,29 @@
+#ifndef AND_HPP
+#define AND_HPP
+
+#include <gnuradio-4.0/Block.hpp>
+#include <gnuradio-4.0/BlockRegistry.hpp>
+#include <concepts>
+
+namespace gr::basic {
+
+GR_REGISTER_BLOCK(gr::basic::And, [uint8_t, int16_t, int32_t])
+
+template<std::integral T>
+struct And : Block<And<T>> {
+    using Description = Doc<"@brief Performs a bitwise AND operation on two inputs, producing one output stream.">;
+
+    PortIn<T> in1;
+    PortIn<T> in2;
+    PortOut<T> out;
+
+    GR_MAKE_REFLECTABLE(And, in1, in2, out);
+
+    [[nodiscard]] constexpr T processOne(T input1, T input2) const noexcept {
+        return input1 & input2;
+    }
+};
+
+} // namespace gr::blocks
+
+#endif // AND_HPP

--- a/blocks/basic/test/CMakeLists.txt
+++ b/blocks/basic/test/CMakeLists.txt
@@ -3,6 +3,7 @@ add_ut_test(qa_Selector)
 add_ut_test(qa_sources)
 add_ut_test(qa_DataSink)
 add_ut_test(qa_TriggerBlocks)
+add_ut_test(qa_And)
 
 if(GR_ENABLE_BLOCK_REGISTRY AND INTERNAL_ENABLE_BLOCK_PLUGINS)
   add_ut_test(qa_BasicKnownBlocks)

--- a/blocks/basic/test/qa_AND.cpp
+++ b/blocks/basic/test/qa_AND.cpp
@@ -1,0 +1,60 @@
+#include <boost/ut.hpp>
+#include <gnuradio-4.0/basic/And.hpp>
+// #include <limits>
+
+using namespace gr::basic;
+using namespace boost::ut;
+
+const suite AndTests = [] {
+    "Bitwise AND operations"_test = [] {
+        And<uint8_t> andBlock;
+        // Basic bitwise AND operation
+        expect(eq(andBlock.processOne(0xFF, 0x0F), 0x0F));  // 0xFF & 0x0F = 0x0F
+        expect(eq(andBlock.processOne(0x00, 0xFF), 0x00));
+        expect(eq(andBlock.processOne(0xAB, 0x22), 0x22));
+    };
+
+    "Edge cases"_test = [] {
+        And<uint8_t> andBlock;
+        // Edge cases for boundary values (max and min values)
+        expect(eq(andBlock.processOne(0xFF, 0xFF), 0xFF));  // 0xFF & 0xFF = 0xFF
+        expect(eq(andBlock.processOne(0x00, 0x00), 0x00));  // 0x00 & 0x00 = 0x00
+    };
+
+    "int16_t support"_test = [] {
+        And<int16_t> andBlock;
+        // Test with int16_t values
+        expect(eq(andBlock.processOne(0x7FFF, 0x00FF), 0x00FF));  // 0x7FFF & 0x00FF = 0x0101
+        expect(eq(andBlock.processOne(static_cast<int16_t>(-1), static_cast<int16_t>(0xAABB)), static_cast<int16_t>(0xAABB))); // -1 & 0xAABB = 0xAABB
+    };
+
+     "int32_t support"_test = [] {
+        And<int32_t> andBlock;
+        // Test bitwise AND on int32_t values (max and min values)
+        expect(eq(andBlock.processOne(0xFFFF, 0x0F0F), 0x0F0F));  // 0xFFFF (1111111111111111) & 0x0F0F (0000111100001111) = 0x0F0F
+        expect(eq(andBlock.processOne(-1, 0x0000), 0x0000));  // -1 & 0x0000 = 0x0000
+    };
+
+    "Boundary cases"_test = [] {
+        And<int32_t> andBlock;
+        // Boundary test cases for int32_t limits
+        expect(eq(andBlock.processOne(std::numeric_limits<int32_t>::max(), std::numeric_limits<int32_t>::min()), 0));  // MAX & MIN = 0
+        expect(eq(andBlock.processOne(std::numeric_limits<int32_t>::max(), -1), std::numeric_limits<int32_t>::max()));  // MAX & -1 = MAX
+    };
+
+    "Negative values"_test = [] {
+        And<int16_t> andBlock;
+        // Test with negative values for int16_t
+        expect(eq(andBlock.processOne(static_cast<int16_t>(-1), static_cast<int16_t>(-1)), static_cast<int16_t>(-1)));  // -1 & -1 = -1
+
+        /*
+              1111 1111 1111 1011   (-5 in two's complement)
+            & 0000 0000 0000 0011   (3 in binary)
+            --------------------
+            0000 0000 0000 0011   (Result = 3)
+         */
+        expect(eq(andBlock.processOne(static_cast<int16_t>(-5), static_cast<int16_t>(3)), static_cast<int16_t>(3)));  // -5 & 3 = 3
+    };
+};
+
+int main() { return boost::ut::cfg<boost::ut::override>.run(); }


### PR DESCRIPTION

## Port Boolean Blocks to GNU Radio 4

**This PR ports Boolean operator blocks as part of EPIC #161.**

### Blocks included in this PR:
- [x] `And` – ✅ **implemented & tested**  
  *(Original implementation by Alex from PR #536; I fixed CI issues and tests.)*

### Additional blocks coming in separate commits (within this same PR):
- [ ] `AndConst` – in progress
- [ ] `Or` – in progress
- [ ] `Xor` – in progress
- [ ] `Not` – in progress

Each block will have clearly separated commits for easier review and potential merge conflicts handling, as suggested by @mormj .

All CI checks (DCO, Restyled, SonarCloud) will be explicitly handled per commit.
