### PR TITLE
Print why gnuradio_4_0_parse_registrations fails to build

### DIFF
--- a/blocklib_generator/CMakeLists.txt
+++ b/blocklib_generator/CMakeLists.txt
@@ -49,7 +49,7 @@ if(NOT
    build_result
    EQUAL
    0)
-  message(FATAL_ERROR "Failed to build gnuradio_4_0_parse_registrations tool: ${build_error}")
+  message(FATAL_ERROR "Failed to build gnuradio_4_0_parse_registrations tool: ${build_error} ${build_output}")
 else()
   if(WIN32)
     set(PARSER_EXECUTABLE "${TOOLS_BUILD_DIR}/gnuradio_4_0_parse_registrations.exe")


### PR DESCRIPTION
Otherwise it just says it failed to build without a reason. Common causes can be missing dependencies (libc++ dev headers and such)