### PR TITLE
win32: fix for qa_FileIo.exe

### DIFF
--- a/meta/include/gnuradio-4.0/meta/formatter.hpp
+++ b/meta/include/gnuradio-4.0/meta/formatter.hpp
@@ -27,7 +27,12 @@ template<typename Clock, typename Duration>
 [[nodiscard]] inline std::string getIsoTime(std::chrono::time_point<Clock, Duration> timePoint) noexcept {
     const auto secs = std::chrono::time_point_cast<std::chrono::seconds>(timePoint);
     const auto ms   = std::chrono::duration_cast<std::chrono::milliseconds>(timePoint - secs).count();
+#if defined(_WIN32)
+    // In windows the colon (:) characer is reserved.  Using _ instead.
+    return std::format("{:%Y-%m-%dT%H_%M_%S}.{:06}", secs, ms); // ms-precision ISO time-format
+#else
     return std::format("{:%Y-%m-%dT%H:%M:%S}.{:06}", secs, ms); // ms-precision ISO time-format
+#endif
 }
 
 [[nodiscard]] inline std::string getIsoTime() noexcept { return getIsoTime(std::chrono::system_clock::now()); }


### PR DESCRIPTION
- fix for https://github.com/fair-acc/gnuradio4/issues/586
- formatter.hpp uses colons in the representation of getIsoTime(), these colons are used in filenames in the BasicFileIo.hpp _actualFileName member varlable.  unfortunately the colons are not allowed in the filenames in windows as it is reserved for c:, etc.
- replaced the use of colons with underscores.
- FWIW, i tried using utf-8 characters instead of the colon and it broke the test, so I settled on underscores.