### PR TITLE
Add math block library to generated plugins

### DIFF
--- a/blocks/basic/include/gnuradio-4.0/basic/CommonBlocks.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/CommonBlocks.hpp
@@ -57,47 +57,4 @@ struct builtin_counter : gr::Block<builtin_counter<T>> {
 template<typename T>
 gr::Size_t builtin_counter<T>::s_event_count = 0;
 
-template<typename T>
-struct MultiAdder : public gr::Block<MultiAdder<T>> {
-    std::vector<gr::PortIn<T>> inputs;
-    gr::PortOut<T>             out;
-
-    gr::Annotated<gr::Size_t, "n_inputs", gr::Visible, gr::Doc<"variable number of inputs">, gr::Limits<1U, 32U>> n_inputs{0U};
-
-    GR_MAKE_REFLECTABLE(MultiAdder, inputs, out, n_inputs);
-
-    void settingsChanged(const gr::property_map& old_settings, const gr::property_map& new_settings) {
-        if (new_settings.contains("n_inputs") && old_settings.at("n_inputs") != new_settings.at("n_inputs")) {
-            // if one of the port is already connected and  n_inputs was changed then throw
-            if (std::any_of(inputs.begin(), inputs.end(), [](const auto& port) { return port.isConnected(); })) {
-                this->emitErrorMessage("settingsChanged(..)", gr::Error("Number of input ports cannot be changed after Graph initialization."));
-            }
-            std::print("{}: configuration changed: n_inputs {} -> {}\n", this->name, old_settings.at("n_inputs"), new_settings.at("n_inputs"));
-            inputs.resize(n_inputs);
-        }
-    }
-
-    template<gr::InputSpanLike TInput>
-    gr::work::Status processBulk(std::span<TInput>& inSpans, gr::OutputSpanLike auto& outSpan) {
-        std::size_t minSizeIn = std::ranges::min_element(inSpans, [](const auto& lhs, const auto& rhs) { return lhs.size() < rhs.size(); })->size();
-        std::size_t available = std::min(outSpan.size(), minSizeIn);
-
-        if (available == 0) {
-            return gr::work::Status::INSUFFICIENT_INPUT_ITEMS;
-        }
-
-        for (std::size_t i = 0; i < available; i++) {
-            outSpan[i] = std::accumulate(inSpans.begin(), inSpans.end(), 0, [i](T sum, auto span) { return sum + span[i]; });
-        }
-        outSpan.publish(available);
-        for (auto& inSpan : inSpans) {
-            [[maybe_unused]] bool success = inSpan.consume(available);
-            assert(success && "Check that consume was successful");
-        }
-
-        return gr::work::Status::OK;
-    }
-};
-static_assert(gr::HasProcessBulkFunction<MultiAdder<float>>);
-
 #endif // include guard

--- a/blocks/math/CMakeLists.txt
+++ b/blocks/math/CMakeLists.txt
@@ -3,6 +3,16 @@ target_link_libraries(gr-math INTERFACE gnuradio-core gnuradio-algorithm exprtk)
 target_include_directories(gr-math INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
                                              $<INSTALL_INTERFACE:include/>)
 
-if(ENABLE_TESTING)
+gr_add_block_library(
+  GrMathBlocks
+  MAKE_SHARED_LIBRARY
+  HEADERS
+  include/gnuradio-4.0/math/ExpressionBlocks.hpp
+  include/gnuradio-4.0/math/Math.hpp
+  include/gnuradio-4.0/math/Rotator.hpp
+  LINK_LIBRARIES
+  gr-math)
+
+if(TARGET GrMathBlocksShared AND ENABLE_TESTING)
   add_subdirectory(test)
 endif()

--- a/blocks/math/include/gnuradio-4.0/math/ExpressionBlocks.hpp
+++ b/blocks/math/include/gnuradio-4.0/math/ExpressionBlocks.hpp
@@ -61,7 +61,7 @@ struct vector_access_rtc : public exprtk::vector_access_runtime_check {
 
 } // namespace detail
 
-GR_REGISTER_BLOCK(gr::blocks::math::ExpressionSISO, [ float, double ]);
+GR_REGISTER_BLOCK(gr::blocks::math::ExpressionSISO, [T], [ float, double ]);
 
 template<typename T>
 requires std::floating_point<T>
@@ -138,7 +138,7 @@ For full syntax, conditionals, loops, and advanced features:
     }
 };
 
-GR_REGISTER_BLOCK(gr::blocks::math::ExpressionDISO, [ float, double ]);
+GR_REGISTER_BLOCK(gr::blocks::math::ExpressionDISO, [T], [ float, double ]);
 
 template<typename T>
 requires std::floating_point<T>
@@ -220,7 +220,7 @@ For full syntax, conditionals, loops, and advanced features:
     }
 };
 
-GR_REGISTER_BLOCK(gr::blocks::math::ExpressionBulk, [ float, double ]);
+GR_REGISTER_BLOCK(gr::blocks::math::ExpressionBulk, [T], [ float, double ]);
 
 template<typename T>
 requires std::floating_point<T>

--- a/blocks/math/include/gnuradio-4.0/math/Math.hpp
+++ b/blocks/math/include/gnuradio-4.0/math/Math.hpp
@@ -21,10 +21,10 @@ T defaultValue() noexcept {
 }
 } // namespace detail
 
-GR_REGISTER_BLOCK("gr::blocks::math::AddConst", gr::blocks::math::MathOpImpl, ([T], '+'), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ])
-GR_REGISTER_BLOCK("gr::blocks::math::SubtractConst", gr::blocks::math::MathOpImpl, ([T], '-'), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ])
-GR_REGISTER_BLOCK("gr::blocks::math::MultiplyConst", gr::blocks::math::MathOpImpl, ([T], '*'), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ])
-GR_REGISTER_BLOCK("gr::blocks::math::DivideConst", gr::blocks::math::MathOpImpl, ([T], '/'), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ])
+GR_REGISTER_BLOCK("gr::blocks::math::AddConst", gr::blocks::math::MathOpImpl, ([T], std::plus<[T]>), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ])
+GR_REGISTER_BLOCK("gr::blocks::math::SubtractConst", gr::blocks::math::MathOpImpl, ([T], std::minus<[T]>), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ])
+GR_REGISTER_BLOCK("gr::blocks::math::MultiplyConst", gr::blocks::math::MathOpImpl, ([T], std::multiplies<[T]>), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ])
+GR_REGISTER_BLOCK("gr::blocks::math::DivideConst", gr::blocks::math::MathOpImpl, ([T], std::divides<[T]>), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, gr::UncertainValue<float>, gr::UncertainValue<double>, std::complex<float>, std::complex<double> ])
 
 template<typename T, typename op>
 struct MathOpImpl : Block<MathOpImpl<T, op>> {

--- a/blocks/math/include/gnuradio-4.0/math/Rotator.hpp
+++ b/blocks/math/include/gnuradio-4.0/math/Rotator.hpp
@@ -12,7 +12,7 @@
 
 namespace gr::blocks::math {
 
-GR_REGISTER_BLOCK(gr::blocks::math::Rotator, [ std::complex<float>, std::complex<double> ])
+GR_REGISTER_BLOCK(gr::blocks::math::Rotator, [T], [ std::complex<float>, std::complex<double> ])
 
 template<pmtv::Complex T>
 struct Rotator : gr::Block<Rotator<T>> {

--- a/core/test/qa_DynamicBlock.cpp
+++ b/core/test/qa_DynamicBlock.cpp
@@ -4,7 +4,7 @@
 
 #include <gnuradio-4.0/Graph.hpp>
 #include <gnuradio-4.0/Scheduler.hpp>
-#include <gnuradio-4.0/basic/CommonBlocks.hpp>
+#include <gnuradio-4.0/math/Math.hpp>
 #include <gnuradio-4.0/testing/TagMonitors.hpp>
 
 #include <gnuradio-4.0/meta/UnitTestHelper.hpp>
@@ -22,15 +22,13 @@ const boost::ut::suite DynamicBlocktests = [] {
 
         gr::Graph graph;
 
-        auto& adder = graph.emplaceBlock<MultiAdder<double>>({{"n_inputs", nInputs}});
-        expect(adder.settings().applyStagedParameters().forwardParameters.empty());
-        auto& sink = graph.emplaceBlock<TagSink<double, ProcessFunction::USE_PROCESS_ONE>>({});
+        auto& adder = graph.emplaceBlock<gr::blocks::math::Add<double>>({{"n_inputs", nInputs}});
+        auto& sink  = graph.emplaceBlock<TagSink<double, ProcessFunction::USE_PROCESS_ONE>>({});
 
         std::vector<TagSource<double>*> sources;
         for (std::size_t i = 0; i < nInputs; ++i) {
             sources.push_back(std::addressof(graph.emplaceBlock<TagSource<double>>({{"n_samples_max", nSamples}, {"mark_tag", false}})));
-            expect(sources.back()->settings().applyStagedParameters().forwardParameters.empty());
-            expect(gr::ConnectionResult::SUCCESS == graph.connect(*sources.back(), "out"s, adder, "inputs#"s + std::to_string(sources.size() - 1)));
+            expect(gr::ConnectionResult::SUCCESS == graph.connect(*sources.back(), "out"s, adder, "in#"s + std::to_string(sources.size() - 1)));
         }
         expect(gr::ConnectionResult::SUCCESS == graph.connect<"out">(adder).to<"in">(sink));
 


### PR DESCRIPTION
Math library was missing but it is needed for some flowgraph in `opendigitizer`.

Add math block library to generated plugins
* Remove obsolet `MultiAdder` block -> use `gr::blocks::math::Add` instead
* Some fixes in math block registration