### PR TITLE
Fix build failure if `clang-scan-deps` is not found. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,24 @@ if(NOT DEFINED GR_TOPLEVEL_PROJECT)
   endif()
 endif()
 
+# clang-scan-deps in required by ccache
+if(CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
+  string(
+    REGEX MATCH
+          "^[0-9]+"
+          CLANG_MAJOR
+          "${CMAKE_CXX_COMPILER_VERSION}")
+  find_program(CLANG_SCAN_DEPS_EXEC NAMES clang-scan-deps-${CLANG_MAJOR} clang-scan-deps)
+  if(CLANG_SCAN_DEPS_EXEC)
+    set(CMAKE_CXX_COMPILER_CLANG_SCAN_DEPS
+        "${CLANG_SCAN_DEPS_EXEC}"
+        CACHE FILEPATH "" FORCE)
+  else()
+    message(WARNING "clang‑scan‑deps not found; module scanning will be disabled")
+    set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
+  endif()
+endif()
+
 # Use ccache if found and enabled
 find_program(CCACHE_PROGRAM ccache)
 option(USE_CCACHE "Use ccache if available" ON)
@@ -427,7 +445,7 @@ if(ENABLE_TESTING AND (UNIX OR APPLE))
   if(ENABLE_COVERAGE)
     message("Coverage reporting enabled")
     include(cmake/CodeCoverage.cmake) # https://github.com/bilke/cmake-modules/blob/master/CodeCoverage.cmake #
-                                      # (License: BSL-1.0)
+    # (License: BSL-1.0)
     target_compile_options(
       gnuradio-options
       INTERFACE --coverage

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,7 +23,7 @@ ENV JAVA_HOME=/opt/java/openjdk \
 # && wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && add-apt-repository 'deb http://apt.llvm.org/mantic/ llvm-toolchain-mantic-18 main'
 # && wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null && echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main' | tee -a /etc/apt/sources.list.d/kitware.list >/dev/null
 RUN apt-get update -y \
-    && apt-get install --no-install-recommends -qqy wget gpg ca-certificates software-properties-common bash locales python3-pip npm sudo cmake git make ninja-build clang-18 libc++-18-dev libc++abi-18-dev gdb lldb-18 gcc-13 g++-13 gcc-14 g++-14 ccache \
+    && apt-get install --no-install-recommends -qqy wget gpg ca-certificates software-properties-common bash locales python3-pip npm sudo cmake git make ninja-build clang-18 clang-tools-18 libc++-18-dev libc++abi-18-dev gdb lldb-18 gcc-13 g++-13 gcc-14 g++-14 ccache \
     && locale-gen en_US.UTF-8 && echo 'LANG="en_US.UTF-8"'>/etc/default/locale \
     && useradd -m -g users user \
     && echo user ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/user && chmod 0440 /etc/sudoers.d/user \


### PR DESCRIPTION
This PR includes the following:

- Resolves build failure when `clang-scan-deps` is missing.
- Enhances CMake logic to automatically locate the `clang-scan-deps` executable matching the Clang compiler version and sets `CMAKE_CXX_COMPILER_CLANG_SCAN_DEPS`.
- Adds the `clang-tools` package to Docker to ensure the availability of `clang-scan-deps`.

