### PR TITLE
Port fixes

### DIFF
--- a/core/include/gnuradio-4.0/Block.hpp
+++ b/core/include/gnuradio-4.0/Block.hpp
@@ -242,13 +242,7 @@ protected:
         if (!_dirtyAvailable) {
             return; // already updated
         }
-        getPortConstraints(_self, _available, [](auto& port) {
-            if constexpr (portDirection == PortDirection::INPUT) {
-                return port.streamReader().available();
-            } else {
-                return port.streamWriter().available();
-            }
-        });
+        getPortConstraints(_self, _available, [](auto& port) { return port.available(); });
         _maxSyncAvailable  = detail::min_element_masked<PortSync::SYNCHRONOUS>(_available, _types).value_or(gr::undefined_size);
         _hasASyncAvailable = detail::compareRangesMasked<PortSync::ASYNCHRONOUS>(_available, _minSamples, _types);
         _dirtyAvailable    = false;
@@ -348,13 +342,7 @@ public:
             }
 
             // can safely assume that port is either INPUT XOR OUTPUT
-            auto getAvailable = [&port]() -> std::size_t {
-                if constexpr (portDirection == PortDirection::INPUT) {
-                    return port.streamReader().available();
-                } else {
-                    return port.streamWriter().available();
-                }
-            };
+            auto getAvailable = [&port]() -> std::size_t { return port.available(); };
 
             std::size_t availableBefore = getAvailable();
             // prime port
@@ -1640,13 +1628,7 @@ protected:
             bool        hasAsync     = false;                                   // true if there is at least one async input/output that has available samples/remaining capacity
         } result;
         auto adjustForInputPort = [&result]<PortLike Port>(Port& port) {
-            const std::size_t available = [&port]() {
-                if constexpr (gr::traits::port::is_input_v<Port>) {
-                    return port.streamReader().available();
-                } else {
-                    return port.streamWriter().available();
-                }
-            }();
+            const std::size_t available = port.available();
             if constexpr (std::remove_cvref_t<Port>::kIsSynch) {
                 result.minSync      = std::max(result.minSync, port.min_samples);
                 result.maxSync      = std::min(result.maxSync, port.max_samples);

--- a/core/include/gnuradio-4.0/Port.hpp
+++ b/core/include/gnuradio-4.0/Port.hpp
@@ -776,14 +776,15 @@ public:
         return true;
     }
 
-    [[nodiscard]] InternalPortBuffers writerHandlerInternal() noexcept {
-        static_assert(kIsOutput, "only to be used with output ports");
+    [[nodiscard]] InternalPortBuffers writerHandlerInternal() noexcept
+    requires(kIsOutput)
+    {
         return {static_cast<void*>(std::addressof(_ioHandler)), static_cast<void*>(std::addressof(_tagIoHandler))};
     }
 
-    [[nodiscard]] bool updateReaderInternal(InternalPortBuffers buffer_writer_handler_other) noexcept {
-        static_assert(kIsInput, "only to be used with input ports");
-
+    [[nodiscard]] bool updateReaderInternal(InternalPortBuffers buffer_writer_handler_other) noexcept
+    requires(kIsInput)
+    {
         if (buffer_writer_handler_other.streamHandler == nullptr) {
             return false;
         }
@@ -1168,18 +1169,18 @@ private:
 
         explicit constexpr PortWrapper(T& arg) noexcept : _value{arg} {
             if constexpr (T::kIsInput) {
-                static_assert(requires { arg.writerHandlerInternal(); }, "'private void* writerHandlerInternal()' not implemented");
-            } else {
                 static_assert(requires { arg.updateReaderInternal(std::declval<InternalPortBuffers>()); }, "'private bool updateReaderInternal(void* buffer)' not implemented");
+            } else {
+                static_assert(requires { arg.writerHandlerInternal(); }, "'private void* writerHandlerInternal()' not implemented");
             }
             arg.metaInfo.data_type = gr::meta::type_name<typename T::value_type>();
         }
 
         explicit constexpr PortWrapper(T&& arg) noexcept : _value{std::move(arg)} {
             if constexpr (T::kIsInput) {
-                static_assert(requires { arg.writerHandlerInternal(); }, "'private void* writerHandlerInternal()' not implemented");
-            } else {
                 static_assert(requires { arg.updateReaderInternal(std::declval<InternalPortBuffers>()); }, "'private bool updateReaderInternal(void* buffer)' not implemented");
+            } else {
+                static_assert(requires { arg.writerHandlerInternal(); }, "'private void* writerHandlerInternal()' not implemented");
             }
             arg.metaInfo.data_type = gr::meta::type_name<typename T::value_type>();
         }

--- a/core/include/gnuradio-4.0/Port.hpp
+++ b/core/include/gnuradio-4.0/Port.hpp
@@ -704,6 +704,14 @@ struct Port {
             if (!isConnected) {
                 return;
             }
+
+            if (tagsPublished + 1 >= tags.size()) {
+                // TODO(error handling): Decide how to surface failures.
+                // Option A: throw an exception, but this function is marked noexcept—either remove noexcept or avoid throwing.
+                // Option B: return an error (or set a port-status flag) that the Scheduler can observe and handle accordingly.
+                // std::println(stderr, "Tags buffer is full (published:{}, size:{}), can not process tag publishing", tagsPublished, tags.size());
+                return;
+            }
             const auto index = streamIndex + tagOffset;
 
             if (tagsPublished > 0) {

--- a/core/include/gnuradio-4.0/Port.hpp
+++ b/core/include/gnuradio-4.0/Port.hpp
@@ -762,7 +762,7 @@ private:
 public:
     constexpr Port() noexcept = default;
     explicit Port(std::int16_t priority_, std::size_t min_samples_ = 0UZ, std::size_t max_samples_ = SIZE_MAX) noexcept : priority{priority_}, min_samples(min_samples_), max_samples(max_samples_), _ioHandler{newIoHandler()}, _tagIoHandler{newTagIoHandler()} {}
-    constexpr Port(Port&& other) noexcept : name(other.name), priority{other.priority}, min_samples(other.min_samples), max_samples(other.max_samples), metaInfo(other.metaInfo), _ioHandler(std::move(other._ioHandler)), _tagIoHandler(std::move(other._tagIoHandler)) {}
+    constexpr Port(Port&& other) noexcept : name(other.name), priority{other.priority}, min_samples(other.min_samples), max_samples(other.max_samples), metaInfo(std::move(other.metaInfo)), _ioHandler(std::move(other._ioHandler)), _tagIoHandler(std::move(other._tagIoHandler)) {}
     Port(const Port&)                       = delete;
     auto            operator=(const Port&)  = delete;
     constexpr Port& operator=(Port&& other) = delete;

--- a/core/include/gnuradio-4.0/Port.hpp
+++ b/core/include/gnuradio-4.0/Port.hpp
@@ -1237,7 +1237,7 @@ private:
                 .portType                  = T::kPortType,
                 .portDirection             = T::kDirection,
                 .portDomain                = T::Domain::Name,
-                .portConnectionResult      = (_value.nReaders() + _value.nWriters() > 0UZ) ? ConnectionResult::SUCCESS : ConnectionResult::FAILED,
+                .portConnectionResult      = _value.isConnected() ? ConnectionResult::SUCCESS : ConnectionResult::FAILED,
                 .valueTypeName             = meta::type_name<typename T::value_type>(),
                 .isValueTypeArithmeticLike = T::kIsArithmeticLikeValueType,
                 .valueTypeSize             = sizeof(typename T::value_type),

--- a/core/include/gnuradio-4.0/Port.hpp
+++ b/core/include/gnuradio-4.0/Port.hpp
@@ -847,7 +847,13 @@ public:
         return false;
     }
 
-    [[nodiscard]] constexpr static std::size_t available() noexcept { return 0; } //  ↔ maps to Buffer::Buffer[Reader, Writer].available()
+    [[nodiscard]] constexpr std::size_t available() const noexcept {
+        if constexpr (kIsInput) {
+            return streamReader().available();
+        } else {
+            return streamWriter().available();
+        }
+    }
 
     [[nodiscard]] constexpr std::size_t min_buffer_size() const noexcept {
         if constexpr (Required::kIsConst) {


### PR DESCRIPTION
The PR includes miscellaneous fixes in Port class.

* Fix: PortWrapper constructor checks were reversed
        * Reason: both writerHandlerInternal and updateReaderInternal exist on Port, so the wrong static checks didn’t fail.
          * Change: swap the checks and use requires constraints to conditionally enable appropriate function
    (input -> updateReaderInternal, output -> writerHandlerInternal).

* Add std::move(portMetaInfo) for Port move constractor
* Implement Port::available() function (before it always returns 0). Use it in Block class where applicable.
* use isConnected instead of nReaders+nWriters > 0 check
* check for out-of-bounds writes to tags span in OutputSpan::processPublishTag
