### PR TITLE
Add missing BlockRegistry.hpp header to StreamToDataSet

### DIFF
--- a/blocks/basic/include/gnuradio-4.0/basic/StreamToDataSet.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/StreamToDataSet.hpp
@@ -3,6 +3,7 @@
 
 #include "gnuradio-4.0/TriggerMatcher.hpp"
 #include <gnuradio-4.0/Block.hpp>
+#include <gnuradio-4.0/BlockRegistry.hpp>
 #include <gnuradio-4.0/DataSet.hpp>
 #include <gnuradio-4.0/HistoryBuffer.hpp>
 #include <gnuradio-4.0/algorithm/dataset/DataSetUtils.hpp>


### PR DESCRIPTION
This fix is required for OD. Including the StreamToDataset.hpp header causes a compilation error due to a missing dependency.