### PR TITLE
Added support for ImChart.hpp in windows

### DIFF
--- a/algorithm/include/gnuradio-4.0/algorithm/ImChart.hpp
+++ b/algorithm/include/gnuradio-4.0/algorithm/ImChart.hpp
@@ -8,7 +8,11 @@
 #include <numeric>
 #include <ranges>
 #include <source_location>
+#ifdef _WIN32
+#include <windows.h>
+#else
 #include <sys/ioctl.h>
+#endif
 #include <vector>
 
 #include <format>
@@ -216,8 +220,8 @@ public:
     double      axis_max_x{0.0};
     double      axis_min_y{0.0};
     double      axis_max_y{0.0};
-    std::size_t n_ticks_x = std::min(10LU, screenWidth / 2U);
-    std::size_t n_ticks_y = std::min(10LU, screenHeight / 2U);
+    std::size_t n_ticks_x = std::min(10UZ, screenWidth / 2UZ);
+    std::size_t n_ticks_y = std::min(10UZ, screenHeight / 2UZ);
 
     constexpr ImChart(std::size_t screenWidth_ = screenWidth, std::size_t screenHeight_ = screenHeight, const std::source_location location = std::source_location::current()) noexcept : _screen_width(screenWidth_), _screen_height(screenHeight_), _screen(_screen_height, std::vector<std::string>(_screen_width, " ")), _brailleArray(_screen_width * kCellWidth, std::vector<uint16_t>(_screen_height * kCellHeight, 0UZ)), _location(location) {}
 
@@ -395,7 +399,7 @@ public:
         std::string srcLocation = std::format("{}:{}", fullPath, _location.line());
 
         // calculate starting position, clamping to screen width
-        std::size_t startX = std::max(0LU, _screen_width - srcLocation.size() - 1UZ);
+        std::size_t startX = std::max(0UZ, _screen_width - srcLocation.size() - 1UZ);
         std::size_t y      = _screen_height - 1; // position for the last line
 
         for (std::size_t i = 0; i < srcLocation.size() && startX + i < _screen_width; ++i) {
@@ -406,7 +410,7 @@ public:
     [[nodiscard]] constexpr std::size_t getHorizontalAxisPositionY() const noexcept {
         const double relative_position = (0.0 - axis_min_y) / (axis_max_y - axis_min_y);
         const auto   position          = static_cast<std::size_t>((1.0 - relative_position) * static_cast<double>(_screen_height));
-        return std::clamp(position, 0LU, _screen_height - 3LU);
+        return std::clamp(position, 0UZ, _screen_height - 3UZ);
     }
 
     [[nodiscard]] constexpr std::size_t getVerticalAxisPositionX() const noexcept {

--- a/algorithm/test/example_ImChart.cpp
+++ b/algorithm/test/example_ImChart.cpp
@@ -7,7 +7,12 @@
 #include <thread>
 
 int main() {
+#ifdef _WIN32
+    SetConsoleOutputCP(CP_UTF8);
+    setlocale(LC_ALL, "C.UTF-8");
+#else
     setlocale(LC_ALL, "");
+#endif
     constexpr std::size_t sizeX = 121;
     constexpr std::size_t sizeY = 41;
     constexpr double      xMin  = 0.0;

--- a/algorithm/test/qa_DataSetEstimators.cpp
+++ b/algorithm/test/qa_DataSetEstimators.cpp
@@ -3,18 +3,12 @@
 #include <gnuradio-4.0/algorithm/ImChart.hpp>
 #include <gnuradio-4.0/algorithm/dataset/DataSetUtils.hpp> // for draw(...)
 #include <gnuradio-4.0/algorithm/filter/FilterTool.hpp>
+#include <gnuradio-4.0/meta/UnitTestHelper.hpp>
 #include <gnuradio-4.0/meta/formatter.hpp>
 
 #include <gnuradio-4.0/algorithm/dataset/DataSetEstimators.hpp>
 #include <gnuradio-4.0/algorithm/dataset/DataSetMath.hpp>
 #include <gnuradio-4.0/algorithm/dataset/DataSetTestFunctions.hpp>
-
-#ifdef _WIN32
-[[maybe_unused]] const auto _ = [] {
-    SetConsoleOutputCP(CP_UTF8);
-    return 0;
-}();
-#endif
 
 namespace test::detail {
 

--- a/algorithm/test/qa_DataSetEstimators.cpp
+++ b/algorithm/test/qa_DataSetEstimators.cpp
@@ -9,6 +9,13 @@
 #include <gnuradio-4.0/algorithm/dataset/DataSetMath.hpp>
 #include <gnuradio-4.0/algorithm/dataset/DataSetTestFunctions.hpp>
 
+#ifdef _WIN32
+[[maybe_unused]] const auto _ = [] {
+    SetConsoleOutputCP(CP_UTF8);
+    return 0;
+}();
+#endif
+
 namespace test::detail {
 
 template<class TLhs, class TRhs, class TEpsilon>

--- a/algorithm/test/qa_FilterTool.cpp
+++ b/algorithm/test/qa_FilterTool.cpp
@@ -12,6 +12,13 @@
 #include <gnuradio-4.0/algorithm/filter/FilterTool.hpp>
 #include <gnuradio-4.0/meta/formatter.hpp>
 
+#ifdef _WIN32
+[[maybe_unused]] const auto _ = [] {
+    SetConsoleOutputCP(CP_UTF8);
+    return 0;
+}();
+#endif
+
 template<gr::filter::ResponseType responseType, std::floating_point T>
 [[nodiscard]] std::vector<T> calculateFrequencyResponse(const std::vector<T>& frequencies, const gr::filter::iir::PoleZeroLocations& value) {
     using namespace gr::filter;

--- a/algorithm/test/qa_FilterTool.cpp
+++ b/algorithm/test/qa_FilterTool.cpp
@@ -10,14 +10,8 @@
 
 #include <gnuradio-4.0/algorithm/ImChart.hpp>
 #include <gnuradio-4.0/algorithm/filter/FilterTool.hpp>
+#include <gnuradio-4.0/meta/UnitTestHelper.hpp>
 #include <gnuradio-4.0/meta/formatter.hpp>
-
-#ifdef _WIN32
-[[maybe_unused]] const auto _ = [] {
-    SetConsoleOutputCP(CP_UTF8);
-    return 0;
-}();
-#endif
 
 template<gr::filter::ResponseType responseType, std::floating_point T>
 [[nodiscard]] std::vector<T> calculateFrequencyResponse(const std::vector<T>& frequencies, const gr::filter::iir::PoleZeroLocations& value) {

--- a/algorithm/test/qa_ImChart.cpp
+++ b/algorithm/test/qa_ImChart.cpp
@@ -6,13 +6,7 @@
 
 #include <gnuradio-4.0/algorithm/ImChart.hpp>
 #include <gnuradio-4.0/algorithm/dataset/DataSetUtils.hpp>
-
-#ifdef _WIN32
-[[maybe_unused]] const auto _ = [] {
-    SetConsoleOutputCP(CP_UTF8);
-    return 0;
-}();
-#endif
+#include <gnuradio-4.0/meta/UnitTestHelper.hpp>
 
 const boost::ut::suite<"ImChart"> windowTests = [] {
     using namespace boost::ut;

--- a/algorithm/test/qa_ImChart.cpp
+++ b/algorithm/test/qa_ImChart.cpp
@@ -7,6 +7,13 @@
 #include <gnuradio-4.0/algorithm/ImChart.hpp>
 #include <gnuradio-4.0/algorithm/dataset/DataSetUtils.hpp>
 
+#ifdef _WIN32
+[[maybe_unused]] const auto _ = [] {
+    SetConsoleOutputCP(CP_UTF8);
+    return 0;
+}();
+#endif
+
 const boost::ut::suite<"ImChart"> windowTests = [] {
     using namespace boost::ut;
     using namespace boost::ut::reflection;

--- a/blocks/basic/test/qa_sources.cpp
+++ b/blocks/basic/test/qa_sources.cpp
@@ -11,6 +11,13 @@
 #include <gnuradio-4.0/basic/SignalGenerator.hpp>
 #include <gnuradio-4.0/testing/TagMonitors.hpp>
 
+#ifdef _WIN32
+[[maybe_unused]] const auto _ = [] {
+    SetConsoleOutputCP(CP_UTF8);
+    return 0;
+}();
+#endif
+
 const boost::ut::suite TagTests = [] {
     using namespace boost::ut;
     using namespace gr;

--- a/blocks/basic/test/qa_sources.cpp
+++ b/blocks/basic/test/qa_sources.cpp
@@ -9,14 +9,8 @@
 #include <gnuradio-4.0/basic/ClockSource.hpp>
 #include <gnuradio-4.0/basic/FunctionGenerator.hpp>
 #include <gnuradio-4.0/basic/SignalGenerator.hpp>
+#include <gnuradio-4.0/meta/UnitTestHelper.hpp>
 #include <gnuradio-4.0/testing/TagMonitors.hpp>
-
-#ifdef _WIN32
-[[maybe_unused]] const auto _ = [] {
-    SetConsoleOutputCP(CP_UTF8);
-    return 0;
-}();
-#endif
 
 const boost::ut::suite TagTests = [] {
     using namespace boost::ut;

--- a/blocks/math/test/qa_Rotator.cpp
+++ b/blocks/math/test/qa_Rotator.cpp
@@ -7,6 +7,13 @@
 
 #include <gnuradio-4.0/algorithm/ImChart.hpp>
 
+#ifdef _WIN32
+[[maybe_unused]] const auto _ = [] {
+    SetConsoleOutputCP(CP_UTF8);
+    return 0;
+}();
+#endif
+
 namespace {
 
 template<typename T>

--- a/blocks/math/test/qa_Rotator.cpp
+++ b/blocks/math/test/qa_Rotator.cpp
@@ -6,13 +6,7 @@
 #include <gnuradio-4.0/math/Rotator.hpp>
 
 #include <gnuradio-4.0/algorithm/ImChart.hpp>
-
-#ifdef _WIN32
-[[maybe_unused]] const auto _ = [] {
-    SetConsoleOutputCP(CP_UTF8);
-    return 0;
-}();
-#endif
+#include <gnuradio-4.0/meta/UnitTestHelper.hpp>
 
 namespace {
 

--- a/blocks/testing/test/qa_UI_Integration.cpp
+++ b/blocks/testing/test/qa_UI_Integration.cpp
@@ -11,6 +11,13 @@
 #include "gnuradio-4.0/testing/ImChartMonitor.hpp"
 #include "gnuradio-4.0/testing/TagMonitors.hpp"
 
+#ifdef _WIN32
+[[maybe_unused]] const auto _ = [] {
+    SetConsoleOutputCP(CP_UTF8);
+    return 0;
+}();
+#endif
+
 const boost::ut::suite TagTests = [] {
     using namespace boost::ut;
     using namespace gr;

--- a/blocks/testing/test/qa_UI_Integration.cpp
+++ b/blocks/testing/test/qa_UI_Integration.cpp
@@ -8,15 +8,9 @@
 #include "gnuradio-4.0/algorithm/ImChart.hpp"
 #include "gnuradio-4.0/basic/ClockSource.hpp"
 #include "gnuradio-4.0/basic/FunctionGenerator.hpp"
+#include "gnuradio-4.0/meta/UnitTestHelper.hpp"
 #include "gnuradio-4.0/testing/ImChartMonitor.hpp"
 #include "gnuradio-4.0/testing/TagMonitors.hpp"
-
-#ifdef _WIN32
-[[maybe_unused]] const auto _ = [] {
-    SetConsoleOutputCP(CP_UTF8);
-    return 0;
-}();
-#endif
 
 const boost::ut::suite TagTests = [] {
     using namespace boost::ut;

--- a/meta/include/gnuradio-4.0/meta/UnitTestHelper.hpp
+++ b/meta/include/gnuradio-4.0/meta/UnitTestHelper.hpp
@@ -9,6 +9,14 @@
 
 #include "formatter.hpp"
 
+#if defined(_WIN32)
+#include <windows.h>
+[[maybe_unused]] inline const int _set_console_output = [] {
+    SetConsoleOutputCP(CP_UTF8);
+    return 0;
+}();
+#endif
+
 namespace gr::test {
 using namespace boost::ut;
 


### PR DESCRIPTION
- added windows.h include to ImChart.hpp
- added win32 call to SetConsoleOutputCP(UTF-8) to cpp programs built with ImChart.hpp
- added setlocale(C.UTF8) call to example_ImChart.cpp
- changed UL size specification to UZ, for std::min, std::max and std::clamp calls
- fixes https://github.com/fair-acc/gnuradio4/issues/584