### PR TITLE
win32: fix for qa_AtomicBitset issue #585

### DIFF
--- a/core/test/qa_AtomicBitset.cpp
+++ b/core/test/qa_AtomicBitset.cpp
@@ -72,7 +72,7 @@ void runAtomicBitsetTest(TBitset& bitset, std::size_t bitsetSize) {
         }
     }
 
-#if not defined(__EMSCRIPTEN__) && not defined(NDEBUG)
+#if not defined(__EMSCRIPTEN__) && not defined(NDEBUG) && not defined(_WIN32)
     expect(aborts([&] { bitset.set(bitsetSize); })) << "Setting bit should throw an assertion.";
     expect(aborts([&] { bitset.reset(bitsetSize); })) << "Resetting bit should throw an assertion.";
     expect(aborts([&] { bitset.test(bitsetSize); })) << "Testing bit should throw an assertion.";


### PR DESCRIPTION
- exclude attempts to use boost::ut's aborts call in qa_AtomicBitset.cpp on win32.
- fixed AtomicBitset.hpp to use ULL instead of UL on win32 as std::size_t is unsigned long long on win32.