### PR TITLE
SchedulerBase: eliminate custom constructors & add Graph exchange(Graph&&)

### DIFF
--- a/blocks/basic/test/qa_DataSink.cpp
+++ b/blocks/basic/test/qa_DataSink.cpp
@@ -352,7 +352,10 @@ const boost::ut::suite DataSinkTests = [] {
             })) << boost::ut::fatal;
         });
 
-        Scheduler sched{std::move(testGraph)};
+        Scheduler sched;
+        if (auto ret = sched.exchange(std::move(testGraph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         expect(sched.runAndWait().has_value());
         registerThread.join();
 
@@ -427,7 +430,10 @@ const boost::ut::suite DataSinkTests = [] {
         });
 
         {
-            Scheduler sched{std::move(testGraph)};
+            Scheduler sched;
+            if (auto ret = sched.exchange(std::move(testGraph)); !ret) {
+                throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+            }
             expect(sched.runAndWait().has_value());
 
             const auto pollerAfterStop = globalDataSinkRegistry().getStreamingPoller<float>(DataSinkQuery::sinkName("test_sink"));
@@ -512,7 +518,10 @@ const boost::ut::suite DataSinkTests = [] {
             return std::make_tuple(poller, receivedData, receivedTags);
         });
 
-        Scheduler sched{std::move(testGraph)};
+        Scheduler sched;
+        if (auto ret = sched.exchange(std::move(testGraph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         expect(sched.runAndWait().has_value());
 
         const auto& [poller, receivedData, receivedTags] = polling.get();
@@ -580,7 +589,10 @@ const boost::ut::suite DataSinkTests = [] {
             return std::make_tuple(poller, receivedData, receivedTags);
         });
 
-        Scheduler sched{std::move(testGraph)};
+        Scheduler sched;
+        if (auto ret = sched.exchange(std::move(testGraph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         expect(sched.runAndWait().has_value());
 
         const auto& [_, receivedData, receivedTags] = polling.get();
@@ -647,7 +659,10 @@ const boost::ut::suite DataSinkTests = [] {
             return std::make_tuple(poller, receivedData);
         });
 
-        Scheduler sched{std::move(testGraph)};
+        Scheduler sched;
+        if (auto ret = sched.exchange(std::move(testGraph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         expect(sched.runAndWait().has_value());
 
         registerThread.join();
@@ -741,7 +756,10 @@ const boost::ut::suite DataSinkTests = [] {
             results.push_back(std::move(f));
         }
 
-        Scheduler sched{std::move(testGraph)};
+        Scheduler sched;
+        if (auto ret = sched.exchange(std::move(testGraph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         expect(sched.runAndWait().has_value());
         registerThread.join();
 
@@ -805,7 +823,10 @@ const boost::ut::suite DataSinkTests = [] {
             return std::make_tuple(poller, receivedData, receivedTags);
         });
 
-        Scheduler sched{std::move(testGraph)};
+        Scheduler sched;
+        if (auto ret = sched.exchange(std::move(testGraph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         expect(sched.runAndWait().has_value());
 
         const auto& [poller, receivedData, receivedTags] = polling.get();
@@ -851,7 +872,10 @@ const boost::ut::suite DataSinkTests = [] {
             expect(spinUntil(4s, [&] { return globalDataSinkRegistry().registerTriggerCallback<float>(DataSinkQuery::sinkName("test_sink"), isTrigger, 3000, 2000, callback); })) << boost::ut::fatal;
         });
 
-        Scheduler sched{std::move(testGraph)};
+        Scheduler sched;
+        if (auto ret = sched.exchange(std::move(testGraph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         expect(sched.runAndWait().has_value());
         registerThread.join();
 
@@ -896,7 +920,10 @@ const boost::ut::suite DataSinkTests = [] {
             return std::make_tuple(poller, samplesSeen);
         });
 
-        Scheduler sched{std::move(testGraph)};
+        Scheduler sched;
+        if (auto ret = sched.exchange(std::move(testGraph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         expect(sched.runAndWait().has_value());
 
         const auto& [poller, samplesSeen] = polling.get();
@@ -938,7 +965,10 @@ const boost::ut::suite DataSinkTests = [] {
             return std::pair(poller, receivedDataSets);
         });
 
-        Scheduler sched{std::move(testGraph)};
+        Scheduler sched;
+        if (auto ret = sched.exchange(std::move(testGraph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         expect(sched.runAndWait().has_value());
 
         const auto& [poller, receivedDataSets] = polling.get();
@@ -986,7 +1016,10 @@ const boost::ut::suite DataSinkTests = [] {
             expect(spinUntil(4s, [&] { return globalDataSinkRegistry().registerDataSetCallback<float>(DataSinkQuery::sinkName("test_sink"), callback); })) << boost::ut::fatal;
         });
 
-        Scheduler sched{std::move(testGraph)};
+        Scheduler sched;
+        if (auto ret = sched.exchange(std::move(testGraph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         expect(sched.runAndWait().has_value());
         registerThread.join();
 

--- a/blocks/basic/test/qa_PythonBlock.cpp
+++ b/blocks/basic/test/qa_PythonBlock.cpp
@@ -197,7 +197,7 @@ def process_bulk(ins, outs):
             throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
         }
 
-        bool              throws = false;
+        bool throws = false;
         try {
             expect(sched.runAndWait().has_value());
         } catch (const std::exception& ex) {

--- a/blocks/basic/test/qa_PythonBlock.cpp
+++ b/blocks/basic/test/qa_PythonBlock.cpp
@@ -192,7 +192,11 @@ def process_bulk(ins, outs):
         expect(gr::ConnectionResult::SUCCESS == graph.connect(src, "out"s, block, "inputs#0"s));
         expect(gr::ConnectionResult::SUCCESS == graph.connect(block, "outputs#0"s, sink, "in"s));
 
-        scheduler::Simple sched{std::move(graph)};
+        gr::scheduler::Simple sched;
+        if (auto ret = sched.exchange(std::move(graph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
+
         bool              throws = false;
         try {
             expect(sched.runAndWait().has_value());
@@ -253,7 +257,11 @@ def process_bulk(ins, outs):
         expect(gr::ConnectionResult::SUCCESS == graph.connect(src, "out"s, block, "inputs#0"s));
         expect(gr::ConnectionResult::SUCCESS == graph.connect(block, "outputs#0"s, sink, "in"s));
 
-        scheduler::Simple sched{std::move(graph)};
+        gr::scheduler::Simple sched;
+        if (auto ret = sched.exchange(std::move(graph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
+
         block.pause();  // simplified calling
         block.resume(); // simplified calling
         block.reset();  // simplified calling

--- a/blocks/basic/test/qa_Selector.cpp
+++ b/blocks/basic/test/qa_Selector.cpp
@@ -65,7 +65,10 @@ void execute_selector_test(TestParams params) {
     expect(monitorSink->settings().applyStagedParameters().forwardParameters.empty());
     expect(gr::ConnectionResult::SUCCESS == graph.connect<"monitor">(*selector).to<"in">(*monitorSink));
 
-    gr::scheduler::Simple sched{std::move(graph)};
+    gr::scheduler::Simple sched;
+    if (auto ret = sched.exchange(std::move(graph)); !ret) {
+        throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+    }
     expect(sched.runAndWait().has_value());
 
     for (std::size_t i = 0; i < selector->inputs.size(); i++) {

--- a/blocks/basic/test/qa_StreamToDataSet.cpp
+++ b/blocks/basic/test/qa_StreamToDataSet.cpp
@@ -92,7 +92,10 @@ const boost::ut::suite<"StreamToDataSet Block"> selectorTest = [] {
             std::this_thread::sleep_for(std::chrono::seconds(1)); // wait for another second before closing down
         });
 
-        gr::scheduler::Simple sched{std::move(graph)};
+        gr::scheduler::Simple sched;
+        if (auto ret = sched.exchange(std::move(graph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         expect(sched.runAndWait().has_value()) << std::format("runAndWait - filter {}", filter);
 
         expect(eq(clockSrc.sample_rate, sample_rate));
@@ -147,7 +150,10 @@ const boost::ut::suite<"StreamToStream test"> streamToStreamTest = [] {
         expect(eq(gr::ConnectionResult::SUCCESS, graph.connect<"out">(tagSrc).template to<"in">(filterStreamToStream)));
         expect(eq(gr::ConnectionResult::SUCCESS, graph.connect<"out">(filterStreamToStream).template to<"in">(streamSink)));
 
-        gr::scheduler::Simple sched{std::move(graph)};
+        gr::scheduler::Simple sched;
+        if (auto ret = sched.exchange(std::move(graph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         std::println("start -> Stream-to-Stream with filter: {} n_pre:{} n_post:{}", filter, preSamples, postSamples);
         expect(sched.runAndWait().has_value()) << std::format("runAndWait - filter {}", filter);
         std::println("done -> Stream-to-Stream with filter: {} n_pre:{} n_post:{}", filter, preSamples, postSamples);
@@ -218,7 +224,10 @@ const boost::ut::suite<"StreamToDataSet test"> streamToDataSetTest = [] {
         expect(eq(gr::ConnectionResult::SUCCESS, graph.connect<"out">(tagSrc).template to<"in">(filterStreamToDataSet)));
         expect(eq(gr::ConnectionResult::SUCCESS, graph.connect<"out">(filterStreamToDataSet).template to<"in">(dataSetSink)));
 
-        gr::scheduler::Simple sched{std::move(graph)};
+        gr::scheduler::Simple sched;
+        if (auto ret = sched.exchange(std::move(graph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         std::println("start -> Stream-to-DataSet with filter: {} n_pre:{} n_post:{}", filter, preSamples, postSamples);
         expect(sched.runAndWait().has_value()) << std::format("runAndWait - filter {}", filter);
         std::println("done -> Stream-to-DataSet with filter: {} n_pre:{} n_post:{}", filter, preSamples, postSamples);

--- a/blocks/basic/test/qa_SyncBlock.cpp
+++ b/blocks/basic/test/qa_SyncBlock.cpp
@@ -69,7 +69,10 @@ void runTest(const TestParams& par) {
         expect(gr::ConnectionResult::SUCCESS == graph.connect(syncBlock, "outputs#"s + std::to_string(i), *sinks[i], "in"s));
     }
 
-    gr::scheduler::Simple sched{std::move(graph)};
+    gr::scheduler::Simple sched;
+    if (auto ret = sched.exchange(std::move(graph)); !ret) {
+        throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+    }
     sched.runAndWait();
 
     for (std::size_t i = 0; i < sinks.size(); i++) {

--- a/blocks/basic/test/qa_TriggerBlocks.cpp
+++ b/blocks/basic/test/qa_TriggerBlocks.cpp
@@ -92,7 +92,10 @@ const suite<"SchmittTrigger Block"> triggerTests = [] {
                 });
             }
 
-            gr::scheduler::Simple sched{std::move(graph)}; // declared here to ensure life-time of graph and blocks inside.
+            gr::scheduler::Simple sched;
+            if (auto ret = sched.exchange(std::move(graph)); !ret) {
+                throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+            }
             expect(sched.runAndWait().has_value()) << "runAndWait";
 
             if (uiLoop.joinable()) {

--- a/blocks/basic/test/qa_sources.cpp
+++ b/blocks/basic/test/qa_sources.cpp
@@ -50,7 +50,10 @@ const boost::ut::suite TagTests = [] {
         expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(src).template to<"in">(sink1)));
         expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(src).template to<"in">(sink2)));
 
-        scheduler::Simple sched{std::move(testGraph)};
+        gr::scheduler::Simple sched;
+        if (auto ret = sched.exchange(std::move(testGraph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         expect(sched.runAndWait().has_value());
         if (verbose) {
             std::println("finished ClockSource sched.runAndWait() w/ {}", useIoThreadPool ? "Graph/Block<T> provided-thread" : "user-provided thread");
@@ -121,7 +124,10 @@ const boost::ut::suite TagTests = [] {
         expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(clockSrc).to<"in">(signalGen)));
         expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(signalGen).to<"in">(sink)));
 
-        scheduler::Simple sched{std::move(testGraph)};
+        gr::scheduler::Simple sched;
+        if (auto ret = sched.exchange(std::move(testGraph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         expect(sched.runAndWait().has_value());
 
         expect(eq(n_samples, static_cast<std::uint32_t>(sink._nSamplesProduced))) << "Number of samples does not match";
@@ -201,7 +207,10 @@ const boost::ut::suite TagTests = [] {
         expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(clockSrc).to<"in">(funcGen)));
         expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(funcGen).to<"in">(sink)));
 
-        scheduler::Simple sched{std::move(testGraph)};
+        gr::scheduler::Simple sched;
+        if (auto ret = sched.exchange(std::move(testGraph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         expect(sched.runAndWait().has_value());
         expect(eq(N, static_cast<std::uint32_t>(sink._samples.size()))) << "Number of samples does not match";
         expect(eq(sink._tags.size(), clockSrc.tags.size())) << [&]() {
@@ -266,7 +275,10 @@ const boost::ut::suite TagTests = [] {
         expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(clockSrc).to<"in">(funcGen)));
         expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(funcGen).to<"in">(sink)));
 
-        scheduler::Simple sched{std::move(testGraph)};
+        gr::scheduler::Simple sched;
+        if (auto ret = sched.exchange(std::move(testGraph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         expect(sched.runAndWait().has_value());
         expect(eq(N, static_cast<std::uint32_t>(sink._samples.size()))) << "Number of samples does not match";
         expect(eq(sink._tags.size(), 9UZ)) << [&]() {

--- a/blocks/fileio/test/qa_FileIo.cpp
+++ b/blocks/fileio/test/qa_FileIo.cpp
@@ -51,7 +51,10 @@ void runTest(const gr::blocks::fileio::Mode mode) {
         auto& fileSink = flow.emplaceBlock<BasicFileSink<DataType>>({{"file_name", fileName}, {"mode", modeName}, {"max_bytes_per_file", maxFileSize}});
         expect(eq(gr::ConnectionResult::SUCCESS, flow.template connect<"out">(source).template to<"in">(fileSink)));
 
-        auto sched                                        = scheduler{std::move(flow)};
+        scheduler sched;
+        if (auto ret = sched.exchange(std::move(flow)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         auto [watchdogThread, externalInterventionNeeded] = createWatchdog(sched, 2s);
         expect(sched.runAndWait().has_value()) << testCaseName;
 
@@ -89,7 +92,10 @@ void runTest(const gr::blocks::fileio::Mode mode) {
 
         expect(eq(gr::ConnectionResult::SUCCESS, flow.template connect<"out">(fileSource).template to<"in">(sink)));
 
-        auto schedRead                                            = scheduler{std::move(flow)};
+        scheduler schedRead;
+        if (auto ret = schedRead.exchange(std::move(flow)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         auto [watchdogThreadRead, externalInterventionNeededRead] = createWatchdog(schedRead, 2s);
         expect(schedRead.runAndWait().has_value()) << testCaseName;
 
@@ -112,7 +118,10 @@ void runTest(const gr::blocks::fileio::Mode mode) {
 
         expect(eq(gr::ConnectionResult::SUCCESS, flow.template connect<"out">(fileSource).template to<"in">(sink)));
 
-        auto schedRead                                            = scheduler{std::move(flow)};
+        scheduler schedRead;
+        if (auto ret = schedRead.exchange(std::move(flow)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         auto [watchdogThreadRead, externalInterventionNeededRead] = createWatchdog(schedRead, 2s);
         expect(schedRead.runAndWait().has_value()) << testCaseName;
 

--- a/blocks/filter/test/qa_filter.cpp
+++ b/blocks/filter/test/qa_filter.cpp
@@ -274,7 +274,11 @@ const boost::ut::suite<"Basic[Decimating]Filter"> BasicFilterTests = [] {
         expect(eq(gr::ConnectionResult::SUCCESS, flow.connect<"out">(source).to<"in">(decimator)));
         expect(eq(gr::ConnectionResult::SUCCESS, flow.connect<"out">(decimator).to<"in">(sink)));
 
-        auto sched = gr::scheduler::Simple<>(std::move(flow));
+        gr::scheduler::Simple<> sched;
+        ;
+        if (auto ret = sched.exchange(std::move(flow)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         expect(sched.runAndWait().has_value());
 
         expect(eq(decimator.decim, decimationFactor));

--- a/blocks/http/test/qa_HttpBlock.cpp
+++ b/blocks/http/test/qa_HttpBlock.cpp
@@ -81,7 +81,10 @@ const boost::ut::suite HttpBlocktests = [] {
         expect(eq(ConnectionResult::SUCCESS, source.msgOut.connect(httpBlock.msgIn)));
         expect(eq(ConnectionResult::SUCCESS, graph.connect<"out">(httpBlock).template to<"in">(sink)));
 
-        auto sched    = gr::scheduler::Simple<>(std::move(graph));
+        gr::scheduler::Simple<> sched;
+        if (auto ret = sched.exchange(std::move(graph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         sink.stopFunc = [&]() { expect(sched.changeStateTo(lifecycle::State::REQUESTED_STOP).has_value()); };
         // make a request
         source.trigger();
@@ -112,7 +115,10 @@ const boost::ut::suite HttpBlocktests = [] {
         expect(eq(ConnectionResult::SUCCESS, source.msgOut.connect(httpBlock.msgIn)));
         expect(eq(ConnectionResult::SUCCESS, graph.connect<"out">(httpBlock).template to<"in">(sink)));
 
-        auto sched    = gr::scheduler::Simple<>(std::move(graph));
+        gr::scheduler::Simple<> sched;
+        if (auto ret = sched.exchange(std::move(graph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         sink.stopFunc = [&]() { expect(sched.changeStateTo(lifecycle::State::REQUESTED_STOP).has_value()); };
         httpBlock.trigger();
         expect(sched.runAndWait().has_value());
@@ -141,7 +147,10 @@ const boost::ut::suite HttpBlocktests = [] {
         expect(eq(ConnectionResult::SUCCESS, source.msgOut.connect(httpBlock.msgIn)));
         expect(eq(ConnectionResult::SUCCESS, graph.connect<"out">(httpBlock).template to<"in">(sink)));
 
-        auto sched    = gr::scheduler::Simple<>(std::move(graph));
+        gr::scheduler::Simple<> sched;
+        if (auto ret = sched.exchange(std::move(graph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         sink.stopFunc = [&]() { expect(sched.changeStateTo(lifecycle::State::REQUESTED_STOP).has_value()); };
         httpBlock.trigger();
         expect(sched.runAndWait().has_value());
@@ -183,7 +192,10 @@ const boost::ut::suite HttpBlocktests = [] {
         expect(eq(ConnectionResult::SUCCESS, source.msgOut.connect(httpBlock.msgIn)));
         expect(eq(ConnectionResult::SUCCESS, graph.connect<"out">(httpBlock).template to<"in">(sink)));
 
-        auto sched    = gr::scheduler::Simple<>(std::move(graph));
+        gr::scheduler::Simple<> sched;
+        if (auto ret = sched.exchange(std::move(graph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         sink.stopFunc = [&]() { expect(sched.changeStateTo(lifecycle::State::REQUESTED_STOP).has_value()); };
         expect(sched.runAndWait().has_value());
         expect(eq(std::get<std::string>(sink.value.at("raw-data")), "event"sv));

--- a/blocks/math/test/qa_ExpressionBlocks.cpp
+++ b/blocks/math/test/qa_ExpressionBlocks.cpp
@@ -31,7 +31,10 @@ const boost::ut::suite<"basic expression block tests"> basicMath = [] {
         expect(eq(gr::ConnectionResult::SUCCESS, graph.connect<"out">(source).template to<"in">(exprBlock)));
         expect(eq(gr::ConnectionResult::SUCCESS, graph.connect<"out">(exprBlock).template to<"in">(tagSink)));
 
-        auto sched = gr::scheduler::Simple<>(std::move(graph));
+        gr::scheduler::Simple<> sched;
+        if (auto ret = sched.exchange(std::move(graph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         expect(sched.runAndWait().has_value());
 
         expect(approx(source.default_value, T(21), T(1e-3f)));
@@ -51,7 +54,10 @@ const boost::ut::suite<"basic expression block tests"> basicMath = [] {
         expect(eq(gr::ConnectionResult::SUCCESS, graph.connect<"out">(source2).template to<"in1">(exprBlock)));
         expect(eq(gr::ConnectionResult::SUCCESS, graph.connect<"out">(exprBlock).template to<"in">(tagSink)));
 
-        auto sched = gr::scheduler::Simple<>(std::move(graph));
+        gr::scheduler::Simple<> sched;
+        if (auto ret = sched.exchange(std::move(graph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         expect(sched.runAndWait().has_value());
 
         expect(approx(source1.default_value, T(7), T(1e-3f)));
@@ -72,7 +78,10 @@ const boost::ut::suite<"basic expression block tests"> basicMath = [] {
         expect(eq(gr::ConnectionResult::SUCCESS, graph.connect<"out">(source).template to<"in">(exprBlock)));
         expect(eq(gr::ConnectionResult::SUCCESS, graph.connect<"out">(exprBlock).template to<"in">(tagSink)));
 
-        auto sched = gr::scheduler::Simple<>(std::move(graph));
+        gr::scheduler::Simple<> sched;
+        if (auto ret = sched.exchange(std::move(graph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         expect(sched.runAndWait().has_value());
 
         expect(eq(tagSink._samples.size(), source.n_samples_max));
@@ -97,7 +106,10 @@ const boost::ut::suite<"basic expression block tests"> basicMath = [] {
         expect(eq(gr::ConnectionResult::SUCCESS, graph.connect<"out">(source).template to<"in">(exprBlock)));
         expect(eq(gr::ConnectionResult::SUCCESS, graph.connect<"out">(exprBlock).template to<"in">(tagSink)));
 
-        auto sched = gr::scheduler::Simple<>(std::move(graph));
+        gr::scheduler::Simple<> sched;
+        if (auto ret = sched.exchange(std::move(graph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
 
         try {
             expect(sched.runAndWait().has_value());

--- a/blocks/soapy/src/soapy_example.cpp
+++ b/blocks/soapy/src/soapy_example.cpp
@@ -94,7 +94,10 @@ Default:
 
     Graph flow = createGraph(fileName1, fileName2, maxFileSize, sampleRate, rxCenterFrequency, bandwidth, rxGains);
 
-    auto sched  = gr::scheduler::Simple<>{std::move(flow)};
+    gr::scheduler::Simple<> sched;
+    if (auto ret = sched.exchange(std::move(flow)); !ret) {
+        throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+    }
     auto retVal = sched.runAndWait();
     expect(retVal.has_value()) << std::format("scheduler execution error: {}", retVal.error());
 

--- a/blocks/soapy/test/qa_Soapy.cpp
+++ b/blocks/soapy/test/qa_Soapy.cpp
@@ -306,7 +306,10 @@ const boost::ut::suite<"Soapy Block API "> soapyBlockAPI = [] {
         expect(eq(gr::ConnectionResult::SUCCESS, flow.connect<"out">(source).to<"in">(monitor)));
         expect(eq(gr::ConnectionResult::SUCCESS, flow.connect<"out">(monitor).to<"in">(sink)));
 
-        auto sched                                        = scheduler{std::move(flow)};
+        scheduler sched;
+        if (auto ret = sched.exchange(std::move(flow)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         auto [watchdogThread, externalInterventionNeeded] = createWatchdog(sched, 6s);
 
         auto retVal = sched.runAndWait();
@@ -347,8 +350,10 @@ const boost::ut::suite<"Soapy Block API "> soapyBlockAPI = [] {
         expect(eq(gr::ConnectionResult::SUCCESS, flow.connect<"out", 0>(source).to<"in">(sink1)));
         expect(eq(gr::ConnectionResult::SUCCESS, flow.connect<"out", 1>(source).to<"in">(sink2)));
 
-        auto sched = scheduler{std::move(flow)};
-
+        scheduler sched;
+        if (auto ret = sched.exchange(std::move(flow)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         auto [watchdogThread, externalInterventionNeeded] = createWatchdog(sched, 6s);
 
         auto retVal = sched.runAndWait();

--- a/blocks/testing/test/qa_NullSources.cpp
+++ b/blocks/testing/test/qa_NullSources.cpp
@@ -22,7 +22,10 @@ const boost::ut::suite<"Null[..] and Testing Blocks"> nullSourcesTests = [] {
 
         expect(eq(g.connect(src, "out"s, sink, "in"s), ConnectionResult::SUCCESS));
 
-        gr::scheduler::Simple sch{std::move(g)};
+        gr::scheduler::Simple sch;
+        if (auto ret = sch.exchange(std::move(g)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         expect(sch.runAndWait().has_value());
         expect(eq(sink.count, N));
     } | kTestTypes;
@@ -37,7 +40,10 @@ const boost::ut::suite<"Null[..] and Testing Blocks"> nullSourcesTests = [] {
 
         expect(eq(g.connect(src, "out"s, sink, "in"s), ConnectionResult::SUCCESS));
 
-        gr::scheduler::Simple sch{std::move(g)};
+        gr::scheduler::Simple sch;
+        if (auto ret = sch.exchange(std::move(g)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         expect(sch.runAndWait().has_value());
     } | kTestTypes;
 
@@ -53,7 +59,10 @@ const boost::ut::suite<"Null[..] and Testing Blocks"> nullSourcesTests = [] {
         expect(eq(g.connect(src, "out"s, copy, "in"s), ConnectionResult::SUCCESS));
         expect(eq(g.connect(copy, "out"s, sink, "in"s), ConnectionResult::SUCCESS));
 
-        gr::scheduler::Simple sch{std::move(g)};
+        gr::scheduler::Simple sch;
+        if (auto ret = sch.exchange(std::move(g)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         expect(sch.runAndWait().has_value());
         expect(eq(sink.count, N));
     } | kTestTypes;
@@ -71,7 +80,10 @@ const boost::ut::suite<"Null[..] and Testing Blocks"> nullSourcesTests = [] {
         expect(eq(g.connect(src, "out"s, head, "in"s), ConnectionResult::SUCCESS));
         expect(eq(g.connect(head, "out"s, sink, "in"s), ConnectionResult::SUCCESS));
 
-        gr::scheduler::Simple sch{std::move(g)};
+        gr::scheduler::Simple sch;
+        if (auto ret = sch.exchange(std::move(g)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         expect(sch.runAndWait().has_value());
         expect(eq(sink.count, N_head));
     } | kTestTypes;
@@ -85,7 +97,10 @@ const boost::ut::suite<"Null[..] and Testing Blocks"> nullSourcesTests = [] {
 
         expect(eq(g.connect(src, "out"s, sink, "in"s), ConnectionResult::SUCCESS));
 
-        gr::scheduler::Simple sch{std::move(g)};
+        gr::scheduler::Simple sch;
+        if (auto ret = sch.exchange(std::move(g)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         expect(sch.runAndWait().has_value());
     } | kTestTypes;
 
@@ -98,7 +113,10 @@ const boost::ut::suite<"Null[..] and Testing Blocks"> nullSourcesTests = [] {
 
         expect(eq(g.connect(src, "out"s, sink, "in"s), ConnectionResult::SUCCESS));
 
-        gr::scheduler::Simple sch{std::move(g)};
+        gr::scheduler::Simple sch;
+        if (auto ret = sch.exchange(std::move(g)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         expect(sch.runAndWait().has_value());
         expect(eq(sink.count, N));
     } | kTestTypes;
@@ -114,8 +132,10 @@ const boost::ut::suite<"Null[..] and Testing Blocks"> nullSourcesTests = [] {
         expect(eq(g.connect(src, "out"s, sim, "in"s), ConnectionResult::SUCCESS));
         expect(eq(g.connect(sim, "out"s, sink, "in"s), ConnectionResult::SUCCESS));
 
-        gr::scheduler::Simple sch{std::move(g)};
-        expect(sch.runAndWait().has_value());
+        gr::scheduler::Simple sch;
+        if (auto ret = sch.exchange(std::move(g)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         expect(eq(sink.count, N));
     } | kTestTypes;
 
@@ -130,7 +150,10 @@ const boost::ut::suite<"Null[..] and Testing Blocks"> nullSourcesTests = [] {
         expect(eq(g.connect(src, "out"s, sim, "in"s), ConnectionResult::SUCCESS));
         expect(eq(g.connect(sim, "out"s, sink, "in"s), ConnectionResult::SUCCESS));
 
-        gr::scheduler::Simple sch{std::move(g)};
+        gr::scheduler::Simple sch;
+        if (auto ret = sch.exchange(std::move(g)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         expect(sch.runAndWait().has_value());
         expect(eq(sink.count, N));
     } | kTestTypes;
@@ -146,7 +169,10 @@ const boost::ut::suite<"Null[..] and Testing Blocks"> nullSourcesTests = [] {
         expect(eq(g.connect(src, "out"s, sim, "in"s), ConnectionResult::SUCCESS));
         expect(eq(g.connect(sim, "out"s, sink, "in"s), ConnectionResult::SUCCESS));
 
-        gr::scheduler::Simple sch{std::move(g)};
+        gr::scheduler::Simple sch;
+        if (auto ret = sch.exchange(std::move(g)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         expect(sch.runAndWait().has_value());
         expect(eq(sink.count, N));
     } | kTestTypes;

--- a/blocks/testing/test/qa_NullSources.cpp
+++ b/blocks/testing/test/qa_NullSources.cpp
@@ -136,6 +136,7 @@ const boost::ut::suite<"Null[..] and Testing Blocks"> nullSourcesTests = [] {
         if (auto ret = sch.exchange(std::move(g)); !ret) {
             throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
         }
+        expect(sch.runAndWait().has_value());
         expect(eq(sink.count, N));
     } | kTestTypes;
 

--- a/blocks/testing/test/qa_UI_Integration.cpp
+++ b/blocks/testing/test/qa_UI_Integration.cpp
@@ -76,7 +76,10 @@ const boost::ut::suite TagTests = [] {
         expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(funcGen).to<"in">(sink)));
         expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(funcGen).to<"in">(uiSink)));
 
-        scheduler::Simple sched{std::move(testGraph)};
+        scheduler::Simple sched;
+        if (auto ret = sched.exchange(std::move(testGraph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
 
         std::thread uiLoop([&uiSink]() {
             std::println("start UI thread");
@@ -110,8 +113,10 @@ const boost::ut::suite TagTests = [] {
         expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(clockSrc).to<"in">(funcGen)));
         expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(funcGen).to<"in">(uiSink)));
 
-        scheduler::Simple sched{std::move(testGraph)};
-
+        scheduler::Simple sched;
+        if (auto ret = sched.exchange(std::move(testGraph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         expect(sched.runAndWait().has_value());
     };
 };

--- a/core/benchmarks/bm-nosonar_node_api.cpp
+++ b/core/benchmarks/bm-nosonar_node_api.cpp
@@ -430,8 +430,10 @@ inline const boost::ut::suite _runtime_tests = [] {
         auto&     sink = testGraph.emplaceBlock<bm::test::sink<float>>();
         expect(eq(gr::ConnectionResult::SUCCESS, testGraph.connect<"out">(src).to<"in">(sink)));
 
-        gr::scheduler::Simple sched{std::move(testGraph)};
-
+        gr::scheduler::Simple sched;
+        if (auto ret = sched.exchange(std::move(testGraph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         "runtime   src->sink overhead"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched]() { invoke_work(sched); };
     }
 
@@ -444,8 +446,10 @@ inline const boost::ut::suite _runtime_tests = [] {
         expect(eq(gr::ConnectionResult::SUCCESS, testGraph.connect<"out">(src).to<"in">(cpy)));
         expect(eq(gr::ConnectionResult::SUCCESS, testGraph.connect<"out">(cpy).to<"in">(sink)));
 
-        gr::scheduler::Simple sched{std::move(testGraph)};
-
+        gr::scheduler::Simple sched;
+        if (auto ret = sched.exchange(std::move(testGraph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         "runtime   src->copy->sink"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched]() { invoke_work(sched); };
     }
 
@@ -468,8 +472,10 @@ inline const boost::ut::suite _runtime_tests = [] {
 
         expect(eq(gr::ConnectionResult::SUCCESS, testGraph.connect<"out">(*cpy[cpy.size() - 1]).to<"in">(sink)));
 
-        gr::scheduler::Simple sched{std::move(testGraph)};
-
+        gr::scheduler::Simple sched;
+        if (auto ret = sched.exchange(std::move(testGraph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         "runtime   src->copy^10->sink"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched]() { invoke_work(sched); };
     }
 
@@ -486,8 +492,10 @@ inline const boost::ut::suite _runtime_tests = [] {
         expect(eq(gr::ConnectionResult::SUCCESS, testGraph.connect<"out">(b2).to<"in">(b3)));
         expect(eq(gr::ConnectionResult::SUCCESS, testGraph.connect<"out">(b3).to<"in">(sink)));
 
-        gr::scheduler::Simple sched{std::move(testGraph)};
-
+        gr::scheduler::Simple sched;
+        if (auto ret = sched.exchange(std::move(testGraph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         "runtime   src(N=1024)->b1(N≤128)->b2(N=1024)->b3(N=32...128)->sink"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched]() { invoke_work(sched); };
     }
 
@@ -504,8 +512,10 @@ inline const boost::ut::suite _runtime_tests = [] {
         expect(eq(gr::ConnectionResult::SUCCESS, testGraph.connect<"out">(div).template to<"in">(add1)));
         expect(eq(gr::ConnectionResult::SUCCESS, testGraph.connect<"out">(add1).template to<"in">(sink)));
 
-        gr::scheduler::Simple sched{std::move(testGraph)};
-
+        gr::scheduler::Simple sched;
+        if (auto ret = sched.exchange(std::move(testGraph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         ::benchmark::benchmark<1LU>{test_name}.repeat<N_ITER>(N_SAMPLES) = [&sched]() { invoke_work(sched); };
     };
     templated_cascaded_test(static_cast<float>(2.0), "runtime   src->mult(2.0)->div(2.0)->add(-1)->sink - float");
@@ -536,8 +546,10 @@ inline const boost::ut::suite _runtime_tests = [] {
         }
         expect(eq(gr::ConnectionResult::SUCCESS, testGraph.connect<"out">(*add1[add1.size() - 1]).template to<"in">(sink)));
 
-        gr::scheduler::Simple sched{std::move(testGraph)};
-
+        gr::scheduler::Simple sched;
+        if (auto ret = sched.exchange(std::move(testGraph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         ::benchmark::benchmark<1LU>{test_name}.repeat<N_ITER>(N_SAMPLES) = [&sched]() {
             bm::test::n_samples_produced = 0LU;
             bm::test::n_samples_consumed = 0LU;
@@ -567,8 +579,10 @@ inline const boost::ut::suite _simd_tests = [] {
         expect(eq(gr::ConnectionResult::SUCCESS, testGraph.connect<"out">(mult2).to<"in">(add1)));
         expect(eq(gr::ConnectionResult::SUCCESS, testGraph.connect<"out">(add1).to<"in">(sink)));
 
-        gr::scheduler::Simple sched{std::move(testGraph)};
-
+        gr::scheduler::Simple sched;
+        if (auto ret = sched.exchange(std::move(testGraph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         "runtime   src->mult(2.0)->mult(0.5)->add(-1)->sink (SIMD)"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched]() {
             bm::test::n_samples_produced = 0LU;
             bm::test::n_samples_consumed = 0LU;
@@ -603,8 +617,10 @@ inline const boost::ut::suite _simd_tests = [] {
         }
         expect(eq(gr::ConnectionResult::SUCCESS, testGraph.connect<"out">(*add1[add1.size() - 1]).to<"in">(sink)));
 
-        gr::scheduler::Simple sched{std::move(testGraph)};
-
+        gr::scheduler::Simple sched;
+        if (auto ret = sched.exchange(std::move(testGraph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         "runtime   src->(mult(2.0)->mult(0.5)->add(-1))^10->sink (SIMD)"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched]() {
             bm::test::n_samples_produced = 0LU;
             bm::test::n_samples_consumed = 0LU;
@@ -636,7 +652,10 @@ inline const boost::ut::suite _sample_by_sample_vs_bulk_access_tests = [] {
         ::benchmark::benchmark<1LU>{test_name}.repeat<N_ITER>(N_SAMPLES) = [&testGraph]() {
             bm::test::n_samples_produced = 0LU;
             bm::test::n_samples_consumed = 0LU;
-            gr::scheduler::Simple sched{std::move(testGraph)};
+            gr::scheduler::Simple sched;
+            if (auto ret = sched.exchange(std::move(testGraph)); !ret) {
+                throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+            }
             expect(sched.runAndWait().has_value());
             expect(eq(bm::test::n_samples_produced, N_SAMPLES)) << "did not produce enough output samples";
             expect(eq(bm::test::n_samples_consumed, N_SAMPLES)) << "did not consume enough input samples";
@@ -658,8 +677,10 @@ inline const boost::ut::suite _sample_by_sample_vs_bulk_access_tests = [] {
         expect(eq(gr::ConnectionResult::SUCCESS, testGraph.connect<"out">(div).template to<"in">(add1)));
         expect(eq(gr::ConnectionResult::SUCCESS, testGraph.connect<"out">(add1).template to<"in">(sink)));
 
-        gr::scheduler::Simple sched{std::move(testGraph)};
-
+        gr::scheduler::Simple sched;
+        if (auto ret = sched.exchange(std::move(testGraph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         ::benchmark::benchmark<1LU>{test_name}.repeat<N_ITER>(N_SAMPLES) = [&sched]() {
             bm::test::n_samples_produced = 0LU;
             bm::test::n_samples_consumed = 0LU;

--- a/core/benchmarks/bm_Profiler.cpp
+++ b/core/benchmarks/bm_Profiler.cpp
@@ -26,12 +26,12 @@ inline void run_without_profiler() {
 template<ProfilerLike TProfiler>
 inline void run_with_profiler(TProfiler& p) {
     const auto start   = detail::clock::now();
-    auto&      handler = p.forThisThread();
+    auto       handler = p.forThisThread();
 
-    [[maybe_unused]] auto whole_calculation_event = handler.startCompleteEvent("whole_calculation");
+    [[maybe_unused]] auto whole_calculation_event = handler->startCompleteEvent("whole_calculation");
     long long             r                       = 0;
     for (std::size_t i = 0; i < 1000; ++i) {
-        auto async_event = handler.startAsyncEvent("iteration", {}, {{"arg1", 2}, {"arg2", "hello"}});
+        auto async_event = handler->startAsyncEvent("iteration", {}, {{"arg1", 2}, {"arg2", "hello"}});
         for (std::size_t j = 0; j < 1000; ++j) {
             std::vector<int> v(10000);
             std::iota(v.begin(), v.end(), 1);

--- a/core/benchmarks/bm_sync.cpp
+++ b/core/benchmarks/bm_sync.cpp
@@ -63,7 +63,10 @@ void runTest() {
         expect(gr::ConnectionResult::SUCCESS == graph.connect(perfBlock, "outputs#"s + std::to_string(i), *sinks[i], "in"s));
     }
 
-    gr::scheduler::Simple sched{std::move(graph)};
+    gr::scheduler::Simple sched;
+    if (auto ret = sched.exchange(std::move(graph)); !ret) {
+        throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+    }
     ::benchmark::benchmark<nRepeats>(std::format("src->{}->sink", gr::meta::type_name<TBlock>()), nSamples) = [&]() {
         sched.runAndWait();
         expect(eq(sinks[0]->_nSamplesProduced, nSamples));
@@ -94,7 +97,10 @@ void runTestPureCopy() {
         expect(gr::ConnectionResult::SUCCESS == graph.connect(*copies[i], "out"s, *sinks[i], "in"s));
     }
 
-    gr::scheduler::Simple sched{std::move(graph)};
+    gr::scheduler::Simple sched;
+    if (auto ret = sched.exchange(std::move(graph)); !ret) {
+        throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+    }
     ::benchmark::benchmark<nRepeats>("src->copy->sink", nSamples) = [&]() {
         sched.runAndWait();
         expect(eq(sinks[0]->_nSamplesProduced, nSamples));

--- a/core/include/gnuradio-4.0/Block.hpp
+++ b/core/include/gnuradio-4.0/Block.hpp
@@ -833,7 +833,7 @@ public:
         : lifecycle::StateMachine<Derived>(std::move(other)),                                                                                                    //
           input_chunk_size(std::move(other.input_chunk_size)), output_chunk_size(std::move(other.output_chunk_size)),                                            //
           stride(std::move(other.stride)), strideCounter(std::move(other.strideCounter)), msgIn(std::move(other.msgIn)),                                         //
-          msgOut(std::move(other.msgOut)), propertyCallbacks(std::move(other.propertyCallbacks)),                                                                //
+          msgOut(std::move(other.msgOut)), propertySubscriptions(std::move(other.propertySubscriptions)),                                                                //
           inputStreamCache(static_cast<Derived&>(*this)), outputStreamCache(static_cast<Derived&>(*this)),                                                       //
           _mergedInputTag(std::move(other._mergedInputTag)), _outputTagsChanged(std::move(other._outputTagsChanged)), _outputTags(std::move(other._outputTags)), ////
           _settings(CtxSettings<Derived>(*static_cast<Derived*>(this), std::move(other._settings))) {}

--- a/core/include/gnuradio-4.0/Block.hpp
+++ b/core/include/gnuradio-4.0/Block.hpp
@@ -833,7 +833,7 @@ public:
         : lifecycle::StateMachine<Derived>(std::move(other)),                                                                                                    //
           input_chunk_size(std::move(other.input_chunk_size)), output_chunk_size(std::move(other.output_chunk_size)),                                            //
           stride(std::move(other.stride)), strideCounter(std::move(other.strideCounter)), msgIn(std::move(other.msgIn)),                                         //
-          msgOut(std::move(other.msgOut)), propertySubscriptions(std::move(other.propertySubscriptions)),                                                                //
+          msgOut(std::move(other.msgOut)), propertySubscriptions(std::move(other.propertySubscriptions)),                                                        //
           inputStreamCache(static_cast<Derived&>(*this)), outputStreamCache(static_cast<Derived&>(*this)),                                                       //
           _mergedInputTag(std::move(other._mergedInputTag)), _outputTagsChanged(std::move(other._outputTagsChanged)), _outputTags(std::move(other._outputTags)), ////
           _settings(CtxSettings<Derived>(*static_cast<Derived*>(this), std::move(other._settings))) {}

--- a/core/include/gnuradio-4.0/Scheduler.hpp
+++ b/core/include/gnuradio-4.0/Scheduler.hpp
@@ -476,11 +476,11 @@ protected:
 
         disconnectAllEdges();
         if (auto result = connectPendingEdges(); !result) {
-            this->emitErrorMessage("init()", "Failed to connect blocks in graph");
+            this->emitErrorMessage("start()", "Failed to connect blocks in graph");
         }
         if (this->state() == IDLE) {
             if (auto result = this->changeStateTo(INITIALISED); !result) { // Need to go to INITIALISED first
-                return std::unexpected(result.error());
+                this->emitErrorMessage("start()", result.error());
             }
         }
 

--- a/core/include/gnuradio-4.0/Scheduler.hpp
+++ b/core/include/gnuradio-4.0/Scheduler.hpp
@@ -276,6 +276,12 @@ public:
     void stateChanged(lifecycle::State newState) { this->notifyListeners(block::property::kLifeCycleState, {{"state", std::string(magic_enum::enum_name(newState))}}); }
 
     void connectBlockMessagePorts() {
+        const auto available = _graph.msgIn.streamReader().available();
+        if (available != 0UZ) {
+            ReaderSpanLike auto msgInSpan = _graph.msgIn.streamReader().get<SpanReleasePolicy::ProcessAll>(available);
+            _pendingMessagesToChildren.append_range(msgInSpan);
+        }
+
         auto toSchedulerBuffer = _fromChildMessagePort.buffer();
         std::ignore            = _toChildMessagePort.connect(_graph.msgIn);
         _graph.msgOut.setBuffer(toSchedulerBuffer.streamBuffer, toSchedulerBuffer.tagBuffer);

--- a/core/include/gnuradio-4.0/Scheduler.hpp
+++ b/core/include/gnuradio-4.0/Scheduler.hpp
@@ -87,16 +87,31 @@ struct SchedulerBase : Block<Derived> {
     using TaskExecutor = gr::thread_pool::TaskExecutor;
     using enum block::Category;
 
+private:
+    static consteval void _forbid_reserved_overrides() {
+        using Base = SchedulerBase<Derived, execution, TProfiler>;
+        // Lifecycle callback functions init/start/stop/pause/resume/reset need to remain reserved to SchedulerBase<Derived, ...>.
+        // Do NOT re-implement them in the Derived custom user-defined scheduler.
+        static_assert(std::same_as<decltype(&Derived::init), decltype(&Base::init)>, "Derived defines 'init()' (reserved). Use 'customInit()' instead.");
+        static_assert(std::same_as<decltype(&Derived::start), decltype(&Base::start)>, "Derived defines 'start()' (reserved). Use 'customStart()' instead.");
+        static_assert(std::same_as<decltype(&Derived::stop), decltype(&Base::stop)>, "Derived defines 'stop()' (reserved). Use 'customStop()' instead.");
+        static_assert(std::same_as<decltype(&Derived::pause), decltype(&Base::pause)>, "Derived defines 'pause()' (reserved). Use 'customPause()' instead.");
+        static_assert(std::same_as<decltype(&Derived::resume), decltype(&Base::resume)>, "Derived defines 'resume()' (reserved). Use 'customResume()' instead.");
+        static_assert(std::same_as<decltype(&Derived::reset), decltype(&Base::reset)>, "Derived defines 'reset()' (reserved). Use 'customReset()' instead.");
+    }
+
 protected:
-    std::atomic_bool                    _valid{true};
-    std::atomic<std::size_t>            _nWatchdogsRunning{0};
-    gr::Graph                           _graph;
-    TProfiler                           _profiler;
-    decltype(_profiler.forThisThread()) _profilerHandler;
-    std::shared_ptr<TaskExecutor>       _pool;
-    std::shared_ptr<gr::Sequence>       _nRunningJobs = std::make_shared<gr::Sequence>();
-    std::recursive_mutex                _executionOrderMutex; // only used when modifying and copying the graph->local job list
-    std::shared_ptr<JobLists>           _executionOrder = std::make_shared<JobLists>();
+    using ProfileHandle = decltype(std::declval<TProfiler&>().forThisThread());
+
+    std::atomic_bool              _valid{true};
+    std::atomic<std::size_t>      _nWatchdogsRunning{0};
+    gr::Graph                     _graph{};
+    TProfiler                     _profiler{};
+    ProfileHandle                 _profilerHandler{_profiler.forThisThread()};
+    std::shared_ptr<TaskExecutor> _pool{gr::thread_pool::Manager::instance().defaultCpuPool()};
+    std::shared_ptr<gr::Sequence> _nRunningJobs = std::make_shared<gr::Sequence>();
+    std::recursive_mutex          _executionOrderMutex; // only used when modifying and copying the graph->local job list
+    std::shared_ptr<JobLists>     _executionOrder = std::make_shared<JobLists>();
 
     std::mutex                               _zombieBlocksMutex;
     std::vector<std::shared_ptr<BlockModel>> _zombieBlocks;
@@ -113,13 +128,21 @@ protected:
 
     std::atomic_flag _processingScheduledMessages;
 
+    void rebuildProfiler(const profiling::Options& opt) {
+        std::destroy_at(std::addressof(_profiler));
+        std::construct_at(std::addressof(_profiler), opt);
+        _profilerHandler = _profiler.forThisThread();
+    }
+
     void registerPropertyCallbacks() noexcept {
-        this->propertyCallbacks[scheduler::property::kEmplaceBlock] = std::mem_fn(&SchedulerBase::propertyCallbackEmplaceBlock);
-        this->propertyCallbacks[scheduler::property::kRemoveBlock]  = std::mem_fn(&SchedulerBase::propertyCallbackRemoveBlock);
-        this->propertyCallbacks[scheduler::property::kRemoveEdge]   = std::mem_fn(&SchedulerBase::propertyCallbackRemoveEdge);
-        this->propertyCallbacks[scheduler::property::kEmplaceEdge]  = std::mem_fn(&SchedulerBase::propertyCallbackEmplaceEdge);
-        this->propertyCallbacks[scheduler::property::kReplaceBlock] = std::mem_fn(&SchedulerBase::propertyCallbackReplaceBlock);
-        this->propertyCallbacks[scheduler::property::kGraphGRC]     = std::mem_fn(&SchedulerBase::propertyCallbackGraphGRC);
+        _forbid_reserved_overrides();
+        auto& callbacks                               = this->propertyCallbacks;
+        callbacks[scheduler::property::kEmplaceBlock] = std::mem_fn(&SchedulerBase::propertyCallbackEmplaceBlock);
+        callbacks[scheduler::property::kRemoveBlock]  = std::mem_fn(&SchedulerBase::propertyCallbackRemoveBlock);
+        callbacks[scheduler::property::kRemoveEdge]   = std::mem_fn(&SchedulerBase::propertyCallbackRemoveEdge);
+        callbacks[scheduler::property::kEmplaceEdge]  = std::mem_fn(&SchedulerBase::propertyCallbackEmplaceEdge);
+        callbacks[scheduler::property::kReplaceBlock] = std::mem_fn(&SchedulerBase::propertyCallbackReplaceBlock);
+        callbacks[scheduler::property::kGraphGRC]     = std::mem_fn(&SchedulerBase::propertyCallbackGraphGRC);
         this->settings().updateActiveParameters();
     }
 
@@ -140,22 +163,38 @@ public:
 
     [[nodiscard]] static constexpr auto executionPolicy() { return execution; }
 
-    explicit SchedulerBase(gr::Graph&& graph, std::string_view defaultPoolName, const profiling::Options& profiling_options = {}) //
-        : _graph(std::move(graph)), _profiler{profiling_options}, _profilerHandler{_profiler.forThisThread()}, _pool(gr::thread_pool::Manager::instance().get(defaultPoolName)) {
-        registerPropertyCallbacks();
-    }
+    SchedulerBase() : base_t(gr::property_map()) { registerPropertyCallbacks(); }
 
-    explicit SchedulerBase(gr::Graph&& graph, property_map initialSettings, std::string_view defaultPoolName = gr::thread_pool::kDefaultCpuPoolId) //
-        : base_t(initialSettings), _graph(std::move(graph)), _profiler{{}}, _profilerHandler{_profiler.forThisThread()}, _pool(gr::thread_pool::Manager::instance().get(defaultPoolName)) {
+    SchedulerBase(std::initializer_list<std::pair<const std::string, pmtv::pmt>> initParameter) noexcept(false) : base_t(initParameter) {
         registerPropertyCallbacks();
-        std::ignore = this->settings().set(initialSettings);
+        std::ignore = this->settings().set(initParameter);
         std::ignore = this->settings().activateContext();
         std::ignore = this->settings().applyStagedParameters();
     }
 
+    explicit SchedulerBase(property_map initParameters) noexcept(false) : base_t(initParameters) {
+        registerPropertyCallbacks();
+        std::ignore = this->settings().set(initParameters);
+        std::ignore = this->settings().activateContext();
+        std::ignore = this->settings().applyStagedParameters();
+    }
+
+    // explicit SchedulerBase(gr::Graph&& graph, std::string_view defaultPoolName, const profiling::Options& profiling_options = {}) //
+    //     : _graph(std::move(graph)), _profiler{profiling_options}, _profilerHandler{_profiler.forThisThread()}, _pool(gr::thread_pool::Manager::instance().get(defaultPoolName)) {
+    //     registerPropertyCallbacks();
+    // }
+    //
+    // explicit SchedulerBase(gr::Graph&& graph, property_map initialSettings, std::string_view defaultPoolName = gr::thread_pool::kDefaultCpuPoolId) //
+    //     : base_t(initialSettings), _graph(std::move(graph)), _profiler{{}}, _profilerHandler{_profiler.forThisThread()}, _pool(gr::thread_pool::Manager::instance().get(defaultPoolName)) {
+    //     registerPropertyCallbacks();
+    //     std::ignore = this->settings().set(initialSettings);
+    //     std::ignore = this->settings().activateContext();
+    //     std::ignore = this->settings().applyStagedParameters();
+    // }
+
     ~SchedulerBase() {
         if (this->state() == lifecycle::RUNNING) {
-            if (auto e = this->changeStateTo(lifecycle::State::REQUESTED_STOP); !e) {
+            if (auto e = this->changeStateTo(lifecycle::REQUESTED_STOP); !e) {
                 std::println(std::cerr, "Failed to stop execution at destruction of scheduler: {} ({})", e.error().message, e.error().srcLoc());
                 std::abort();
             }
@@ -170,6 +209,62 @@ public:
         }
 
         _executionOrder.reset(); // force earlier crashes if this is accessed after destruction (e.g. from thread that was kept running)
+    }
+
+    [[nodiscard]] std::expected<gr::Graph, Error> exchange(gr::Graph&& newGraph, std::string_view defaultPoolName = gr::thread_pool::kDefaultCpuPoolId, const profiling::Options& option = {}) {
+        using enum lifecycle::State;
+        const auto oldState = this->state();
+        if (lifecycle::isActive(oldState)) { // need to stop running scheduler
+            if (auto result = this->changeStateTo(REQUESTED_STOP); !result) {
+                return std::unexpected(result.error());
+            }
+            waitDone(); // wait for all jobs to complete
+
+            if (auto result = this->changeStateTo(STOPPED); !result) {
+                return std::unexpected(result.error());
+            }
+        }
+
+        if (this->state() == ERROR || this->state() == STOPPED) {
+            reset(); // reset internal states
+        }
+
+        auto oldGraph = std::exchange(_graph, std::forward<Graph>(newGraph));
+
+        if ((option != profiling::Options{})) { // need to update profiler
+            rebuildProfiler(option);
+        }
+
+        if (_pool->name() != defaultPoolName) { // need to update thread pool
+            _pool = gr::thread_pool::Manager::instance().get(defaultPoolName);
+        }
+
+        init(); // re-initialize scheduler
+        assert(this->state() == IDLE);
+
+        // restore the original lifecycle state
+        if (lifecycle::isActive(oldState)) {
+            if (auto result = this->changeStateTo(INITIALISED); !result) { // Need to go to INITIALISED first
+                return std::unexpected(result.error());
+            }
+            if (auto result = this->changeStateTo(RUNNING); !result) {
+                return std::unexpected(result.error());
+            }
+
+            if (oldState == REQUESTED_PAUSE) {
+                if (auto result = this->changeStateTo(REQUESTED_PAUSE); !result) {
+                    return std::unexpected(result.error());
+                }
+            } else if (oldState == PAUSED) {
+                if (auto result = this->changeStateTo(REQUESTED_PAUSE); !result) {
+                    return std::unexpected(result.error());
+                }
+                if (auto result = this->changeStateTo(PAUSED); !result) {
+                    return std::unexpected(result.error());
+                }
+            }
+        }
+        return oldGraph;
     }
 
     [[nodiscard]] const gr::Graph& graph() const noexcept { return _graph; }
@@ -212,7 +307,7 @@ public:
                 // only forward wildcard, non-scheduler messages, and non-lifecycle messages (N.B. the latter is exclusively handled by the scheduler)
                 if (_messagePortsConnected) {
                     WriterSpanLike auto msgSpan = _toChildMessagePort.streamWriter().reserve<SpanReleasePolicy::ProcessAll>(1UZ);
-                    msgSpan[0]                  = std::move(msg);
+                    msgSpan[0]                  = msg;
                 } else {
                     // if not yet connected, keep messages to children in cache and forward when connecting
                     _pendingMessagesToChildren.push_back(msg);
@@ -262,21 +357,22 @@ public:
     }
 
     std::expected<void, Error> runAndWait() {
-        [[maybe_unused]] const auto pe = this->_profilerHandler.startCompleteEvent("scheduler_base.runAndWait");
+        using enum lifecycle::State;
+        [[maybe_unused]] const auto pe = this->_profilerHandler->startCompleteEvent("scheduler_base.runAndWait");
         processScheduledMessages(); // make sure initial subscriptions are processed
-        if (this->state() == lifecycle::State::STOPPED || this->state() == lifecycle::State::ERROR) {
-            if (auto e = this->changeStateTo(lifecycle::State::INITIALISED); !e) {
+        if (this->state() == STOPPED || this->state() == ERROR) {
+            if (auto e = this->changeStateTo(INITIALISED); !e) {
                 this->emitErrorMessage("runAndWait() -> LifecycleState", e.error());
                 return std::unexpected(e.error());
             }
         }
-        if (this->state() == lifecycle::State::IDLE) {
-            if (auto e = this->changeStateTo(lifecycle::State::INITIALISED); !e) {
+        if (this->state() == IDLE) {
+            if (auto e = this->changeStateTo(INITIALISED); !e) {
                 this->emitErrorMessage("runAndWait() -> LifecycleState", e.error());
                 return std::unexpected(e.error());
             }
         }
-        if (auto e = this->changeStateTo(lifecycle::State::RUNNING); !e) {
+        if (auto e = this->changeStateTo(RUNNING); !e) {
             this->emitErrorMessage("runAndWait() -> LifecycleState", e.error());
             return std::unexpected(e.error());
         }
@@ -287,14 +383,14 @@ public:
         waitDone();
         processScheduledMessages();
 
-        if (this->state() == lifecycle::State::RUNNING) {
-            if (auto e = this->changeStateTo(lifecycle::State::REQUESTED_STOP); !e) {
+        if (this->state() == RUNNING) {
+            if (auto e = this->changeStateTo(REQUESTED_STOP); !e) {
                 this->emitErrorMessage("runAndWait() -> LifecycleState", e.error());
                 return std::unexpected(e.error());
             }
         }
-        if (this->state() == lifecycle::State::REQUESTED_STOP) {
-            if (auto e = this->changeStateTo(lifecycle::State::STOPPED); !e) {
+        if (this->state() == REQUESTED_STOP) {
+            if (auto e = this->changeStateTo(STOPPED); !e) {
                 this->emitErrorMessage("runAndWait() -> LifecycleState", e.error());
             }
         }
@@ -303,7 +399,7 @@ public:
     }
 
     void waitDone() {
-        [[maybe_unused]] const auto pe = _profilerHandler.startCompleteEvent("scheduler_base.waitDone");
+        [[maybe_unused]] const auto pe = _profilerHandler->startCompleteEvent("scheduler_base.waitDone");
         while (_nRunningJobs->value() > 0UZ) {
             std::this_thread::sleep_for(std::chrono::milliseconds(timeout_ms));
         }
@@ -315,7 +411,7 @@ protected:
     void disconnectAllEdges() {
         _graph.disconnectAllEdges();
         graph::forEachBlock<TransparentBlockGroup>(_graph, [&](auto& block) {
-            if (block->blockCategory() == block::Category::TransparentBlockGroup) {
+            if (block->blockCategory() == TransparentBlockGroup) {
                 auto* graph = static_cast<GraphWrapper<gr::Graph>*>(block.get());
                 graph->blockRef().disconnectAllEdges();
             }
@@ -325,7 +421,7 @@ protected:
     bool connectPendingEdges() {
         bool result = _graph.connectPendingEdges();
         graph::forEachBlock<TransparentBlockGroup>(_graph, [&](auto& block) {
-            if (block->blockCategory() == block::Category::TransparentBlockGroup) {
+            if (block->blockCategory() == TransparentBlockGroup) {
                 auto* graph = static_cast<GraphWrapper<gr::Graph>*>(block.get());
                 result      = result && graph->blockRef().connectPendingEdges();
             }
@@ -354,22 +450,27 @@ protected:
     }
 
     void init() {
-        [[maybe_unused]] const auto pe = _profilerHandler.startCompleteEvent("scheduler_base.init");
+        [[maybe_unused]] const auto pe = _profilerHandler->startCompleteEvent("scheduler_base.init");
         base_t::processScheduledMessages(); // make sure initial subscriptions are processed
         connectBlockMessagePorts();
+
+        if constexpr (requires(Derived& d) { d.customInit(); }) {
+            static_cast<Derived*>(this)->customInit();
+        }
     }
 
     void reset() {
-        _executionOrder->clear();
         graph::forEachBlock<TransparentBlockGroup>(_graph, [this](auto& block) { this->emitErrorMessageIfAny("reset() -> LifecycleState", block->changeStateTo(lifecycle::INITIALISED)); });
         disconnectAllEdges();
+
+        if constexpr (requires(Derived& d) { d.customReset(); }) {
+            static_cast<Derived*>(this)->customReset();
+        }
     }
 
     void start() {
         disconnectAllEdges();
-        auto result = connectPendingEdges();
-
-        if (!result) {
+        if (auto result = connectPendingEdges(); !result) {
             this->emitErrorMessage("init()", "Failed to connect blocks in graph");
         }
 
@@ -386,13 +487,13 @@ protected:
 
         ioThreadPool->execute([this] { this->runWatchDog(watchdog_timeout.value, timeout_inactivity_count.value); });
 
+        assert(_nRunningJobs->value() == 0UZ);
+        assert(!_executionOrder->empty());
         if constexpr (executionPolicy() == ExecutionPolicy::singleThreaded || executionPolicy() == ExecutionPolicy::singleThreadedBlocking) {
-            assert(_nRunningJobs->value() == 0UZ);
             static_cast<Derived*>(this)->poolWorker(0UZ, _executionOrder);
         } else { // run on processing thread pool
-            [[maybe_unused]] const auto pe = _profilerHandler.startCompleteEvent("scheduler_base.runOnPool");
-            assert(_nRunningJobs->value() == 0UZ);
-            auto jobListsCopy = _executionOrder;
+            [[maybe_unused]] const auto pe           = _profilerHandler->startCompleteEvent("scheduler_base.runOnPool");
+            auto                        jobListsCopy = _executionOrder;
             for (std::size_t runnerID = 0UZ; runnerID < _executionOrder->size(); runnerID++) {
                 _pool->execute([this, runnerID, jobListsCopy]() { static_cast<Derived*>(this)->poolWorker(runnerID, jobListsCopy); });
             }
@@ -400,9 +501,13 @@ protected:
                 _nRunningJobs->wait(0UZ); // waits until at least one pool worker started
             }
         }
+        if constexpr (requires(Derived& d) { d.customStart(); }) {
+            static_cast<Derived*>(this)->customStart();
+        }
     }
 
     void poolWorker(const std::size_t runnerID, std::shared_ptr<std::vector<std::vector<std::shared_ptr<BlockModel>>>> jobList) noexcept {
+        using enum lifecycle::State;
         std::shared_ptr<gr::Sequence> progress     = _graph._progress; // life-time guaranteed
         std::shared_ptr<gr::Sequence> nRunningJobs = _nRunningJobs;
 
@@ -410,11 +515,12 @@ protected:
         nRunningJobs->notify_all();
         gr::thread_pool::thread::setThreadName(std::format("pW{}-{}", runnerID, gr::meta::shorten_type_name(this->unique_name)));
 
-        [[maybe_unused]] auto& profiler_handler = _profiler.forThisThread();
+        [[maybe_unused]] auto profiler_handler = _profiler.forThisThread();
 
         std::vector<std::shared_ptr<BlockModel>> localBlockList;
         {
-            std::lock_guard                          lock(_executionOrderMutex);
+            std::lock_guard lock(_executionOrderMutex);
+            assert(jobList->size() > runnerID);
             std::vector<std::shared_ptr<BlockModel>> blocks = jobList->at(runnerID);
             localBlockList.reserve(blocks.size());
             for (const auto& block : blocks) {
@@ -427,7 +533,7 @@ protected:
         std::size_t           msgToCount         = 0UZ;
         auto                  activeState        = this->state();
         do {
-            [[maybe_unused]] auto pe = profiler_handler.startCompleteEvent("scheduler_base.work");
+            [[maybe_unused]] auto pe = profiler_handler->startCompleteEvent("scheduler_base.work");
             if constexpr (executionPolicy() == ExecutionPolicy::singleThreadedBlocking) {
                 // optionally tracking progress and block if there is none
                 currentProgress = progress->value();
@@ -456,15 +562,15 @@ protected:
                 }
             }
 
-            if (activeState == lifecycle::State::RUNNING) {
+            if (activeState == RUNNING) {
                 gr::work::Result result = traverseBlockListOnce(localBlockList);
                 if (result.status == work::Status::DONE) {
                     break; // nothing happened -> shutdown this worker
                 } else if (result.status == work::Status::ERROR) {
-                    this->emitErrorMessageIfAny("LifecycleState (ERROR)", this->changeStateTo(lifecycle::State::ERROR));
+                    this->emitErrorMessageIfAny("LifecycleState (ERROR)", this->changeStateTo(ERROR));
                     break;
                 }
-            } else if (activeState == lifecycle::State::PAUSED) {
+            } else if (activeState == PAUSED) {
                 std::this_thread::sleep_for(std::chrono::milliseconds(timeout_ms));
                 msgToCount = 0UZ;
             } else { // other states
@@ -533,35 +639,48 @@ protected:
     }
 
     void stop() {
+        using enum lifecycle::State;
         graph::forEachBlock<TransparentBlockGroup>(_graph, [this](auto& block) {
-            this->emitErrorMessageIfAny("forEachBlock -> stop() -> LifecycleState", block->changeStateTo(lifecycle::State::REQUESTED_STOP));
+            this->emitErrorMessageIfAny("forEachBlock -> stop() -> LifecycleState", block->changeStateTo(REQUESTED_STOP));
             if (!block->isBlocking()) { // N.B. no other thread/constraint to consider before shutting down
-                this->emitErrorMessageIfAny("forEachBlock -> stop() -> LifecycleState", block->changeStateTo(lifecycle::State::STOPPED));
+                this->emitErrorMessageIfAny("forEachBlock -> stop() -> LifecycleState", block->changeStateTo(STOPPED));
             }
         });
 
-        this->emitErrorMessageIfAny("stop() -> LifecycleState ->STOPPED", this->changeStateTo(lifecycle::State::STOPPED));
+        this->emitErrorMessageIfAny("stop() -> LifecycleState ->STOPPED", this->changeStateTo(STOPPED));
+        if constexpr (requires(Derived& d) { d.customStop(); }) {
+            static_cast<Derived*>(this)->customStop();
+        }
     }
 
     void pause() {
+        using enum lifecycle::State;
         graph::forEachBlock<TransparentBlockGroup>(_graph, [this](auto& block) {
-            this->emitErrorMessageIfAny("pause() -> LifecycleState", block->changeStateTo(lifecycle::State::REQUESTED_PAUSE));
+            this->emitErrorMessageIfAny("pause() -> LifecycleState", block->changeStateTo(REQUESTED_PAUSE));
             if (!block->isBlocking()) { // N.B. no other thread/constraint to consider before shutting down
-                this->emitErrorMessageIfAny("pause() -> LifecycleState", block->changeStateTo(lifecycle::State::PAUSED));
+                this->emitErrorMessageIfAny("pause() -> LifecycleState", block->changeStateTo(PAUSED));
             }
         });
-        this->emitErrorMessageIfAny("pause() -> LifecycleState", this->changeStateTo(lifecycle::State::PAUSED));
+        this->emitErrorMessageIfAny("pause() -> LifecycleState", this->changeStateTo(PAUSED));
+        if constexpr (requires(Derived& d) { d.customPause(); }) {
+            static_cast<Derived*>(this)->customPause();
+        }
     }
 
     void resume() {
+        using enum lifecycle::State;
         auto result = connectPendingEdges();
         if (!result) {
             this->emitErrorMessage("init()", "Failed to connect blocks in graph");
         }
-        graph::forEachBlock<TransparentBlockGroup>(_graph, [this](auto& block) { this->emitErrorMessageIfAny("resume() -> LifecycleState", block->changeStateTo(lifecycle::RUNNING)); });
+        graph::forEachBlock<TransparentBlockGroup>(_graph, [this](auto& block) { this->emitErrorMessageIfAny("resume() -> LifecycleState", block->changeStateTo(RUNNING)); });
+        if constexpr (requires(Derived& d) { d.customResume(); }) {
+            static_cast<Derived*>(this)->customResume();
+        }
     }
 
     std::optional<Message> propertyCallbackEmplaceBlock([[maybe_unused]] std::string_view propertyName, Message message) {
+        using enum lifecycle::State;
         assert(propertyName == scheduler::property::kEmplaceBlock);
         using namespace std::string_literals;
         const auto&         data       = message.data.value();
@@ -587,19 +706,19 @@ protected:
                 _adoptionBlocks[runnerIndex].push_back(newBlock);
 
                 switch (newBlock->state()) {
-                case lifecycle::State::STOPPED:
-                case lifecycle::State::IDLE: //
-                    this->emitErrorMessageIfAny("adoptBlocks -> INITIALIZED", newBlock->changeStateTo(lifecycle::State::INITIALISED));
-                    this->emitErrorMessageIfAny("adoptBlocks -> INITIALIZED", newBlock->changeStateTo(lifecycle::State::RUNNING));
+                case STOPPED:
+                case IDLE: //
+                    this->emitErrorMessageIfAny("adoptBlocks -> INITIALIZED", newBlock->changeStateTo(INITIALISED));
+                    this->emitErrorMessageIfAny("adoptBlocks -> INITIALIZED", newBlock->changeStateTo(RUNNING));
                     break;
-                case lifecycle::State::INITIALISED: //
-                    this->emitErrorMessageIfAny("adoptBlocks -> INITIALIZED", newBlock->changeStateTo(lifecycle::State::RUNNING));
+                case INITIALISED: //
+                    this->emitErrorMessageIfAny("adoptBlocks -> INITIALIZED", newBlock->changeStateTo(RUNNING));
                     break;
-                case lifecycle::State::RUNNING:
-                case lifecycle::State::REQUESTED_PAUSE:
-                case lifecycle::State::PAUSED:
-                case lifecycle::State::REQUESTED_STOP:
-                case lifecycle::State::ERROR: //
+                case RUNNING:
+                case REQUESTED_PAUSE:
+                case PAUSED:
+                case REQUESTED_STOP:
+                case ERROR: //
                     this->emitErrorMessage("propertyCallbackEmplaceBlock", std::format("Unexpected block state during emplacement: {}", magic_enum::enum_name(newBlock->state())));
                     break;
                 }
@@ -671,6 +790,7 @@ protected:
       This mechanism supports safe dynamic block removal while the scheduler is running, without blocking execution.
     */
     void cleanupZombieBlocks(std::vector<std::shared_ptr<BlockModel>>& localBlockList) {
+        using enum lifecycle::State;
         if (localBlockList.empty()) {
             return;
         }
@@ -680,7 +800,7 @@ protected:
         auto it = _zombieBlocks.begin();
 
         while (it != _zombieBlocks.end()) {
-            auto localBlockIt = std::find(localBlockList.begin(), localBlockList.end(), *it);
+            const auto localBlockIt = std::ranges::find(localBlockList, *it);
             if (localBlockIt == localBlockList.end()) {
                 // we only care about the blocks local to our thread.
                 ++it;
@@ -690,25 +810,25 @@ protected:
             bool shouldDelete = false;
 
             switch ((*it)->state()) {
-            case lifecycle::State::IDLE:
-            case lifecycle::State::STOPPED:
-            case lifecycle::State::INITIALISED: // block can be deleted immediately
+            case IDLE:
+            case STOPPED:
+            case INITIALISED: // block can be deleted immediately
                 shouldDelete = true;
                 break;
-            case lifecycle::State::ERROR: // delete as well
+            case ERROR: // delete as well
                 shouldDelete = true;
                 break;
-            case lifecycle::State::REQUESTED_STOP: // block will be deleted later
+            case REQUESTED_STOP: // block will be deleted later
                 break;
-            case lifecycle::State::REQUESTED_PAUSE: // block will be deleted later
+            case REQUESTED_PAUSE: // block will be deleted later
                 // There's no transition from REQUESTED_PAUSE to REQUESTED_STOP
                 // Will be moved to REQUESTED_STOP as soon as it's possible
                 break;
-            case lifecycle::State::PAUSED: // zombie was in REQUESTED_PAUSE and now finally in PAUSED. Can be stopped now.
+            case PAUSED: // zombie was in REQUESTED_PAUSE and now finally in PAUSED. Can be stopped now.
                 // Will be deleted in a next zombie maintenance period
-                this->emitErrorMessageIfAny("cleanupZombieBlocks", (*it)->changeStateTo(lifecycle::State::REQUESTED_STOP));
+                this->emitErrorMessageIfAny("cleanupZombieBlocks", (*it)->changeStateTo(REQUESTED_STOP));
                 break;
-            case lifecycle::State::RUNNING: assert(false && "Doesn't happen: zombie blocks are never running"); break;
+            case RUNNING: assert(false && "Doesn't happen: zombie blocks are never running"); break;
             }
 
             if (shouldDelete) {
@@ -754,8 +874,9 @@ protected:
       The block will be physically deleted by cleanupZombieBlocks() when it reaches a safe state.
     */
     void makeZombie(std::shared_ptr<BlockModel> block) {
-        if (block->state() == lifecycle::State::PAUSED || block->state() == lifecycle::State::RUNNING) {
-            this->emitErrorMessageIfAny("makeZombie", block->changeStateTo(lifecycle::State::REQUESTED_STOP));
+        using enum lifecycle::State;
+        if (block->state() == PAUSED || block->state() == RUNNING) {
+            this->emitErrorMessageIfAny("makeZombie", block->changeStateTo(REQUESTED_STOP));
         }
 
         {
@@ -763,8 +884,7 @@ protected:
             // it would be zombie before being adopted, so we need to remove it from adoption list
             std::lock_guard guard(_adoptionBlocksMutex);
             for (std::vector<std::shared_ptr<BlockModel>>& adoptionList : _adoptionBlocks) {
-                auto it = std::find(adoptionList.begin(), adoptionList.end(), block);
-                if (it != adoptionList.end()) {
+                if (auto it = std::ranges::find(adoptionList, block); it != adoptionList.end()) {
                     adoptionList.erase(it);
                     break;
                 }
@@ -778,23 +898,24 @@ protected:
     // Moves all blocks into the zombie list
     // Useful for bulk operations such as "set grc yaml" message
     void makeAllZombies() {
+        using enum lifecycle::State;
         std::lock_guard guard(_zombieBlocksMutex);
 
         for (auto& block : this->_graph.blocks()) {
             switch (block->state()) {
-            case lifecycle::State::RUNNING:
-            case lifecycle::State::REQUESTED_PAUSE:
-            case lifecycle::State::PAUSED: //
-                this->emitErrorMessageIfAny("makeAllZombies", block->changeStateTo(lifecycle::State::REQUESTED_STOP));
+            case RUNNING:
+            case REQUESTED_PAUSE:
+            case PAUSED: //
+                this->emitErrorMessageIfAny("makeAllZombies", block->changeStateTo(REQUESTED_STOP));
                 break;
 
-            case lifecycle::State::INITIALISED: //
-                this->emitErrorMessageIfAny("makeAllZombies", block->changeStateTo(lifecycle::State::STOPPED));
+            case INITIALISED: //
+                this->emitErrorMessageIfAny("makeAllZombies", block->changeStateTo(STOPPED));
                 break;
-            case lifecycle::State::IDLE:
-            case lifecycle::State::STOPPED:
-            case lifecycle::State::ERROR:
-            case lifecycle::State::REQUESTED_STOP:
+            case IDLE:
+            case STOPPED:
+            case ERROR:
+            case REQUESTED_STOP:
                 // Can go into the zombie list and deleted
                 break;
             default:;
@@ -807,6 +928,7 @@ protected:
     }
 
     std::optional<Message> propertyCallbackGraphGRC([[maybe_unused]] std::string_view propertyName, Message message) {
+        using enum lifecycle::State;
         assert(propertyName == scheduler::property::kGraphGRC);
 
         auto& pluginLoader = gr::globalPluginLoader();
@@ -823,32 +945,36 @@ protected:
 
                 const auto originalState = this->state();
 
-                switch (originalState) {
-                case lifecycle::State::RUNNING:
-                case lifecycle::State::REQUESTED_PAUSE:
-                case lifecycle::State::PAUSED: //
-                    this->emitErrorMessageIfAny("propertyCallbackGraphGRC -> REQUESTED_STOP", this->changeStateTo(lifecycle::State::REQUESTED_STOP));
-                    this->emitErrorMessageIfAny("propertyCallbackGraphGRC -> STOPPED", this->changeStateTo(lifecycle::State::STOPPED));
-                    break;
-                case lifecycle::State::REQUESTED_STOP:
-                case lifecycle::State::INITIALISED: //
-                    this->emitErrorMessageIfAny("propertyCallbackGraphGRC -> REQUESTED_STOP", this->changeStateTo(lifecycle::State::STOPPED));
-                    break;
-                case lifecycle::State::IDLE:
-                    assert(false); // doesn't happen
-                    break;
-                case lifecycle::State::STOPPED:
-                case lifecycle::State::ERROR: break;
-                default:;
+                if (auto result = this->exchange(std::move(newGraph)); !result) {
+                    this->emitErrorMessage("propertyCallbackGraphGRC", "Failed to exchange graph");
+                    return {};
                 }
-
-                _graph = std::move(newGraph);
-
-                // Now ideally we'd just restart the Scheduler, but we can't since we're processing a message inside a working thread.
-                // When the scheduler starts running it asserts that _nRunningJobs is 0, so we can't start it now, we're in the job.
-                // We need to let poolWorker() unwind, decrement _nRunningJobs and then move scheduler to its original value.
-                // Alternatively, we could forbid kGraphGRC unless Scheduler was in STOPPED state. That would simplify logic, but
-                // put more burden on the client.
+                // switch (originalState) {
+                // case RUNNING:
+                // case REQUESTED_PAUSE:
+                // case PAUSED: //
+                //     this->emitErrorMessageIfAny("propertyCallbackGraphGRC -> REQUESTED_STOP", this->changeStateTo(REQUESTED_STOP));
+                //     this->emitErrorMessageIfAny("propertyCallbackGraphGRC -> STOPPED", this->changeStateTo(STOPPED));
+                //     break;
+                // case REQUESTED_STOP:
+                // case INITIALISED: //
+                //     this->emitErrorMessageIfAny("propertyCallbackGraphGRC -> REQUESTED_STOP", this->changeStateTo(STOPPED));
+                //     break;
+                // case IDLE:
+                //     assert(false); // doesn't happen
+                //     break;
+                // case STOPPED:
+                // case ERROR: break;
+                // default:;
+                // }
+                //
+                // _graph = std::move(newGraph);
+                //
+                // // Now ideally we'd just restart the Scheduler, but we can't since we're processing a message inside a working thread.
+                // // When the scheduler starts running it asserts that _nRunningJobs is 0, so we can't start it now, we're in the job.
+                // // We need to let poolWorker() unwind, decrement _nRunningJobs and then move scheduler to its original value.
+                // // Alternatively, we could forbid kGraphGRC unless Scheduler was in STOPPED state. That would simplify logic, but
+                // // put more burden on the client.
 
                 message.data = property_map{{"originalSchedulerState", static_cast<int>(originalState)}};
             } catch (const std::exception& e) {
@@ -890,36 +1016,25 @@ protected:
 };
 
 template<ExecutionPolicy execution = ExecutionPolicy::singleThreaded, profiling::ProfilerLike TProfiler = profiling::null::Profiler>
-class Simple : public SchedulerBase<Simple<execution, TProfiler>, execution, TProfiler> {
+struct Simple : SchedulerBase<Simple<execution, TProfiler>, execution, TProfiler> {
     using Description = Doc<R""(Simple loop based Scheduler, which iterates over all blocks in the order they have beein defined and emplaced definition in the graph.)"">;
 
-    friend class lifecycle::StateMachine<Simple<execution, TProfiler>>;
-    friend struct SchedulerBase<Simple<execution, TProfiler>, execution, TProfiler>;
-
-public:
-    using base_t = SchedulerBase<Simple<execution, TProfiler>, execution, TProfiler>;
-
-    explicit Simple(gr::Graph&& graph, std::string_view defaultThreadPool = gr::thread_pool::kDefaultCpuPoolId, const profiling::Options& profiling_options = {}) : base_t(std::move(graph), defaultThreadPool, profiling_options) {}
-    explicit Simple(gr::Graph&& graph, property_map initialSettings, std::string_view defaultThreadPool = gr::thread_pool::kDefaultCpuPoolId) : base_t(std::move(graph), std::move(initialSettings), defaultThreadPool) {}
-
-private:
-    void init() {
-        base_t::init();
-        [[maybe_unused]] const auto pe = this->_profilerHandler.startCompleteEvent("scheduler_simple.init");
+    void customInit() {
+        [[maybe_unused]] const auto pe = this->_profilerHandler->startCompleteEvent("scheduler_simple.init");
 
         // generate job list
         const gr::Graph   flatGraph = graph::flatten(this->_graph);
         const std::size_t nBlocks   = flatGraph.blocks().size();
 
         std::size_t n_batches = 1UZ;
-        switch (base_t::executionPolicy()) {
+        switch (this->executionPolicy()) {
         case ExecutionPolicy::singleThreaded:
         case ExecutionPolicy::singleThreadedBlocking: break;
         case ExecutionPolicy::multiThreaded: n_batches = std::min(static_cast<std::size_t>(this->_pool->maxThreads()), nBlocks); break;
         default:;
         }
 
-        std::lock_guard lock(base_t::_executionOrderMutex);
+        std::lock_guard lock(this->_executionOrderMutex);
         this->_adoptionBlocks.clear();
         this->_adoptionBlocks.resize(n_batches);
         this->_executionOrder->clear();
@@ -932,11 +1047,6 @@ private:
                 job.push_back(flatGraph.blocks()[j]);
             }
         }
-    }
-
-    void reset() {
-        base_t::reset();
-        init();
     }
 };
 
@@ -965,22 +1075,13 @@ inline void printExecutionOrder(const std::vector<std::vector<std::shared_ptr<Bl
 } // namespace detail
 
 template<ExecutionPolicy execution = ExecutionPolicy::singleThreaded, profiling::ProfilerLike TProfiler = profiling::null::Profiler>
-class BreadthFirst : public SchedulerBase<BreadthFirst<execution, TProfiler>, execution, TProfiler> {
+struct BreadthFirst : SchedulerBase<BreadthFirst<execution, TProfiler>, execution, TProfiler> {
     using Description = Doc<R""(Breadth First Scheduler which traverses the graph starting from the source blocks in a breath first fashion
 detecting cycles and blocks which can be reached from several source blocks.)"">;
 
-    friend class lifecycle::StateMachine<BreadthFirst<execution, TProfiler>>;
-    friend struct SchedulerBase<BreadthFirst<execution, TProfiler>, execution, TProfiler>;
     static_assert(execution == ExecutionPolicy::singleThreaded || execution == ExecutionPolicy::multiThreaded, "Unsupported execution policy");
 
-public:
-    using base_t = SchedulerBase<BreadthFirst<execution, TProfiler>, execution, TProfiler>;
-
-    explicit BreadthFirst(gr::Graph&& graph, std::string_view defaultThreadPool = gr::thread_pool::kDefaultCpuPoolId, const profiling::Options& profiling_options = {}) : base_t(std::move(graph), defaultThreadPool, profiling_options) {}
-    explicit BreadthFirst(gr::Graph&& graph, property_map initialSettings, std::string_view defaultThreadPool = gr::thread_pool::kDefaultCpuPoolId) : base_t(std::move(graph), std::move(initialSettings), defaultThreadPool) {}
-
-private:
-    void init() {
+    void customInit() {
         /* implements Breadth-first search scheduling algorithm (https://en.wikipedia.org/wiki/Breadth-first_search)
          * 1. compute 'adjacencyList'
          * 2. determine all 'sourceBlocks' S (no incoming edges)
@@ -998,8 +1099,7 @@ private:
          * [2] P. Morin, "Open Data Structures". [Online]. available at: https://opendatastructures.org/
          */
         using block_t                  = std::shared_ptr<BlockModel>;
-        [[maybe_unused]] const auto pe = this->_profilerHandler.startCompleteEvent("breadth_first.init");
-        base_t::init();
+        [[maybe_unused]] const auto pe = this->_profilerHandler->startCompleteEvent("breadth_first.init");
 
         gr::Graph                      flatGraph     = gr::graph::flatten(this->_graph);
         const gr::graph::AdjacencyList adjacencyList = graph::computeAdjacencyList(flatGraph);
@@ -1039,35 +1139,20 @@ private:
 
         const std::size_t n_batches = (execution == ExecutionPolicy::multiThreaded) ? std::min(static_cast<std::size_t>(this->_pool->maxThreads()), blockList.size()) : 1UZ;
 
-        std::lock_guard guard(base_t::_adoptionBlocksMutex);
-        std::lock_guard lock(base_t::_executionOrderMutex);
+        std::lock_guard guard(this->_adoptionBlocksMutex);
+        std::lock_guard lock(this->_executionOrderMutex);
         this->_adoptionBlocks.clear();
         this->_adoptionBlocks.resize(n_batches);
         *this->_executionOrder = detail::batchBlocks(blockList, n_batches);
     }
-
-    void reset() {
-        base_t::reset();
-        init();
-    }
 };
 
 template<ExecutionPolicy execution = ExecutionPolicy::singleThreaded, profiling::ProfilerLike TProfiler = profiling::null::Profiler>
-class DepthFirst : public SchedulerBase<DepthFirst<execution, TProfiler>, execution, TProfiler> {
+struct DepthFirst : SchedulerBase<DepthFirst<execution, TProfiler>, execution, TProfiler> {
     using Description = Doc<R""(Depth First Scheduler which traverses the graph starting from the source blocks in a depth-first manner.)"">;
-
-    friend class lifecycle::StateMachine<DepthFirst<execution, TProfiler>>;
-    friend struct SchedulerBase<DepthFirst<execution, TProfiler>, execution, TProfiler>;
     static_assert(execution == ExecutionPolicy::singleThreaded || execution == ExecutionPolicy::multiThreaded, "Unsupported execution policy");
 
-public:
-    using base_t = SchedulerBase<DepthFirst<execution, TProfiler>, execution, TProfiler>;
-
-    explicit DepthFirst(gr::Graph&& graph, std::string_view defaultThreadPool = gr::thread_pool::kDefaultCpuPoolId, const profiling::Options& profiling_options = {}) : base_t(std::move(graph), defaultThreadPool, profiling_options) {}
-    explicit DepthFirst(gr::Graph&& graph, property_map initialSettings, std::string_view defaultThreadPool = gr::thread_pool::kDefaultCpuPoolId) : base_t(std::move(graph), std::move(initialSettings), defaultThreadPool) {}
-
-private:
-    void init() {
+    void customInit() {
         /**
          * implements Depth-first search scheduling algorithm (https://en.wikipedia.org/wiki/Depth-first_search)
          * 1. compute 'adjacencyList'
@@ -1087,8 +1172,7 @@ private:
          * [2] P. Morin, "Open Data Structures". [Online]. available at: https://opendatastructures.org/
          */
         using block_t                  = std::shared_ptr<BlockModel>;
-        [[maybe_unused]] const auto pe = this->_profilerHandler.startCompleteEvent("depth_first.init");
-        base_t::init();
+        [[maybe_unused]] const auto pe = this->_profilerHandler->startCompleteEvent("depth_first.init");
 
         gr::Graph                  flatGraph     = gr::graph::flatten(this->_graph);
         const graph::AdjacencyList adjacencyList = graph::computeAdjacencyList(flatGraph);
@@ -1097,37 +1181,32 @@ private:
         std::vector<block_t> blockList;
         std::set<block_t>    visited;
 
-        auto dfs = [&]<typename Self>(Self&& self, const block_t& node) -> void {
+        auto dfs = [&](this auto&& self, const block_t& node) -> void {
             if (!visited.insert(node).second) {
                 return; // already visited
             }
             blockList.push_back(node);
-            // recursively visit all outgoing neighbours
+
             if (adjacencyList.contains(node)) {
                 for (const auto& edges : adjacencyList.at(node) | std::views::values) {
                     for (const auto* edge : edges) {
-                        self(self, edge->destinationBlock());
+                        self(edge->destinationBlock());
                     }
                 }
             }
         };
 
         for (const auto& src : sourceBlocks) {
-            dfs(dfs, src);
+            dfs(src);
         }
 
         const std::size_t n_batches = (execution == ExecutionPolicy::multiThreaded) ? std::min(static_cast<std::size_t>(this->_pool->maxThreads()), blockList.size()) : 1UZ;
 
-        std::lock_guard guard(base_t::_adoptionBlocksMutex);
-        std::lock_guard lock(base_t::_executionOrderMutex);
+        std::lock_guard guard(this->_adoptionBlocksMutex);
+        std::lock_guard lock(this->_executionOrderMutex);
         this->_adoptionBlocks.clear();
         this->_adoptionBlocks.resize(n_batches);
         *this->_executionOrder = detail::batchBlocks(blockList, n_batches);
-    }
-
-    void reset() {
-        base_t::reset();
-        init();
     }
 };
 

--- a/core/test/qa_DynamicBlock.cpp
+++ b/core/test/qa_DynamicBlock.cpp
@@ -32,7 +32,10 @@ const boost::ut::suite DynamicBlocktests = [] {
         }
         expect(gr::ConnectionResult::SUCCESS == graph.connect<"out">(adder).to<"in">(sink));
 
-        gr::scheduler::Simple sched(std::move(graph));
+        gr::scheduler::Simple sched;
+        if (auto ret = sched.exchange(std::move(graph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
 
         expect(sched.runAndWait().has_value());
 

--- a/core/test/qa_DynamicPort.cpp
+++ b/core/test/qa_DynamicPort.cpp
@@ -192,7 +192,10 @@ const boost::ut::suite PortApiTests = [] {
 
         expect(eq(ConnectionResult::SUCCESS, flow.connect<"sum">(added).to<"sink">(out)));
 
-        gr::scheduler::Simple sched{std::move(flow)};
+        gr::scheduler::Simple sched;
+        if (auto ret = sched.exchange(std::move(flow)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         expect(sched.runAndWait().has_value());
     };
 

--- a/core/test/qa_Graph.cpp
+++ b/core/test/qa_Graph.cpp
@@ -103,7 +103,10 @@ const boost::ut::suite<"GraphTests"> _1 = [] {
         // only the first port is connected
         expect(eq(ConnectionResult::SUCCESS, graph.connect<"out", 0>(src, customBufferSize).to<"in">(sink1)));
 
-        scheduler::Simple<scheduler::ExecutionPolicy::multiThreaded> sched{std::move(graph)};
+        scheduler::Simple<scheduler::ExecutionPolicy::multiThreaded> sched;
+        if (auto ret = sched.exchange(std::move(graph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         expect(sched.runAndWait().has_value());
 
         expect(eq(src.out[0].bufferSize(), customBufferSize));

--- a/core/test/qa_HierBlock.cpp
+++ b/core/test/qa_HierBlock.cpp
@@ -65,10 +65,13 @@ const boost::ut::suite ExportPortsTests_ = [] {
         std::shared_ptr<BlockModel> subGraph       = initGraph.addBlock(subGraphDirect);
 
         // Connecting the message ports
-        gr::scheduler::Simple scheduler{std::move(initGraph)};
-        const auto&           graph = scheduler.graph();
-        gr::MsgPortOut        toScheduler;
-        gr::MsgPortIn         fromScheduler;
+        gr::scheduler::Simple scheduler;
+        if (auto ret = scheduler.exchange(std::move(initGraph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
+        const auto&    graph = scheduler.graph();
+        gr::MsgPortOut toScheduler;
+        gr::MsgPortIn  fromScheduler;
         expect(eq(ConnectionResult::SUCCESS, toScheduler.connect(scheduler.msgIn)));
         expect(eq(ConnectionResult::SUCCESS, scheduler.msgOut.connect(fromScheduler)));
 
@@ -177,7 +180,10 @@ const boost::ut::suite SchedulerDiveIntoSubgraphTests_ = [] {
         expect(eq(initGraph.edges().size(), 2UZ));
         expect(eq(subGraphDirect->blockRef().edges().size(), 1UZ));
 
-        gr::scheduler::Simple scheduler{std::move(initGraph)};
+        gr::scheduler::Simple scheduler;
+        if (auto ret = scheduler.exchange(std::move(initGraph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
 
         auto schedulerThreadHandle = gr::test::thread_pool::executeScheduler("qa_HierBlock::scheduler", scheduler);
 
@@ -227,10 +233,13 @@ const boost::ut::suite SubgraphBlockSettingsTests_ = [] {
         std::shared_ptr<BlockModel> subGraph       = initGraph.addBlock(subGraphDirect);
 
         // Connecting the message ports
-        gr::scheduler::Simple scheduler{std::move(initGraph)};
-        const auto&           graph = scheduler.graph();
-        gr::MsgPortOut        toScheduler;
-        gr::MsgPortIn         fromScheduler;
+        gr::scheduler::Simple scheduler;
+        if (auto ret = scheduler.exchange(std::move(initGraph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
+        const auto&    graph = scheduler.graph();
+        gr::MsgPortOut toScheduler;
+        gr::MsgPortIn  fromScheduler;
         expect(eq(ConnectionResult::SUCCESS, toScheduler.connect(scheduler.msgIn)));
         expect(eq(ConnectionResult::SUCCESS, scheduler.msgOut.connect(fromScheduler)));
 

--- a/core/test/qa_Messages.cpp
+++ b/core/test/qa_Messages.cpp
@@ -617,9 +617,12 @@ const boost::ut::suite MessagesTests = [] {
         expect(eq(ConnectionResult::SUCCESS, flow.connect<"out">(source).to<"in">(process)));
         expect(eq(ConnectionResult::SUCCESS, flow.connect<"out">(process).to<"in">(sink)));
 
-        gr::MsgPortOut toScheduler;
-        gr::MsgPortIn  fromScheduler;
-        auto           scheduler = scheduler::Simple<SchedulerPolicy::value>(std::move(flow));
+        gr::MsgPortOut                                toScheduler;
+        gr::MsgPortIn                                 fromScheduler;
+        gr::scheduler::Simple<SchedulerPolicy::value> scheduler;
+        if (auto ret = scheduler.exchange(std::move(flow)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
 
         expect(eq(ConnectionResult::SUCCESS, toScheduler.connect(scheduler.msgIn)));
         expect(eq(ConnectionResult::SUCCESS, scheduler.msgOut.connect(fromScheduler)));
@@ -795,9 +798,12 @@ const boost::ut::suite MessagesTests = [] {
         expect(eq(ConnectionResult::SUCCESS, flow.connect<"out">(source).to<"in">(process)));
         expect(eq(ConnectionResult::SUCCESS, flow.connect<"out">(process).to<"in">(sink)));
 
-        gr::MsgPortIn  fromScheduler;
-        gr::MsgPortOut toScheduler;
-        auto           scheduler = scheduler::Simple<SchedulerPolicy::value>(std::move(flow));
+        gr::MsgPortIn                                 fromScheduler;
+        gr::MsgPortOut                                toScheduler;
+        gr::scheduler::Simple<SchedulerPolicy::value> scheduler;
+        if (auto ret = scheduler.exchange(std::move(flow)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         expect(eq(ConnectionResult::SUCCESS, scheduler.msgOut.connect(fromScheduler)));
         expect(eq(ConnectionResult::SUCCESS, toScheduler.connect(scheduler.msgIn)));
         sendMessage<Command::Subscribe>(toScheduler, scheduler.unique_name, block::property::kLifeCycleState, {}, "TestClient#42");
@@ -846,7 +852,10 @@ const boost::ut::suite MessagesTests = [] {
         expect(eq(ConnectionResult::SUCCESS, flow.connect<"out">(source).to<"in">(testBlock)));
         expect(eq(ConnectionResult::SUCCESS, flow.connect<"out">(testBlock).to<"in">(sink)));
 
-        auto scheduler = scheduler::Simple<SchedulerPolicy::value>(std::move(flow));
+        gr::scheduler::Simple<SchedulerPolicy::value> scheduler;
+        if (auto ret = scheduler.exchange(std::move(flow)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
 
         gr::MsgPortIn  fromScheduler;
         gr::MsgPortOut toScheduler;

--- a/core/test/qa_PerformanceMonitor.cpp
+++ b/core/test/qa_PerformanceMonitor.cpp
@@ -95,7 +95,10 @@ int main(int argc, char* argv[]) {
     expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"outRes">(monitorPerformance).to<"in">(sinkRes)));
     expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"outRate">(monitorPerformance).to<"in">(sinkRate)));
 
-    auto sched                                        = scheduler::Simple{std::move(testGraph)};
+    gr::scheduler::Simple<> sched;
+    if (auto ret = sched.exchange(std::move(testGraph)); !ret) {
+        throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+    }
     auto [watchdogThread, externalInterventionNeeded] = createWatchdog(sched, runTime > 0 ? std::chrono::seconds(runTime) : 2s);
     expect(sched.runAndWait().has_value());
 

--- a/core/test/qa_Scheduler.cpp
+++ b/core/test/qa_Scheduler.cpp
@@ -326,9 +326,11 @@ const boost::ut::suite<"SchedulerTests"> SchedulerSettingsTests = [] {
     using namespace gr;
 
     "Direct settings change"_test = [] {
-        using scheduler               = gr::scheduler::Simple<>;
         std::shared_ptr<Tracer> trace = std::make_shared<Tracer>();
-        auto                    sched = scheduler{getGraphLinear(trace), gr::thread_pool::kDefaultCpuPoolId};
+        gr::scheduler::Simple<> sched;
+        if (auto ret = sched.exchange(getGraphLinear(trace)); !ret) {
+            expect(false) << std::format("couldn't initialise scheduler. error: {}", ret.error()) << fatal;
+        }
 
         auto ret1 = sched.settings().set({{"timeout_ms", gr::Size_t(6)}});
         expect(ret1.empty()) << "setting one known parameter";
@@ -380,9 +382,11 @@ const boost::ut::suite<"SchedulerTests"> SchedulerTests = [] {
     std::println("INFO: std::thread::hardware_concurrency() = {} - CPU thread bounds = [{}, {}]", std::thread::hardware_concurrency(), minThreads, maxThreads);
 
     "SimpleScheduler_linear"_test = [] {
-        using scheduler               = gr::scheduler::Simple<>;
         std::shared_ptr<Tracer> trace = std::make_shared<Tracer>();
-        auto                    sched = scheduler{getGraphLinear(trace), gr::thread_pool::kDefaultCpuPoolId};
+        gr::scheduler::Simple<> sched;
+        if (auto ret = sched.exchange(getGraphLinear(trace)); !ret) {
+            expect(false) << std::format("couldn't initialise scheduler. error: {}", ret.error()) << fatal;
+        }
         expect(sched.runAndWait().has_value());
         auto t = trace->getVector();
         expect(boost::ut::that % t.size() == 8u);
@@ -390,9 +394,11 @@ const boost::ut::suite<"SchedulerTests"> SchedulerTests = [] {
     };
 
     "BreadthFirstScheduler_linear"_test = [] {
-        using scheduler               = gr::scheduler::BreadthFirst<>;
-        std::shared_ptr<Tracer> trace = std::make_shared<Tracer>();
-        auto                    sched = scheduler{getGraphLinear(trace), gr::thread_pool::kDefaultCpuPoolId};
+        std::shared_ptr<Tracer>       trace = std::make_shared<Tracer>();
+        gr::scheduler::BreadthFirst<> sched;
+        if (auto ret = sched.exchange(getGraphLinear(trace)); !ret) {
+            expect(false) << std::format("couldn't initialise scheduler. error: {}", ret.error()) << fatal;
+        }
         expect(sched.runAndWait().has_value());
         auto t = trace->getVector();
         expect(boost::ut::that % t.size() == 8u);
@@ -400,9 +406,11 @@ const boost::ut::suite<"SchedulerTests"> SchedulerTests = [] {
     };
 
     "SimpleScheduler_parallel"_test = [] {
-        using scheduler               = gr::scheduler::Simple<>;
         std::shared_ptr<Tracer> trace = std::make_shared<Tracer>();
-        auto                    sched = scheduler{getGraphParallel(trace), gr::thread_pool::kDefaultCpuPoolId};
+        gr::scheduler::Simple<> sched;
+        if (auto ret = sched.exchange(getGraphParallel(trace)); !ret) {
+            expect(false) << std::format("couldn't initialise scheduler. error: {}", ret.error()) << fatal;
+        }
         expect(sched.runAndWait().has_value());
         auto t = trace->getVector();
         expect(boost::ut::that % t.size() == 14u);
@@ -410,9 +418,11 @@ const boost::ut::suite<"SchedulerTests"> SchedulerTests = [] {
     };
 
     "BreadthFirstScheduler_parallel"_test = [] {
-        using scheduler               = gr::scheduler::BreadthFirst<>;
-        std::shared_ptr<Tracer> trace = std::make_shared<Tracer>();
-        auto                    sched = scheduler{getGraphParallel(trace), gr::thread_pool::kDefaultCpuPoolId};
+        std::shared_ptr<Tracer>       trace = std::make_shared<Tracer>();
+        gr::scheduler::BreadthFirst<> sched;
+        if (auto ret = sched.exchange(getGraphParallel(trace)); !ret) {
+            expect(false) << std::format("couldn't initialise scheduler. error: {}", ret.error()) << fatal;
+        }
         expect(sched.runAndWait().has_value());
         auto t = trace->getVector();
         expect(boost::ut::that % t.size() == 14u);
@@ -435,10 +445,12 @@ const boost::ut::suite<"SchedulerTests"> SchedulerTests = [] {
     };
 
     "SimpleScheduler_scaled_sum"_test = [] {
-        using scheduler = gr::scheduler::Simple<>;
         // construct an example graph and get an adjacency list for it
         std::shared_ptr<Tracer> trace = std::make_shared<Tracer>();
-        auto                    sched = scheduler{getGraphScaledSum(trace), gr::thread_pool::kDefaultCpuPoolId};
+        gr::scheduler::Simple<> sched;
+        if (auto ret = sched.exchange(getGraphScaledSum(trace)); !ret) {
+            expect(false) << std::format("couldn't initialise scheduler. error: {}", ret.error()) << fatal;
+        }
         expect(sched.runAndWait().has_value());
         auto t = trace->getVector();
         expect(boost::ut::that % t.size() == 10u);
@@ -446,9 +458,11 @@ const boost::ut::suite<"SchedulerTests"> SchedulerTests = [] {
     };
 
     "BreadthFirstScheduler_scaled_sum"_test = [] {
-        using scheduler               = gr::scheduler::BreadthFirst<>;
-        std::shared_ptr<Tracer> trace = std::make_shared<Tracer>();
-        auto                    sched = scheduler{getGraphScaledSum(trace), gr::thread_pool::kDefaultCpuPoolId};
+        std::shared_ptr<Tracer>       trace = std::make_shared<Tracer>();
+        gr::scheduler::BreadthFirst<> sched;
+        if (auto ret = sched.exchange(getGraphScaledSum(trace)); !ret) {
+            expect(false) << std::format("couldn't initialise scheduler. error: {}", ret.error()) << fatal;
+        }
         expect(sched.runAndWait().has_value());
         auto t = trace->getVector();
         expect(boost::ut::that % t.size() == 10u);
@@ -456,18 +470,22 @@ const boost::ut::suite<"SchedulerTests"> SchedulerTests = [] {
     };
 
     "SimpleScheduler_linear_multi_threaded"_test = [] {
-        using scheduler               = gr::scheduler::Simple<gr::scheduler::ExecutionPolicy::multiThreaded>;
-        std::shared_ptr<Tracer> trace = std::make_shared<Tracer>();
-        auto                    sched = scheduler{getGraphLinear(trace), gr::thread_pool::kDefaultCpuPoolId};
+        std::shared_ptr<Tracer>                                              trace = std::make_shared<Tracer>();
+        gr::scheduler::Simple<gr::scheduler::ExecutionPolicy::multiThreaded> sched;
+        if (auto ret = sched.exchange(getGraphLinear(trace)); !ret) {
+            expect(false) << std::format("couldn't initialise scheduler. error: {}", ret.error()) << fatal;
+        }
         expect(sched.runAndWait().has_value());
         auto t = trace->getVector();
         expect(that % t.size() >= 8u);
     };
 
     "BreadthFirstScheduler_linear_multi_threaded"_test = [] {
-        using scheduler               = gr::scheduler::BreadthFirst<gr::scheduler::ExecutionPolicy::multiThreaded>;
-        std::shared_ptr<Tracer> trace = std::make_shared<Tracer>();
-        auto                    sched = scheduler{getGraphLinear(trace), gr::thread_pool::kDefaultCpuPoolId};
+        std::shared_ptr<Tracer>                                                    trace = std::make_shared<Tracer>();
+        gr::scheduler::BreadthFirst<gr::scheduler::ExecutionPolicy::multiThreaded> sched;
+        if (auto ret = sched.exchange(getGraphLinear(trace)); !ret) {
+            expect(false) << std::format("couldn't initialise scheduler. error: {}", ret.error()) << fatal;
+        }
         expect(sched.changeStateTo(gr::lifecycle::State::INITIALISED).has_value());
         expect(sched.jobs()->size() == 2u);
         checkBlockNames(sched.jobs()->at(0), {"s1", "mult2"});
@@ -478,18 +496,22 @@ const boost::ut::suite<"SchedulerTests"> SchedulerTests = [] {
     };
 
     "SimpleScheduler_parallel_multi_threaded"_test = [] {
-        using scheduler               = gr::scheduler::Simple<gr::scheduler::ExecutionPolicy::multiThreaded>;
-        std::shared_ptr<Tracer> trace = std::make_shared<Tracer>();
-        auto                    sched = scheduler{getGraphParallel(trace), gr::thread_pool::kDefaultCpuPoolId};
+        std::shared_ptr<Tracer>                                              trace = std::make_shared<Tracer>();
+        gr::scheduler::Simple<gr::scheduler::ExecutionPolicy::multiThreaded> sched;
+        if (auto ret = sched.exchange(getGraphParallel(trace)); !ret) {
+            expect(false) << std::format("couldn't initialise scheduler. error: {}", ret.error()) << fatal;
+        }
         expect(sched.runAndWait().has_value());
         auto t = trace->getVector();
         expect(boost::ut::that % t.size() >= 14u) << std::format("execution order incomplete: {}", gr::join(t, ", "));
     };
 
     "BreadthFirstScheduler_parallel_multi_threaded"_test = [] {
-        using scheduler               = gr::scheduler::BreadthFirst<gr::scheduler::ExecutionPolicy::multiThreaded>;
-        std::shared_ptr<Tracer> trace = std::make_shared<Tracer>();
-        auto                    sched = scheduler{getGraphParallel(trace), gr::thread_pool::kDefaultCpuPoolId};
+        std::shared_ptr<Tracer>                                                    trace = std::make_shared<Tracer>();
+        gr::scheduler::BreadthFirst<gr::scheduler::ExecutionPolicy::multiThreaded> sched;
+        if (auto ret = sched.exchange(getGraphParallel(trace)); !ret) {
+            expect(false) << std::format("couldn't initialise scheduler. error: {}", ret.error()) << fatal;
+        }
         expect(sched.changeStateTo(gr::lifecycle::State::INITIALISED).has_value());
         expect(sched.jobs()->size() == 2u);
         checkBlockNames(sched.jobs()->at(0), {"s1", "mult1b", "mult2b", "outb"});
@@ -500,19 +522,23 @@ const boost::ut::suite<"SchedulerTests"> SchedulerTests = [] {
     };
 
     "SimpleScheduler_scaled_sum_multi_threaded"_test = [] {
-        using scheduler = gr::scheduler::Simple<gr::scheduler::ExecutionPolicy::multiThreaded>;
         // construct an example graph and get an adjacency list for it
-        std::shared_ptr<Tracer> trace = std::make_shared<Tracer>();
-        auto                    sched = scheduler{getGraphScaledSum(trace), gr::thread_pool::kDefaultCpuPoolId};
+        std::shared_ptr<Tracer>                                              trace = std::make_shared<Tracer>();
+        gr::scheduler::Simple<gr::scheduler::ExecutionPolicy::multiThreaded> sched;
+        if (auto ret = sched.exchange(getGraphScaledSum(trace)); !ret) {
+            expect(false) << std::format("couldn't initialise scheduler. error: {}", ret.error()) << fatal;
+        }
         expect(sched.runAndWait().has_value());
         auto t = trace->getVector();
         expect(boost::ut::that % t.size() >= 10u);
     };
 
     "BreadthFirstScheduler_scaled_sum_multi_threaded"_test = [] {
-        using scheduler               = gr::scheduler::BreadthFirst<gr::scheduler::ExecutionPolicy::multiThreaded>;
-        std::shared_ptr<Tracer> trace = std::make_shared<Tracer>();
-        auto                    sched = scheduler{getGraphScaledSum(trace), gr::thread_pool::kDefaultCpuPoolId};
+        std::shared_ptr<Tracer>                                                    trace = std::make_shared<Tracer>();
+        gr::scheduler::BreadthFirst<gr::scheduler::ExecutionPolicy::multiThreaded> sched;
+        if (auto ret = sched.exchange(getGraphScaledSum(trace)); !ret) {
+            expect(false) << std::format("couldn't initialise scheduler. error: {}", ret.error()) << fatal;
+        }
         expect(sched.changeStateTo(gr::lifecycle::State::INITIALISED).has_value());
         expect(eq(sched.jobs()->size(), 2u));
         checkBlockNames(sched.jobs()->at(0), {"s1", "mult", "out"});
@@ -523,14 +549,16 @@ const boost::ut::suite<"SchedulerTests"> SchedulerTests = [] {
     };
 
     "LifecycleBlock"_test = [] {
-        using scheduler = gr::scheduler::Simple<>;
         gr::Graph flow;
 
         auto& lifecycleSource = flow.emplaceBlock<LifecycleSource<float>>();
         auto& lifecycleBlock  = flow.emplaceBlock<LifecycleBlock<float>>();
         expect(eq(gr::ConnectionResult::SUCCESS, flow.connect<"out">(lifecycleSource).to<"in">(lifecycleBlock)));
 
-        auto sched = scheduler{std::move(flow), gr::thread_pool::kDefaultCpuPoolId};
+        gr::scheduler::Simple<> sched;
+        if (auto ret = sched.exchange(std::move(flow)); !ret) {
+            expect(false) << std::format("couldn't initialise scheduler. error: {}", ret.error()) << fatal;
+        }
         expect(sched.runAndWait().has_value());
         expect(sched.changeStateTo(gr::lifecycle::State::INITIALISED).has_value());
 
@@ -547,7 +575,6 @@ const boost::ut::suite<"SchedulerTests"> SchedulerTests = [] {
 
     "propagate DONE check-infinite loop"_test = [] {
         using namespace gr::testing;
-        using scheduler = gr::scheduler::Simple<>;
         gr::Graph flow;
 
         auto& source  = flow.emplaceBlock<CountingSource<float>>();
@@ -556,8 +583,10 @@ const boost::ut::suite<"SchedulerTests"> SchedulerTests = [] {
         expect(eq(gr::ConnectionResult::SUCCESS, flow.connect<"out">(source).to<"in">(monitor)));
         expect(eq(gr::ConnectionResult::SUCCESS, flow.connect<"out">(monitor).to<"in">(sink)));
 
-        auto sched = scheduler{std::move(flow), gr::thread_pool::kDefaultCpuPoolId};
-
+        gr::scheduler::Simple<> sched;
+        if (auto ret = sched.exchange(std::move(flow)); !ret) {
+            expect(false) << std::format("couldn't initialise scheduler. error: {}", ret.error()) << fatal;
+        }
         std::atomic_bool shutDownByWatchdog{false};
 
         auto watchdogThread = gr::test::thread_pool::execute("watchdog", [&sched, &shutDownByWatchdog]() {
@@ -607,7 +636,6 @@ const boost::ut::suite<"SchedulerTests"> SchedulerTests = [] {
 
     "propagate source DONE state: down-stream using EOS tag"_test = [&createWatchdog] {
         using namespace gr::testing;
-        using scheduler = gr::scheduler::Simple<>;
         gr::Graph flow;
 
         auto& source  = flow.emplaceBlock<ConstantSource<float>>({{"n_samples_max", 1024U}});
@@ -616,7 +644,10 @@ const boost::ut::suite<"SchedulerTests"> SchedulerTests = [] {
         expect(eq(gr::ConnectionResult::SUCCESS, flow.connect<"out">(source).to<"in">(monitor)));
         expect(eq(gr::ConnectionResult::SUCCESS, flow.connect<"out">(monitor).to<"in">(sink)));
 
-        auto sched                                        = scheduler{std::move(flow), gr::thread_pool::kDefaultCpuPoolId};
+        gr::scheduler::Simple<> sched;
+        if (auto ret = sched.exchange(std::move(flow)); !ret) {
+            expect(false) << std::format("couldn't initialise scheduler. error: {}", ret.error()) << fatal;
+        }
         auto [watchdogThread, externalInterventionNeeded] = createWatchdog(sched, 2s);
         expect(sched.runAndWait().has_value());
 
@@ -630,7 +661,6 @@ const boost::ut::suite<"SchedulerTests"> SchedulerTests = [] {
 
     "propagate monitor DONE status: down-stream using EOS tag, upstream via disconnecting ports"_test = [&createWatchdog] {
         using namespace gr::testing;
-        using scheduler = gr::scheduler::Simple<>;
         gr::Graph flow;
 
         auto& source  = flow.emplaceBlock<NullSource<float>>();
@@ -639,7 +669,10 @@ const boost::ut::suite<"SchedulerTests"> SchedulerTests = [] {
         expect(eq(gr::ConnectionResult::SUCCESS, flow.connect<"out">(source).to<"in">(monitor)));
         expect(eq(gr::ConnectionResult::SUCCESS, flow.connect<"out">(monitor).to<"in">(sink)));
 
-        auto sched                                        = scheduler{std::move(flow), gr::thread_pool::kDefaultCpuPoolId};
+        gr::scheduler::Simple<> sched;
+        if (auto ret = sched.exchange(std::move(flow)); !ret) {
+            expect(false) << std::format("couldn't initialise scheduler. error: {}", ret.error()) << fatal;
+        }
         auto [watchdogThread, externalInterventionNeeded] = createWatchdog(sched, 2s);
         expect(sched.runAndWait().has_value());
 
@@ -653,7 +686,6 @@ const boost::ut::suite<"SchedulerTests"> SchedulerTests = [] {
 
     "propagate sink DONE status: upstream via disconnecting ports"_test = [&createWatchdog] {
         using namespace gr::testing;
-        using scheduler = gr::scheduler::Simple<>;
         gr::Graph flow;
 
         auto& source  = flow.emplaceBlock<NullSource<float>>();
@@ -662,7 +694,10 @@ const boost::ut::suite<"SchedulerTests"> SchedulerTests = [] {
         expect(eq(gr::ConnectionResult::SUCCESS, flow.connect<"out">(source).to<"in">(monitor)));
         expect(eq(gr::ConnectionResult::SUCCESS, flow.connect<"out">(monitor).to<"in">(sink)));
 
-        auto sched                                        = scheduler{std::move(flow), gr::thread_pool::kDefaultCpuPoolId};
+        gr::scheduler::Simple<> sched;
+        if (auto ret = sched.exchange(std::move(flow)); !ret) {
+            expect(false) << std::format("couldn't initialise scheduler. error: {}", ret.error()) << fatal;
+        }
         auto [watchdogThread, externalInterventionNeeded] = createWatchdog(sched, 2s);
         expect(sched.runAndWait().has_value());
 
@@ -676,7 +711,6 @@ const boost::ut::suite<"SchedulerTests"> SchedulerTests = [] {
     "blocking scheduler"_test = [] {
         using namespace gr;
         using namespace gr::testing;
-        using TScheduler = scheduler::Simple<scheduler::ExecutionPolicy::singleThreadedBlocking>;
 
         Graph flow;
         auto& source  = flow.emplaceBlock<NullSource<float>>();
@@ -685,7 +719,10 @@ const boost::ut::suite<"SchedulerTests"> SchedulerTests = [] {
         expect(eq(gr::ConnectionResult::SUCCESS, flow.connect<"out">(source).to<"in">(monitor)));
         expect(eq(gr::ConnectionResult::SUCCESS, flow.connect<"out">(monitor).to<"in">(sink)));
 
-        auto scheduler                     = TScheduler{std::move(flow), gr::thread_pool::kDefaultCpuPoolId};
+        scheduler::Simple<scheduler::ExecutionPolicy::singleThreadedBlocking> scheduler;
+        if (auto ret = scheduler.exchange(std::move(flow)); !ret) {
+            expect(false) << std::format("couldn't initialise scheduler. error: {}", ret.error()) << fatal;
+        }
         scheduler.timeout_ms               = 100U; // also dynamically settable via messages/block interface
         scheduler.timeout_inactivity_count = 10U;  // also dynamically settable via messages/block interface
 

--- a/core/test/qa_Tags.cpp
+++ b/core/test/qa_Tags.cpp
@@ -256,7 +256,10 @@ const boost::ut::suite TagPropagation = [] {
         expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(autoForwardBlock).to<"in">(monitor)));
         expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(monitor).to<"in">(sink)));
 
-        scheduler::Simple sched{std::move(testGraph)};
+        gr::scheduler::Simple<> sched;
+        if (auto ret = sched.exchange(std::move(testGraph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         expect(sched.runAndWait().has_value());
 
         expect(eq(src._nSamplesProduced, nSamples));
@@ -327,7 +330,10 @@ const boost::ut::suite TagPropagation = [] {
         expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(monitorBulk2).to<"in">(sinkOne)));
         expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(monitorBulk2).to<"in">(sinkBulk)));
 
-        scheduler::Simple sched{std::move(testGraph)};
+        gr::scheduler::Simple<> sched;
+        if (auto ret = sched.exchange(std::move(testGraph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         expect(sched.runAndWait().has_value());
 
         expect(eq(src._nSamplesProduced, nSamples));
@@ -404,7 +410,10 @@ const boost::ut::suite TagPropagation = [] {
         expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(src).template to<"inPort">(realign)));
         expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"outPort">(realign).to<"in">(sink)));
 
-        scheduler::Simple sched{std::move(testGraph)};
+        gr::scheduler::Simple<> sched;
+        if (auto ret = sched.exchange(std::move(testGraph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         expect(sched.runAndWait().has_value());
 
         expect(eq(src._nSamplesProduced, n_samples)) << "src did not produce enough output samples";
@@ -436,7 +445,10 @@ const boost::ut::suite TagPropagation = [] {
         expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(src).template to<"in">(decimator)));
         expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(decimator).template to<"in">(sink)));
 
-        scheduler::Simple sched{std::move(testGraph)};
+        gr::scheduler::Simple<> sched;
+        if (auto ret = sched.exchange(std::move(testGraph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         expect(sched.runAndWait().has_value());
 
         expect(eq(src._nSamplesProduced, nSamples));
@@ -485,7 +497,10 @@ const boost::ut::suite RepeatedTags = [] {
         expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(src).template to<"in">(monitorOne)));
         expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(monitorOne).to<"in">(sinkOne)));
 
-        scheduler::Simple sched{std::move(testGraph)};
+        gr::scheduler::Simple<> sched;
+        if (auto ret = sched.exchange(std::move(testGraph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
         expect(sched.runAndWait().has_value());
 
         expect(eq(src._tags.size(), 4UZ));

--- a/core/test/qa_grc.cpp
+++ b/core/test/qa_grc.cpp
@@ -234,8 +234,11 @@ connections:
 
             expect(checkAndPrintMissingBlocks(graphSrc2, graphSavedSrc));
 
-            gr::scheduler::Simple scheduler(std::move(graph));
-            expect(scheduler.runAndWait().has_value());
+            gr::scheduler::Simple sched;
+            if (auto ret = sched.exchange(std::move(graph)); !ret) {
+                throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+            }
+            expect(sched.runAndWait().has_value());
         } catch (const std::string& e) {
             std::println(std::cerr, "Unexpected exception: {}", e);
             expect(false);


### PR DESCRIPTION
*Design Goals*:
Remove custom constructors and add `Graph` exchange API so that the scheduler behaves more consistently like a standard `Block<T>` and be used for managed sub-graphs.

*Specific changes*:
- remove graph-taking constructors from user-defined schedulers (Simple, BreadthFirst, DepthFirst)
- add `std::expected<Graph, Error> exchange(Graph&& ...)` method for runtime graph replacement
- Schedulers now use customInit()/customStart()/etc. hooks instead of overriding lifecycle methods (needed due to double CRTP-indirection)
- minimises CPU thread resource allocations by reusing scheduler instances
- update all tests to use default constructor + exchange() pattern
- fix profiler to use pointer semantics for thread-local handlers

Thanks to @drslebedev and @wirew0rm for the additional changes, fixes and pre-review.