### PR TITLE
Add string() member to filesystem paths

### DIFF
--- a/blocklib_generator/tools/parse_registrations.cpp
+++ b/blocklib_generator/tools/parse_registrations.cpp
@@ -298,7 +298,7 @@ int main(int argc, char** argv) try {
 
     const auto integratorSourceFile = (options.outDir / "integrator.cpp");
     if (!std::filesystem::exists(integratorSourceFile)) {
-        std::ofstream integrator = openFile(integratorSourceFile);
+        std::ofstream integrator = openFile(integratorSourceFile.string());
         integrator << std::format(R"cppcode(
             #include <gnuradio-4.0/BlockRegistry.hpp>
 
@@ -318,7 +318,7 @@ int main(int argc, char** argv) try {
 
     const auto integratorHeaderFile = (options.outDir / (moduleName + ".hpp"));
     if (!std::filesystem::exists(integratorHeaderFile)) {
-        std::ofstream integrator = openFile(integratorHeaderFile);
+        std::ofstream integrator = openFile(integratorHeaderFile.string());
         integrator << std::format(R"cppcode(
             #ifndef GR_BLOCKLIB_INIT_MODULE_{0}
             #define GR_BLOCKLIB_INIT_MODULE_{0}

--- a/blocks/fileio/include/gnuradio-4.0/fileio/BasicFileIo.hpp
+++ b/blocks/fileio/include/gnuradio-4.0/fileio/BasicFileIo.hpp
@@ -154,7 +154,7 @@ private:
         } break;
         case Mode::multi: {
             // _fileCounter ensures that the filenames are unique and still sortable by date-time, with an additional counter to handle rapid successive file creation.
-            _actualFileName = filePath.parent_path() / (gr::time::getIsoTime() + "_" + std::to_string(_fileCounter++) + "_" + filePath.filename().string());
+            _actualFileName = (filePath.parent_path() / (gr::time::getIsoTime() + "_" + std::to_string(_fileCounter++) + "_" + filePath.filename().string())).string();
             _file.open(_actualFileName, std::ios::binary);
             break;
         }

--- a/blocks/soapy/src/soapy_example.cpp
+++ b/blocks/soapy/src/soapy_example.cpp
@@ -71,7 +71,7 @@ int main(int argc, char* argv[]) {
     constexpr double     defaultRxGains           = 10.0;            // 10 dB
 
     std::filesystem::path exePath    = std::filesystem::current_path();
-    auto                  parsedArgs = parseArguments(argc, argv, exePath / "test_ch0.bin", exePath / "test_ch1.bin", defaultMaxFileSize, defaultSampleRate, defaultRxCenterFrequency, defaultBandwidth, defaultRxGains);
+    auto                  parsedArgs = parseArguments(argc, argv, (exePath / "test_ch0.bin").string(), (exePath / "test_ch1.bin").string(), defaultMaxFileSize, defaultSampleRate, defaultRxCenterFrequency, defaultBandwidth, defaultRxGains);
     if (!parsedArgs) {
         std::println(R"(
 Usage:

--- a/core/include/gnuradio-4.0/PluginLoader.hpp
+++ b/core/include/gnuradio-4.0/PluginLoader.hpp
@@ -157,7 +157,7 @@ public:
                         _pluginHandlers.push_back(std::move(handler));
 
                     } else {
-                        _failedPlugins[file.path()] = handler.status();
+                        _failedPlugins[file.path().string()] = handler.status();
                     }
                 }
             }


### PR DESCRIPTION
- win32 requires the explicit use of the string() member on filesystem paths whereas linux allows the use of filesystem paths without string().

- windows uses wchar_t for the std::filesystem::path format where linux uses char.  Therefore we would need to be using std::wstring rather than std::string for our string representations to use the implicit conversion.  Since we are using std::string, under windows we must add a .string() member suffix to build our string properly.

- tested on windows and linux.