### PR TITLE
Dockerfile: add `file` utility

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,7 +23,7 @@ ENV JAVA_HOME=/opt/java/openjdk \
 # && wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && add-apt-repository 'deb http://apt.llvm.org/mantic/ llvm-toolchain-mantic-18 main'
 # && wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null && echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main' | tee -a /etc/apt/sources.list.d/kitware.list >/dev/null
 RUN apt-get update -y \
-    && apt-get install --no-install-recommends -qqy wget gpg ca-certificates software-properties-common bash locales python3-pip npm sudo cmake git make ninja-build clang-18 clang-tools-18 libc++-18-dev libc++abi-18-dev gdb lldb-18 gcc-13 g++-13 gcc-14 g++-14 ccache \
+    && apt-get install --no-install-recommends -qqy wget gpg ca-certificates software-properties-common bash file locales python3-pip npm sudo cmake git make ninja-build clang-18 clang-tools-18 libc++-18-dev libc++abi-18-dev gdb lldb-18 gcc-13 g++-13 gcc-14 g++-14 ccache \
     && locale-gen en_US.UTF-8 && echo 'LANG="en_US.UTF-8"'>/etc/default/locale \
     && useradd -m -g users user \
     && echo user ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/user && chmod 0440 /etc/sudoers.d/user \


### PR DESCRIPTION
`file` is invoked by fftw's configuration scripts and although compilation continues without any problems, installing file should remove some confusing warning messages from the build.

Thanks @iamsergio for reporting this.