### PR TITLE
qa_SchedulerMessages: fix flaky test

### DIFF
--- a/core/test/qa_SchedulerMessages.cpp
+++ b/core/test/qa_SchedulerMessages.cpp
@@ -404,7 +404,7 @@ const boost::ut::suite TopologyGraphTests = [] {
 
             // setting staged setting via staged setting (N.B. non-real-time <-> real-time setting decoupling
             sendMessage<Set>(scheduler.toScheduler, "" /* serviceName */, block::property::kSetting /* endpoint */, {{"timeout_ms", 43}} /* data  */);
-            expect(nothrow([&] { scheduler.scheduler().processScheduledMessages(); })) << "manually execute processing of messages";
+            waitForReply(scheduler.fromScheduler);
 
             stagedSettings = scheduler.scheduler().settings().stagedParameters();
             expect(stagedSettings.contains("timeout_ms"));


### PR DESCRIPTION
kSetting is async, only evaluate its effect after message reply from scheduler.
Also no need to manually process messages since the scheduler already does that internally

We'll soon refactor how we wait for messages, but this should fix the CI asap.