### PR TITLE
Refactor Graph/Scheduler ownership & traversal: shared_ptr<BlockModel>, freestanding forEachBlock/Edge, better diagnostics

### DIFF
--- a/core/include/gnuradio-4.0/Block.hpp
+++ b/core/include/gnuradio-4.0/Block.hpp
@@ -209,6 +209,7 @@ inline static const char* kSettingsContexts = "SettingsContexts"; ///< retrieve/
 
 namespace block {
 enum class Category {
+    All,                   ///< all Blocks
     NormalBlock,           ///< Block that does not contain children blocks
     TransparentBlockGroup, ///< Block with children blocks which do not have a dedicated scheduler
     ScheduledBlockGroup    ///< Block with children that have a dedicated scheduler

--- a/core/include/gnuradio-4.0/BlockModel.hpp
+++ b/core/include/gnuradio-4.0/BlockModel.hpp
@@ -212,7 +212,7 @@ public:
             portOrCollection);
     }
 
-    [[nodiscard]] virtual std::span<std::unique_ptr<BlockModel>> blocks() noexcept { return {}; };
+    [[nodiscard]] virtual std::span<std::shared_ptr<BlockModel>> blocks() noexcept { return {}; };
     [[nodiscard]] virtual std::span<Edge>                        edges() noexcept { return {}; }
 
     DynamicPorts& dynamicInputPorts() {
@@ -518,7 +518,7 @@ public:
     void processScheduledMessages() override { return blockRef().processScheduledMessages(); }
 
     // For blocks that contain nested blocks (Graphs, Schedulers)
-    [[nodiscard]] std::span<std::unique_ptr<BlockModel>> blocks() noexcept override {
+    [[nodiscard]] std::span<std::shared_ptr<BlockModel>> blocks() noexcept override {
         if constexpr (requires { blockRef().blocks(); }) {
             return blockRef().blocks();
         } else {

--- a/core/include/gnuradio-4.0/BlockModel.hpp
+++ b/core/include/gnuradio-4.0/BlockModel.hpp
@@ -81,15 +81,7 @@ struct Edge {
     constexpr std::size_t nWriters() const { return _destinationPort ? _destinationPort->nWriters() : -1UZ; }
     constexpr PortType    edgeType() const { return _edgeType; }
 
-    constexpr bool hasSameSourcePort(const Edge& other) const noexcept {
-        if (_sourceBlock.get() != other._sourceBlock.get()) {
-            return false;
-        }
-        if (_sourcePortDefinition.definition == other._sourcePortDefinition.definition) {
-            return true;
-        }
-        return false;
-    }
+    constexpr bool hasSameSourcePort(const Edge& other) const noexcept { return sourceBlock() == other.sourceBlock() && sourcePortDefinition().definition == other.sourcePortDefinition().definition; }
 
     constexpr bool operator==(const Edge& other) const noexcept {
         return sourceBlock() == other.sourceBlock()                                                       //

--- a/core/include/gnuradio-4.0/Graph_yaml_importer.hpp
+++ b/core/include/gnuradio-4.0/Graph_yaml_importer.hpp
@@ -24,8 +24,8 @@ inline void loadGraphFromMap(PluginLoader& loader, gr::Graph& resultGraph, gr::p
         const auto blockType = std::get<std::string>(grcBlock["id"]);
 
         if (blockType == "SUBGRAPH") {
-            std::shared_ptr<BlockModel>& subGraph = resultGraph.addBlock(std::make_shared<GraphWrapper<gr::Graph>>());
-            createdBlocks[blockName]              = subGraph;
+            const std::shared_ptr<BlockModel>& subGraph = resultGraph.addBlock(std::make_shared<GraphWrapper<gr::Graph>>());
+            createdBlocks[blockName]                    = subGraph;
             subGraph->setName(blockName);
 
             auto* subGraphDirect = static_cast<GraphWrapper<gr::Graph>*>(subGraph.get());

--- a/core/include/gnuradio-4.0/Graph_yaml_importer.hpp
+++ b/core/include/gnuradio-4.0/Graph_yaml_importer.hpp
@@ -14,7 +14,7 @@ namespace detail {
 
 inline void loadGraphFromMap(PluginLoader& loader, gr::Graph& resultGraph, gr::property_map yaml, std::source_location location = std::source_location::current()) {
 
-    std::map<std::string, BlockModel*> createdBlocks;
+    std::map<std::string, std::shared_ptr<BlockModel>> createdBlocks;
 
     auto blks = std::get<std::vector<pmtv::pmt>>(yaml.at("blocks"));
     for (const auto& blk : blks) {
@@ -24,11 +24,11 @@ inline void loadGraphFromMap(PluginLoader& loader, gr::Graph& resultGraph, gr::p
         const auto blockType = std::get<std::string>(grcBlock["id"]);
 
         if (blockType == "SUBGRAPH") {
-            auto& subGraph           = resultGraph.addBlock(std::make_unique<GraphWrapper<gr::Graph>>());
-            createdBlocks[blockName] = &subGraph;
-            subGraph.setName(blockName);
+            std::shared_ptr<BlockModel>& subGraph = resultGraph.addBlock(std::make_shared<GraphWrapper<gr::Graph>>());
+            createdBlocks[blockName]              = subGraph;
+            subGraph->setName(blockName);
 
-            auto* subGraphDirect = static_cast<GraphWrapper<gr::Graph>*>(&subGraph);
+            auto* subGraphDirect = static_cast<GraphWrapper<gr::Graph>*>(subGraph.get());
             subGraphDirect->setName(blockName);
 
             const auto& graphData = std::get<property_map>(grcBlock["graph"]);
@@ -41,10 +41,19 @@ inline void loadGraphFromMap(PluginLoader& loader, gr::Graph& resultGraph, gr::p
                     throw std::format("Unable to parse exported port ({} instead of 4 elements)", exportedPort.size());
                 }
 
-                auto& block = graph::findFirstBlockWithName(subGraphDirect->blockRef(), std::get<std::string>(exportedPort[0]));
+                std::string requiredBlockName = std::get<std::string>(exportedPort[0]);
+                std::string blockUniqueName;
+                for (auto& b : subGraphDirect->blockRef().blocks()) {
+                    if (b->name() == requiredBlockName) {
+                        blockUniqueName = b->uniqueName();
+                    }
+                }
+                if (blockUniqueName.empty()) {
+                    throw gr::exception(std::format("Required Block {} not found in:\n{}", requiredBlockName, gr::graph::format(subGraphDirect->blockRef())), location);
+                }
 
                 subGraphDirect->exportPort(true,
-                    /* block's unique name */ std::string(block.uniqueName()),
+                    /* block's unique name */ blockUniqueName,
                     /* port direction */ std::get<std::string>(exportedPort[1]) == "INPUT" ? PortDirection::INPUT : PortDirection::OUTPUT,
                     /* port name */ std::get<std::string>(exportedPort[2]));
             }
@@ -77,7 +86,7 @@ inline void loadGraphFromMap(PluginLoader& loader, gr::Graph& resultGraph, gr::p
             if (const auto failed = currentBlock->settings().activateContext(); failed == std::nullopt) {
                 throw gr::exception("Settings for context could not be activated");
             }
-            createdBlocks[blockName] = &resultGraph.addBlock(std::move(currentBlock));
+            createdBlocks[blockName] = resultGraph.addBlock(std::move(currentBlock));
         }
     } // for blocks
 
@@ -118,7 +127,7 @@ inline void loadGraphFromMap(PluginLoader& loader, gr::Graph& resultGraph, gr::p
         auto dst = parseBlockPort(connection[2], connection[3]);
 
         if (connection.size() == 4) {
-            resultGraph.connect(*src.block_it->second, src.port_definition, *dst.block_it->second, dst.port_definition, undefined_size, graph::defaultWeight, graph::defaultEdgeName, location);
+            resultGraph.connect(src.block_it->second, src.port_definition, dst.block_it->second, dst.port_definition, undefined_size, graph::defaultWeight, graph::defaultEdgeName, location);
         } else {
             auto minBufferSize = std::visit(
                 []<typename TValue>(const TValue& value) {
@@ -132,7 +141,7 @@ inline void loadGraphFromMap(PluginLoader& loader, gr::Graph& resultGraph, gr::p
                 },
                 connection[4]);
 
-            resultGraph.connect(*src.block_it->second, src.port_definition, *dst.block_it->second, dst.port_definition, minBufferSize, graph::defaultWeight, graph::defaultEdgeName, location);
+            resultGraph.connect(src.block_it->second, src.port_definition, dst.block_it->second, dst.port_definition, minBufferSize, graph::defaultWeight, graph::defaultEdgeName, location);
         }
     } // for connections
 }
@@ -142,16 +151,16 @@ inline gr::property_map saveGraphToMap(PluginLoader& loader, const gr::Graph& ro
 
     {
         std::vector<pmtv::pmt> serializedBlocks;
-        rootGraph.forEachBlock([&](const auto& block) {
+        gr::graph::forAllBlocks<gr::block::Category::NormalBlock>(rootGraph, [&](const std::shared_ptr<BlockModel> block) {
             pmtv::map_t map;
-            map["name"] = std::string(block.name());
+            map["name"] = std::string(block->name());
 
-            const auto& fullTypeName = loader.registry().typeName(block);
+            const auto& fullTypeName = loader.registry().typeName(*block);
             if (fullTypeName == "gr::Graph") {
                 map.emplace("id", "SUBGRAPH");
-                auto* subGraphDirect = dynamic_cast<const GraphWrapper<gr::Graph>*>(std::addressof(block));
+                auto* subGraphDirect = dynamic_cast<const GraphWrapper<gr::Graph>*>(block.get());
                 if (subGraphDirect == nullptr) {
-                    throw gr::Error(std::format("Can not serialize gr::Graph-based subgraph {} which is not added to the parent graph {} via GraphWrapper", block.uniqueName(), rootGraph.unique_name));
+                    throw gr::Error(std::format("Can not serialize gr::Graph-based subgraph {} which is not added to the parent graph {} via GraphWrapper", block->uniqueName(), rootGraph.unique_name));
                 }
                 property_map graphYaml = detail::saveGraphToMap(loader, subGraphDirect->blockRef());
 
@@ -184,18 +193,19 @@ inline gr::property_map saveGraphToMap(PluginLoader& loader, const gr::Graph& ro
                     return parameters;
                 };
 
-                const auto& stored = block.settings().getStoredAll();
+                const auto& stored = block->settings().getStoredAll();
                 if (stored.contains("")) {
                     const auto& ctxParameters = stored.at("");
                     const auto& settingsMap   = ctxParameters.back().second; // write only the last parameters
-                    if (!block.metaInformation().empty() || !settingsMap.empty()) {
-                        map["parameters"] = writeParameters(settingsMap, block.metaInformation());
+                    if (!block->metaInformation().empty() || !settingsMap.empty()) {
+                        map["parameters"] = writeParameters(settingsMap, block->metaInformation());
                     }
                 }
 
+                using namespace std::string_literals;
                 std::vector<pmtv::pmt> ctxParamsSeq;
                 for (const auto& [ctx, ctxParameters] : stored) {
-                    if (ctx == "") {
+                    if (std::holds_alternative<std::string>(ctx) && std::get<std::string>(ctx) == ""s) {
                         continue;
                     }
 
@@ -251,10 +261,10 @@ inline gr::property_map saveGraphToMap(PluginLoader& loader, const gr::Graph& ro
                     definition.definition);
             };
 
-            seq.push_back(edge.sourceBlock().name().data());
+            seq.push_back(edge.sourceBlock()->name().data());
             writePortDefinition(edge.sourcePortDefinition());
 
-            seq.push_back(edge.destinationBlock().name().data());
+            seq.push_back(edge.destinationBlock()->name().data());
             writePortDefinition(edge.destinationPortDefinition());
 
             if (edge.minBufferSize() != std::numeric_limits<std::size_t>::max()) {

--- a/core/include/gnuradio-4.0/Graph_yaml_importer.hpp
+++ b/core/include/gnuradio-4.0/Graph_yaml_importer.hpp
@@ -41,7 +41,7 @@ inline void loadGraphFromMap(PluginLoader& loader, gr::Graph& resultGraph, gr::p
                     throw std::format("Unable to parse exported port ({} instead of 4 elements)", exportedPort.size());
                 }
 
-                auto& block = subGraphDirect->findFirstBlockWithName(std::get<std::string>(exportedPort[0]));
+                auto& block = graph::findFirstBlockWithName(subGraphDirect->blockRef(), std::get<std::string>(exportedPort[0]));
 
                 subGraphDirect->exportPort(true,
                     /* block's unique name */ std::string(block.uniqueName()),

--- a/core/include/gnuradio-4.0/Graph_yaml_importer.hpp
+++ b/core/include/gnuradio-4.0/Graph_yaml_importer.hpp
@@ -151,7 +151,7 @@ inline gr::property_map saveGraphToMap(PluginLoader& loader, const gr::Graph& ro
 
     {
         std::vector<pmtv::pmt> serializedBlocks;
-        gr::graph::forAllBlocks<gr::block::Category::NormalBlock>(rootGraph, [&](const std::shared_ptr<BlockModel> block) {
+        gr::graph::forEachBlock<gr::block::Category::NormalBlock>(rootGraph, [&](const std::shared_ptr<BlockModel> block) {
             pmtv::map_t map;
             map["name"] = std::string(block->name());
 

--- a/core/include/gnuradio-4.0/Graph_yaml_importer.hpp
+++ b/core/include/gnuradio-4.0/Graph_yaml_importer.hpp
@@ -241,7 +241,7 @@ inline gr::property_map saveGraphToMap(PluginLoader& loader, const gr::Graph& ro
 
     {
         std::vector<pmtv::pmt> serializedConnections;
-        rootGraph.forEachEdge([&](const auto& edge) {
+        graph::forEachEdge<block::Category::NormalBlock>(rootGraph, [&](const Edge& edge) { // NormalBlock -> perhaps can be modelled to 'ALL' for a cleaner sub-graph handling
             std::vector<pmtv::pmt> seq;
 
             auto writePortDefinition = [&](const auto& definition) { //

--- a/core/include/gnuradio-4.0/PluginLoader.hpp
+++ b/core/include/gnuradio-4.0/PluginLoader.hpp
@@ -184,7 +184,7 @@ public:
         return result;
     }
 
-    std::unique_ptr<gr::BlockModel> instantiate(std::string_view name, const property_map& params = {}) {
+    std::shared_ptr<gr::BlockModel> instantiate(std::string_view name, const property_map& params = {}) {
         // Try to create a node from the global registry
         if (auto result = _registry->create(name, params)) {
             return result;
@@ -229,7 +229,7 @@ public:
 
     auto availableBlocks() const { return _registry->keys(); }
 
-    std::unique_ptr<gr::BlockModel> instantiate(std::string_view name, const property_map& params = {}) { return _registry->create(name, params); }
+    std::shared_ptr<gr::BlockModel> instantiate(std::string_view name, const property_map& params = {}) { return _registry->create(name, params); }
 
     bool isBlockAvailable(std::string_view block) const { return _registry->contains(block); }
 };

--- a/core/include/gnuradio-4.0/Scheduler.hpp
+++ b/core/include/gnuradio-4.0/Scheduler.hpp
@@ -939,7 +939,8 @@ private:
         std::vector<block_t>                    _source_blocks{};
         // compute the adjacency list
         std::set<block_t> block_reached;
-        for (auto& e : this->_graph.edges()) {
+        const gr::Graph   flatGraph = gr::graph::flatten(this->_graph);
+        for (auto& e : flatGraph.edges()) {
             _adjacency_list[e._sourceBlock].push_back(e._destinationBlock);
             _source_blocks.push_back(e._sourceBlock);
             block_reached.insert(e._destinationBlock);
@@ -1033,7 +1034,8 @@ private:
         std::vector<block_t>                    _source_blocks{};
         std::set<block_t>                       block_reached;
 
-        for (auto& e : this->_graph.edges()) {
+        const gr::Graph flatGraph = gr::graph::flatten(this->_graph);
+        for (auto& e : flatGraph.edges()) {
             _adjacency_list[e._sourceBlock].push_back(e._destinationBlock);
             _source_blocks.push_back(e._sourceBlock);
             block_reached.insert(e._destinationBlock);

--- a/core/include/gnuradio-4.0/Scheduler.hpp
+++ b/core/include/gnuradio-4.0/Scheduler.hpp
@@ -75,7 +75,7 @@ enum class ExecutionPolicy {
 template<typename Derived, ExecutionPolicy execution = ExecutionPolicy::singleThreaded, profiling::ProfilerLike TProfiler = profiling::null::Profiler>
 class SchedulerBase : public Block<Derived> {
     friend class lifecycle::StateMachine<Derived>;
-    using JobLists     = std::shared_ptr<std::vector<std::vector<BlockModel*>>>;
+    using JobLists     = std::shared_ptr<std::vector<std::vector<std::shared_ptr<BlockModel>>>>;
     using TaskExecutor = gr::thread_pool::TaskExecutor;
     using enum block::Category;
 
@@ -86,7 +86,7 @@ protected:
     std::shared_ptr<TaskExecutor>       _pool;
     std::shared_ptr<gr::Sequence>       _nRunningJobs = std::make_shared<gr::Sequence>();
     std::recursive_mutex                _executionOrderMutex; // only used when modifying and copying the graph->local job list
-    JobLists                            _executionOrder = std::make_shared<std::vector<std::vector<BlockModel*>>>();
+    JobLists                            _executionOrder = std::make_shared<std::vector<std::vector<std::shared_ptr<BlockModel>>>>();
 
     std::mutex                               _zombieBlocksMutex;
     std::vector<std::shared_ptr<BlockModel>> _zombieBlocks;
@@ -94,7 +94,7 @@ protected:
     // for blocks that were added while scheduler was running. They need to be adopted by a thread
     std::mutex _adoptionBlocksMutex;
     // fixed-sized vector indexed by runnerId. Cheaper than a map.
-    std::vector<std::vector<BlockModel*>> _adoptionBlocks;
+    std::vector<std::vector<std::shared_ptr<BlockModel>>> _adoptionBlocks;
 
     MsgPortOutForChildren    _toChildMessagePort;
     MsgPortInFromChildren    _fromChildMessagePort;
@@ -315,7 +315,7 @@ protected:
         return result;
     }
 
-    work::Result traverseBlockListOnce(const std::vector<BlockModel*>& blocks) const {
+    work::Result traverseBlockListOnce(const std::vector<std::shared_ptr<BlockModel>>& blocks) const {
         const std::size_t requestedWorkAllBlocks = max_work_items;
         std::size_t       performedWorkAllBlocks = 0UZ;
         bool              unfinishedBlocksExist  = false; // i.e. at least one block returned OK, INSUFFICIENT_INPUT_ITEMS, or INSUFFICIENT_OUTPU_ITEMS
@@ -380,7 +380,7 @@ protected:
         }
     }
 
-    void poolWorker(const std::size_t runnerID, std::shared_ptr<std::vector<std::vector<BlockModel*>>> jobList) noexcept {
+    void poolWorker(const std::size_t runnerID, std::shared_ptr<std::vector<std::vector<std::shared_ptr<BlockModel>>>> jobList) noexcept {
         std::shared_ptr<gr::Sequence> progress     = _graph._progress; // life-time guaranteed
         std::shared_ptr<gr::Sequence> nRunningJobs = _nRunningJobs;
 
@@ -390,10 +390,10 @@ protected:
 
         [[maybe_unused]] auto& profiler_handler = _profiler.forThisThread();
 
-        std::vector<BlockModel*> localBlockList;
+        std::vector<std::shared_ptr<BlockModel>> localBlockList;
         {
-            std::lock_guard          lock(_executionOrderMutex);
-            std::vector<BlockModel*> blocks = jobList->at(runnerID);
+            std::lock_guard                          lock(_executionOrderMutex);
+            std::vector<std::shared_ptr<BlockModel>> blocks = jobList->at(runnerID);
             localBlockList.reserve(blocks.size());
             for (const auto& block : blocks) {
                 localBlockList.push_back(block);
@@ -557,29 +557,29 @@ protected:
                 // pseudo-randomize which thread gets it
                 auto blockAddress = reinterpret_cast<std::uintptr_t>(&newBlock);
                 auto runnerIndex  = (blockAddress / sizeof(void*)) % nBatches;
-                _adoptionBlocks[runnerIndex].push_back(&newBlock);
+                _adoptionBlocks[runnerIndex].push_back(newBlock);
 
-                switch (newBlock.state()) {
+                switch (newBlock->state()) {
                 case lifecycle::State::STOPPED:
                 case lifecycle::State::IDLE: //
-                    this->emitErrorMessageIfAny("adoptBlocks -> INITIALIZED", newBlock.changeStateTo(lifecycle::State::INITIALISED));
-                    this->emitErrorMessageIfAny("adoptBlocks -> INITIALIZED", newBlock.changeStateTo(lifecycle::State::RUNNING));
+                    this->emitErrorMessageIfAny("adoptBlocks -> INITIALIZED", newBlock->changeStateTo(lifecycle::State::INITIALISED));
+                    this->emitErrorMessageIfAny("adoptBlocks -> INITIALIZED", newBlock->changeStateTo(lifecycle::State::RUNNING));
                     break;
                 case lifecycle::State::INITIALISED: //
-                    this->emitErrorMessageIfAny("adoptBlocks -> INITIALIZED", newBlock.changeStateTo(lifecycle::State::RUNNING));
+                    this->emitErrorMessageIfAny("adoptBlocks -> INITIALIZED", newBlock->changeStateTo(lifecycle::State::RUNNING));
                     break;
                 case lifecycle::State::RUNNING:
                 case lifecycle::State::REQUESTED_PAUSE:
                 case lifecycle::State::PAUSED:
                 case lifecycle::State::REQUESTED_STOP:
                 case lifecycle::State::ERROR: //
-                    this->emitErrorMessage("propertyCallbackEmplaceBlock", std::format("Unexpected block state during emplacement: {}", magic_enum::enum_name(newBlock.state())));
+                    this->emitErrorMessage("propertyCallbackEmplaceBlock", std::format("Unexpected block state during emplacement: {}", magic_enum::enum_name(newBlock->state())));
                     break;
                 }
             }
         }
 
-        this->emitMessage(scheduler::property::kBlockEmplaced, Graph::serializeBlock(std::addressof(newBlock)));
+        this->emitMessage(scheduler::property::kBlockEmplaced, Graph::serializeBlock(newBlock));
 
         // Message is sent as a reaction to emplaceBlock, no need for a separate one
         return {};
@@ -643,7 +643,7 @@ protected:
 
       This mechanism supports safe dynamic block removal while the scheduler is running, without blocking execution.
     */
-    void cleanupZombieBlocks(std::vector<BlockModel*>& localBlockList) {
+    void cleanupZombieBlocks(std::vector<std::shared_ptr<BlockModel>>& localBlockList) {
         if (localBlockList.empty()) {
             return;
         }
@@ -653,7 +653,7 @@ protected:
         auto it = _zombieBlocks.begin();
 
         while (it != _zombieBlocks.end()) {
-            auto localBlockIt = std::find(localBlockList.begin(), localBlockList.end(), it->get());
+            auto localBlockIt = std::find(localBlockList.begin(), localBlockList.end(), *it);
             if (localBlockIt == localBlockList.end()) {
                 // we only care about the blocks local to our thread.
                 ++it;
@@ -687,8 +687,8 @@ protected:
             if (shouldDelete) {
                 localBlockList.erase(localBlockIt);
 
-                BlockModel* zombieRaw = it->get();
-                it                    = _zombieBlocks.erase(it); // ~Block() runs here
+                std::shared_ptr<BlockModel> zombieRaw = *it;
+                it                                    = _zombieBlocks.erase(it); // ~Block() runs here
 
                 // We need to remove zombieRaw from jobLists as well, in case Scheduler ever goes to INITIALIZED again.
                 std::lock_guard lock(_executionOrderMutex);
@@ -706,7 +706,7 @@ protected:
         }
     }
 
-    void adoptBlocks(std::size_t runnerID, std::vector<BlockModel*>& localBlockList) {
+    void adoptBlocks(std::size_t runnerID, std::vector<std::shared_ptr<BlockModel>>& localBlockList) {
         std::lock_guard guard(_adoptionBlocksMutex);
 
         assert(_adoptionBlocks.size() > runnerID);
@@ -735,8 +735,8 @@ protected:
             // Handle edge case: If we receive two consecutive "Add Block X" "Remove Block X" messages
             // it would be zombie before being adopted, so we need to remove it from adoption list
             std::lock_guard guard(_adoptionBlocksMutex);
-            for (auto& adoptionList : _adoptionBlocks) {
-                auto it = std::find(adoptionList.begin(), adoptionList.end(), block.get());
+            for (std::vector<std::shared_ptr<BlockModel>>& adoptionList : _adoptionBlocks) {
+                auto it = std::find(adoptionList.begin(), adoptionList.end(), block);
                 if (it != adoptionList.end()) {
                     adoptionList.erase(it);
                     break;
@@ -899,10 +899,10 @@ private:
         this->_executionOrder->reserve(n_batches);
         for (std::size_t i = 0; i < n_batches; i++) {
             // create job-set for thread
-            auto& job = this->_executionOrder->emplace_back(std::vector<BlockModel*>());
+            auto& job = this->_executionOrder->emplace_back(std::vector<std::shared_ptr<BlockModel>>());
             job.reserve(nBlocks / n_batches + 1);
             for (std::size_t j = i; j < nBlocks; j += n_batches) {
-                job.push_back(flatGraph.blocks()[j].get());
+                job.push_back(flatGraph.blocks()[j]);
             }
         }
     }
@@ -930,9 +930,9 @@ public:
 
 private:
     void init() {
-        std::vector<BlockModel*>    blockList;
-        [[maybe_unused]] const auto pe = this->_profilerHandler.startCompleteEvent("breadth_first.init");
-        using block_t                  = BlockModel*;
+        std::vector<std::shared_ptr<BlockModel>> blockList;
+        [[maybe_unused]] const auto              pe = this->_profilerHandler.startCompleteEvent("breadth_first.init");
+        using block_t                               = std::shared_ptr<BlockModel>;
         base_t::init();
         // calculate adjacency list
         std::map<block_t, std::vector<block_t>> _adjacency_list{};
@@ -993,7 +993,7 @@ private:
         this->_executionOrder->reserve(n_batches);
         for (std::size_t i = 0; i < n_batches; i++) {
             // create job-set for thread
-            auto& job = this->_executionOrder->emplace_back(std::vector<BlockModel*>());
+            auto& job = this->_executionOrder->emplace_back(std::vector<std::shared_ptr<BlockModel>>());
             job.reserve(blockList.size() / n_batches + 1);
             for (std::size_t j = i; j < blockList.size(); j += n_batches) {
                 job.push_back(blockList[j]);
@@ -1023,9 +1023,9 @@ public:
 
 private:
     void init() {
-        std::vector<BlockModel*>    blocklist;
-        [[maybe_unused]] const auto pe = this->_profilerHandler.startCompleteEvent("depth_first.init");
-        using block_t                  = BlockModel*;
+        std::vector<std::shared_ptr<BlockModel>> blocklist;
+        [[maybe_unused]] const auto              pe = this->_profilerHandler.startCompleteEvent("depth_first.init");
+        using block_t                               = std::shared_ptr<BlockModel>;
         base_t::init();
 
         // adjacency list
@@ -1080,7 +1080,7 @@ private:
         this->_executionOrder->clear();
         this->_executionOrder->reserve(n_batches);
         for (std::size_t i = 0; i < n_batches; i++) {
-            auto& job = this->_executionOrder->emplace_back(std::vector<BlockModel*>());
+            auto& job = this->_executionOrder->emplace_back(std::vector<std::shared_ptr<BlockModel>>());
             job.reserve(blocklist.size() / n_batches + 1);
             for (std::size_t j = i; j < blocklist.size(); j += n_batches) {
                 job.push_back(blocklist[j]);

--- a/core/include/gnuradio-4.0/Scheduler.hpp
+++ b/core/include/gnuradio-4.0/Scheduler.hpp
@@ -89,7 +89,7 @@ protected:
     JobLists                            _executionOrder = std::make_shared<std::vector<std::vector<BlockModel*>>>();
 
     std::mutex                               _zombieBlocksMutex;
-    std::vector<std::unique_ptr<BlockModel>> _zombieBlocks;
+    std::vector<std::shared_ptr<BlockModel>> _zombieBlocks;
 
     // for blocks that were added while scheduler was running. They need to be adopted by a thread
     std::mutex _adoptionBlocksMutex;
@@ -726,7 +726,7 @@ protected:
 
       The block will be physically deleted by cleanupZombieBlocks() when it reaches a safe state.
     */
-    void makeZombie(std::unique_ptr<BlockModel> block) {
+    void makeZombie(std::shared_ptr<BlockModel> block) {
         if (block->state() == lifecycle::State::PAUSED || block->state() == lifecycle::State::RUNNING) {
             this->emitErrorMessageIfAny("makeZombie", block->changeStateTo(lifecycle::State::REQUESTED_STOP));
         }
@@ -881,11 +881,8 @@ private:
         [[maybe_unused]] const auto pe = this->_profilerHandler.startCompleteEvent("scheduler_simple.init");
 
         // generate job list
-        std::size_t nBlocks = 0UZ;
-        graph::forAllBlocks<block::Category::TransparentBlockGroup>(this->_graph, [&nBlocks](auto&& /*block*/) { nBlocks++; });
-        std::vector<BlockModel*> allBlocks;
-        allBlocks.reserve(nBlocks);
-        graph::forAllBlocks<block::Category::TransparentBlockGroup>(this->_graph, [&allBlocks](auto&& block) { allBlocks.push_back(block.get()); });
+        const gr::Graph   flatGraph = graph::flatten(this->_graph);
+        const std::size_t nBlocks   = flatGraph.blocks().size();
 
         std::size_t n_batches = 1UZ;
         switch (base_t::executionPolicy()) {
@@ -903,9 +900,9 @@ private:
         for (std::size_t i = 0; i < n_batches; i++) {
             // create job-set for thread
             auto& job = this->_executionOrder->emplace_back(std::vector<BlockModel*>());
-            job.reserve(allBlocks.size() / n_batches + 1);
-            for (std::size_t j = i; j < allBlocks.size(); j += n_batches) {
-                job.push_back(allBlocks[j]);
+            job.reserve(nBlocks / n_batches + 1);
+            for (std::size_t j = i; j < nBlocks; j += n_batches) {
+                job.push_back(flatGraph.blocks()[j].get());
             }
         }
     }

--- a/core/test/qa_GraphMessages.cpp
+++ b/core/test/qa_GraphMessages.cpp
@@ -37,7 +37,7 @@ const boost::ut::suite<"Graph Formatter Tests"> graphFormatterTests = [] {
         Graph                  graph;
         [[maybe_unused]] auto& source = graph.emplaceBlock<NullSource<float>>();
         [[maybe_unused]] auto& sink   = graph.emplaceBlock<NullSink<float>>();
-        Edge                   edge{graph.blocks()[0UZ].get(), {1}, graph.blocks()[1UZ].get(), {2}, 1024, 1, "test_edge"};
+        Edge                   edge{graph.blocks()[0UZ], {1}, graph.blocks()[1UZ], {2}, 1024, 1, "test_edge"};
 
         "default"_test = [&edge] {
             std::string result = std::format("{:s}", edge);

--- a/core/test/qa_HierBlock.cpp
+++ b/core/test/qa_HierBlock.cpp
@@ -204,8 +204,8 @@ const boost::ut::suite SchedulerDiveIntoSubgraphTests_ = [] {
 
         expect(source.state() == lifecycle::State::RUNNING);
         expect(sink.state() == lifecycle::State::RUNNING);
-        expect(graph::findBlockWithUniqueName(*subGraphDirect, subGraphDirect->blockRef().pass1_unique_id).value()->state() == lifecycle::State::RUNNING);
-        expect(graph::findBlockWithUniqueName(*subGraphDirect, subGraphDirect->blockRef().pass2_unique_id).value()->state() == lifecycle::State::RUNNING);
+        expect(graph::findBlock(*subGraphDirect, subGraphDirect->blockRef().pass1_unique_id).value()->state() == lifecycle::State::RUNNING);
+        expect(graph::findBlock(*subGraphDirect, subGraphDirect->blockRef().pass2_unique_id).value()->state() == lifecycle::State::RUNNING);
 
         // Stopping scheduler
         scheduler.requestStop();

--- a/core/test/qa_HierBlock.cpp
+++ b/core/test/qa_HierBlock.cpp
@@ -157,7 +157,8 @@ const boost::ut::suite ExportPortsTests_ = [] {
         }
 
         // return to initial state
-        expect(scheduler.changeStateTo(lifecycle::State::INITIALISED).has_value()) << "could switch to INITIALISED?";
+        const auto initRet = scheduler.changeStateTo(lifecycle::State::INITIALISED);
+        expect(initRet.has_value()) << [&initRet] { return std::format("could switch to INITIALISED - error: {}", initRet.error()); };
         expect(awaitCondition(1s, [&scheduler] { return scheduler.state() == lifecycle::State::INITIALISED; })) << "scheduler INITIALISED w/ timeout";
         expect(scheduler.state() == lifecycle::State::INITIALISED) << std::format("scheduler INITIALISED - actual: {}\n", magic_enum::enum_name(scheduler.state()));
     };

--- a/core/test/qa_Scheduler.cpp
+++ b/core/test/qa_Scheduler.cpp
@@ -359,6 +359,8 @@ const boost::ut::suite<"SchedulerTests"> SchedulerSettingsTests = [] {
         expect(eq(sched.timeout_ms.value, 42U));
 
         sched.settings().updateActiveParameters();
+
+        expect(sched.runAndWait().has_value());
     };
 };
 

--- a/core/test/qa_SchedulerMessages.cpp
+++ b/core/test/qa_SchedulerMessages.cpp
@@ -213,7 +213,7 @@ const boost::ut::suite TopologyGraphTests = [] {
             expect(eq(getNReplyMessages(scheduler.fromScheduler), 0UZ)); // all messages are consumed
 
             sendMessage<Set>(scheduler.toScheduler, scheduler.scheduler_.unique_name, scheduler::property::kRemoveBlock /* endpoint */, //
-                {{"uniqueName", std::string(temporaryBlock.uniqueName())}} /* data */);
+                {{"uniqueName", std::string(temporaryBlock->uniqueName())}} /* data */);
 
             waitForReply(scheduler.fromScheduler);
             // expect(nothrow([&] { testGraph.processScheduledMessages(); })) << "manually execute processing of messages";
@@ -250,7 +250,7 @@ const boost::ut::suite TopologyGraphTests = [] {
             expect(eq(scheduler.graph().blocks().size(), 4UZ));
 
             sendMessage<Set>(scheduler.toScheduler, scheduler.scheduler_.unique_name, scheduler::property::kReplaceBlock /* endpoint */, //
-                {{"uniqueName", std::string(temporaryBlock.uniqueName())},                                                               //
+                {{"uniqueName", std::string(temporaryBlock->uniqueName())},                                                              //
                     {"type", "gr::testing::Copy<float32>"}, {"properties", property_map{}}} /* data */);
             waitForReply(scheduler.fromScheduler);
 
@@ -275,7 +275,7 @@ const boost::ut::suite TopologyGraphTests = [] {
 
         "Replace with an unknown block"_test = [&] {
             sendMessage<Set>(scheduler.toScheduler, scheduler.scheduler_.unique_name, scheduler::property::kReplaceBlock /* endpoint */, //
-                {{"uniqueName", std::string(block.uniqueName())},                                                                        //
+                {{"uniqueName", std::string(block->uniqueName())},                                                                       //
                     {"type", "doesnt_exist::multiply<float32>"}, {"properties", property_map{}}} /* data */);
             waitForReply(scheduler.fromScheduler);
 
@@ -296,8 +296,8 @@ const boost::ut::suite TopologyGraphTests = [] {
         TestScheduler scheduler(std::move(testGraph));
 
         "Add an edge"_test = [&] {
-            property_map data = {{"sourceBlock", std::string(blockOut.uniqueName())}, {"sourcePort", "out"}, //
-                {"destinationBlock", std::string(blockIn.uniqueName())}, {"destinationPort", "in"},          //
+            property_map data = {{"sourceBlock", std::string(blockOut->uniqueName())}, {"sourcePort", "out"}, //
+                {"destinationBlock", std::string(blockIn->uniqueName())}, {"destinationPort", "in"},          //
                 {"minBufferSize", gr::Size_t()}, {"weight", 0}, {"edgeName", "unnamed edge"}};
 
             sendMessage<Set>(scheduler.toScheduler, scheduler.scheduler_.unique_name, scheduler::property::kEmplaceEdge /* endpoint */, data /* data */);
@@ -312,8 +312,8 @@ const boost::ut::suite TopologyGraphTests = [] {
 
         "Fail to add an edge because source port is invalid"_test = [&] {
             sendMessage<Set>(scheduler.toScheduler, scheduler.scheduler_.unique_name, scheduler::property::kEmplaceEdge /* endpoint */, //
-                {{"sourceBlock", std::string(blockOut.uniqueName())}, {"sourcePort", "OUTPUT"},                                         //
-                    {"destinationBlock", std::string(blockIn.uniqueName())}, {"destinationPort", "in"}} /* data */);
+                {{"sourceBlock", std::string(blockOut->uniqueName())}, {"sourcePort", "OUTPUT"},                                        //
+                    {"destinationBlock", std::string(blockIn->uniqueName())}, {"destinationPort", "in"}} /* data */);
             waitForReply(scheduler.fromScheduler);
 
             expect(eq(getNReplyMessages(scheduler.fromScheduler), 1UZ));
@@ -323,8 +323,8 @@ const boost::ut::suite TopologyGraphTests = [] {
 
         "Fail to add an edge because destination port is invalid"_test = [&] {
             sendMessage<Set>(scheduler.toScheduler, scheduler.scheduler_.unique_name, scheduler::property::kEmplaceEdge /* endpoint */, //
-                {{"sourceBlock", std::string(blockOut.uniqueName())}, {"sourcePort", "in"},                                             //
-                    {"destinationBlock", std::string(blockIn.uniqueName())}, {"destinationPort", "INPUT"}} /* data */);
+                {{"sourceBlock", std::string(blockOut->uniqueName())}, {"sourcePort", "in"},                                            //
+                    {"destinationBlock", std::string(blockIn->uniqueName())}, {"destinationPort", "INPUT"}} /* data */);
             waitForReply(scheduler.fromScheduler);
 
             expect(eq(getNReplyMessages(scheduler.fromScheduler), 1UZ));
@@ -334,8 +334,8 @@ const boost::ut::suite TopologyGraphTests = [] {
 
         "Fail to add an edge because ports are not compatible"_test = [&] {
             sendMessage<Set>(scheduler.toScheduler, scheduler.scheduler_.unique_name, scheduler::property::kEmplaceEdge /* endpoint */, //
-                {{"sourceBlock", std::string(blockOut.uniqueName())}, {"sourcePort", "out"},                                            //
-                    {"destinationBlock", std::string(blockWrongType.uniqueName())}, {"destinationPort", "in"}} /* data */);
+                {{"sourceBlock", std::string(blockOut->uniqueName())}, {"sourcePort", "out"},                                           //
+                    {"destinationBlock", std::string(blockWrongType->uniqueName())}, {"destinationPort", "in"}} /* data */);
             waitForReply(scheduler.fromScheduler);
 
             expect(eq(getNReplyMessages(scheduler.fromScheduler), 1UZ));

--- a/core/test/qa_Settings.cpp
+++ b/core/test/qa_Settings.cpp
@@ -921,7 +921,7 @@ connections:
         try {
             scheduler::Simple sched{loadGrc(loader, std::string(grc))};
             expect(sched.runAndWait().has_value());
-            gr::graph::forAllBlocks<gr::block::Category::NormalBlock>(sched.graph(), [](std::shared_ptr<BlockModel> block) { expect(eq(std::get<float>(*block->settings().get(gr::tag::SAMPLE_RATE.shortKey())), 123456.f)) << std::format("sample_rate forwarded to {}", block->name()); });
+            gr::graph::forEachBlock<gr::block::Category::NormalBlock>(sched.graph(), [](std::shared_ptr<BlockModel> block) { expect(eq(std::get<float>(*block->settings().get(gr::tag::SAMPLE_RATE.shortKey())), 123456.f)) << std::format("sample_rate forwarded to {}", block->name()); });
         } catch (const std::string& e) {
             expect(false) << std::format("GRC loading failed: {}\n", e);
         }

--- a/core/test/qa_Settings.cpp
+++ b/core/test/qa_Settings.cpp
@@ -921,7 +921,7 @@ connections:
         try {
             scheduler::Simple sched{loadGrc(loader, std::string(grc))};
             expect(sched.runAndWait().has_value());
-            sched.graph().forEachBlock([](auto& block) { expect(eq(std::get<float>(*block.settings().get(gr::tag::SAMPLE_RATE.shortKey())), 123456.f)) << std::format("sample_rate forwarded to {}", block.name()); });
+            gr::graph::forAllBlocks<gr::block::Category::NormalBlock>(sched.graph(), [](std::shared_ptr<BlockModel> block) { expect(eq(std::get<float>(*block->settings().get(gr::tag::SAMPLE_RATE.shortKey())), 123456.f)) << std::format("sample_rate forwarded to {}", block->name()); });
         } catch (const std::string& e) {
             expect(false) << std::format("GRC loading failed: {}\n", e);
         }

--- a/core/test/qa_grc.cpp
+++ b/core/test/qa_grc.cpp
@@ -37,7 +37,7 @@ auto makeTestContext() {
 namespace {
 auto collectBlocks(const gr::Graph& graph) {
     std::set<std::string> result;
-    gr::graph::forAllBlocks<gr::block::Category::NormalBlock>(graph, [&](const auto node) { result.insert(std::format("{}-{}", node->name(), node->typeName())); });
+    gr::graph::forEachBlock<gr::block::Category::NormalBlock>(graph, [&](const auto node) { result.insert(std::format("{}-{}", node->name(), node->typeName())); });
     return result;
 }
 
@@ -445,7 +445,7 @@ const boost::ut::suite SettingsTests = [] {
 
             const auto graph1Saved = gr::saveGrc(context->loader, graph1);
             const auto graph2      = gr::loadGrc(context->loader, graph1Saved);
-            gr::graph::forAllBlocks<gr::block::Category::NormalBlock>(graph2, [&](const auto node) {
+            gr::graph::forEachBlock<gr::block::Category::NormalBlock>(graph2, [&](const auto node) {
                 const auto settings = node->settings().get();
                 expect(eq(std::get<bool>(settings.at("bool_setting")), expectedBool));
                 expect(eq(std::get<std::string>(settings.at("string_setting")), expectedString));
@@ -481,7 +481,7 @@ const boost::ut::suite SettingsTests = [] {
             const auto graph1Saved = gr::saveGrc(context->loader, graph1);
             const auto graph2      = gr::loadGrc(context->loader, graph1Saved);
 
-            gr::graph::forAllBlocks<gr::block::Category::NormalBlock>(graph2, [&](const auto node) {
+            gr::graph::forEachBlock<gr::block::Category::NormalBlock>(graph2, [&](const auto node) {
                 const auto& stored = node->settings().getStoredAll();
                 expect(eq(node->settings().getNStoredParameters(), 6UZ));
                 for (const auto& [ctx, ctxParameters] : stored) {

--- a/core/test/qa_grc.cpp
+++ b/core/test/qa_grc.cpp
@@ -43,7 +43,7 @@ auto collectBlocks(const gr::Graph& graph) {
 
 auto collectEdges(const gr::Graph& graph) {
     std::set<std::string> result;
-    graph.forEachEdge([&](const auto& edge) {
+    gr::graph::forEachEdge<gr::block::Category::NormalBlock>(graph, [&](const auto& edge) {
         auto portDefinitionToString = [](const gr::PortDefinition& definition) {
             return std::visit(gr::meta::overloaded(                                                                                                                   //
                                   [](const gr::PortDefinition::IndexBased& _definition) { return std::format("{}#{}", _definition.topLevel, _definition.subIndex); }, //
@@ -327,7 +327,7 @@ connections:
 
             {
                 std::unordered_set expectedSizes{1024UZ, 2048UZ, 8192UZ};
-                graph.forEachEdge([&expectedSizes](const auto& edge) {
+                gr::graph::forEachEdge<gr::block::Category::NormalBlock>(graph, [&expectedSizes](const auto& edge) {
                     auto it = expectedSizes.find(edge.minBufferSize());
                     if (it != expectedSizes.end()) {
                         expectedSizes.erase(it);
@@ -340,7 +340,7 @@ connections:
                 expect(graph.connectPendingEdges());
 
                 std::size_t thresholdSize = 2 * 8192UZ;
-                graph.forEachEdge([&thresholdSize](const auto& edge) { //
+                gr::graph::forEachEdge<gr::block::Category::NormalBlock>(graph, [&thresholdSize](const auto& edge) { //
                     expect(thresholdSize >= edge.bufferSize());
                 });
             }
@@ -350,7 +350,7 @@ connections:
             {
                 auto               graphDuplicate = gr::loadGrc(context->loader, graphSrc);
                 std::unordered_set expectedSizes{1024UZ, 2048UZ, 8192UZ};
-                graph.forEachEdge([&expectedSizes](const auto& edge) {
+                gr::graph::forEachEdge<gr::block::Category::NormalBlock>(graph, [&expectedSizes](const auto& edge) {
                     auto it = expectedSizes.find(edge.minBufferSize());
                     if (it != expectedSizes.end()) {
                         expectedSizes.erase(it);

--- a/core/test/qa_grc.cpp
+++ b/core/test/qa_grc.cpp
@@ -37,7 +37,7 @@ auto makeTestContext() {
 namespace {
 auto collectBlocks(const gr::Graph& graph) {
     std::set<std::string> result;
-    graph.forEachBlock([&](const auto& node) { result.insert(std::format("{}-{}", node.name(), node.typeName())); });
+    gr::graph::forAllBlocks<gr::block::Category::NormalBlock>(graph, [&](const auto node) { result.insert(std::format("{}-{}", node->name(), node->typeName())); });
     return result;
 }
 
@@ -50,9 +50,9 @@ auto collectEdges(const gr::Graph& graph) {
                                   [](const gr::PortDefinition::StringBased& _definition) { return _definition.name; }),                                               //
                 definition.definition);
         };
-        result.insert(std::format("{}#{} - {}#{}",                                          //
-            edge.sourceBlock().name(), portDefinitionToString(edge.sourcePortDefinition()), //
-            edge.destinationBlock().name(), portDefinitionToString(edge.destinationPortDefinition())));
+        result.insert(std::format("{}#{} - {}#{}",                                           //
+            edge.sourceBlock()->name(), portDefinitionToString(edge.sourcePortDefinition()), //
+            edge.destinationBlock()->name(), portDefinitionToString(edge.destinationPortDefinition())));
     });
     return result;
 }
@@ -445,8 +445,8 @@ const boost::ut::suite SettingsTests = [] {
 
             const auto graph1Saved = gr::saveGrc(context->loader, graph1);
             const auto graph2      = gr::loadGrc(context->loader, graph1Saved);
-            graph2.forEachBlock([&](const auto& node) {
-                const auto settings = node.settings().get();
+            gr::graph::forAllBlocks<gr::block::Category::NormalBlock>(graph2, [&](const auto node) {
+                const auto settings = node->settings().get();
                 expect(eq(std::get<bool>(settings.at("bool_setting")), expectedBool));
                 expect(eq(std::get<std::string>(settings.at("string_setting")), expectedString));
                 expect(eq(std::get<std::complex<double>>(settings.at("complex_setting")), expectedComplex));
@@ -481,9 +481,9 @@ const boost::ut::suite SettingsTests = [] {
             const auto graph1Saved = gr::saveGrc(context->loader, graph1);
             const auto graph2      = gr::loadGrc(context->loader, graph1Saved);
 
-            graph2.forEachBlock([&](const auto& node) {
-                const auto& stored = node.settings().getStoredAll();
-                expect(eq(node.settings().getNStoredParameters(), 6UZ));
+            gr::graph::forAllBlocks<gr::block::Category::NormalBlock>(graph2, [&](const auto node) {
+                const auto& stored = node->settings().getStoredAll();
+                expect(eq(node->settings().getNStoredParameters(), 6UZ));
                 for (const auto& [ctx, ctxParameters] : stored) {
                     for (const auto& [ctxTime, settingsMap] : ctxParameters) {
                         std::string expectedName = "ArraySink0";

--- a/core/test/qa_plugins_test.cpp
+++ b/core/test/qa_plugins_test.cpp
@@ -153,12 +153,12 @@ const boost::ut::suite BasicPluginBlocksConnectionTests = [] {
         expect(connection_5 == gr::ConnectionResult::SUCCESS);
 
         for (std::size_t i = 0; i < repeats; ++i) {
-            std::ignore = block_source.work(std::numeric_limits<std::size_t>::max());
+            std::ignore = block_source->work(std::numeric_limits<std::size_t>::max());
             std::ignore = block_multiply_double.work(std::numeric_limits<std::size_t>::max());
-            std::ignore = block_convert_to_float.work(std::numeric_limits<std::size_t>::max());
-            std::ignore = block_multiply_float.work(std::numeric_limits<std::size_t>::max());
-            std::ignore = block_convert_to_double.work(std::numeric_limits<std::size_t>::max());
-            std::ignore = block_sink.work(std::numeric_limits<std::size_t>::max());
+            std::ignore = block_convert_to_float->work(std::numeric_limits<std::size_t>::max());
+            std::ignore = block_multiply_float->work(std::numeric_limits<std::size_t>::max());
+            std::ignore = block_convert_to_double->work(std::numeric_limits<std::size_t>::max());
+            std::ignore = block_sink->work(std::numeric_limits<std::size_t>::max());
         }
     };
 };


### PR DESCRIPTION
This PR introduces a series of internal refactorings and ownership improvements for the `Graph`, `Edge`, and `SchedulerBase` subsystems, centred on robustness, reusability, and safe inspection of nested sub-graphs:

---

### Key changes:

* **Ownership modernisation**

  * Changed `Graph::_blocks` and `Edge::_sourceBlock/_destinationBlock` to use `std::shared_ptr<BlockModel>` instead of `unique_ptr` or raw pointers.
  * This enables:

    * **Safe flattening of nested sub-graphs** (copy-by-reference).
    * **Thread-safe traversal and introspection**, especially across scheduler boundaries.
    * **Consistent lifetime guarantees** during runtime reconfiguration (e.g., adoption, zombie cleanup).

* **New freestanding traversal functions** (replacing `forAllUnmanagedBlocks(...)`, `Graph::forEachBlock(...)`, etc.)
  Introduced under `namespace gr::graph`, with support for nested traversal:

  ```cpp
  template<block::Category traverseCategory, typename Fn>
  void forEachBlock(GraphLike auto const& root, Fn&& function, block::Category filter = block::Category::All);

  template<block::Category traverseCategory, typename Fn>
  void forEachEdge(GraphLike auto const& root, Fn&& function, Edge::EdgeState filter = Edge::EdgeState::Unknown);
  ```

* These support recursive traversal of arbitrary sub-graph structures (including transparent and scheduled block groups).

* new `GraphLike` new concept to generalise over `Graph`, `Block` (managed/unmanaged sub-graphs) and `GraphWrapper`.

* **Changed return types of `findBlock(...)`** to `std::expected`, to allow better diagnostics in failure cases
* **Renamed and removed redundant in-Graph traversal methods**
* **Simplified `Edge` structure**
  * Replaced move/delete logic with simple `shared_ptr`-based value semantics.
  * Added `operator==` for edge comparisons.
  * Updated `graph::flatten(...)` to support reusable sub-graph collapsing logic.

---

### Rationale

* **Shared ownership** enables dynamic composition and graph transformation without invalidating references.
* **Freestanding algorithms** decouple traversal logic from `Graph`, enabling composability across wrappers and future scheduler backends.
* **`expected` over `optional`** improves observability in graph diagnostics and integration testing.

-- 

Please have a look at the new API, notably free-standing helper functions. I kept the individual commits for those who prefer comit-by-comit reading. However, they can be squash-merged if deemed necessary or not useful for future readers. 

Thanks in advance.