### PR TITLE
chrisjohgorman gcc-15 compiler errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -315,6 +315,8 @@ endif()
 set_source_files_properties(third_party/exprtk.cpp PROPERTIES COMPILE_OPTIONS "-fvisibility=hidden")
 # include exprtk header-only - END
 
+set(vir-simd_patch git apply ${CMAKE_CURRENT_SOURCE_DIR}/patches/0001-vir-smid-src_constexpr_wrapper_h.patch)
+
 include(FetchContent)
 FetchContent_Declare(
   fmt
@@ -336,7 +338,10 @@ FetchContent_Declare(
 FetchContent_Declare(
   vir-simd
   GIT_REPOSITORY https://github.com/mattkretz/vir-simd.git
-  GIT_TAG v0.4.0)
+  GIT_TAG v0.4.0
+  PATCH_COMMAND ${vir-simd_patch}
+  UPDATE_DISCONNECTED 1
+)
 
 FetchContent_Declare(
   cpp-httplib

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,6 +299,13 @@ target_link_libraries(pmtv INTERFACE)
 add_library(vir INTERFACE)
 target_include_directories(vir INTERFACE ${vir-simd_SOURCE_DIR}/)
 
+# the script configure won't run on win32 without asking bash to do it
+if(WIN32)
+  set(BASH "bash.exe")
+else()
+  set(BASH "")
+endif()
+
 # FFTW3 is build 2 times for float and double precisions
 set(FFTW_PREFIX ${CMAKE_CURRENT_BINARY_DIR}/fftw)
 if(EMSCRIPTEN)
@@ -335,6 +342,7 @@ if(EMSCRIPTEN)
 else()
   set(FFTW_CFLAGS "${CFLAGS} -fPIC -w -O3 -march=native -mtune=native")
   set(FFTW_CONFIG
+      ${BASH}
       ${FFTW_PREFIX}/src/configure
       --enable-silent-rules
       --quiet
@@ -421,7 +429,7 @@ endif()
 option(ENABLE_EXAMPLES "Enable Example Builds" ${GR_TOPLEVEL_PROJECT})
 
 option(ENABLE_TESTING "Enable Test Builds" ${GR_TOPLEVEL_PROJECT})
-if(ENABLE_TESTING AND (UNIX OR APPLE))
+if(ENABLE_TESTING AND (UNIX OR APPLE OR WIN32))
   list(APPEND CMAKE_CTEST_ARGUMENTS "--output-on-failure")
   enable_testing()
   if(ENABLE_COVERAGE)

--- a/algorithm/include/gnuradio-4.0/algorithm/ImChart.hpp
+++ b/algorithm/include/gnuradio-4.0/algorithm/ImChart.hpp
@@ -8,7 +8,11 @@
 #include <numeric>
 #include <ranges>
 #include <source_location>
+#ifdef _WIN32
+#include <windows.h>
+#else
 #include <sys/ioctl.h>
+#endif
 #include <vector>
 
 #include <fmt/format.h> // TODO: remove for fmt::print until std::format and std::print is available in gcc & emscripten
@@ -216,8 +220,8 @@ public:
     double      axis_max_x{0.0};
     double      axis_min_y{0.0};
     double      axis_max_y{0.0};
-    std::size_t n_ticks_x = std::min(10LU, screenWidth / 2U);
-    std::size_t n_ticks_y = std::min(10LU, screenHeight / 2U);
+    std::size_t n_ticks_x = std::min(static_cast<std::size_t>(10), screenWidth / 2U);
+    std::size_t n_ticks_y = std::min(static_cast<std::size_t>(10), screenHeight / 2U);
 
     constexpr ImChart(std::size_t screenWidth_ = screenWidth, std::size_t screenHeight_ = screenHeight, const std::source_location location = std::source_location::current()) noexcept : _screen_width(screenWidth_), _screen_height(screenHeight_), _screen(_screen_height, std::vector<std::string>(_screen_width, " ")), _brailleArray(_screen_width * kCellWidth, std::vector<uint16_t>(_screen_height * kCellHeight, 0UZ)), _location(location) {}
 
@@ -392,7 +396,7 @@ public:
         std::string srcLocation = fmt::format("{}:{}", fullPath, _location.line());
 
         // calculate starting position, clamping to screen width
-        std::size_t startX = std::max(0LU, _screen_width - srcLocation.size() - 1UZ);
+        std::size_t startX = std::max(static_cast<std::size_t>(0), _screen_width - srcLocation.size() - 1UZ);
         std::size_t y      = _screen_height - 1; // position for the last line
 
         for (std::size_t i = 0; i < srcLocation.size() && startX + i < _screen_width; ++i) {
@@ -403,7 +407,7 @@ public:
     [[nodiscard]] constexpr std::size_t getHorizontalAxisPositionY() const noexcept {
         const double relative_position = (0.0 - axis_min_y) / (axis_max_y - axis_min_y);
         const auto   position          = static_cast<std::size_t>((1.0 - relative_position) * static_cast<double>(_screen_height));
-        return std::clamp(position, 0LU, _screen_height - 3LU);
+        return std::clamp(position, static_cast<std::size_t>(0), static_cast<std::size_t>(_screen_height - 3));
     }
 
     [[nodiscard]] constexpr std::size_t getVerticalAxisPositionX() const noexcept {

--- a/algorithm/test/qa_ImChart.cpp
+++ b/algorithm/test/qa_ImChart.cpp
@@ -74,12 +74,12 @@ const boost::ut::suite<"ImChart"> windowTests = [] {
         }
     } | std::vector{10UZ, 20UZ, 42UZ, 50UZ, 100UZ};
 
-    constexpr std::size_t sizeX = 120;
-    constexpr std::size_t sizeY = 16;
-    constexpr double      xMin  = 0.0;
-    constexpr double      xMax  = 100.0;
-    constexpr double      yMin  = -5.0;
-    constexpr double      yMax  = +5.0;
+    constexpr std::size_t             sizeX = 120;
+    constexpr std::size_t             sizeY = 16;
+    constexpr double                  xMin  = 0.0;
+    constexpr double                  xMax  = 100.0;
+    [[maybe_unused]] constexpr double yMin  = -5.0;
+    [[maybe_unused]] constexpr double yMax  = +5.0;
 
     "basic chart - lines"_test = [&](bool defaultConstructor) {
         using namespace gr::graphs;

--- a/blocklib_generator/tools/parse_registrations.cpp
+++ b/blocklib_generator/tools/parse_registrations.cpp
@@ -31,6 +31,14 @@
 #include <string_view>
 #include <vector>
 
+inline std::string pathToString(const std::filesystem::path& path) {
+#if defined(_WIN32)
+    return path.string();
+#else
+    return path;
+#endif
+}
+
 constexpr std::string_view kRegistrationMacroName = "GR_REGISTER_BLOCK";
 
 namespace detail {
@@ -296,9 +304,10 @@ int main(int argc, char** argv) try {
 
     const auto moduleName = options.outDir.filename().string();
 
+
     const auto integratorSourceFile = (options.outDir / "integrator.cpp");
     if (!std::filesystem::exists(integratorSourceFile)) {
-        std::ofstream integrator = openFile(integratorSourceFile);
+        std::ofstream integrator = openFile(pathToString(integratorSourceFile));
         integrator << std::format(R"cppcode(
             #include <gnuradio-4.0/BlockRegistry.hpp>
 
@@ -318,7 +327,7 @@ int main(int argc, char** argv) try {
 
     const auto integratorHeaderFile = (options.outDir / moduleName);
     if (!std::filesystem::exists(integratorHeaderFile)) {
-        std::ofstream integrator = openFile(integratorHeaderFile);
+        std::ofstream integrator = openFile(pathToString(integratorHeaderFile));
         integrator << std::format(R"cppcode(
             #ifndef GR_BLOCKLIB_INIT_MODULE_{0}
             #define GR_BLOCKLIB_INIT_MODULE_{0}

--- a/blocks/electrical/CMakeLists.txt
+++ b/blocks/electrical/CMakeLists.txt
@@ -2,6 +2,9 @@ add_library(gr-electrical INTERFACE)
 target_link_libraries(gr-electrical INTERFACE gnuradio-core gnuradio-algorithm)
 target_include_directories(gr-electrical INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
                                                    $<INSTALL_INTERFACE:include/>)
+if(WIN32)
+  target_compile_definitions(gr-electrical INTERFACE BUILDING_MYPLUGIN)
+endif()
 
 gr_add_block_library(
   GrElectricalBlocks

--- a/blocks/fileio/CMakeLists.txt
+++ b/blocks/fileio/CMakeLists.txt
@@ -2,6 +2,9 @@ add_library(gr-fileio INTERFACE)
 target_link_libraries(gr-fileio INTERFACE gnuradio-core)
 target_include_directories(gr-fileio INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
                                                $<INSTALL_INTERFACE:include/>)
+if(WIN32)
+  target_compile_definitions(gr-fileio INTERFACE BUILDING_MYPLUGIN)
+endif()
 
 gr_add_block_library(
   GrFileIoBlocks

--- a/blocks/fileio/include/gnuradio-4.0/fileio/BasicFileIo.hpp
+++ b/blocks/fileio/include/gnuradio-4.0/fileio/BasicFileIo.hpp
@@ -156,7 +156,7 @@ private:
         } break;
         case Mode::multi: {
             // _fileCounter ensures that the filenames are unique and still sortable by date-time, with an additional counter to handle rapid successive file creation.
-            _actualFileName = filePath.parent_path() / (gr::time::getIsoTime() + "_" + std::to_string(_fileCounter++) + "_" + filePath.filename().string());
+            _actualFileName = (filePath.parent_path() / (gr::time::getIsoTime() + "_" + std::to_string(_fileCounter++) + "_" + filePath.filename().string())).string();
             _file.open(_actualFileName, std::ios::binary);
             break;
         }

--- a/blocks/filter/CMakeLists.txt
+++ b/blocks/filter/CMakeLists.txt
@@ -2,6 +2,9 @@ add_library(gr-filter INTERFACE)
 target_link_libraries(gr-filter INTERFACE gnuradio-core)
 target_include_directories(gr-filter INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
                                                $<INSTALL_INTERFACE:include/>)
+if(WIN32)
+  target_compile_definitions(gr-filter INTERFACE BUILDING_MYPLUGIN)
+endif()
 
 gr_add_block_library(
   GrFilterBlocks

--- a/blocks/fourier/CMakeLists.txt
+++ b/blocks/fourier/CMakeLists.txt
@@ -2,6 +2,9 @@ add_library(gr-fourier INTERFACE)
 target_link_libraries(gr-fourier INTERFACE gnuradio-core gnuradio-algorithm)
 target_include_directories(gr-fourier INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
                                                 $<INSTALL_INTERFACE:include/>)
+if(WIN32)
+  target_compile_definitions(gr-fourier INTERFACE BUILDING_MYPLUGIN)
+endif()
 
 gr_add_block_library(
   GrFourierBlocks

--- a/blocks/http/CMakeLists.txt
+++ b/blocks/http/CMakeLists.txt
@@ -2,6 +2,9 @@ add_library(gr-http INTERFACE)
 target_link_libraries(gr-http INTERFACE gnuradio-core gnuradio-algorithm httplib::httplib)
 target_include_directories(gr-http INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
                                              $<INSTALL_INTERFACE:include/>)
+if(WIN32)
+  target_compile_definitions(gr-http INTERFACE BUILDING_MYPLUGIN)
+endif()
 
 gr_add_block_library(
   GrHttpBlocks

--- a/blocks/soapy/include/gnuradio-4.0/soapy/Soapy.hpp
+++ b/blocks/soapy/include/gnuradio-4.0/soapy/Soapy.hpp
@@ -133,7 +133,7 @@ This block supports multiple output ports and was tested against the 'rtlsdr' an
             for (std::size_t i = 0UZ; i < rx_channels->size(); ++i) {
                 output[i] = std::span<T>(outputs[i]).subspan(0, maxSamples);
             }
-            ret = _rxStream.readStreamIntoBufferList(flags, time_ns, max_time_out_us, output);
+            ret = _rxStream.readStreamIntoBufferList(flags, time_ns, static_cast<long int>(max_time_out_us), output);
         }
         // for detailed debugging: detail::printSoapyReturnDebugInfo(ret, flags, time_ns);
 

--- a/blocks/soapy/src/CMakeLists.txt
+++ b/blocks/soapy/src/CMakeLists.txt
@@ -8,3 +8,6 @@ target_link_libraries(
           gr-testing
           gr-soapy
           ut)
+if(WIN32)
+  target_link_libraries(soapy_example PRIVATE dl)
+endif()

--- a/blocks/soapy/src/soapy_example.cpp
+++ b/blocks/soapy/src/soapy_example.cpp
@@ -71,7 +71,7 @@ int main(int argc, char* argv[]) {
     constexpr double     defaultRxGains           = 10.0;            // 10 dB
 
     std::filesystem::path exePath    = std::filesystem::current_path();
-    auto                  parsedArgs = parseArguments(argc, argv, exePath / "test_ch0.bin", exePath / "test_ch1.bin", defaultMaxFileSize, defaultSampleRate, defaultRxCenterFrequency, defaultBandwidth, defaultRxGains);
+    auto                  parsedArgs = parseArguments(argc, argv, (exePath / "test_ch0.bin").string(), (exePath / "test_ch1.bin").string(), defaultMaxFileSize, defaultSampleRate, defaultRxCenterFrequency, defaultBandwidth, defaultRxGains);
     if (!parsedArgs) {
         fmt::println(R"(
 Usage:

--- a/blocks/soapy/test/CMakeLists.txt
+++ b/blocks/soapy/test/CMakeLists.txt
@@ -10,4 +10,7 @@ target_link_libraries(
           gr-soapy
           gr-testing
           ut)
+if(WIN32)
+  target_link_libraries(qa_Soapy PRIVATE dl)
+endif()
 add_test(NAME qa_Soapy COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${CMAKE_CURRENT_BINARY_DIR}/qa_Soapy)

--- a/blocks/testing/CMakeLists.txt
+++ b/blocks/testing/CMakeLists.txt
@@ -2,6 +2,9 @@ add_library(gr-testing INTERFACE)
 target_link_libraries(gr-testing INTERFACE gnuradio-core ut-benchmark)
 target_include_directories(gr-testing INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
                                                 $<INSTALL_INTERFACE:include/>)
+if(WIN32)
+  target_compile_definitions(gr-testing INTERFACE BUILDING_MYPLUGIN)
+endif()
 
 gr_add_block_library(
   GrTestingBlocks

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -52,6 +52,9 @@ set_target_properties(gnuradio-blocklib-core
 message(WARNING "PATH include " $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/>)
 target_include_directories(gnuradio-blocklib-core PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/>)
 target_link_libraries(gnuradio-blocklib-core PUBLIC gnuradio-core)
+if(WIN32)
+  target_compile_definitions(gnuradio-blocklib-core PRIVATE BUILDING_MYPLUGIN)
+endif()
 
 # configure a header file to pass the CMake settings to the source code
 configure_file("${PROJECT_SOURCE_DIR}/cmake/config.hpp.in"

--- a/core/include/gnuradio-4.0/HistoryBuffer.hpp
+++ b/core/include/gnuradio-4.0/HistoryBuffer.hpp
@@ -316,7 +316,7 @@ public:
      * @brief Returns a span of elements with given (optional) length with the last element being the newest
      */
     [[nodiscard]] constexpr std::span<const T> get_span(std::size_t index, std::size_t length = std::dynamic_extent) const {
-        length = std::clamp(length, 0LU, std::min(_size - index, length));
+        length = std::clamp(length, std::size_t(0), std::min(_size - index, length));
         return std::span<const T>(&_buffer[map_index(index)], length);
     }
 

--- a/core/include/gnuradio-4.0/PluginLoader.hpp
+++ b/core/include/gnuradio-4.0/PluginLoader.hpp
@@ -162,7 +162,7 @@ public:
                         _handlers.push_back(std::move(handler));
 
                     } else {
-                        _failedPlugins[file.path()] = handler.status();
+                        _failedPlugins[file.path().string()] = handler.status();
                     }
                 }
             }

--- a/core/include/gnuradio-4.0/Scheduler.hpp
+++ b/core/include/gnuradio-4.0/Scheduler.hpp
@@ -18,6 +18,13 @@
 #include <gnuradio-4.0/meta/reflection.hpp>
 #include <gnuradio-4.0/thread/thread_pool.hpp>
 
+//FIXME - this is a hack to see if I can get the codebase built.  Findout "properly" where the
+//failure is.  The problem is that under Windows windows.h defines ERROR as 0.  This messes the
+//ERROR function work::status::ERROR.
+#ifdef ERROR
+#  undef ERROR
+#endif
+
 namespace gr::scheduler {
 using gr::thread_pool::BasicThreadPool;
 using namespace gr::message;

--- a/core/include/gnuradio-4.0/YamlPmt.hpp
+++ b/core/include/gnuradio-4.0/YamlPmt.hpp
@@ -890,7 +890,7 @@ struct ConvertList {
 
 enum class FlowType { List, Map };
 template<FlowType Type>
-auto parseFlow(ParseContext& ctx, std::string_view typeTag, int parentIndentLevel) {
+inline auto parseFlow(ParseContext& ctx, std::string_view typeTag, int parentIndentLevel) {
     using ResultType          = std::conditional_t<Type == FlowType::List, pmtv::pmt, pmtv::map_t>;
     using TemporaryResultType = std::conditional_t<Type == FlowType::List, std::vector<pmtv::pmt>, pmtv::map_t>;
     using ReturnType          = std::expected<ResultType, ParseError>;

--- a/core/include/gnuradio-4.0/thread/MemoryMonitor.hpp
+++ b/core/include/gnuradio-4.0/thread/MemoryMonitor.hpp
@@ -6,8 +6,8 @@
 #include <string>
 
 #if defined(_WIN32) || defined(_WIN64)
-#include <psapi.h>
 #include <windows.h>
+#include <psapi.h>
 #elif defined(__linux__)
 #include <fstream>
 #include <unistd.h>

--- a/core/include/gnuradio-4.0/thread/thread_pool.hpp
+++ b/core/include/gnuradio-4.0/thread/thread_pool.hpp
@@ -23,6 +23,12 @@
 #include "../WaitStrategy.hpp"
 #include "thread_affinity.hpp"
 
+#if defined(_WIN32)
+using ThreadCountType = unsigned long long;
+#else
+using ThreadCountType = unsigned long;
+#endif
+
 namespace gr::thread_pool {
 namespace detail {
 
@@ -628,7 +634,7 @@ private:
                 }
                 running = false;
             } else if (timeDiffSinceLastUsed > keepAliveDuration) { // decrease to the minimum of _minThreads in a thread safe way
-                unsigned long nThreads = numThreads();
+                ThreadCountType nThreads = numThreads();
                 while (nThreads > minThreads()) { // compare and swap loop
                     if (_numThreads.compare_exchange_weak(nThreads, nThreads - 1, std::memory_order_acq_rel)) {
                         _numThreads.notify_all();

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -16,6 +16,9 @@ if(NOT EMSCRIPTEN)
            gnuradio-options
            pmtv
            fmt)
+  if(WIN32)
+    target_compile_definitions(gnuradio-plugin PRIVATE BUILDING_MYPLUGIN)
+  endif()
 
   install(
     TARGETS gnuradio-plugin

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -19,6 +19,9 @@ function(setup_test_no_asan TEST_NAME)
             gr-basic
             gr-filter
             ut)
+  if(WIN32)
+    target_link_libraries(${TEST_NAME} PRIVATE dl)
+  endif()
   add_test(NAME ${TEST_NAME} COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${CMAKE_CURRENT_BINARY_DIR}/${TEST_NAME})
 endfunction()
 

--- a/core/test/plugins/CMakeLists.txt
+++ b/core/test/plugins/CMakeLists.txt
@@ -20,6 +20,9 @@ function(add_non_blocklib_plugin PLUGIN_NAME)
            gnuradio-core
            gnuradio-plugin
            fmt)
+  if(WIN32)
+    target_compile_definitions(gnuradio-plugin INTERFACE BUILDING_MYPLUGIN)
+  endif()
 endfunction()
 
 add_non_blocklib_plugin(good_math_plugin)

--- a/core/test/qa_AtomicBitset.cpp
+++ b/core/test/qa_AtomicBitset.cpp
@@ -73,7 +73,7 @@ void runAtomicBitsetTest(TBitset& bitset, std::size_t bitsetSize) {
         }
     }
 
-#if not defined(__EMSCRIPTEN__) && not defined(NDEBUG)
+#if not defined(__EMSCRIPTEN__) && not defined(NDEBUG) && not defined(_WIN32)
     expect(aborts([&] { bitset.set(bitsetSize); })) << "Setting bit should throw an assertion.";
     expect(aborts([&] { bitset.reset(bitsetSize); })) << "Resetting bit should throw an assertion.";
     expect(aborts([&] { bitset.test(bitsetSize); })) << "Testing bit should throw an assertion.";

--- a/core/test/qa_buffer.cpp
+++ b/core/test/qa_buffer.cpp
@@ -304,7 +304,7 @@ const boost::ut::suite CircularBufferTests = [] {
 
         expect(eq(reader.available(), 0UZ));
         expect(eq(reader.get().size(), 0UZ));
-#if not defined(__EMSCRIPTEN__) && not defined(NDEBUG)
+#if not defined(__EMSCRIPTEN__) && not defined(NDEBUG) && not defined (_WIN32)
         expect(aborts([&reader] { std::ignore = reader.get(1); }));
 #endif
         expect(eq(writer.available(), buffer.size()));
@@ -341,7 +341,7 @@ const boost::ut::suite CircularBufferTests = [] {
         expect(!reader.isConsumeRequested());
         expect(eq(reader.available(), buffer.size()));
 
-#if not defined(__EMSCRIPTEN__) && not defined(NDEBUG)
+#if not defined(__EMSCRIPTEN__) && not defined(NDEBUG) && not defined(_WIN32)
         expect(aborts([&reader] {
             {
                 ReaderSpanLike auto inSpan4 = reader.template get<SpanReleasePolicy::Terminate>(3);

--- a/patches/0001-vir-smid-src_constexpr_wrapper_h.patch
+++ b/patches/0001-vir-smid-src_constexpr_wrapper_h.patch
@@ -1,0 +1,13 @@
+diff --git a/vir/constexpr_wrapper.h b/vir/constexpr_wrapper.h
+index 0005b7d..4414745 100644
+--- a/vir/constexpr_wrapper.h
++++ b/vir/constexpr_wrapper.h
+@@ -459,7 +459,7 @@ namespace vir
+   namespace literals
+   {
+     template <char... Chars>
+-      constexpr auto operator"" _cw()
++      constexpr auto operator""_cw()
+       { return vir::cw<vir::detail::cw_parse<Chars...>()>; }
+   }
+ 


### PR DESCRIPTION
Arch just updated me to gcc-15.  I realize this is not one of the build environments, but I thought I should fix the build errors and submit the changes for review.

I am not a c++ expert, so please review this patch carefully, although I believe I have created a good patch.  It works under both gcc 14.2.0 and 15.1.1.

What follows are the notes from the commit.
CMakeList.txt
- vir-smid has a space between quotes and suffix which is deprecatd in
  c++23.  gcc-14 lets this go, but gcc-15 catches it.
- add patch to vir-smid via FetchContent

qa_ImChart.cpp
- with gcc-15, yMin and yMax are seen as not used, label them as
  [[maybe_unused]].

YamlPmt.hpp
- we are using auto where the return type cannot be deduced at the 
  point of use.  mark as inline to ensure the compiler knows it's a
  header-only inline template.