### PR TITLE
Report an error message for unsupported platforms

### DIFF
--- a/core/include/gnuradio-4.0/thread/thread_pool.hpp
+++ b/core/include/gnuradio-4.0/thread/thread_pool.hpp
@@ -684,7 +684,7 @@ inline std::size_t getTotalThreadCount() {
 #else
     return BasicThreadPool::_globalThreadCount.load(std::memory_order_relaxed);
 #endif
-#else
+#elif defined(__linux__)
     std::ifstream status{"/proc/self/status"};
     std::string   line;
     while (std::getline(status, line)) {
@@ -697,6 +697,10 @@ inline std::size_t getTotalThreadCount() {
         }
     }
     throw std::runtime_error("could not get total thread count");
+    return 0UZ;
+#else
+    // TODO Implement this function for Windows, Apple and other platforms
+    throw std::runtime_error("could not get total thread count, platform not supported yet");
     return 0UZ;
 #endif
 }


### PR DESCRIPTION
When users are on a platform that is not supported yet, report a proper error message instead of them getting a 'file not found' error.