### PR TITLE
Fixing various win32 errors that occur when trying to build

### DIFF
--- a/blocks/soapy/include/gnuradio-4.0/soapy/Soapy.hpp
+++ b/blocks/soapy/include/gnuradio-4.0/soapy/Soapy.hpp
@@ -145,7 +145,7 @@ This block supports multiple output ports and was tested against the 'rtlsdr' an
             for (std::size_t i = 0UZ; i < rx_channels->size(); ++i) {
                 output[i] = std::span<T>(outputs[i]).subspan(0, maxSamples);
             }
-            ret = _rxStream.readStreamIntoBufferList(flags, time_ns, max_time_out_us, output);
+            ret = _rxStream.readStreamIntoBufferList(flags, time_ns, static_cast<long int>(max_time_out_us), output);
         }
         // for detailed debugging: detail::printSoapyReturnDebugInfo(ret, flags, time_ns);
 

--- a/core/benchmarks/bm_Buffer.cpp
+++ b/core/benchmarks/bm_Buffer.cpp
@@ -15,7 +15,7 @@
 
 using namespace gr;
 
-#if defined(__has_include) && not defined(__EMSCRIPTEN__) && not defined(__APPLE__)
+#if defined(__has_include) && not defined(__EMSCRIPTEN__) && not defined(__APPLE__) && not defined(_WIN32)
 #if __has_include(<pthread.h>) && __has_include(<sched.h>)
 #include <errno.h>
 #include <pthread.h>
@@ -138,7 +138,7 @@ inline const boost::ut::suite _buffer_tests = [] {
             benchmark::results::add_separator();
             for (std::size_t nP = 1; nP <= maxProducers; nP *= 2) {
                 for (std::size_t nC = 1; nC <= maxConsumers; nC *= 2) {
-                    const std::size_t size      = std::max(4096UL, veclen) * nC * 10UL;
+                    const std::size_t size      = std::max(4096UZ, veclen) * nC * 10UZ;
                     const bool        isPosix   = strategy == BufferStrategy::posix;
                     const auto        allocator = (isPosix) ? gr::double_mapped_memory_resource::allocator<int32_t>() : std::pmr::polymorphic_allocator<int32_t>();
                     auto              invoke    = [&](auto buffer) { runTest(buffer, veclen, samples, nP, nC, isPosix ? "POSIX" : "portable"); };

--- a/core/include/gnuradio-4.0/HistoryBuffer.hpp
+++ b/core/include/gnuradio-4.0/HistoryBuffer.hpp
@@ -317,7 +317,7 @@ public:
      * @brief Returns a span of elements with given (optional) length with the last element being the newest
      */
     [[nodiscard]] constexpr std::span<const T> get_span(std::size_t index, std::size_t length = std::dynamic_extent) const {
-        length = std::clamp(length, 0LU, std::min(_size - index, length));
+        length = std::clamp(length, 0UZ, std::min(_size - index, length));
         return std::span<const T>(&_buffer[map_index(index)], length);
     }
 

--- a/core/include/gnuradio-4.0/Scheduler.hpp
+++ b/core/include/gnuradio-4.0/Scheduler.hpp
@@ -24,6 +24,13 @@
 #include <emscripten/threading.h>
 #endif
 
+// Under Windows windows.h defines ERROR as 0.  This messes the ERROR function work::status::ERROR.
+#ifdef _WIN32
+#ifdef ERROR
+#undef ERROR
+#endif // #ifdef ERROR
+#endif // #ifdef _WIN32
+
 template<typename T>
 inline void waitUntilChanged(gr::Sequence& sequence, T oldValue, [[maybe_unused]] unsigned int delay_ms = 1U) {
     if (sequence.value() != oldValue) {

--- a/core/include/gnuradio-4.0/thread/MemoryMonitor.hpp
+++ b/core/include/gnuradio-4.0/thread/MemoryMonitor.hpp
@@ -6,8 +6,10 @@
 #include <string>
 
 #if defined(_WIN32) || defined(_WIN64)
-#include <psapi.h>
+// clang-format off
 #include <windows.h>
+#include <psapi.h>
+// clang-format on
 #elif defined(__linux__)
 #include <fstream>
 #include <unistd.h>

--- a/core/include/gnuradio-4.0/thread/thread_pool.hpp
+++ b/core/include/gnuradio-4.0/thread/thread_pool.hpp
@@ -632,7 +632,7 @@ private:
                 }
                 running = false;
             } else if (timeDiffSinceLastUsed > keepAliveDuration) { // decrease to the minimum of _minThreads in a thread safe way
-                unsigned long nThreads = numThreads();
+                std::size_t nThreads = numThreads();
                 while (nThreads > minThreads()) { // compare and swap loop
                     if (_numThreads.compare_exchange_weak(nThreads, nThreads - 1, std::memory_order_acq_rel)) {
                         _numThreads.notify_all();


### PR DESCRIPTION
- Soapy.hpp needs a static_cast<long int> to build.
- bm_Buffer.cpp needs to conditionally exclude _WIN32 for setCpuAffinity even though we have the required headers.  We also need a UL to UZ type change.
- HistoryBuffer.cpp needs a UL to UZ type change.
- Scheduler.hpp need to unset ERROR defined in windows.h so the macro is not substituted in the work::status::ERROR method.
- MemoryMonitor.cpp windows.h needs to be included before psapi.h. psapi.h has alot of windows specific types that we don't know about before including windows.h
- thread_pool.hpp replace unsigned long type with std::size_t.  This squares with the type for numThreads() and will allow ULL under windows and UL on linux.

- tested on windows and linux