### PR TITLE
Automatically forward tags only from Settings::autoForwardParameters

### DIFF
--- a/blocks/testing/include/gnuradio-4.0/testing/TagMonitors.hpp
+++ b/blocks/testing/include/gnuradio-4.0/testing/TagMonitors.hpp
@@ -28,9 +28,11 @@ inline constexpr void print_tag(const Tag& tag, std::string_view prefix = {}) no
 
 template<typename MapType>
 inline constexpr void map_diff_report(const MapType& map1, const MapType& map2, const std::string& name1, const std::string& name2, const std::optional<std::vector<std::string>>& ignoreKeys = std::nullopt) {
+    const auto skipKey = [&](const auto& key) { return ignoreKeys != std::nullopt && std::ranges::find(ignoreKeys.value(), key) != ignoreKeys.value().end(); };
+
     for (const auto& [key, value] : map1) {
-        if (ignoreKeys != std::nullopt && std::ranges::find(ignoreKeys.value(), key) != ignoreKeys.value().end()) {
-            continue; // skip this key
+        if (skipKey(key)) {
+            continue;
         }
         const auto it = map2.find(key);
         if (it == map2.end()) {
@@ -38,6 +40,13 @@ inline constexpr void map_diff_report(const MapType& map1, const MapType& map2, 
         } else if (it->second != value) {
             fmt::print("    key '{}' has different values ('{}' vs '{}')\n", key, value, it->second);
         }
+    }
+
+    for (const auto& [key, value] : map2) {
+        if (skipKey(key) || map1.contains(key)) {
+            continue;
+        }
+        fmt::print("    key '{}' is present in {} but not in {}\n", key, name2, name1);
     }
 }
 

--- a/core/include/gnuradio-4.0/Block.hpp
+++ b/core/include/gnuradio-4.0/Block.hpp
@@ -697,7 +697,10 @@ public:
     constexpr void publishMergedInputTag(auto& outputSpanTuple) noexcept {
         if constexpr (!noDefaultTagForwarding) {
             if (inputTagsPresent()) {
-                for_each_writer_span([this](auto& outSpan) { outSpan.publishTag(_mergedInputTag.map, 0); }, outputSpanTuple);
+                const auto&  autoForwardKeys = settings().autoForwardParameters();
+                property_map onlyAutoForwardMap;
+                std::ranges::copy_if(_mergedInputTag.map, std::inserter(onlyAutoForwardMap, onlyAutoForwardMap.end()), [&autoForwardKeys](const auto& kv) { return autoForwardKeys.contains(kv.first); });
+                for_each_writer_span([&onlyAutoForwardMap](auto& outSpan) { outSpan.publishTag(onlyAutoForwardMap, 0); }, outputSpanTuple);
             }
         }
     }

--- a/core/include/gnuradio-4.0/Tag.hpp
+++ b/core/include/gnuradio-4.0/Tag.hpp
@@ -171,7 +171,7 @@ inline EM_CONSTEXPR_STATIC DefaultTag<"signal_quantity", std::string, "", "signa
 inline EM_CONSTEXPR_STATIC DefaultTag<"signal_unit", std::string, "", "signal's physical SI unit"> SIGNAL_UNIT;
 inline EM_CONSTEXPR_STATIC DefaultTag<"signal_min", float, "a.u.", "signal physical max. (e.g. DAQ) limit"> SIGNAL_MIN;
 inline EM_CONSTEXPR_STATIC DefaultTag<"signal_max", float, "a.u.", "signal physical max. (e.g. DAQ) limit"> SIGNAL_MAX;
-inline EM_CONSTEXPR_STATIC DefaultTag<"n_dropped_samples", std::size_t, "", "number of dropped samples"> N_DROPPED_SAMPLES;
+inline EM_CONSTEXPR_STATIC DefaultTag<"n_dropped_samples", gr::Size_t, "", "number of dropped samples"> N_DROPPED_SAMPLES;
 inline EM_CONSTEXPR_STATIC DefaultTag<"trigger_name", std::string> TRIGGER_NAME;
 inline EM_CONSTEXPR_STATIC DefaultTag<"trigger_time", uint64_t, "ns", "UTC-based time-stamp"> TRIGGER_TIME;
 inline EM_CONSTEXPR_STATIC DefaultTag<"trigger_offset", float, "s", "sample delay w.r.t. the trigger (e.g.compensating analog group delays)"> TRIGGER_OFFSET;

--- a/core/test/qa_Settings.cpp
+++ b/core/test/qa_Settings.cpp
@@ -574,7 +574,7 @@ const boost::ut::suite SettingsCtxTests = [] {
     };
 };
 
-const boost::ut::suite TransactionTests = [] {
+const boost::ut::suite CtxSettingsTests = [] {
     using namespace boost::ut;
     using namespace gr;
     using namespace gr::setting_test;
@@ -615,7 +615,7 @@ const boost::ut::suite TransactionTests = [] {
 
         const property_map params = settings.getStored(parameterKeys).value(); // return as ctx.time = std::chrono::system_clock::now()
         expect(eq(std::get<float>(params.at("scaling_factor")), 10.f));
-        expect(eq(std::get<std::string>(params.at("name")), std::string("TestName10")));
+        expect(eq(std::get<std::string>(params.at("name")), "TestName10"s));
         const property_map paramsAll = settings.getStored().value(); // test API without parameters, should return all keys
         expect(eq(paramsAll.size(), 2UZ));
 
@@ -623,31 +623,31 @@ const boost::ut::suite TransactionTests = [] {
 
         const property_map params0 = settings.getStored(parameterKeys, ctx0).value(); // return exact
         expect(eq(std::get<float>(params0.at("scaling_factor")), 10.f));
-        expect(eq(std::get<std::string>(params0.at("name")), std::string("TestName10")));
+        expect(eq(std::get<std::string>(params0.at("name")), "TestName10"s));
 
         const property_map params1 = settings.getStored(parameterKeys, ctx1).value(); // return previous
         expect(eq(std::get<float>(params1.at("scaling_factor")), 10.f));
-        expect(eq(std::get<std::string>(params1.at("name")), std::string("TestName10")));
+        expect(eq(std::get<std::string>(params1.at("name")), "TestName10"s));
 
         const property_map params2 = settings.getStored(parameterKeys, ctx2).value(); // return exact
         expect(eq(std::get<float>(params2.at("scaling_factor")), 12.f));
-        expect(eq(std::get<std::string>(params2.at("name")), std::string("TestName12")));
+        expect(eq(std::get<std::string>(params2.at("name")), "TestName12"s));
 
         const property_map params3 = settings.getStored(parameterKeys, ctx3).value(); // return previous
         expect(eq(std::get<float>(params3.at("scaling_factor")), 12.f));
-        expect(eq(std::get<std::string>(params3.at("name")), std::string("TestName12")));
+        expect(eq(std::get<std::string>(params3.at("name")), "TestName12"s));
 
         const property_map params4 = settings.getStored(parameterKeys, ctx4).value(); // return exact
         expect(eq(std::get<float>(params4.at("scaling_factor")), 14.f));
-        expect(eq(std::get<std::string>(params4.at("name")), std::string("TestName14")));
+        expect(eq(std::get<std::string>(params4.at("name")), "TestName14"s));
 
         const property_map params5 = settings.getStored(parameterKeys, ctx5).value(); // return latest
         expect(eq(std::get<float>(params5.at("scaling_factor")), 14.f));
-        expect(eq(std::get<std::string>(params5.at("name")), std::string("TestName14")));
+        expect(eq(std::get<std::string>(params5.at("name")), "TestName14"s));
 
         const property_map paramsNull = settings.getStored(parameterKeys, ctxNull).value(); // return as ctx.time = std::chrono::system_clock::now()
         expect(eq(std::get<float>(paramsNull.at("scaling_factor")), 10.f));
-        expect(eq(std::get<std::string>(paramsNull.at("name")), std::string("TestName10")));
+        expect(eq(std::get<std::string>(paramsNull.at("name")), "TestName10"s));
     };
 #ifdef __EMSCRIPTEN__
     "CtxSettings Resolve Duplicate Timestamp"_test = [] {
@@ -787,7 +787,7 @@ const boost::ut::suite TransactionTests = [] {
         expect(eq(std::get<float>(block.settings().getStored("scaling_factor").value()), 42.f)); // TODO:
     };
 
-    "CtxSettings autoUpdate settings"_test = [&] {
+    "CtxSettings autoUpdateParameters"_test = [&] {
         using namespace gr::testing;
 
         gr::Size_t         n_samples      = 20;


### PR DESCRIPTION
This PR includes the following updates:
- Restrict auto-forwarding to only the tags defined in `Settings::autoForwardParameters`.
- Update existing tests accordingly.
- Add custom auto-forward tags in specific tests, for example in `qa_DataSink`:
```cpp
std::vector<std::string> customAutoForwardKeys = {"DAY", "MONTH", "YEAR"};
delay.settings().autoForwardParameters().insert(customAutoForwardKeys.begin(), customAutoForwardKeys.end());
```
- Change `gr::tag::N_DROPPED_SAMPLES` type to `gr::Size_t`
- Update `map_diff_report` to check also for missing keys from the second map.

