### PR TITLE
Revert lazy threadPoolManager initialisation

### DIFF
--- a/core/include/gnuradio-4.0/thread/thread_pool.hpp
+++ b/core/include/gnuradio-4.0/thread/thread_pool.hpp
@@ -770,18 +770,7 @@ class Manager {
     mutable std::mutex                                             _mutex;
     std::unordered_map<std::string, std::shared_ptr<TaskExecutor>> _pools;
 
-    Manager() {
-#ifdef __EMSCRIPTEN__
-        const std::size_t maxConcurrency = std::max(4U, std::thread::hardware_concurrency());
-#else
-        const std::size_t maxConcurrency = std::thread::hardware_concurrency();
-#endif
-        const std::size_t maxThread = maxConcurrency <= 2UZ ? 2UZ : maxConcurrency - 2UZ;
-        auto              cpu       = std::make_shared<ThreadPoolWrapper>(std::make_unique<BasicThreadPool>(std::string(kDefaultCpuPoolId), TaskType::CPU_BOUND, maxThread, maxThread), "CPU");
-        auto              io        = std::make_shared<ThreadPoolWrapper>(std::make_unique<BasicThreadPool>(std::string(kDefaultIoPoolId), TaskType::IO_BOUND, 2U, std::numeric_limits<uint32_t>::max()), "CPU");
-        registerPool(std::string(kDefaultCpuPoolId), std::move(cpu));
-        registerPool(std::string(kDefaultIoPoolId), std::move(io));
-    }
+    Manager() {}
 
 public:
     static Manager& instance() {
@@ -809,8 +798,27 @@ public:
         throw std::out_of_range(std::format("pool '{}' not found", name));
     }
 
-    [[nodiscard]] static std::shared_ptr<TaskExecutor> defaultCpuPool() { return instance().get(kDefaultCpuPoolId); }
-    [[nodiscard]] static std::shared_ptr<TaskExecutor> defaultIoPool() { return instance().get(kDefaultIoPoolId); }
+    [[nodiscard]] static std::shared_ptr<TaskExecutor> defaultCpuPool() {
+        if (!instance()._pools.contains(std::string(kDefaultCpuPoolId))) {
+#ifdef __EMSCRIPTEN__
+            const std::size_t maxConcurrency = std::max(4U, std::thread::hardware_concurrency());
+#else
+            const std::size_t maxConcurrency = std::thread::hardware_concurrency();
+#endif
+            const std::size_t maxThread = maxConcurrency <= 2UZ ? 2UZ : maxConcurrency - 2UZ;
+            auto              cpu       = std::make_shared<ThreadPoolWrapper>(std::make_unique<BasicThreadPool>(std::string(kDefaultCpuPoolId), TaskType::CPU_BOUND, maxThread, maxThread), "CPU");
+            instance().registerPool(std::string(kDefaultCpuPoolId), std::move(cpu));
+        }
+        return instance().get(kDefaultCpuPoolId);
+    }
+
+    [[nodiscard]] static std::shared_ptr<TaskExecutor> defaultIoPool() {
+        if (!instance()._pools.contains(std::string(kDefaultIoPoolId))) {
+            auto io = std::make_shared<ThreadPoolWrapper>(std::make_unique<BasicThreadPool>(std::string(kDefaultIoPoolId), TaskType::IO_BOUND, 2U, std::numeric_limits<uint32_t>::max()), "CPU");
+            instance().registerPool(std::string(kDefaultIoPoolId), std::move(io));
+        }
+        return instance().get(kDefaultIoPoolId);
+    }
 
     [[nodiscard]] std::vector<std::string> list() const {
         std::scoped_lock         lock(_mutex);


### PR DESCRIPTION
This reverts commit d795d21babcb8f23abe9551c586f7299dca98059 (PR #613) and instead limits the number of threads in the default pool from hardware-concurrency to 2 (assumes 4 cores minus 2 for IO tasks).

Users that explicitly want more threads in an emscripten context can always replace the default cpu pool, but then they have to make sure that emscripten has enough threads available since it will block otherwise.

Sorry for the noise and the incomplete previous fix. I'm still verifying if this change now is sufficient to build a working opendigitizer service & ui, should only be merged once that is verified.

since it's hard to see the actual change with the revert, here is the relevant change:
``` diff
$ git diff HEAD~2
diff --git a/core/include/gnuradio-4.0/thread/thread_pool.hpp b/core/include/gnuradio-4.0/thread/thread_pool.hpp
index 7dd7530..c68c261 100644
--- a/core/include/gnuradio-4.0/thread/thread_pool.hpp
+++ b/core/include/gnuradio-4.0/thread/thread_pool.hpp
@@ -772,7 +772,7 @@ class Manager {
 
     Manager() {
 #ifdef __EMSCRIPTEN__
-        const std::size_t maxConcurrency = std::max(4U, std::thread::hardware_concurrency());
+        const std::size_t maxConcurrency = std::min(4U, std::thread::hardware_concurrency());
 #else
         const std::size_t maxConcurrency = std::thread::hardware_concurrency();
 #endif

```