### PR TITLE
Fix problem with DataSinkRegistry singleton instances

### DIFF
--- a/blocks/basic/test/qa_PythonBlock.cpp
+++ b/blocks/basic/test/qa_PythonBlock.cpp
@@ -4,6 +4,7 @@
 #include <gnuradio-4.0/basic/PythonBlock.hpp>
 
 #include <gnuradio-4.0/Scheduler.hpp>
+#include <gnuradio-4.0/meta/UnitTestHelper.hpp>
 #include <gnuradio-4.0/testing/TagMonitors.hpp>
 
 const boost::ut::suite<"python::<C-API abstraction interfaces>"> pythonInterfaceTests = [] {

--- a/meta/include/gnuradio-4.0/meta/formatter.hpp
+++ b/meta/include/gnuradio-4.0/meta/formatter.hpp
@@ -13,10 +13,9 @@
 
 namespace gr {
 namespace time {
-[[nodiscard]] inline std::string getIsoTime() noexcept {
-    std::chrono::system_clock::time_point now  = std::chrono::system_clock::now();
-    const auto                            secs = std::chrono::time_point_cast<std::chrono::seconds>(now);
-    const auto                            ms   = std::chrono::duration_cast<std::chrono::milliseconds>(now - secs).count();
+[[nodiscard]] inline std::string getIsoTime(std::chrono::system_clock::time_point timePoint = std::chrono::system_clock::now()) noexcept {
+    const auto secs = std::chrono::time_point_cast<std::chrono::seconds>(timePoint);
+    const auto ms   = std::chrono::duration_cast<std::chrono::milliseconds>(timePoint - secs).count();
     return std::format("{:%Y-%m-%dT%H:%M:%S}.{:06}", secs, ms); // ms-precision ISO time-format
 }
 } // namespace time


### PR DESCRIPTION
#### Problem
Each `.so` that included `DataSink.hpp` created its own `DataSinkRegistry`
instance (one per translation unit), so the executable and its plug‑ins
worked with different instances of `DataSinkRegistry`.

Make the singleton symbol visible process-wide using `__attribute__((visibility("default")))` :
```cpp
__attribute__((visibility("default")))
inline DataSinkRegistry& globalDataSinkRegistry() {
    static DataSinkRegistry instance;
    return instance;
}
```

exports the singleton with default visibility, giving the whole process a single, shared `DataSinkRegistry`.



#### Alternative  fix
Move the definition out of the header and into a single .cpp compiled into a common library, then drop both inline and the visibility attribute:

