### PR TITLE
Bump pmtv library version to resolve segfaults

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -332,7 +332,7 @@ include(FetchContent)
 FetchContent_Declare(
   pmt
   GIT_REPOSITORY https://github.com/gnuradio/pmt.git
-  GIT_TAG e1a46cb61decb044f6ab0a58a77211beb3630340 # latest as of 2023-12-06
+  GIT_TAG 5960738cd35827acceb5a4de9e1c4005d2d02305 # latest as of 2025-08-13
 )
 
 set(BOOST_UT_DISABLE_MODULE
@@ -578,7 +578,7 @@ endif()
 configure_file(cmake/gnuradio4.pc.in ${CMAKE_CURRENT_BINARY_DIR}/gnuradio4.pc @ONLY)
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/gnuradio4.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig # Standard location
-                                                                                                     # for .pc files
+        # for .pc files
 )
 
 # print effective options

--- a/core/include/gnuradio-4.0/BlockModel.hpp
+++ b/core/include/gnuradio-4.0/BlockModel.hpp
@@ -579,6 +579,7 @@ inline property_map serializeBlock(PluginLoader& pluginLoader, const std::shared
 
         using namespace std::string_literals;
         std::vector<pmtv::pmt> ctxParamsSeq;
+        ctxParamsSeq.reserve(stored.size());
         for (const auto& [ctx, ctxParameters] : stored) {
             if (std::holds_alternative<std::string>(ctx) && std::get<std::string>(ctx) == ""s) {
                 continue;

--- a/core/include/gnuradio-4.0/Graph.hpp
+++ b/core/include/gnuradio-4.0/Graph.hpp
@@ -765,6 +765,13 @@ void forEachBlock(GraphLike auto const& root, Fn&& function, block::Category fil
     });
 }
 
+template<block::Category traverseCategory>
+[[nodiscard]] std::size_t countBlocks(GraphLike auto const& root, block::Category filter = block::Category::All) {
+    std::size_t n = 0;
+    forEachBlock<traverseCategory>(root, [&](auto const&) { n++; }, filter);
+    return n;
+}
+
 template<block::Category traverseCategory, typename Fn>
 void forEachEdge(GraphLike auto const& root, Fn&& function, Edge::EdgeState filter) {
     using enum Edge::EdgeState;
@@ -776,6 +783,13 @@ void forEachEdge(GraphLike auto const& root, Fn&& function, Edge::EdgeState filt
             }
         }
     });
+}
+
+template<block::Category traverseCategory>
+[[nodiscard]] std::size_t countEdges(GraphLike auto const& root, Edge::EdgeState filter = Edge::EdgeState::Unknown) {
+    std::size_t n = 0;
+    forEachEdge<traverseCategory>(root, [&](auto const&) { n++; }, filter);
+    return n;
 }
 
 template<gr::block::Category traverseCategory = gr::block::Category::TransparentBlockGroup>

--- a/core/test/qa_SchedulerMessages.cpp
+++ b/core/test/qa_SchedulerMessages.cpp
@@ -326,6 +326,20 @@ const boost::ut::suite TopologyGraphTests = [] {
         };
     };
 
+    "std::vector<pmtv::pmt> segfault test"_test = [] {
+        // Regression test kept because a now-fixed bug in pmtv::pmt’s trivial relocation caused a segfault
+        // with Clang 18/19 when std::vector<pmtv::pmt> reallocated (first seen in “Get GRC Yaml tests”);
+        // this ensures it doesn’t regress.
+
+        std::vector<pmtv::pmt> vec;
+        for (int i = 0; i < 2000; ++i) {
+            vec.push_back(property_map{{std::string("key"), std::string("value")}});
+        }
+        std::println("std::vector<pmtv::pmt> segfault test before");
+        [[maybe_unused]] auto p0 = vec[0]; // Segfault happens here
+        std::println("std::vector<pmtv::pmt> segfault test after");
+    };
+
     "Get GRC Yaml tests"_test = [] {
         gr::Graph testGraph(context->loader);
         testGraph.emplaceBlock("gr::testing::Copy<float32>", {});


### PR DESCRIPTION
* This PR depends on https://github.com/gnuradio/pmt/pull/117 and https://github.com/gnuradio/pmt/pull/118
* pmt library `GIT_TAG` must be updated before merging 

Bump pmtv library version to resolve segfaults from std::vector reallocation

- Switch to the new pmtv::pmt implementation, which fixes the crash triggered when std::vector<pmtv::pmt> grew and reallocated under Clang 18/19.
- Add/keep a minimal “simple” test (first surfaced in “Get GRC Yaml tests”) as a regression to ensure the allocator/reallocation path stays stable.
- Additionally reserve vector capacity up front in hot paths to minimize relocations where possible.