### PR TITLE
Make unit tests running again.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,8 @@ jobs:
         uses: dorny/paths-filter@v3
         with:
           filters: |
-             docker:
-               - 'docker/Dockerfile'
+            docker:
+              - 'docker/Dockerfile'
 
       - name: Set up Docker Label
         id: docker-label

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -511,7 +511,8 @@ if(ENABLE_TESTING
   ) # fortify_source is not possible without optimization
   target_link_libraries(gnuradio-options INTERFACE --coverage)
   append_coverage_compiler_flags()
-  set(GCOVR_ADDITIONAL_ARGS "--merge-mode-functions=merge-use-line-min")
+  set(GCOVR_ADDITIONAL_ARGS "--merge-mode-functions=merge-use-line-min"
+                            "--gcov-ignore-parse-errors=negative_hits.warn_once_per_file")
   setup_target_for_coverage_gcovr_xml(
     NAME
     coverage

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,13 @@ option(ENABLE_TBB "Enable the TBB dependency for std::execution::par in gcc" OFF
 option(ENABLE_EXAMPLES "Enable Example Builds" ${GR_TOPLEVEL_PROJECT})
 option(ENABLE_TESTING "Enable Test Builds" ${GR_TOPLEVEL_PROJECT})
 
+if(ENABLE_TESTING AND (UNIX OR APPLE))
+  include(CTest)
+  list(APPEND CMAKE_CTEST_ARGUMENTS "--output-on-failure")
+  enable_testing()
+  message("Building Tests and benchmarks.")
+endif()
+
 if(EMSCRIPTEN OR NOT GR_ENABLE_BLOCK_REGISTRY)
   set(INTERNAL_ENABLE_BLOCK_PLUGINS OFF)
 endif()
@@ -488,71 +495,67 @@ add_subdirectory(meta)
 add_subdirectory(algorithm)
 add_subdirectory(blocks)
 
-if(ENABLE_TESTING AND (UNIX OR APPLE))
-  list(APPEND CMAKE_CTEST_ARGUMENTS "--output-on-failure")
-  enable_testing()
-  if(ENABLE_COVERAGE)
-    message("Coverage reporting enabled")
-    include(cmake/CodeCoverage.cmake) # https://github.com/bilke/cmake-modules/blob/master/CodeCoverage.cmake #
-    # (License: BSL-1.0)
-    target_compile_options(
-      gnuradio-options
-      INTERFACE --coverage
-                -Og
-                -g1
-                -gz
-                # -gdwarf-2 -gstrict-dwarf
-      # -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0
-    ) # fortify_source is not possible without optimization
-    target_link_libraries(gnuradio-options INTERFACE --coverage)
-    append_coverage_compiler_flags()
-    set(GCOVR_ADDITIONAL_ARGS "--merge-mode-functions=merge-use-line-min")
-    setup_target_for_coverage_gcovr_xml(
-      NAME
-      coverage
-      EXECUTABLE
-      ctest
-      EXECUTABLE_ARGS
-      "--output-on-failure"
-      DEPENDENCIES
-      qa_buffer
-      qa_DataSink
-      qa_DynamicPort
-      qa_DynamicBlock
-      qa_HierBlock
-      qa_filter
-      qa_Settings
-      qa_Tags
-      qa_Scheduler
-      qa_thread_pool
-      qa_thread_affinity
-      qa_YamlPmt
-      EXCLUDE
-      "$CMAKE_BUILD_DIR/*")
-    setup_target_for_coverage_gcovr_html(
-      NAME
-      coverage_html
-      EXECUTABLE
-      ctest
-      EXECUTABLE_ARGS
-      "--output-on-failure"
-      DEPENDENCIES
-      qa_buffer
-      qa_DataSink
-      qa_DynamicPort
-      qa_DynamicBlock
-      qa_HierBlock
-      qa_filter
-      qa_Settings
-      qa_Tags
-      qa_Scheduler
-      qa_thread_pool
-      qa_thread_affinity
-      qa_YamlPmt
-      EXCLUDE
-      "$CMAKE_BUILD_DIR/*")
-  endif()
-  message("Building Tests and benchmarks.")
+if(ENABLE_TESTING
+   AND (UNIX OR APPLE)
+   AND ENABLE_COVERAGE)
+  message("Coverage reporting enabled")
+  include(cmake/CodeCoverage.cmake) # https://github.com/bilke/cmake-modules/blob/master/CodeCoverage.cmake #
+  # (License: BSL-1.0)
+  target_compile_options(
+    gnuradio-options
+    INTERFACE --coverage
+              -Og
+              -g1
+              -gz
+    # -gdwarf-2 -gstrict-dwarf -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0
+  ) # fortify_source is not possible without optimization
+  target_link_libraries(gnuradio-options INTERFACE --coverage)
+  append_coverage_compiler_flags()
+  set(GCOVR_ADDITIONAL_ARGS "--merge-mode-functions=merge-use-line-min")
+  setup_target_for_coverage_gcovr_xml(
+    NAME
+    coverage
+    EXECUTABLE
+    ctest
+    EXECUTABLE_ARGS
+    "--output-on-failure"
+    DEPENDENCIES
+    qa_buffer
+    qa_DataSink
+    qa_DynamicPort
+    qa_DynamicBlock
+    qa_HierBlock
+    qa_filter
+    qa_Settings
+    qa_Tags
+    qa_Scheduler
+    qa_thread_pool
+    qa_thread_affinity
+    qa_YamlPmt
+    EXCLUDE
+    "$CMAKE_BUILD_DIR/*")
+  setup_target_for_coverage_gcovr_html(
+    NAME
+    coverage_html
+    EXECUTABLE
+    ctest
+    EXECUTABLE_ARGS
+    "--output-on-failure"
+    DEPENDENCIES
+    qa_buffer
+    qa_DataSink
+    qa_DynamicPort
+    qa_DynamicBlock
+    qa_HierBlock
+    qa_filter
+    qa_Settings
+    qa_Tags
+    qa_Scheduler
+    qa_thread_pool
+    qa_thread_affinity
+    qa_YamlPmt
+    EXCLUDE
+    "$CMAKE_BUILD_DIR/*")
 endif()
 
 # print effective options

--- a/blocks/basic/include/gnuradio-4.0/basic/StreamToDataSet.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/StreamToDataSet.hpp
@@ -232,14 +232,6 @@ If multiple 'start' or 'stop' Tags arrive in a single merged tag, only one DataS
                 auto& ds       = _tempDataSets[i];
                 auto& accState = _accState[i];
 
-                // Note: Tags for pre-samples are not added to DataSet
-                if (n_max.value == 0UZ || ds.signal_values.size() < n_max.value) { // Add tags only if the DataSet is not full
-                    const Tag& mergedTag = this->mergedInputTag();
-                    if (!ds.timing_events.empty() && !mergedTag.map.empty() && accState.isActive) {
-                        ds.timing_events[0].emplace_back(static_cast<std::ptrdiff_t>(ds.signal_values.size()), mergedTag.map);
-                    }
-                }
-
                 // pre samples data accumulation
                 if (accState.isPreActive) {
                     // no need to check for n_max here: n_pre + n_post <= n_max
@@ -250,6 +242,14 @@ If multiple 'start' or 'stop' Tags arrive in a single merged tag, only one DataS
                     accState.isPreActive = false;
                     accState.nPreSamples = nPreSamplesToCopy;
                     accState.nSamples += nPreSamplesToCopy;
+                }
+
+                // Note: Tags for pre-samples are not added to DataSet
+                if (n_max.value == 0UZ || ds.signal_values.size() < n_max.value) { // Add tags only if the DataSet is not full
+                    const Tag& mergedTag = this->mergedInputTag();
+                    if (!ds.timing_events.empty() && !mergedTag.map.empty() && accState.isActive) {
+                        ds.timing_events[0].emplace_back(static_cast<std::ptrdiff_t>(ds.signal_values.size()), mergedTag.map);
+                    }
                 }
 
                 if (!accState.isPostActive) { // normal data accumulation

--- a/blocks/basic/test/qa_DataSink.cpp
+++ b/blocks/basic/test/qa_DataSink.cpp
@@ -946,10 +946,13 @@ const boost::ut::suite DataSinkTests = [] {
         expect(eq_collections(receivedDataSets[0UZ].signalValues(0UZ), getIota(300, 300.f)));
         expect(eq(receivedDataSets[0UZ].signalName(0UZ), "test signal"s));
         expect(eq(receivedDataSets[0UZ].signalUnit(0UZ), "test unit"s));
-        expect(eq(receivedDataSets[0UZ].timingEvents(0UZ).size(), 0UZ));
+        expect(eq(receivedDataSets[0UZ].timingEvents(0UZ).size(), 1UZ));
+        expect(eq(receivedDataSets[0UZ].timingEvents(0UZ)[0UZ].first, 100));
         expect(eq_collections(receivedDataSets[1UZ].signalValues(0UZ), getIota(300, 700.f)));
         expect(eq(receivedDataSets[1UZ].signalName(0UZ), "test signal"s));
         expect(eq(receivedDataSets[1UZ].signalUnit(0UZ), "test unit"s));
+        expect(eq(receivedDataSets[1UZ].timingEvents(0UZ).size(), 1UZ));
+        expect(eq(receivedDataSets[1UZ].timingEvents(0UZ)[0UZ].first, 100));
     };
 
     "data set callback"_test = [] {
@@ -990,10 +993,13 @@ const boost::ut::suite DataSinkTests = [] {
         expect(eq_collections(receivedDataSets[0UZ].signalValues(0UZ), getIota(300, 300.f)));
         expect(eq(receivedDataSets[0UZ].signalName(0UZ), "test signal"s));
         expect(eq(receivedDataSets[0UZ].signalUnit(0UZ), "test unit"s));
-        expect(eq(receivedDataSets[0UZ].timingEvents(0UZ).size(), 0UZ));
+        expect(eq(receivedDataSets[0UZ].timingEvents(0UZ).size(), 1UZ));
+        expect(eq(receivedDataSets[0UZ].timingEvents(0UZ)[0UZ].first, 100));
         expect(eq_collections(receivedDataSets[1UZ].signalValues(0UZ), getIota(300, 700.f)));
         expect(eq(receivedDataSets[1UZ].signalName(0UZ), "test signal"s));
         expect(eq(receivedDataSets[1UZ].signalUnit(0UZ), "test unit"s));
+        expect(eq(receivedDataSets[1UZ].timingEvents(0UZ).size(), 1UZ));
+        expect(eq(receivedDataSets[1UZ].timingEvents(0UZ)[0UZ].first, 100));
     };
 };
 


### PR DESCRIPTION
This PR includes 3 commits:
1) Make unit tests running again.
Fix ‑ move `enable_testing()` and include(CTest) before any directory that adds tests, right after the option(ENABLE_TESTING …) block and before the first add_subdirectory().

2) Fix qa_DataSink test, add additinal checks.
    Fix in StreamToDataSet: add timing_events only after pre samples are added.
    
 3) Fix gcc-14 Coverage: workaround GCC #68080 by adding --gcov-ignore-parse-errors=negative_hits.warn_once_per_file to gcovr args
