### PR TITLE
Add .hpp extension to the blocklib header to avoid name conflicts.

### DIFF
--- a/blocklib_generator/tools/parse_registrations.cpp
+++ b/blocklib_generator/tools/parse_registrations.cpp
@@ -316,7 +316,7 @@ int main(int argc, char** argv) try {
             moduleName);
     }
 
-    const auto integratorHeaderFile = (options.outDir / moduleName);
+    const auto integratorHeaderFile = (options.outDir / (moduleName + ".hpp"));
     if (!std::filesystem::exists(integratorHeaderFile)) {
         std::ofstream integrator = openFile(integratorHeaderFile);
         integrator << std::format(R"cppcode(

--- a/blocks/basic/test/qa_BasicKnownBlocks.cpp
+++ b/blocks/basic/test/qa_BasicKnownBlocks.cpp
@@ -6,7 +6,7 @@
 #include <gnuradio-4.0/basic/Selector.hpp>
 #include <gnuradio-4.0/basic/SignalGenerator.hpp>
 
-#include <GrBasicBlocks>
+#include <GrBasicBlocks.hpp>
 
 const boost::ut::suite KnownBlockTests = [] {
     using namespace boost::ut;

--- a/blocks/libs/test/qa_KnownSharedLibBlocks.cpp
+++ b/blocks/libs/test/qa_KnownSharedLibBlocks.cpp
@@ -9,13 +9,13 @@ using namespace boost::ut;
 
 using namespace std::string_view_literals;
 
-#include <GrBasicBlocks>
-#include <GrElectricalBlocks>
-#include <GrFileIoBlocks>
-#include <GrFilterBlocks>
-#include <GrFourierBlocks>
-#include <GrHttpBlocks>
-#include <GrTestingBlocks>
+#include <GrBasicBlocks.hpp>
+#include <GrElectricalBlocks.hpp>
+#include <GrFileIoBlocks.hpp>
+#include <GrFilterBlocks.hpp>
+#include <GrFourierBlocks.hpp>
+#include <GrHttpBlocks.hpp>
+#include <GrTestingBlocks.hpp>
 
 const boost::ut::suite TagTests = [] {
     auto&       registry = gr::globalBlockRegistry();

--- a/blocks/libs/test/qa_apptest_KnownStaticLibBlocks.cpp
+++ b/blocks/libs/test/qa_apptest_KnownStaticLibBlocks.cpp
@@ -4,7 +4,7 @@
 #include <cassert>
 #include <iostream>
 
-#include <GrBasicBlocks>
+#include <GrBasicBlocks.hpp>
 
 using namespace std::string_literals;
 

--- a/core/test/qa_GraphMessages.cpp
+++ b/core/test/qa_GraphMessages.cpp
@@ -3,8 +3,8 @@
 #include <gnuradio-4.0/Scheduler.hpp>
 #include <gnuradio-4.0/testing/NullSources.hpp>
 
-#include <GrBasicBlocks>
-#include <GrTestingBlocks>
+#include <GrBasicBlocks.hpp>
+#include <GrTestingBlocks.hpp>
 
 #include "TestBlockRegistryContext.hpp"
 

--- a/core/test/qa_grc.cpp
+++ b/core/test/qa_grc.cpp
@@ -15,9 +15,9 @@
 
 #include "CollectionTestBlocks.hpp"
 
-#include <GrBasicBlocks>
-#include <GrTestingBlocks>
-#include <qa_grc>
+#include <GrBasicBlocks.hpp>
+#include <GrTestingBlocks.hpp>
+#include <qa_grc.hpp>
 
 #include "TestBlockRegistryContext.hpp"
 #include "gnuradio-4.0/BlockModel.hpp"

--- a/core/test/qa_plugins_test.cpp
+++ b/core/test/qa_plugins_test.cpp
@@ -10,8 +10,8 @@
 #include <gnuradio-4.0/Graph.hpp>
 #include <gnuradio-4.0/basic/CommonBlocks.hpp>
 
-#include <GrBasicBlocks>
-#include <GrTestingBlocks>
+#include <GrBasicBlocks.hpp>
+#include <GrTestingBlocks.hpp>
 
 #include "TestBlockRegistryContext.hpp"
 


### PR DESCRIPTION

The header files were previously generated without the `.hpp` extension, causing naming conflicts: for example, the `qa_grc` test executable was incorrectly identified as a header file.

This PR resolves the issue by adding the `.hpp` extension to the blocklib headers, preventing these naming conflicts.

This minimal change directly addresses the immediate issue. However, future naming conflicts could still occur. Potential further enhancements include:

- Adding a `_blocklib` suffix to clearly indicate that the headers originate from the block library.
- Generating a structured directory layout such as `gr4/<libname>/<header_name>.hpp`, enabling users to explicitly reference headers even when name overlaps exist.

