### PR TITLE
win32: miscellaneous build fixes

### DIFF
--- a/blocklib_generator/CMakeLists.txt
+++ b/blocklib_generator/CMakeLists.txt
@@ -51,7 +51,11 @@ if(NOT
    0)
   message(FATAL_ERROR "Failed to build gnuradio_4_0_parse_registrations tool: ${build_error}")
 else()
-  set(PARSER_EXECUTABLE "${TOOLS_BUILD_DIR}/gnuradio_4_0_parse_registrations")
+  if(WIN32)
+    set(PARSER_EXECUTABLE "${TOOLS_BUILD_DIR}/gnuradio_4_0_parse_registrations.exe")
+  else()
+    set(PARSER_EXECUTABLE "${TOOLS_BUILD_DIR}/gnuradio_4_0_parse_registrations")
+  endif()
   message(STATUS "Parser tool built: ${PARSER_EXECUTABLE}")
 endif()
 

--- a/core/include/gnuradio-4.0/PluginLoader.hpp
+++ b/core/include/gnuradio-4.0/PluginLoader.hpp
@@ -142,7 +142,11 @@ public:
             }
 
             for (const auto& file : std::filesystem::directory_iterator{directory}) {
+#if defined(_WIN32)
+                if (file.is_regular_file() && file.path().extension() == ".dll") {
+#else
                 if (file.is_regular_file() && file.path().extension() == ".so") {
+#endif
                     auto fileString = file.path().string();
                     if (_loadedPluginFiles.contains(fileString)) {
                         continue;

--- a/core/include/gnuradio-4.0/thread/thread_affinity.hpp
+++ b/core/include/gnuradio-4.0/thread/thread_affinity.hpp
@@ -27,7 +27,9 @@
 #include <cstdlib> // for atoi()
 #include <emscripten.h>
 #else
+#if !defined(_WIN32)
 #include <sys/resource.h>
+#endif
 #endif
 
 namespace gr::thread_pool::thread {

--- a/core/test/qa_plugins_test.cpp
+++ b/core/test/qa_plugins_test.cpp
@@ -41,7 +41,11 @@ const boost::ut::suite PluginLoaderTests = [] {
     "BadPlugins"_test = [&] {
         expect(!context->loader.failedPlugins().empty());
         for (const auto& plugin : context->loader.failedPlugins()) {
+#if defined(_WIN32)
+            expect(plugin.first.ends_with("bad_plugin.dll"));
+#else
             expect(plugin.first.ends_with("bad_plugin.so"));
+#endif
         }
     };
 


### PR DESCRIPTION
- blocklib_generator/CMakeLists.txt
  - in windows we need to set PARSER_EXECUTABLE to gnuradio_4_parse_registrations.exe

- core/include/gnuradio-4.0/PluginLoader.hpp
  - Conditional to allow loading of files ending in .dll on windows.

- core/include/gnuradio-4.0/thread/thread_affinity.hpp
  - make inclusion of sys/resource dependent on not building on win32.

- core/test/qa_plugins_test.cpp
  - Make conditional to use bad_plugin.dll instead of bad_plugin.so under windows.