### PR TITLE
core: add .pc and update install targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -293,6 +293,10 @@ if(NOT (TARGET magic_enum))
   add_library(magic_enum INTERFACE)
   target_include_directories(magic_enum ${CMAKE_EXT_DEP_WARNING_GUARD}
                              INTERFACE ${PROJECT_SOURCE_DIR}/third_party/magic_enum/)
+
+  set(magic_enum_public_headers third_party/magic_enum/magic_enum.hpp third_party/magic_enum/magic_enum_utility.hpp)
+  set_target_properties(magic_enum PROPERTIES PUBLIC_HEADER "${magic_enum_public_headers}")
+  install(TARGETS magic_enum PUBLIC_HEADER DESTINATION include)
 endif()
 
 # include exprtk header-only libraries available as a statically linked library to simplify/speed-up builds
@@ -350,6 +354,8 @@ endif()
 add_library(pmtv INTERFACE)
 target_include_directories(pmtv INTERFACE ${pmt_SOURCE_DIR}/include/)
 target_link_libraries(pmtv INTERFACE)
+
+install(DIRECTORY ${pmt_SOURCE_DIR}/include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 add_library(vir INTERFACE)
 target_include_directories(vir INTERFACE ${vir-simd_SOURCE_DIR}/)
@@ -543,6 +549,13 @@ if(ENABLE_TESTING
     EXCLUDE
     "$CMAKE_BUILD_DIR/*")
 endif()
+
+# Configure and install the pkg-config file TODO: This should become more granular - .pc for each in-tree module
+configure_file(cmake/gnuradio4.pc.in ${CMAKE_CURRENT_BINARY_DIR}/gnuradio4.pc @ONLY)
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/gnuradio4.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig # Standard location
+                                                                                                     # for .pc files
+)
 
 # print effective options
 message(STATUS "================================================")

--- a/cmake/gnuradio4.pc.in
+++ b/cmake/gnuradio4.pc.in
@@ -1,0 +1,13 @@
+# cmake/gnuradio4.pc.in
+
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+
+Name: GNU Radio 4
+Description: Next-generation GNU Radio framework
+Version: @PROJECT_VERSION@
+
+Cflags: -I${includedir}
+Libs: -L${libdir} -lgnuradio-core

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -57,11 +57,16 @@ configure_file("${PROJECT_SOURCE_DIR}/cmake/config.hpp.in"
                "${CMAKE_CURRENT_BINARY_DIR}/include/gnuradio-4.0/config.hpp" @ONLY)
 # TODO: install configure file... but not really meaningful for header only library, since compile flags are defined by
 # the user...
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/include/gnuradio-4.0/config.hpp"
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/gnuradio-4.0")
 
 install(
   TARGETS gnuradio-core
-  EXPORT graphTargets
-  PUBLIC_HEADER DESTINATION include/)
+  EXPORT gnuradio4Targets
+  PUBLIC_HEADER DESTINATION include/gnuradio-4.0)
+
+# Just install the entire include directory
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 add_subdirectory(src)
 

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -18,8 +18,8 @@ if(NOT EMSCRIPTEN)
 
   install(
     TARGETS gnuradio-plugin
-    EXPORT graphPluginTargets
-    PUBLIC_HEADER DESTINATION include/)
+    EXPORT gnuradio4PluginTargets
+    PUBLIC_HEADER DESTINATION include/gnuradio-4.0)
 endif()
 
 if(ENABLE_EXAMPLES)

--- a/meta/CMakeLists.txt
+++ b/meta/CMakeLists.txt
@@ -1,7 +1,21 @@
 add_library(gnuradio-meta INTERFACE)
-target_include_directories(gnuradio-meta INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/> $<INSTALL_INTERFACE:include/>)
+target_include_directories(gnuradio-meta INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
+                                                   $<INSTALL_INTERFACE:include/>)
 target_link_libraries(gnuradio-meta INTERFACE gnuradio-options vir)
 
-if (ENABLE_TESTING)
-    add_subdirectory(test)
-endif ()
+set(meta_public_headers
+    include/gnuradio-4.0/meta/formatter.hpp
+    include/gnuradio-4.0/meta/reflection.hpp
+    include/gnuradio-4.0/meta/typelist.hpp
+    include/gnuradio-4.0/meta/utils.hpp
+    include/gnuradio-4.0/meta/UncertainValue.hpp)
+
+set_target_properties(gnuradio-meta PROPERTIES PUBLIC_HEADER "${meta_public_headers}")
+install(
+  TARGETS gnuradio-meta
+  EXPORT gnuradio4Targets
+  PUBLIC_HEADER DESTINATION include/gnuradio-4.0/meta)
+
+if(ENABLE_TESTING)
+  add_subdirectory(test)
+endif()


### PR DESCRIPTION
The goal of these changes is to be able to create a standalone install prefix for gnuradio4 such that an OOT can be defined without gnuradio4 as a subproject.

There will be more steps involved, but this is the minimal amount of changes that I needed to compile a basic OOT block in a separate repo while finding the appropriate include and lib using the installed .pc file

Ideally a follow on PR will install generated cmake files that publish all the targets