### PR TITLE
updated bm_Scheduler

### DIFF
--- a/bench/benchmark.hpp
+++ b/bench/benchmark.hpp
@@ -801,7 +801,19 @@ public:
                             keyID < transposed_map.size() - 1 ? "├" : "└", keyID, transposed_map[0].first, transposed_map[keyID].first);
 
                         auto& marker_result_map = ResultType::add_result(meas);
-                        add_statistics(marker_result_map, utils::diff<N_ITERATIONS, long double>(transposed_map[keyID].second, transposed_map[0].second));
+
+                        const auto marker_latencies = utils::diff<N_ITERATIONS, long double>(transposed_map[keyID].second, transposed_map[0].second);
+
+                        if constexpr (N_ITERATIONS > 1) {
+                            add_statistics(marker_result_map, marker_latencies);
+                        } else {
+                            // even with N_ITER=1: show "min" and "mean" as the actual latency
+                            marker_result_map.try_emplace("min", marker_latencies[0], "s", _precision);
+                            marker_result_map.try_emplace("mean", marker_latencies[0], "s", _precision);
+                            marker_result_map.try_emplace("stddev", std::monostate{}, "s", _precision);
+                            marker_result_map.try_emplace("median", std::monostate{}, "s", _precision);
+                            marker_result_map.try_emplace("max", marker_latencies[0], "s", _precision);
+                        }
                     }
                 }
             }

--- a/blocks/testing/test/CMakeLists.txt
+++ b/blocks/testing/test/CMakeLists.txt
@@ -1,1 +1,2 @@
+add_ut_test(qa_NullSources)
 add_ut_test(qa_UI_Integration)

--- a/blocks/testing/test/qa_NullSources.cpp
+++ b/blocks/testing/test/qa_NullSources.cpp
@@ -1,0 +1,171 @@
+#include <boost/ut.hpp>
+
+#include <gnuradio-4.0/Block.hpp>
+#include <gnuradio-4.0/Graph.hpp>
+#include <gnuradio-4.0/Scheduler.hpp>
+
+#include <gnuradio-4.0/testing/NullSources.hpp>
+
+const boost::ut::suite<"Null[..] and Testing Blocks"> nullSourcesTests = [] {
+    using namespace boost::ut;
+    using namespace gr;
+    using namespace gr::testing;
+
+    constexpr auto kTestTypes = std::tuple<uint8_t, int16_t, int32_t, float, double>(); // only a limited set of test cases, could be improved to use pre-built modules
+
+    "NullSource->CountingSink"_test = []<typename T>(const T&) {
+        constexpr gr::Size_t N = 12;
+
+        Graph g;
+        auto& src  = g.emplaceBlock<NullSource<T>>();
+        auto& sink = g.emplaceBlock<CountingSink<T>>(property_map{{"n_samples_max", N}});
+
+        expect(eq(g.connect(src, "out"s, sink, "in"s), ConnectionResult::SUCCESS));
+
+        gr::scheduler::Simple sch{std::move(g)};
+        expect(sch.runAndWait().has_value());
+        expect(eq(sink.count, N));
+    } | kTestTypes;
+
+    "CountingSource->NullSink"_test = []<typename T>(const T&) {
+        constexpr gr::Size_t N_total     = 7;
+        constexpr T          start_value = T(3);
+
+        Graph g;
+        auto& src  = g.emplaceBlock<CountingSource<T>>(property_map{{"default_value", start_value}, {"n_samples_max", N_total}});
+        auto& sink = g.emplaceBlock<NullSink<T>>();
+
+        expect(eq(g.connect(src, "out"s, sink, "in"s), ConnectionResult::SUCCESS));
+
+        gr::scheduler::Simple sch{std::move(g)};
+        expect(sch.runAndWait().has_value());
+    } | kTestTypes;
+
+    "ConstantSource->Copy->CountingSink"_test = []<typename T>(const T&) {
+        constexpr gr::Size_t N     = 10;
+        constexpr T          value = T(7);
+
+        Graph g;
+        auto& src  = g.emplaceBlock<ConstantSource<T>>(property_map{{"default_value", value}, {"n_samples_max", N}});
+        auto& copy = g.emplaceBlock<Copy<T>>();
+        auto& sink = g.emplaceBlock<CountingSink<T>>(property_map{{"n_samples_max", N}});
+
+        expect(eq(g.connect(src, "out"s, copy, "in"s), ConnectionResult::SUCCESS));
+        expect(eq(g.connect(copy, "out"s, sink, "in"s), ConnectionResult::SUCCESS));
+
+        gr::scheduler::Simple sch{std::move(g)};
+        expect(sch.runAndWait().has_value());
+        expect(eq(sink.count, N));
+    } | kTestTypes;
+
+    "CountingSource->HeadBlock->CountingSink"_test = []<typename T>(const T&) {
+        constexpr gr::Size_t N_total     = 10;
+        constexpr gr::Size_t N_head      = 4;
+        constexpr T          start_value = T(5);
+
+        Graph g;
+        auto& src  = g.emplaceBlock<CountingSource<T>>(property_map{{"default_value", start_value}, {"n_samples_max", N_total}});
+        auto& head = g.emplaceBlock<HeadBlock<T>>(property_map{{"n_samples_max", N_head}});
+        auto& sink = g.emplaceBlock<CountingSink<T>>(property_map{{"n_samples_max", N_head}});
+
+        expect(eq(g.connect(src, "out"s, head, "in"s), ConnectionResult::SUCCESS));
+        expect(eq(g.connect(head, "out"s, sink, "in"s), ConnectionResult::SUCCESS));
+
+        gr::scheduler::Simple sch{std::move(g)};
+        expect(sch.runAndWait().has_value());
+        expect(eq(sink.count, N_head));
+    } | kTestTypes;
+
+    "ConstantSource->NullSink"_test = []<typename T>(const T&) {
+        constexpr gr::Size_t N = 5;
+
+        Graph g;
+        auto& src  = g.emplaceBlock<ConstantSource<T>>(property_map{{"default_value", T(99)}, {"n_samples_max", N}});
+        auto& sink = g.emplaceBlock<NullSink<T>>();
+
+        expect(eq(g.connect(src, "out"s, sink, "in"s), ConnectionResult::SUCCESS));
+
+        gr::scheduler::Simple sch{std::move(g)};
+        expect(sch.runAndWait().has_value());
+    } | kTestTypes;
+
+    "SlowSource->CountingSink"_test = []<typename T>(const T&) {
+        constexpr gr::Size_t N = 3;
+
+        Graph g;
+        auto& src  = g.emplaceBlock<SlowSource<T>>(property_map{{"default_value", T(77)}, {"delay", 10U}});
+        auto& sink = g.emplaceBlock<CountingSink<T>>(property_map{{"n_samples_max", N}});
+
+        expect(eq(g.connect(src, "out"s, sink, "in"s), ConnectionResult::SUCCESS));
+
+        gr::scheduler::Simple sch{std::move(g)};
+        expect(sch.runAndWait().has_value());
+        expect(eq(sink.count, N));
+    } | kTestTypes;
+
+    "SimCompute(zero)->CountingSink"_test = []<typename T>(const T&) {
+        constexpr gr::Size_t N = 8;
+
+        Graph g;
+        auto& src  = g.emplaceBlock<ConstantSource<T>>(property_map{{"default_value", T(5)}, {"n_samples_max", N}});
+        auto& sim  = g.emplaceBlock<SimCompute<T>>(property_map{{"complexity_order", 0.0f}, {"busy_wait", true}});
+        auto& sink = g.emplaceBlock<CountingSink<T>>(property_map{{"n_samples_max", N}});
+
+        expect(eq(g.connect(src, "out"s, sim, "in"s), ConnectionResult::SUCCESS));
+        expect(eq(g.connect(sim, "out"s, sink, "in"s), ConnectionResult::SUCCESS));
+
+        gr::scheduler::Simple sch{std::move(g)};
+        expect(sch.runAndWait().has_value());
+        expect(eq(sink.count, N));
+    } | kTestTypes;
+
+    "SimCompute(linear)->CountingSink"_test = []<typename T>(const T&) {
+        constexpr gr::Size_t N = 8;
+
+        Graph g;
+        auto& src  = g.emplaceBlock<ConstantSource<T>>(property_map{{"default_value", T(5)}, {"n_samples_max", N}});
+        auto& sim  = g.emplaceBlock<SimCompute<T>>(property_map{{"complexity_order", 1.0f}, {"busy_wait", true}});
+        auto& sink = g.emplaceBlock<CountingSink<T>>(property_map{{"n_samples_max", N}});
+
+        expect(eq(g.connect(src, "out"s, sim, "in"s), ConnectionResult::SUCCESS));
+        expect(eq(g.connect(sim, "out"s, sink, "in"s), ConnectionResult::SUCCESS));
+
+        gr::scheduler::Simple sch{std::move(g)};
+        expect(sch.runAndWait().has_value());
+        expect(eq(sink.count, N));
+    } | kTestTypes;
+
+    "SimCompute(quadratic)->CountingSink"_test = []<typename T>(const T&) {
+        constexpr gr::Size_t N = 6;
+
+        Graph g;
+        auto& src  = g.emplaceBlock<CountingSource<T>>(property_map{{"default_value", T(0)}, {"n_samples_max", N}});
+        auto& sim  = g.emplaceBlock<SimCompute<T>>(property_map{{"complexity_order", 2.0f}, {"busy_wait", false}});
+        auto& sink = g.emplaceBlock<CountingSink<T>>(property_map{{"n_samples_max", N}});
+
+        expect(eq(g.connect(src, "out"s, sim, "in"s), ConnectionResult::SUCCESS));
+        expect(eq(g.connect(sim, "out"s, sink, "in"s), ConnectionResult::SUCCESS));
+
+        gr::scheduler::Simple sch{std::move(g)};
+        expect(sch.runAndWait().has_value());
+        expect(eq(sink.count, N));
+    } | kTestTypes;
+
+    "SimCompute.compute_delay_seconds"_test = [] {
+        using namespace gr::testing;
+
+        SimCompute<float> sim;
+        sim.target_throughput   = 1e6f;  // 1 MS/s
+        sim.reference_work_size = 1000U; // 1000 samples
+        sim.complexity_order    = 2.0f;  // quadratic
+
+        constexpr std::size_t N = 2000;
+
+        const auto   delay        = sim.compute_delay_seconds(N);
+        const double expected_sec = std::pow(double(N) / 1000.0, 2.0) * (1000.0 / 1e6);
+
+        expect(approx(delay.count(), expected_sec, 1e-3));
+    };
+};
+
+int main() { /* not needed for UT */ }

--- a/core/benchmarks/bm_Scheduler.cpp
+++ b/core/benchmarks/bm_Scheduler.cpp
@@ -3,13 +3,21 @@
 #include <gnuradio-4.0/Graph.hpp>
 #include <gnuradio-4.0/Profiler.hpp>
 #include <gnuradio-4.0/Scheduler.hpp>
+#include <gnuradio-4.0/meta/reflection.hpp>
 
 #include <gnuradio-4.0/math/Math.hpp>
 #include <gnuradio-4.0/testing/NullSources.hpp>
+#include <gnuradio-4.0/testing/TagMonitors.hpp>
 
-inline constexpr std::size_t N_ITER    = 10;
-inline constexpr gr::Size_t  N_SAMPLES = gr::util::round_up(10'000'000, 1024);
-inline constexpr std::size_t N_NODES   = 5;
+using T          = float;
+using TestMarker = benchmark::MarkerMap<"first-out", "last-out", "first-in", "last-in">;
+
+inline constexpr std::size_t N_ITER        = 10; // TODO: identify/fix why scheduler `runAndWait()' doesn't re-initialises the connections properly for multi-threaded schedulers
+inline constexpr gr::Size_t  N_SAMPLES     = gr::util::round_up(10'000'000, 1024);
+inline constexpr std::size_t N_NODES       = 10;                                // the larger, the more pronounced the latency for non-critical-path aware scheduler
+inline constexpr gr::Size_t  N_BUFFER_SIZE = gr::util::round_up(200'000, 1024); // the larger, the more pronounced the latency for non-critical-path aware scheduler
+
+inline static TestMarker* _testMarker;
 
 template<typename T, typename Sink, typename Source>
 void create_cascade(gr::Graph& testGraph, Sink& src, Source& sink, std::size_t depth = 1) {
@@ -26,13 +34,13 @@ void create_cascade(gr::Graph& testGraph, Sink& src, Source& sink, std::size_t d
 
     for (std::size_t i = 0; i < mult1.size(); i++) {
         if (i == 0) {
-            expect(eq(gr::ConnectionResult::SUCCESS, testGraph.connect<"out">(src).template to<"in">(*mult1[i])));
+            expect(eq(gr::ConnectionResult::SUCCESS, testGraph.connect<"out">(src, N_BUFFER_SIZE).template to<"in">(*mult1[i])));
         } else {
-            expect(eq(gr::ConnectionResult::SUCCESS, testGraph.connect<"out">(*mult2[i - 1]).template to<"in">(*mult1[i])));
+            expect(eq(gr::ConnectionResult::SUCCESS, testGraph.connect<"out">(*mult2[i - 1], N_BUFFER_SIZE).template to<"in">(*mult1[i])));
         }
-        expect(eq(gr::ConnectionResult::SUCCESS, testGraph.connect<"out">(*mult1[i]).template to<"in">(*mult2[i])));
+        expect(eq(gr::ConnectionResult::SUCCESS, testGraph.connect<"out">(*mult1[i], N_BUFFER_SIZE).template to<"in">(*mult2[i])));
     }
-    expect(eq(gr::ConnectionResult::SUCCESS, testGraph.connect<"out">(*mult2[mult2.size() - 1]).template to<"in">(sink)));
+    expect(eq(gr::ConnectionResult::SUCCESS, testGraph.connect<"out">(*mult2[mult2.size() - 1], N_BUFFER_SIZE).template to<"in">(sink)));
 }
 
 template<typename T>
@@ -63,13 +71,14 @@ gr::Graph test_graph_bifurcated(std::size_t depth = 1) {
     return testGraph;
 }
 
-void exec_bm(auto& scheduler, const std::string& test_case) {
-    using namespace boost::ut;
+void exec_bm(auto& scheduler, const std::string& test_case, [[maybe_unused]] TestMarker& testMarker, std::source_location srcLoc = std::source_location::current()) {
     using namespace benchmark;
-    expect(scheduler.runAndWait().has_value()) << std::format("scheduler failure for test-case: {}", test_case);
+    _testMarker    = &testMarker;
+    const auto res = scheduler.runAndWait();
+    boost::ut::expect(res.has_value(), srcLoc) << [&] { return std::format("scheduler failure for test-case: {}\n    - error: {}", test_case, res.error()); } << boost::ut::fatal;
 }
 
-[[maybe_unused]] inline const boost::ut::suite scheduler_tests = [] {
+[[maybe_unused]] inline const boost::ut::suite<"basic scheduler tests"> scheduler_tests = [] {
     using namespace gr::profiling;
     using namespace boost::ut;
     using namespace benchmark;
@@ -81,33 +90,188 @@ void exec_bm(auto& scheduler, const std::string& test_case) {
     const auto minThreads = gr::thread_pool::Manager::defaultCpuPool()->minThreads();
     const auto maxThreads = gr::thread_pool::Manager::defaultCpuPool()->maxThreads();
     std::println("INFO: std::thread::hardware_concurrency() = {} - CPU thread bounds = [{}, {}]", std::thread::hardware_concurrency(), minThreads, maxThreads);
+    TestMarker marker;
 
-    gr::scheduler::Simple sched1(test_graph_linear<float>(2 * N_NODES));
-    "linear graph - simple scheduler"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched1]() { exec_bm(sched1, "linear-graph simple-sched"); };
+    gr::scheduler::Simple sched1(test_graph_linear<T>(2 * N_NODES));
+    "linear graph - simple scheduler"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched1, &marker]() { exec_bm(sched1, "linear-graph simple-sched", marker); };
 
-    gr::scheduler::BreadthFirst sched2(test_graph_linear<float>(2 * N_NODES));
-    "linear graph - BFS scheduler"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched2]() { exec_bm(sched2, "linear-graph BFS-sched"); };
+    gr::scheduler::BreadthFirst sched2(test_graph_linear<T>(2 * N_NODES));
+    "linear graph - BFS scheduler"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched2, &marker]() { exec_bm(sched2, "linear-graph BFS-sched", marker); };
 
-    gr::scheduler::Simple sched3(test_graph_bifurcated<float>(N_NODES));
-    "bifurcated graph - simple scheduler"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched3]() { exec_bm(sched3, "bifurcated-graph simple-sched"); };
+    gr::scheduler::Simple sched3(test_graph_bifurcated<T>(N_NODES));
+    "bifurcated graph - simple scheduler"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched3, &marker]() { exec_bm(sched3, "bifurcated-graph simple-sched", marker); };
 
-    gr::scheduler::BreadthFirst sched4(test_graph_bifurcated<float>(N_NODES));
-    "bifurcated graph - BFS scheduler"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched4]() { exec_bm(sched4, "bifurcated-graph BFS-sched"); };
+    gr::scheduler::BreadthFirst sched4(test_graph_bifurcated<T>(N_NODES));
+    "bifurcated graph - BFS scheduler"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched4, &marker]() { exec_bm(sched4, "bifurcated-graph BFS-sched", marker); };
 
-    gr::scheduler::Simple<multiThreaded> sched1_mt(test_graph_linear<float>(2 * N_NODES));
-    "linear graph - simple scheduler (multi-threaded)"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched1_mt]() { exec_bm(sched1_mt, "linear-graph simple-sched (multi-threaded)"); };
+    gr::scheduler::Simple<multiThreaded> sched1_mt(test_graph_linear<T>(2 * N_NODES));
+    "linear graph - simple scheduler (multi-threaded)"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched1_mt, &marker]() { exec_bm(sched1_mt, "linear-graph simple-sched (multi-threaded)", marker); };
 
-    gr::scheduler::BreadthFirst<multiThreaded> sched2_mt(test_graph_linear<float>(2 * N_NODES));
-    "linear graph - BFS scheduler (multi-threaded)"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched2_mt]() { exec_bm(sched2_mt, "linear-graph BFS-sched (multi-threaded)"); };
+    gr::scheduler::BreadthFirst<multiThreaded> sched2_mt(test_graph_linear<T>(2 * N_NODES));
+    "linear graph - BFS scheduler (multi-threaded)"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched2_mt, &marker]() { exec_bm(sched2_mt, "linear-graph BFS-sched (multi-threaded)", marker); };
 
-    gr::scheduler::Simple<multiThreaded> sched3_mt(test_graph_bifurcated<float>(N_NODES));
-    "bifurcated graph - simple scheduler (multi-threaded)"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched3_mt]() { exec_bm(sched3_mt, "bifurcated-graph simple-sched (multi-threaded)"); };
+    gr::scheduler::Simple<multiThreaded> sched3_mt(test_graph_bifurcated<T>(N_NODES));
+    "bifurcated graph - simple scheduler (multi-threaded)"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched3_mt, &marker]() { exec_bm(sched3_mt, "bifurcated-graph simple-sched (multi-threaded)", marker); };
 
-    gr::scheduler::BreadthFirst<multiThreaded> sched4_mt(test_graph_bifurcated<float>(N_NODES));
-    "bifurcated graph - BFS scheduler (multi-threaded)"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched4_mt]() { exec_bm(sched4_mt, "bifurcated-graph BFS-sched (multi-threaded)"); };
+    gr::scheduler::BreadthFirst<multiThreaded> sched4_mt(test_graph_bifurcated<T>(N_NODES));
+    "bifurcated graph - BFS scheduler (multi-threaded)"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched4_mt, &marker]() { exec_bm(sched4_mt, "bifurcated-graph BFS-sched (multi-threaded)", marker); };
 
-    gr::scheduler::BreadthFirst<multiThreaded, Profiler> sched4_mt_prof(test_graph_bifurcated<float>(N_NODES));
-    "bifurcated graph - BFS scheduler (multi-threaded) with profiling"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched4_mt_prof]() { exec_bm(sched4_mt_prof, "bifurcated-graph BFS-sched (multi-threaded) with profiling"); };
+    gr::scheduler::BreadthFirst<multiThreaded, Profiler> sched4_mt_prof(test_graph_bifurcated<T>(N_NODES));
+    "bifurcated graph - BFS scheduler (multi-threaded) with profiling"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched4_mt_prof, &marker]() { exec_bm(sched4_mt_prof, "bifurcated-graph BFS-sched (multi-threaded) with profiling", marker); };
+
+    ::benchmark::results::add_separator();
+};
+
+template<typename T>
+auto& createSource(gr::Graph& graph) {
+    using namespace gr::testing;
+    auto& src = graph.emplaceBlock<TagSource<T, ProcessFunction::USE_PROCESS_BULK>>({{"name", "source"}, {"n_samples_max", N_SAMPLES}});
+    src._tags = {
+        {0UZ, {{gr::tag::TRIGGER_NAME.shortKey(), "first"}, {gr::tag::TRIGGER_TIME.shortKey(), static_cast<uint64_t>(0)}, {gr::tag::TRIGGER_OFFSET.shortKey(), 0.f}}},             //
+        {(N_SAMPLES - 1UZ), {{gr::tag::TRIGGER_NAME.shortKey(), "last"}, {gr::tag::TRIGGER_TIME.shortKey(), static_cast<uint64_t>(0)}, {gr::tag::TRIGGER_OFFSET.shortKey(), 0.f}}} //
+    };
+    src._tagCallback = [](const gr::Tag& tag) {
+        std::string triggerName = std::get<std::string>(tag.map.at(gr::tag::TRIGGER_NAME.shortKey()));
+        if (triggerName == "first") {
+            _testMarker->at<"first-out">().now();
+        } else if (triggerName == "last") {
+            _testMarker->at<"last-out">().now();
+        } else {
+            throw gr::exception("unknown trigger name");
+        }
+    };
+    return src;
+}
+
+template<typename T>
+auto& createSink(gr::Graph& graph, bool instrumentalise = true) {
+    using namespace gr::testing;
+    auto& sink = graph.emplaceBlock<TagSink<T, ProcessFunction::USE_PROCESS_BULK>>({{"name", "sink"}});
+    if (!instrumentalise) {
+        return sink;
+    }
+    sink._tagCallback = [=](const gr::Tag& tag) {
+        std::string triggerName = std::get<std::string>(tag.map.at(gr::tag::TRIGGER_NAME.shortKey()));
+        if (triggerName == "first") {
+            _testMarker->at<"first-in">().now();
+        } else if (triggerName == "last") {
+            _testMarker->at<"last-in">().now();
+        } else {
+            throw gr::exception("unknown trigger name");
+        }
+    };
+    return sink;
+}
+
+enum class GraphTopology { DEFAULT, LINEAR, FORKED, SPLIT };
+
+void printGraphTopology(const gr::Graph& graph, GraphTopology topology) {
+    std::println("Graph Topology: {}:", magic_enum::enum_name(topology));
+    for (const auto& block : graph.blocks()) {
+        std::println("  - block: {}", block->name());
+    }
+    for (const auto& edge : graph.edges()) {
+        std::println("  - edge: {}", edge);
+    }
+}
+
+template<typename T>
+gr::Graph createInstrumentalisedGraph(GraphTopology topology = GraphTopology::LINEAR) {
+    using namespace boost::ut;
+    using namespace gr::testing;
+
+    gr::Graph graph;
+
+    switch (topology) {
+    case GraphTopology::LINEAR: { // creates a linear sequence of nodes -- deliberately in reverse order
+        std::size_t    depth = 4UZ;
+        auto&          sink  = createSink<T>(graph);
+        SimCompute<T>* lastBlock;
+        for (std::size_t i = 0UZ; i < depth; i++) {
+            std::string blockName = std::format("sim{}", depth - i);
+            auto&       simBlock  = graph.emplaceBlock<SimCompute<T>>({{"name", blockName}});
+            if (i == 0UZ) {
+                expect(eq(graph.connect(simBlock, "out"s, sink, "in"s, N_BUFFER_SIZE), gr::ConnectionResult::SUCCESS));
+            } else {
+                expect(eq(graph.connect(simBlock, "out"s, *lastBlock, "in"s, N_BUFFER_SIZE), gr::ConnectionResult::SUCCESS));
+            }
+            lastBlock = &simBlock;
+        }
+        auto& src = createSource<T>(graph);
+        expect(eq(graph.connect(src, "out"s, *lastBlock, "in"s, N_BUFFER_SIZE), gr::ConnectionResult::SUCCESS));
+    } break;
+    case GraphTopology::FORKED: { // deliberately 4 sim blocks to mimic the total time of the linear test-case
+        auto& src = createSource<T>(graph);
+        // branch #1
+        auto& simBlock1 = graph.emplaceBlock<SimCompute<T>>({{"name", "sim1"}});
+        expect(eq(graph.connect(src, "out"s, simBlock1, "in"s, N_BUFFER_SIZE), gr::ConnectionResult::SUCCESS));
+        // branch #2
+        auto& simBlock2 = graph.emplaceBlock<SimCompute<T>>({{"name", "sim2"}});
+        expect(eq(graph.connect(src, "out"s, simBlock2, "in"s, N_BUFFER_SIZE), gr::ConnectionResult::SUCCESS));
+        auto& simBlock3 = graph.emplaceBlock<SimCompute<T>>({{"name", "sim3"}});
+        expect(eq(graph.connect(simBlock2, "out"s, simBlock3, "in"s, N_BUFFER_SIZE), gr::ConnectionResult::SUCCESS));
+        // merge branch #1 & #2
+        auto& adder = graph.emplaceBlock<gr::blocks::math::Add<T>>({{"name", "adder"}, {"n_inputs", 2U}});
+        expect(eq(graph.connect(simBlock1, "out"s, adder, "in#0"s, N_BUFFER_SIZE), gr::ConnectionResult::SUCCESS));
+        expect(eq(graph.connect(simBlock3, "out"s, adder, "in#1"s, N_BUFFER_SIZE), gr::ConnectionResult::SUCCESS));
+
+        auto& simBlock4 = graph.emplaceBlock<SimCompute<T>>({{"name", "sim4"}});
+        expect(eq(graph.connect(adder, "out"s, simBlock4, "in"s, N_BUFFER_SIZE), gr::ConnectionResult::SUCCESS));
+
+        // final sink
+        auto& sink = createSink<T>(graph);
+        expect(eq(graph.connect(simBlock4, "out"s, sink, "in"s, N_BUFFER_SIZE), gr::ConnectionResult::SUCCESS));
+    } break;
+    case GraphTopology::SPLIT: { // deliberately 4 sim blocks to mimic the total time of the linear test-case
+        auto& src       = createSource<T>(graph);
+        auto& simBlock1 = graph.emplaceBlock<SimCompute<T>>({{"name", "sim1"}});
+        expect(eq(graph.connect(src, "out"s, simBlock1, "in"s, N_BUFFER_SIZE), gr::ConnectionResult::SUCCESS));
+        auto& simBlock2 = graph.emplaceBlock<SimCompute<T>>({{"name", "sim2"}});
+        expect(eq(graph.connect(simBlock1, "out"s, simBlock2, "in"s, N_BUFFER_SIZE), gr::ConnectionResult::SUCCESS));
+        auto& simBlock3 = graph.emplaceBlock<SimCompute<T>>({{"name", "sim3"}});
+        expect(eq(graph.connect(simBlock2, "out"s, simBlock3, "in"s, N_BUFFER_SIZE), gr::ConnectionResult::SUCCESS));
+        auto& simBlock4 = graph.emplaceBlock<SimCompute<T>>({{"name", "sim4"}});
+        expect(eq(graph.connect(simBlock3, "out"s, simBlock4, "in"s, N_BUFFER_SIZE), gr::ConnectionResult::SUCCESS));
+
+        auto& sink1 = createSink<T>(graph, false);
+        expect(eq(graph.connect(simBlock2, "out"s, sink1, "in"s, N_BUFFER_SIZE), gr::ConnectionResult::SUCCESS));
+        auto& sink2 = createSink<T>(graph, true);
+        expect(eq(graph.connect(simBlock4, "out"s, sink2, "in"s, N_BUFFER_SIZE), gr::ConnectionResult::SUCCESS));
+    } break;
+    default: {
+        create_cascade<T>(graph, createSource<T>(graph), createSink<T>(graph), 3UZ);
+    }
+    }
+
+    return graph;
+}
+
+[[maybe_unused]] inline const boost::ut::suite<"scheduler topology tests"> _timed_scheduler_tests = [] {
+    using namespace gr::profiling;
+    using namespace boost::ut;
+    using namespace benchmark;
+
+    "scheduler topology loop"_test = [](GraphTopology topology) {
+        const std::string topologyName(magic_enum::enum_name(topology));
+
+        gr::scheduler::Simple simple(createInstrumentalisedGraph<T>(topology));
+        printGraphTopology(simple.graph(), topology);
+        ::benchmark::benchmark(std::format("Simple scheduler - unlimited work - {}", topologyName)).repeat<N_ITER>(N_SAMPLES) = [&simple](TestMarker& marker) { exec_bm(simple, "test case #1", marker); };
+
+        gr::scheduler::DepthFirst depthFirstSched1(createInstrumentalisedGraph<T>(topology));
+        ::benchmark::benchmark(std::format("DFS scheduler - unlimited work - {}", topologyName)).repeat<N_ITER>(N_SAMPLES) = [&depthFirstSched1](TestMarker& marker) { exec_bm(depthFirstSched1, "test case #1", marker); };
+
+        gr::scheduler::BreadthFirst breathFirstSched1(createInstrumentalisedGraph<T>(topology));
+        ::benchmark::benchmark(std::format("BFS scheduler - unlimited work - {}", topologyName)).repeat<N_ITER>(N_SAMPLES) = [&breathFirstSched1](TestMarker& marker) { exec_bm(breathFirstSched1, "test case #2", marker); };
+
+        gr::scheduler::DepthFirst depthFirstSched2(createInstrumentalisedGraph<T>(topology), {{"max_work_items", 1024UZ}});
+        ::benchmark::benchmark(std::format("DFS scheduler - work limited to 1024 - {}", topologyName)).repeat<N_ITER>(N_SAMPLES) = [&depthFirstSched2](TestMarker& marker) { exec_bm(depthFirstSched2, "test case #2", marker); };
+
+        gr::scheduler::BreadthFirst breathFirstSched2(createInstrumentalisedGraph<T>(topology), {{"max_work_items", 1024UZ}});
+        ::benchmark::benchmark(std::format("BFS scheduler - work limited to 1024 - {}", topologyName)).repeat<N_ITER>(N_SAMPLES) = [&breathFirstSched2](TestMarker& marker) { exec_bm(breathFirstSched2, "test case #2", marker); };
+
+        ::benchmark::results::add_separator();
+    } | std::vector{GraphTopology::LINEAR, GraphTopology::FORKED, GraphTopology::SPLIT};
 };
 
 int main() { /* not needed by the UT framework */ }

--- a/core/include/gnuradio-4.0/Graph.hpp
+++ b/core/include/gnuradio-4.0/Graph.hpp
@@ -341,8 +341,10 @@ public:
         return *this;
     }
 
-    [[nodiscard]] std::span<std::unique_ptr<BlockModel>> blocks() noexcept { return {_blocks}; }
-    [[nodiscard]] std::span<Edge>                        edges() noexcept { return {_edges}; }
+    [[nodiscard]] std::span<const std::unique_ptr<BlockModel>> blocks() const noexcept { return {_blocks}; }
+    [[nodiscard]] std::span<std::unique_ptr<BlockModel>>       blocks() noexcept { return {_blocks}; }
+    [[nodiscard]] std::span<const Edge>                        edges() const noexcept { return {_edges}; }
+    [[nodiscard]] std::span<Edge>                              edges() noexcept { return {_edges}; }
 
     void clear() {
         _blocks.clear();
@@ -352,7 +354,7 @@ public:
     /**
      * @return atomic sequence counter that indicates if any block could process some data or messages
      */
-    [[nodiscard]] const Sequence& progress() noexcept { return *_progress.get(); }
+    [[nodiscard]] const Sequence& progress() const noexcept { return *_progress.get(); }
 
     BlockModel& addBlock(std::unique_ptr<BlockModel> block) {
         auto& newBlock = _blocks.emplace_back(std::move(block));

--- a/core/include/gnuradio-4.0/Profiler.hpp
+++ b/core/include/gnuradio-4.0/Profiler.hpp
@@ -281,7 +281,8 @@ public:
 };
 
 class Profiler {
-    gr::CircularBuffer<detail::TraceEvent> _buffer;
+    using BufferType = gr::CircularBuffer<detail::TraceEvent, std::dynamic_extent, ProducerType::Multi>;
+    BufferType _buffer;
     using WriterType  = decltype(_buffer.new_writer());
     using HandlerType = Handler<Profiler, WriterType>;
     std::mutex                             _handlers_lock;
@@ -292,7 +293,7 @@ class Profiler {
     detail::time_point                     _start = detail::clock::now();
 
 public:
-    explicit Profiler(const Options& options = {}) : _buffer(500000) {
+    explicit Profiler(const Options& options = {}) : _buffer(524288) {
         _event_handler = std::thread([options, &reader = _reader, &finished = _finished]() {
             auto          file_name = options.output_file;
             std::ofstream out_file;

--- a/core/include/gnuradio-4.0/Scheduler.hpp
+++ b/core/include/gnuradio-4.0/Scheduler.hpp
@@ -57,8 +57,8 @@ protected:
     decltype(_profiler.forThisThread()) _profilerHandler;
     std::shared_ptr<TaskExecutor>       _pool;
     std::atomic_size_t                  _nRunningJobs{0UZ};
-    std::recursive_mutex                _jobListsMutex; // only used when modifying and copying the graph->local job list
-    JobLists                            _jobLists = std::make_shared<std::vector<std::vector<BlockModel*>>>();
+    std::recursive_mutex                _executionOrderMutex; // only used when modifying and copying the graph->local job list
+    JobLists                            _executionOrder = std::make_shared<std::vector<std::vector<BlockModel*>>>();
 
     std::mutex                               _zombieBlocksMutex;
     std::vector<std::unique_ptr<BlockModel>> _zombieBlocks;
@@ -96,22 +96,7 @@ protected:
         doForNestedBlocks(doForNestedBlocks, _graph);
     }
 
-public:
-    using base_t = Block<Derived>;
-
-    Annotated<gr::Size_t, "timeout", Doc<"sleep timeout to wait if graph has made no progress ">>                              timeout_ms                      = 10U;
-    Annotated<gr::Size_t, "timeout_inactivity_count", Doc<"number of inactive cycles w/o progress before sleep is triggered">> timeout_inactivity_count        = 20U;
-    Annotated<gr::Size_t, "process_stream_to_message_ratio", Doc<"number of stream to msg processing">>                        process_stream_to_message_ratio = 16U;
-    Annotated<std::string, "pool name", Doc<"default pool name">>                                                              poolName                        = std::string(gr::thread_pool::kDefaultCpuPoolId);
-
-    GR_MAKE_REFLECTABLE(SchedulerBase, timeout_ms, timeout_inactivity_count, process_stream_to_message_ratio);
-
-    constexpr static block::Category blockCategory = block::Category::ScheduledBlockGroup;
-
-    [[nodiscard]] static constexpr auto executionPolicy() { return execution; }
-
-    explicit SchedulerBase(gr::Graph&& graph, std::string_view defaultPoolName, const profiling::Options& profiling_options = {}) //
-        : _graph(std::move(graph)), _profiler{profiling_options}, _profilerHandler{_profiler.forThisThread()}, _pool(gr::thread_pool::Manager::instance().get(defaultPoolName)) {
+    void registerPropertyCallBacks() noexcept {
         this->propertyCallbacks[scheduler::property::kEmplaceBlock] = std::mem_fn(&SchedulerBase::propertyCallbackEmplaceBlock);
         this->propertyCallbacks[scheduler::property::kRemoveBlock]  = std::mem_fn(&SchedulerBase::propertyCallbackRemoveBlock);
         this->propertyCallbacks[scheduler::property::kRemoveEdge]   = std::mem_fn(&SchedulerBase::propertyCallbackRemoveEdge);
@@ -119,6 +104,35 @@ public:
         this->propertyCallbacks[scheduler::property::kReplaceBlock] = std::mem_fn(&SchedulerBase::propertyCallbackReplaceBlock);
         this->propertyCallbacks[scheduler::property::kGraphGRC]     = std::mem_fn(&SchedulerBase::propertyCallbackGraphGRC);
         this->settings().updateActiveParameters();
+    }
+
+public:
+    using base_t = Block<Derived>;
+
+    Annotated<gr::Size_t, "timeout", Doc<"sleep timeout to wait if graph has made no progress ">>                              timeout_ms                      = 10U;
+    Annotated<gr::Size_t, "timeout_inactivity_count", Doc<"number of inactive cycles w/o progress before sleep is triggered">> timeout_inactivity_count        = 20U;
+    Annotated<gr::Size_t, "process_stream_to_message_ratio", Doc<"number of stream to msg processing">>                        process_stream_to_message_ratio = 16U;
+    Annotated<std::string, "pool name", Doc<"default pool name">>                                                              poolName                        = std::string(gr::thread_pool::kDefaultCpuPoolId);
+    Annotated<std::size_t, "max_work_items", Doc<"number of work items per work scheduling interval (controls latency)">>      max_work_items                  = std::numeric_limits<std::size_t>::max(); // TODO: check whether we can keep this std::size_t or more consistently to gr::Size_t
+    Annotated<property_map, "sched_settings", Doc<"scheduler implementation specific settings">>                               sched_settings{};
+
+    GR_MAKE_REFLECTABLE(SchedulerBase, timeout_ms, timeout_inactivity_count, process_stream_to_message_ratio, max_work_items, sched_settings);
+
+    constexpr static block::Category blockCategory = block::Category::ScheduledBlockGroup;
+
+    [[nodiscard]] static constexpr auto executionPolicy() { return execution; }
+
+    explicit SchedulerBase(gr::Graph&& graph, std::string_view defaultPoolName, const profiling::Options& profiling_options = {}) //
+        : _graph(std::move(graph)), _profiler{profiling_options}, _profilerHandler{_profiler.forThisThread()}, _pool(gr::thread_pool::Manager::instance().get(defaultPoolName)) {
+        registerPropertyCallBacks();
+    }
+
+    explicit SchedulerBase(gr::Graph&& graph, property_map initialSettings, std::string_view defaultPoolName = gr::thread_pool::kDefaultCpuPoolId) //
+        : base_t(initialSettings), _graph(std::move(graph)), _profiler{{}}, _profilerHandler{_profiler.forThisThread()}, _pool(gr::thread_pool::Manager::instance().get(defaultPoolName)) {
+        registerPropertyCallBacks();
+        std::ignore = this->settings().set(initialSettings);
+        std::ignore = this->settings().activateContext();
+        std::ignore = this->settings().applyStagedParameters();
     }
 
     ~SchedulerBase() {
@@ -129,8 +143,11 @@ public:
             }
         }
         waitDone();
-        _jobLists.reset(); // force earlier crashes is accessed after destruction
+        _executionOrder.reset(); // force earlier crashes if this is accessed after destruction (e.g. from thread that was kept running)
     }
+
+    [[nodiscard]] const gr::Graph& graph() const noexcept { return _graph; }
+    [[nodiscard]] const TProfiler& profiler() const noexcept { return _profiler; }
 
     [[nodiscard]] bool isProcessing() const
     requires(executionPolicy() == ExecutionPolicy::multiThreaded)
@@ -212,11 +229,15 @@ public:
         }
     }
 
-    [[nodiscard]] constexpr auto& graph() { return _graph; }
-
     std::expected<void, Error> runAndWait() {
         [[maybe_unused]] const auto pe = this->_profilerHandler.startCompleteEvent("scheduler_base.runAndWait");
         processScheduledMessages(); // make sure initial subscriptions are processed
+        if (this->state() == lifecycle::State::STOPPED || this->state() == lifecycle::State::ERROR) {
+            if (auto e = this->changeStateTo(lifecycle::State::INITIALISED); !e) {
+                this->emitErrorMessage("runAndWait() -> LifecycleState", e.error());
+                return std::unexpected(e.error());
+            }
+        }
         if (this->state() == lifecycle::State::IDLE) {
             if (auto e = this->changeStateTo(lifecycle::State::INITIALISED); !e) {
                 this->emitErrorMessage("runAndWait() -> LifecycleState", e.error());
@@ -256,7 +277,7 @@ public:
         }
     }
 
-    [[nodiscard]] const JobLists& jobs() const noexcept { return _jobLists; }
+    [[nodiscard]] const JobLists& jobs() const noexcept { return _executionOrder; }
 
 protected:
     void disconnectAllEdges() {
@@ -280,10 +301,10 @@ protected:
         return result;
     }
 
-    work::Result traverseBlockListOnce(const std::vector<BlockModel*>& blocks) noexcept {
-        constexpr std::size_t requestedWorkAllBlocks = std::numeric_limits<std::size_t>::max();
-        std::size_t           performedWorkAllBlocks = 0UZ;
-        bool                  unfinishedBlocksExist  = false; // i.e. at least one block returned OK, INSUFFICIENT_INPUT_ITEMS, or INSUFFICIENT_OUTPU_ITEMS
+    work::Result traverseBlockListOnce(const std::vector<BlockModel*>& blocks) const {
+        const std::size_t requestedWorkAllBlocks = max_work_items;
+        std::size_t       performedWorkAllBlocks = 0UZ;
+        bool              unfinishedBlocksExist  = false; // i.e. at least one block returned OK, INSUFFICIENT_INPUT_ITEMS, or INSUFFICIENT_OUTPU_ITEMS
         for (auto& currentBlock : blocks) {
             const auto [requested_work, performed_work, status] = currentBlock->work(requestedWorkAllBlocks);
             performedWorkAllBlocks += performed_work;
@@ -297,7 +318,7 @@ protected:
 #ifdef __EMSCRIPTEN__
         std::this_thread::sleep_for(std::chrono::microseconds(10u)); // workaround for incomplete std::atomic implementation (at least it seems for nodejs)
 #endif
-        return {requestedWorkAllBlocks, performedWorkAllBlocks, unfinishedBlocksExist ? work::Status::OK : work::Status::DONE};
+        return {max_work_items, performedWorkAllBlocks, unfinishedBlocksExist ? work::Status::OK : work::Status::DONE};
     }
 
     void init() {
@@ -307,6 +328,7 @@ protected:
     }
 
     void reset() {
+        _executionOrder->clear();
         forAllUnmanagedBlocks([this](auto& block) { this->emitErrorMessageIfAny("reset() -> LifecycleState", block->changeStateTo(lifecycle::INITIALISED)); });
         disconnectAllEdges();
     }
@@ -319,21 +341,21 @@ protected:
             this->emitErrorMessage("init()", "Failed to connect blocks in graph");
         }
 
-        std::lock_guard lock(_jobListsMutex);
+        std::lock_guard lock(_executionOrderMutex);
         forAllUnmanagedBlocks([this](auto& block) { //
             this->emitErrorMessageIfAny("LifecycleState -> RUNNING", block->changeStateTo(lifecycle::RUNNING));
         });
         if constexpr (executionPolicy() == ExecutionPolicy::singleThreaded || executionPolicy() == ExecutionPolicy::singleThreadedBlocking) {
             assert(_nRunningJobs.load(std::memory_order_acquire) == 0UZ);
-            static_cast<Derived*>(this)->poolWorker(0UZ, _jobLists);
+            static_cast<Derived*>(this)->poolWorker(0UZ, _executionOrder);
         } else { // run on processing thread pool
             [[maybe_unused]] const auto pe = _profilerHandler.startCompleteEvent("scheduler_base.runOnPool");
             assert(_nRunningJobs.load(std::memory_order_acquire) == 0UZ);
-            auto jobListsCopy = _jobLists;
-            for (std::size_t runnerID = 0UZ; runnerID < _jobLists->size(); runnerID++) {
+            auto jobListsCopy = _executionOrder;
+            for (std::size_t runnerID = 0UZ; runnerID < _executionOrder->size(); runnerID++) {
                 _pool->execute([this, runnerID, jobListsCopy]() { static_cast<Derived*>(this)->poolWorker(runnerID, jobListsCopy); });
             }
-            if (!_jobLists->empty()) {
+            if (!_executionOrder->empty()) {
                 _nRunningJobs.wait(0UZ, std::memory_order_acquire); // waits until at least one pool worker started
             }
         }
@@ -347,7 +369,7 @@ protected:
 
         std::vector<BlockModel*> localBlockList;
         {
-            std::lock_guard          lock(_jobListsMutex);
+            std::lock_guard          lock(_executionOrderMutex);
             std::vector<BlockModel*> blocks = jobList->at(runnerID);
             localBlockList.reserve(blocks.size());
             for (const auto& block : blocks) {
@@ -553,18 +575,17 @@ protected:
     /*
       Zombie Tutorial:
 
-      Blocks can't be deleted unless stopped, but since stopping can take time (async) we move such blocks
-      to the "zombie list" and disconnect them immediately from the graph. This allows them to stop and be deleted
-      safely.
+      Blocks cannot be deleted unless stopped, but stopping may take time (asynchronous).
+      We therefore move such blocks to the "zombie list" and disconnect them immediately from the graph,
+      allowing them to stop and be deleted safely.
 
-      Periodically, we call cleanupZombieBlocks(), which iterates the zombie list and deletes the blocks that are now stopped.
+      Each worker thread periodically calls cleanupZombieBlocks(), which:
+      - removes fully stopped zombies from the zombie list
+      - erases corresponding entries from its own localBlockList
+      - updates the shared _executionOrder to ensure zombies do not reappear on restart
 
-      cleanupZombieBlocks() is called *per-thread*, since we also need to update the localBlockList, i.e.: removing dangling block pointers
-      from the localBlockList.
-
-      We also update the _jobLists member variable, but probably that member can be removed, seems unneeded and only used so unit-tests can
-      query it.
-     */
+      This mechanism supports safe dynamic block removal while the scheduler is running, without blocking execution.
+    */
     void cleanupZombieBlocks(std::vector<BlockModel*>& localBlockList) {
         if (localBlockList.empty()) {
             return;
@@ -587,24 +608,19 @@ protected:
             switch ((*it)->state()) {
             case lifecycle::State::IDLE:
             case lifecycle::State::STOPPED:
-            case lifecycle::State::INITIALISED:
-                // This block can be deleted immediately
+            case lifecycle::State::INITIALISED: // block can be deleted immediately
                 shouldDelete = true;
                 break;
-            case lifecycle::State::ERROR:
-                // Delete as well. (Separate case block, as better ideas welcome)
+            case lifecycle::State::ERROR: // delete as well
                 shouldDelete = true;
                 break;
-            case lifecycle::State::REQUESTED_STOP:
-                // This block will be deleted later
+            case lifecycle::State::REQUESTED_STOP: // block will be deleted later
                 break;
-            case lifecycle::State::REQUESTED_PAUSE:
-                // This block will be deleted later
+            case lifecycle::State::REQUESTED_PAUSE: // block will be deleted later
                 // There's no transition from REQUESTED_PAUSE to REQUESTED_STOP
                 // Will be moved to REQUESTED_STOP as soon as it's possible
                 break;
-            case lifecycle::State::PAUSED:
-                // This zombie was in REQUESTED_PAUSE and now finally in PAUSED. Can be stopped now.
+            case lifecycle::State::PAUSED: // zombie was in REQUESTED_PAUSE and now finally in PAUSED. Can be stopped now.
                 // Will be deleted in a next zombie maintenance period
                 this->emitErrorMessageIfAny("cleanupZombieBlocks", (*it)->changeStateTo(lifecycle::State::REQUESTED_STOP));
                 break;
@@ -617,12 +633,9 @@ protected:
                 BlockModel* zombieRaw = it->get();
                 it                    = _zombieBlocks.erase(it); // ~Block() runs here
 
-                // We need to remove zombieRaw from jobLists as well, in case Scheduler ever goes to INITIALIZED
-                // again.
-                // TODO: I'd argue we should remove _jobLists to minimize having to maintain state. Instead, a job list can be
-                // calculated in start().
-                std::lock_guard lock(_jobListsMutex);
-                for (auto& jobList : *this->_jobLists) {
+                // We need to remove zombieRaw from jobLists as well, in case Scheduler ever goes to INITIALIZED again.
+                std::lock_guard lock(_executionOrderMutex);
+                for (auto& jobList : *this->_executionOrder) {
                     auto job_it = std::remove(jobList.begin(), jobList.end(), zombieRaw);
                     if (job_it != jobList.end()) {
                         jobList.erase(job_it, jobList.end());
@@ -647,6 +660,15 @@ protected:
         newBlocks.clear();
     }
 
+    /*
+      Moves a block to the zombie list:
+
+      - Requests stop if the block is still running or paused.
+      - Removes the block from adoption lists (to handle edge cases such as Add Block → Remove Block).
+      - Adds it to the zombie list.
+
+      The block will be physically deleted by cleanupZombieBlocks() when it reaches a safe state.
+    */
     void makeZombie(std::unique_ptr<BlockModel> block) {
         if (block->state() == lifecycle::State::PAUSED || block->state() == lifecycle::State::RUNNING) {
             this->emitErrorMessageIfAny("makeZombie", block->changeStateTo(lifecycle::State::REQUESTED_STOP));
@@ -691,6 +713,7 @@ protected:
             case lifecycle::State::REQUESTED_STOP:
                 // Can go into the zombie list and deleted
                 break;
+            default:;
             }
 
             _zombieBlocks.push_back(std::move(block));
@@ -732,6 +755,7 @@ protected:
                     break;
                 case lifecycle::State::STOPPED:
                 case lifecycle::State::ERROR: break;
+                default:;
                 }
 
                 _graph = std::move(newGraph);
@@ -742,7 +766,7 @@ protected:
                 // Alternatively, we could forbid kGraphGRC unless Scheduler was in STOPPED state. That would simplify logic, but
                 // put more burden on the client.
 
-                message.data = property_map{{"originalSchedulerState", int(originalState)}};
+                message.data = property_map{{"originalSchedulerState", static_cast<int>(originalState)}};
             } catch (const std::exception& e) {
                 message.data = std::unexpected(Error{std::format("Error parsing YAML: {}", e.what())});
             }
@@ -792,6 +816,7 @@ public:
     using base_t = SchedulerBase<Simple<execution, TProfiler>, execution, TProfiler>;
 
     explicit Simple(gr::Graph&& graph, std::string_view defaultThreadPool = gr::thread_pool::kDefaultCpuPoolId, const profiling::Options& profiling_options = {}) : base_t(std::move(graph), defaultThreadPool, profiling_options) {}
+    explicit Simple(gr::Graph&& graph, property_map initialSettings, std::string_view defaultThreadPool = gr::thread_pool::kDefaultCpuPoolId) : base_t(std::move(graph), std::move(initialSettings), defaultThreadPool) {}
 
 private:
     void init() {
@@ -799,28 +824,28 @@ private:
         [[maybe_unused]] const auto pe = this->_profilerHandler.startCompleteEvent("scheduler_simple.init");
 
         // generate job list
+        std::size_t nBlocks = 0UZ;
+        this->forAllUnmanagedBlocks([&nBlocks](auto&& /*block*/) { nBlocks++; });
+        std::vector<BlockModel*> allBlocks;
+        allBlocks.reserve(nBlocks);
+        this->forAllUnmanagedBlocks([&allBlocks](auto&& block) { allBlocks.push_back(block.get()); });
+
         std::size_t n_batches = 1UZ;
         switch (base_t::executionPolicy()) {
         case ExecutionPolicy::singleThreaded:
         case ExecutionPolicy::singleThreadedBlocking: break;
-        case ExecutionPolicy::multiThreaded: n_batches = std::min(static_cast<std::size_t>(this->_pool->maxThreads()), this->_graph.blocks().size()); break;
+        case ExecutionPolicy::multiThreaded: n_batches = std::min(static_cast<std::size_t>(this->_pool->maxThreads()), nBlocks); break;
+        default:;
         }
 
-        std::lock_guard lock(base_t::_jobListsMutex);
-
-        std::size_t blockCount = 0UZ;
-        this->forAllUnmanagedBlocks([&blockCount](auto&& /*block*/) { blockCount++; });
-        std::vector<BlockModel*> allBlocks;
-        allBlocks.reserve(blockCount);
-        this->forAllUnmanagedBlocks([&allBlocks](auto&& block) { allBlocks.push_back(block.get()); });
-
+        std::lock_guard lock(base_t::_executionOrderMutex);
         this->_adoptionBlocks.clear();
         this->_adoptionBlocks.resize(n_batches);
-        this->_jobLists->clear();
-        this->_jobLists->reserve(n_batches);
+        this->_executionOrder->clear();
+        this->_executionOrder->reserve(n_batches);
         for (std::size_t i = 0; i < n_batches; i++) {
             // create job-set for thread
-            auto& job = this->_jobLists->emplace_back(std::vector<BlockModel*>());
+            auto& job = this->_executionOrder->emplace_back(std::vector<BlockModel*>());
             job.reserve(allBlocks.size() / n_batches + 1);
             for (std::size_t j = i; j < allBlocks.size(); j += n_batches) {
                 job.push_back(allBlocks[j]);
@@ -842,15 +867,16 @@ detecting cycles and blocks which can be reached from several source blocks.)"">
     friend class lifecycle::StateMachine<BreadthFirst<execution, TProfiler>>;
     friend class SchedulerBase<BreadthFirst<execution, TProfiler>, execution, TProfiler>;
     static_assert(execution == ExecutionPolicy::singleThreaded || execution == ExecutionPolicy::multiThreaded, "Unsupported execution policy");
-    std::vector<BlockModel*> _blocklist;
 
 public:
     using base_t = SchedulerBase<BreadthFirst<execution, TProfiler>, execution, TProfiler>;
 
     explicit BreadthFirst(gr::Graph&& graph, std::string_view defaultThreadPool = gr::thread_pool::kDefaultCpuPoolId, const profiling::Options& profiling_options = {}) : base_t(std::move(graph), defaultThreadPool, profiling_options) {}
+    explicit BreadthFirst(gr::Graph&& graph, property_map initialSettings, std::string_view defaultThreadPool = gr::thread_pool::kDefaultCpuPoolId) : base_t(std::move(graph), std::move(initialSettings), defaultThreadPool) {}
 
 private:
     void init() {
+        std::vector<BlockModel*>    blockList;
         [[maybe_unused]] const auto pe = this->_profilerHandler.startCompleteEvent("breadth_first.init");
         using block_t                  = BlockModel*;
         base_t::init();
@@ -877,10 +903,16 @@ private:
         }
 
         // process all blocks, adding all unvisited child blocks to the queue
+        std::unordered_set<block_t> visited;
         while (!queue.empty()) {
             block_t currentBlock = queue.front();
             queue.pop();
-            _blocklist.push_back(currentBlock);
+
+            if (visited.insert(currentBlock).second) {
+                blockList.push_back(currentBlock);
+                visited.insert(currentBlock);
+            }
+
             if (_adjacency_list.contains(currentBlock)) { // node has outgoing edges
                 for (auto& dst : _adjacency_list.at(currentBlock)) {
                     if (!reached.contains(dst)) { // detect cycles. this could be removed if we guarantee cycle free graphs earlier
@@ -896,20 +928,21 @@ private:
         switch (base_t::executionPolicy()) {
         case ExecutionPolicy::singleThreaded:
         case ExecutionPolicy::singleThreadedBlocking: break;
-        case ExecutionPolicy::multiThreaded: n_batches = std::min(static_cast<std::size_t>(this->_pool->maxThreads()), _blocklist.size()); break;
+        case ExecutionPolicy::multiThreaded: n_batches = std::min(static_cast<std::size_t>(this->_pool->maxThreads()), blockList.size()); break;
+        default: assert(false && "ExecutionPolicy case not handled");
         }
 
         this->_adoptionBlocks.clear();
         this->_adoptionBlocks.resize(n_batches);
-        std::lock_guard lock(base_t::_jobListsMutex);
-        this->_jobLists->clear();
-        this->_jobLists->reserve(n_batches);
+        std::lock_guard lock(base_t::_executionOrderMutex);
+        this->_executionOrder->clear();
+        this->_executionOrder->reserve(n_batches);
         for (std::size_t i = 0; i < n_batches; i++) {
             // create job-set for thread
-            auto& job = this->_jobLists->emplace_back(std::vector<BlockModel*>());
-            job.reserve(_blocklist.size() / n_batches + 1);
-            for (std::size_t j = i; j < _blocklist.size(); j += n_batches) {
-                job.push_back(_blocklist[j]);
+            auto& job = this->_executionOrder->emplace_back(std::vector<BlockModel*>());
+            job.reserve(blockList.size() / n_batches + 1);
+            for (std::size_t j = i; j < blockList.size(); j += n_batches) {
+                job.push_back(blockList[j]);
             }
         }
     }
@@ -919,6 +952,94 @@ private:
         init();
     }
 };
+
+template<ExecutionPolicy execution = ExecutionPolicy::singleThreaded, profiling::ProfilerLike TProfiler = profiling::null::Profiler>
+class DepthFirst : public SchedulerBase<DepthFirst<execution, TProfiler>, execution, TProfiler> {
+    using Description = Doc<R""(Depth First Scheduler which traverses the graph starting from the source blocks in a depth-first manner.)"">;
+
+    friend class lifecycle::StateMachine<DepthFirst<execution, TProfiler>>;
+    friend class SchedulerBase<DepthFirst<execution, TProfiler>, execution, TProfiler>;
+    static_assert(execution == ExecutionPolicy::singleThreaded || execution == ExecutionPolicy::multiThreaded, "Unsupported execution policy");
+
+public:
+    using base_t = SchedulerBase<DepthFirst<execution, TProfiler>, execution, TProfiler>;
+
+    explicit DepthFirst(gr::Graph&& graph, std::string_view defaultThreadPool = gr::thread_pool::kDefaultCpuPoolId, const profiling::Options& profiling_options = {}) : base_t(std::move(graph), defaultThreadPool, profiling_options) {}
+    explicit DepthFirst(gr::Graph&& graph, property_map initialSettings, std::string_view defaultThreadPool = gr::thread_pool::kDefaultCpuPoolId) : base_t(std::move(graph), std::move(initialSettings), defaultThreadPool) {}
+
+private:
+    void init() {
+        std::vector<BlockModel*>    blocklist;
+        [[maybe_unused]] const auto pe = this->_profilerHandler.startCompleteEvent("depth_first.init");
+        using block_t                  = BlockModel*;
+        base_t::init();
+
+        // adjacency list
+        std::map<block_t, std::vector<block_t>> _adjacency_list{};
+        std::vector<block_t>                    _source_blocks{};
+        std::set<block_t>                       block_reached;
+
+        for (auto& e : this->_graph.edges()) {
+            _adjacency_list[e._sourceBlock].push_back(e._destinationBlock);
+            _source_blocks.push_back(e._sourceBlock);
+            block_reached.insert(e._destinationBlock);
+        }
+
+        _source_blocks.erase(std::remove_if(_source_blocks.begin(), _source_blocks.end(), [&block_reached](auto currentBlock) { return block_reached.contains(currentBlock); }), _source_blocks.end());
+
+        // depth first traversal — use stack
+        std::set<block_t> visited;
+
+        std::function<void(block_t)> dfs = [&](block_t node) {
+            if (visited.contains(node)) {
+                return;
+            }
+            visited.insert(node);
+
+            blocklist.push_back(node);
+
+            if (_adjacency_list.contains(node)) {
+                for (auto& dst : _adjacency_list.at(node)) {
+                    dfs(dst);
+                }
+            }
+        };
+
+        // launch from all source blocks
+        for (auto sourceBlock : _source_blocks) {
+            dfs(sourceBlock);
+        }
+
+        // batching
+        std::size_t n_batches = 1UZ;
+        switch (base_t::executionPolicy()) {
+        case ExecutionPolicy::singleThreaded:
+        case ExecutionPolicy::singleThreadedBlocking: break;
+        case ExecutionPolicy::multiThreaded: n_batches = std::min(static_cast<std::size_t>(this->_pool->maxThreads()), blocklist.size()); break;
+        default: assert(false && "ExecutionPolicy case not handled");
+        }
+
+        this->_adoptionBlocks.clear();
+        this->_adoptionBlocks.resize(n_batches);
+
+        std::lock_guard lock(base_t::_executionOrderMutex);
+        this->_executionOrder->clear();
+        this->_executionOrder->reserve(n_batches);
+        for (std::size_t i = 0; i < n_batches; i++) {
+            auto& job = this->_executionOrder->emplace_back(std::vector<BlockModel*>());
+            job.reserve(blocklist.size() / n_batches + 1);
+            for (std::size_t j = i; j < blocklist.size(); j += n_batches) {
+                job.push_back(blocklist[j]);
+            }
+        }
+    }
+
+    void reset() {
+        base_t::reset();
+        init();
+    }
+};
+
 } // namespace gr::scheduler
 
 #endif // GNURADIO_SCHEDULER_HPP

--- a/core/include/gnuradio-4.0/Tag.hpp
+++ b/core/include/gnuradio-4.0/Tag.hpp
@@ -136,7 +136,7 @@ public:
 };
 
 template<fixed_string Key, typename PMT_TYPE, fixed_string Unit, fixed_string Description, gr::meta::string_like TOtherString>
-inline constexpr std::strong_ordering operator<=>(const DefaultTag<Key, PMT_TYPE, Unit, Description>& dt, const TOtherString& str) noexcept {
+constexpr std::strong_ordering operator<=>(const DefaultTag<Key, PMT_TYPE, Unit, Description>& dt, const TOtherString& str) noexcept {
     if ((dt.shortKey() <=> str) == 0) {
         return std::strong_ordering::equal; // shortKeys are equal
     } else {
@@ -145,7 +145,7 @@ inline constexpr std::strong_ordering operator<=>(const DefaultTag<Key, PMT_TYPE
 }
 
 template<fixed_string Key, typename PMT_TYPE, fixed_string Unit, fixed_string Description, gr::meta::string_like TOtherString>
-inline constexpr std::strong_ordering operator<=>(const TOtherString& str, const DefaultTag<Key, PMT_TYPE, Unit, Description>& dt) noexcept {
+constexpr std::strong_ordering operator<=>(const TOtherString& str, const DefaultTag<Key, PMT_TYPE, Unit, Description>& dt) noexcept {
     if ((str <=> dt.shortKey()) == std::strong_ordering::equal) {
         return std::strong_ordering::equal; // shortKeys are equal
     } else {
@@ -154,12 +154,12 @@ inline constexpr std::strong_ordering operator<=>(const TOtherString& str, const
 }
 
 template<fixed_string Key, typename PMT_TYPE, fixed_string Unit, fixed_string Description, gr::meta::string_like TOtherString>
-inline constexpr bool operator==(const DefaultTag<Key, PMT_TYPE, Unit, Description>& dt, const TOtherString& str) noexcept {
+constexpr bool operator==(const DefaultTag<Key, PMT_TYPE, Unit, Description>& dt, const TOtherString& str) noexcept {
     return (dt <=> std::string_view(str)) == 0;
 }
 
 template<fixed_string Key, typename PMT_TYPE, fixed_string Unit, fixed_string Description, gr::meta::string_like TOtherString>
-inline constexpr bool operator==(const TOtherString& str, const DefaultTag<Key, PMT_TYPE, Unit, Description>& dt) noexcept {
+constexpr bool operator==(const TOtherString& str, const DefaultTag<Key, PMT_TYPE, Unit, Description>& dt) noexcept {
     return (std::string_view(str) <=> dt) == 0;
 }
 
@@ -176,6 +176,7 @@ inline EM_CONSTEXPR_STATIC DefaultTag<"trigger_name", std::string> TRIGGER_NAME;
 inline EM_CONSTEXPR_STATIC DefaultTag<"trigger_time", uint64_t, "ns", "UTC-based time-stamp"> TRIGGER_TIME;
 inline EM_CONSTEXPR_STATIC DefaultTag<"trigger_offset", float, "s", "sample delay w.r.t. the trigger (e.g.compensating analog group delays)"> TRIGGER_OFFSET;
 inline EM_CONSTEXPR_STATIC DefaultTag<"trigger_meta_info", property_map, "", "maps containing additional trigger information"> TRIGGER_META_INFO;
+inline EM_CONSTEXPR_STATIC DefaultTag<"local_time", uint64_t, "ns", "UTC-based time-stamp (host)"> LOCAL_TIME; // should be only in 'TRIGGER_META_INFO', used for metering sample vs. time propagation delays
 inline EM_CONSTEXPR_STATIC DefaultTag<"context", std::string, "", "multiplexing key to orchestrate node settings/behavioural changes"> CONTEXT;
 inline EM_CONSTEXPR_STATIC DefaultTag<"time", std::uint64_t, "", "multiplexing UTC-time in [ns] when ctx should be applied"> CONTEXT_TIME; // TODO: for backward compatibility -> rename to `ctx_time'
 inline EM_CONSTEXPR_STATIC DefaultTag<"reset_default", bool, "", "reset block state to stored default"> RESET_DEFAULTS;

--- a/core/test/qa_Scheduler.cpp
+++ b/core/test/qa_Scheduler.cpp
@@ -704,11 +704,6 @@ const boost::ut::suite<"SchedulerTests"> SchedulerTests = [] {
         scheduler.timeout_ms               = 100U; // also dynamically settable via messages/block interface
         scheduler.timeout_inactivity_count = 10U;  // also dynamically settable via messages/block interface
 
-        expect(scheduler.graph().reconnectAllEdges());
-        expect(source.out.isConnected()) << "source.out is connected";
-        expect(monitor.in.isConnected()) << "monitor.in is connected";
-        expect(monitor.out.isConnected()) << "monitor.out is connected";
-
         expect(eq(0UZ, scheduler.graph().progress().value())) << "initial progress definition (0)";
         std::expected<void, Error> schedulerResult;
         auto                       schedulerThread = std::thread([&scheduler, &schedulerResult] { schedulerResult = scheduler.runAndWait(); });

--- a/core/test/qa_SchedulerMessages.cpp
+++ b/core/test/qa_SchedulerMessages.cpp
@@ -29,7 +29,7 @@ class TestScheduler {
     std::expected<void, gr::Error> schedulerRet_;
     std::thread                    schedulerThread_;
 
-    gr::Graph& addSourceSink(gr::Graph& graph) const noexcept {
+    gr::Graph& withTestingSourceAndSink(gr::Graph& graph) const noexcept {
         graph.emplaceBlock<gr::testing::SlowSource<float>>();
         graph.emplaceBlock<gr::testing::CountingSink<float>>();
         return graph;
@@ -40,7 +40,7 @@ public:
     gr::MsgPortOut toScheduler;
     gr::MsgPortIn  fromScheduler;
 
-    TestScheduler(gr::Graph graph) : scheduler_(std::move(addSourceSink(graph))) {
+    TestScheduler(gr::Graph graph) : scheduler_(std::move(withTestingSourceAndSink(graph))) {
         using namespace gr::testing;
         expect(eq(ConnectionResult::SUCCESS, toScheduler.connect(scheduler_.msgIn)));
         expect(eq(ConnectionResult::SUCCESS, scheduler_.msgOut.connect(fromScheduler)));
@@ -189,7 +189,7 @@ const boost::ut::suite TopologyGraphTests = [] {
     };
 
     "Block removal tests"_test = [] {
-        gr::Graph graph = gr::Graph(context->loader);
+        gr::Graph graph(context->loader);
         graph.emplaceBlock("gr::testing::Copy<float32>", {});
         auto& temporaryBlock = graph.emplaceBlock("gr::testing::Copy<float32>", {});
 
@@ -449,7 +449,7 @@ const boost::ut::suite MoreTopologyGraphTests = [] {
     using namespace gr::testing;
     using enum gr::message::Command;
 
-    gr::Graph graph  = gr::Graph(context->loader);
+    gr::Graph graph(context->loader);
     auto&     source = graph.emplaceBlock<SlowSource<float>>();
     auto&     sink   = graph.emplaceBlock<CountingSink<float>>();
     expect(eq(ConnectionResult::SUCCESS, graph.connect<"out">(source).to<"in">(sink)));


### PR DESCRIPTION
 * added `SimCompute<T>` block to simulate compute delay and model latency effects for a given complexity order
 * added unit-tests for Null[Source, Sink], Counting[Sink, Source], ...
 * renamed _jobList to _executionOrder (better naming)
 * corrected latency statistic print-out in benchmark.hpp
 * added DFS scheduler, and added benchmark added cases
   * A - linear graph
   * B - forked graph
   * C - split graph
 * fixed bug by removing _blockList class member field in BFS and DFS scheduler (block list got duplicated on each init())
 * added property_map constructor to SchedulerBase
 
 Example output (N.B. 'first-out -> first-in' latency):
 
![image](https://github.com/user-attachments/assets/555af0d7-467e-48c8-bb90-92f937ab6add)
![image](https://github.com/user-attachments/assets/ef7061cf-7d16-47ae-b529-a509135ba24e)
![image](https://github.com/user-attachments/assets/3a87af66-d78f-4287-ba55-a7c6ac2a2397)

 
 