### PR TITLE
win32: fix for qa_KnownSharedLibBlocks.exe

### DIFF
--- a/blocks/libs/test/qa_KnownSharedLibBlocks.cpp
+++ b/blocks/libs/test/qa_KnownSharedLibBlocks.cpp
@@ -76,7 +76,11 @@ const boost::ut::suite TagTests = [] {
         expect(registry.contains("gr::blocks::type::converter::ScalingConvert<float32, float64>"sv));
         expect(registry.contains("gr::basic::DataSink<float32>"sv));
         expect(registry.contains("gr::blocks::basic::SchmittTrigger<float32, (gr::trigger::InterpolationMethod)0>"sv));
+#if defined(_WIN32)
+        expect(registry.contains("gr::electrical::PowerMetrics<float32, 3ull>"sv));
+#else
         expect(registry.contains("gr::electrical::PowerMetrics<float32, 3ul>"sv));
+#endif
         expect(registry.contains("gr::http::HttpBlock<float32>"sv));
         expect(registry.contains("gr::filter::fir_filter<float32>"sv));
         expect(registry.contains("gr::blocks::fft::FFT<float32>"sv));


### PR DESCRIPTION
- in win32 std::size_t is unsigned long long and in linux it's unsigned long.  So the string retured by the registry under windows for gr::electrical::PowerMetrics is gr::electrical::PowerMetrics<float32, 3ull> rather than gr::electrical::PowerMetrics<float32, 3ul>. Used if-def macro to test the different expected string values.
- fixes issue https://github.com/fair-acc/gnuradio4/issues/587