### PR TITLE
Remove Block::mergedInputTag

### DIFF
--- a/blocks/basic/include/gnuradio-4.0/basic/Selector.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/Selector.hpp
@@ -164,7 +164,7 @@ you can set the `backPressure` property to false.
             const auto tags = inputSpan.tags(); // Tag handling
             for (const auto& [normalisedTagIndex, tagMap] : tags) {
                 if (normalisedTagIndex < static_cast<std::ptrdiff_t>(nSamplesToCopy)) {
-                    outputSpan.publishTag(tagMap, std::max(static_cast<std::size_t>(normalisedTagIndex) + static_cast<std::size_t>(diffOffset), 0UZ));
+                    outputSpan.publishTag(tagMap.get(), std::max(static_cast<std::size_t>(normalisedTagIndex) + static_cast<std::size_t>(diffOffset), 0UZ));
                 }
             }
             outputSpan.publish(nSamplesToCopy);

--- a/blocks/basic/include/gnuradio-4.0/basic/SyncBlock.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/SyncBlock.hpp
@@ -167,15 +167,15 @@ Note: We assume that desynchronization should not exceed the buffer size of the 
         std::size_t nPorts = ins.size();
 
         const std::vector<SyncData> syncData = synchronize(ins);
-        const bool                  canSync  = !syncData.empty();
+        const bool                  canSync  = syncData.size() == nPorts;
 
         if (canSync) {
-            const std::size_t minPre            = std::ranges::min(syncData | std::views::transform([](const SyncData& data) { return data.nPre; }));
-            const std::size_t minPost           = std::ranges::min(syncData | std::views::transform([](const SyncData& data) { return data.nPost; }));
+            const std::size_t minPre            = std::ranges::min(syncData | std::views::transform(&SyncData::nPre));
+            const std::size_t minPost           = std::ranges::min(syncData | std::views::transform(&SyncData::nPost));
             const std::size_t minSamplesOut     = std::ranges::min(outs | std::views::transform([&](const auto& out) { return out.size(); }));
             const std::size_t nSamplesToPublish = std::min(minPre + 1 + minPost, minSamplesOut);
 
-            for (std::size_t i = 0UZ; i < ins.size(); i++) {
+            for (std::size_t i = 0UZ; i < nPorts; i++) {
                 const std::size_t nSamplesToDrop    = syncData[i].index - minPre;
                 const std::size_t nSamplesToConsume = nSamplesToDrop + nSamplesToPublish;
 
@@ -234,7 +234,7 @@ Note: We assume that desynchronization should not exceed the buffer size of the 
 
     constexpr void publishDroppedSamplesTagIfNotZero(OutputSpanLike auto& out, std::size_t nDroppedSamples) {
         if (nDroppedSamples > 0UZ) {
-            out.publishTag({{gr::tag::N_DROPPED_SAMPLES.shortKey(), nDroppedSamples}}, 0UZ);
+            out.publishTag(property_map{{gr::tag::N_DROPPED_SAMPLES.shortKey(), nDroppedSamples}}, 0UZ);
         }
     }
 

--- a/blocks/basic/test/qa_StreamToDataSet.cpp
+++ b/blocks/basic/test/qa_StreamToDataSet.cpp
@@ -116,10 +116,62 @@ const boost::ut::suite<"StreamToDataSet Block"> selectorTest = [] {
     tag("visual") / "single trigger"_test              = [&runUIExample] { runUIExample(10, "CMD_DIAG_TRIGGER1", 30, 30); };
 };
 
-gr::Tag genTrigger(std::size_t index, std::string triggerName, std::string triggerCtx = {}) {
-    return {index, {{gr::tag::TRIGGER_NAME.shortKey(), triggerName}, {gr::tag::TRIGGER_TIME.shortKey(), std::uint64_t(0)}, {gr::tag::TRIGGER_OFFSET.shortKey(), 0.f}, //
-                       {gr::tag::CONTEXT.shortKey(), triggerCtx},                                                                                                     //
-                       {gr::tag::TRIGGER_META_INFO.shortKey(), gr::property_map{}}}};
+// Provide unique time values to avoid deduplication of tags
+inline std::uint64_t gTriggerTimeCounter = 0;
+inline std::uint64_t nextTriggerTime() { return gTriggerTimeCounter++; }
+inline void          resetTriggerTime(std::uint64_t v = 0) { gTriggerTimeCounter = v; }
+gr::Tag              genTrigger(std::size_t index, std::string triggerName, std::string triggerCtx, std::uint64_t triggerTime) {
+    return {index, {{gr::tag::TRIGGER_NAME.shortKey(), triggerName}, {gr::tag::TRIGGER_TIME.shortKey(), triggerTime}, {gr::tag::TRIGGER_OFFSET.shortKey(), 0.f}, //
+                                    {gr::tag::CONTEXT.shortKey(), triggerCtx}, {gr::tag::TRIGGER_META_INFO.shortKey(), gr::property_map{}}}};
+};
+
+gr::Tag genStart(std::size_t index, std::uint64_t triggerTime = std::numeric_limits<std::uint64_t>::max()) { return genTrigger(index, "CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=1", std::numeric_limits<std::uint64_t>::max() ? nextTriggerTime() : triggerTime); };
+
+gr::Tag genStop(std::size_t index, std::uint64_t triggerTime = std::numeric_limits<std::uint64_t>::max()) { return genTrigger(index, "CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=2", std::numeric_limits<std::uint64_t>::max() ? nextTriggerTime() : triggerTime); };
+
+gr::Tag genSingle(std::size_t index, std::uint64_t triggerTime = std::numeric_limits<std::uint64_t>::max()) { return genTrigger(index, "CMD_DIAG_TRIGGER1", "", std::numeric_limits<std::uint64_t>::max() ? nextTriggerTime() : triggerTime); };
+
+gr::Tag genNoTrigger(std::size_t index, std::uint64_t triggerTime = std::numeric_limits<std::uint64_t>::max()) { return genTrigger(index, "NO_TRIGGER", "", std::numeric_limits<std::uint64_t>::max() ? nextTriggerTime() : triggerTime); };
+
+void runTestStream(gr::Size_t nSamples, std::string filter, gr::Size_t preSamples, gr::Size_t postSamples, const std::vector<float>& expectedValues, const std::vector<gr::Tag>& expectedTags, std::source_location srcLocation = std::source_location::current()) {
+    using namespace boost::ut;
+    using namespace gr;
+    using namespace gr::basic;
+    using namespace gr::testing;
+
+    const auto locationStr = std::format("{}:{} ", srcLocation.file_name(), srcLocation.line());
+
+    constexpr float sampleRate = 1'000.f;
+    Graph           graph;
+
+    auto& tagSrc = graph.emplaceBlock<TagSource<float, ProcessFunction::USE_PROCESS_BULK>>({{"sample_rate", sampleRate}, //
+        {"n_samples_max", nSamples}, {"name", "TagSource"}, {"verbose_console", false}, {"repeat_tags", false}, {"mark_tag", false}});
+
+    resetTriggerTime();
+    // 'NoTrigger' and 'Single' can split processing into two iterations or act as the end trigger in "including" mode.
+    tagSrc._tags = {genNoTrigger(2), genSingle(4), genStart(5), genSingle(8), genStop(10), genSingle(12), genStart(15), genStop(20), genSingle(22)};
+
+    const property_map blockSettings        = {{"filter", filter}, {"n_pre", preSamples}, {"n_post", postSamples}};
+    auto&              filterStreamToStream = graph.emplaceBlock<StreamFilter<float>>(blockSettings);
+    auto&              streamSink           = graph.emplaceBlock<TagSink<float, ProcessFunction::USE_PROCESS_ONE>>({{"name", "streamSink"}, {"log_tags", true}, {"log_samples", true}, {"verbose_console", false}});
+    expect(eq(gr::ConnectionResult::SUCCESS, graph.connect<"out">(tagSrc).template to<"in">(filterStreamToStream))) << locationStr;
+    expect(eq(gr::ConnectionResult::SUCCESS, graph.connect<"out">(filterStreamToStream).template to<"in">(streamSink))) << locationStr;
+
+    gr::scheduler::Simple sched;
+    if (auto ret = sched.exchange(std::move(graph)); !ret) {
+        throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+    }
+    std::println("start -> Stream-to-Stream with filter: {} n_pre:{} n_post:{}", filter, preSamples, postSamples);
+    expect(sched.runAndWait().has_value()) << std::format("runAndWait - filter {}", filter) << locationStr;
+    std::println("done -> Stream-to-Stream with filter: {} n_pre:{} n_post:{}", filter, preSamples, postSamples);
+
+    expect(eq(tagSrc.sample_rate, sampleRate)) << locationStr;
+    expect(eq(filterStreamToStream.sample_rate, sampleRate)) << locationStr;
+    expect(eq(streamSink.sample_rate, sampleRate)) << locationStr;
+
+    expect(eq(streamSink._samples.size(), expectedValues.size())) << locationStr;
+    expect(std::ranges::equal(streamSink._samples, expectedValues)) << locationStr;
+    expect(equal_tag_lists(streamSink._tags, expectedTags)) << locationStr;
 };
 
 const boost::ut::suite<"StreamToStream test"> streamToStreamTest = [] {
@@ -128,65 +180,160 @@ const boost::ut::suite<"StreamToStream test"> streamToStreamTest = [] {
     using namespace gr::basic;
     using namespace gr::testing;
 
-    auto runTestStream = [](gr::Size_t nSamples, std::string filter, gr::Size_t preSamples, gr::Size_t postSamples, const std::vector<float>& expectedValues, std::size_t nTags) {
-        constexpr float sample_rate = 1'000.f;
-        Graph           graph;
-
-        auto& tagSrc = graph.emplaceBlock<TagSource<float, ProcessFunction::USE_PROCESS_BULK>>({{"sample_rate", sample_rate}, //
-            {"n_samples_max", nSamples}, {"name", "TagSource"}, {"verbose_console", false}, {"repeat_tags", false}, {"mark_tag", false}});
-        tagSrc._tags = {
-            genTrigger(5, "CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=1"),  // start
-            genTrigger(8, "CMD_DIAG_TRIGGER1", ""),                      // it is also used to split samples processing into 2 iterations
-            genTrigger(10, "CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=2"), // stop
-            genTrigger(12, "CMD_DIAG_TRIGGER1", ""),                     // it is also used as end trigger for "including" mode
-            genTrigger(15, "CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=1"), // start
-            genTrigger(20, "CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=2"), // stop
-            genTrigger(22, "CMD_DIAG_TRIGGER1", "")                      // it is also used as end trigger for "including" mode
-        };
-
-        const property_map blockSettings        = {{"filter", filter}, {"n_pre", preSamples}, {"n_post", postSamples}};
-        auto&              filterStreamToStream = graph.emplaceBlock<StreamFilter<float>>(blockSettings);
-        auto&              streamSink           = graph.emplaceBlock<TagSink<float, ProcessFunction::USE_PROCESS_ONE>>({{"name", "streamSink"}, {"log_tags", true}, {"log_samples", true}, {"verbose_console", false}});
-        expect(eq(gr::ConnectionResult::SUCCESS, graph.connect<"out">(tagSrc).template to<"in">(filterStreamToStream)));
-        expect(eq(gr::ConnectionResult::SUCCESS, graph.connect<"out">(filterStreamToStream).template to<"in">(streamSink)));
-
-        gr::scheduler::Simple sched;
-        if (auto ret = sched.exchange(std::move(graph)); !ret) {
-            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
-        }
-        std::println("start -> Stream-to-Stream with filter: {} n_pre:{} n_post:{}", filter, preSamples, postSamples);
-        expect(sched.runAndWait().has_value()) << std::format("runAndWait - filter {}", filter);
-        std::println("done -> Stream-to-Stream with filter: {} n_pre:{} n_post:{}", filter, preSamples, postSamples);
-
-        expect(eq(tagSrc.sample_rate, sample_rate));
-        expect(eq(filterStreamToStream.sample_rate, sample_rate));
-        expect(eq(streamSink.sample_rate, sample_rate));
-
-        expect(eq(streamSink._samples.size(), expectedValues.size()));
-        expect(std::ranges::equal(streamSink._samples, expectedValues));
-
-        expect(eq(streamSink._tags.size(), nTags)) << [&]() {
-            std::string ret = std::format("Stream nTags: {}\n", streamSink._tags.size());
-            for (const auto& tag : streamSink._tags) {
-                ret += std::format("tag.index: {} .map: {}\n", tag.index, tag.map);
-            }
-            return ret;
-        }();
-    };
     // We always test scenarios where no overlaps occur. If accumulation is currently active in the block, no new "Start" should happen.
     // Any new Start events are ignored, and this behavior is considered undefined for stream-to-stream mode
-    std::vector<float> expectedValues                = {5, 6, 7, 8, 9, 15, 16, 17, 18, 19};
-    "start->stop matcher (excluding)"_test           = [&runTestStream, &expectedValues] { runTestStream(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2]", 0, 0, expectedValues, 3UZ /* 2 BPs (2 starts) + custom diag trigger */); };
-    expectedValues                                   = {3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 14, 15, 16, 17, 18, 19, 20, 21};
-    "start->stop matcher (excluding +pre/post)"_test = [&runTestStream, &expectedValues] { runTestStream(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2]", 2, 2, expectedValues, 5UZ /* 4 BPs (2 starts + 2 stops) + custom diag trigger */); };
 
-    expectedValues                                     = {5, 6, 7, 8, 9, 10, 11, 15, 16, 17, 18, 19, 20, 21};
-    "start->^stop matcher (including)"_test            = [&runTestStream, &expectedValues] { runTestStream(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/^FAIR.SELECTOR.C=1:S=1:P=2]", 0, 0, expectedValues, 5UZ /* 4 BPs (2 starts + 2 stops) + custom diag trigger */); };
-    expectedValues                                     = {3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23};
-    "start->^stop matcher (including. +pre/post)"_test = [&runTestStream, &expectedValues] { runTestStream(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/^FAIR.SELECTOR.C=1:S=1:P=2]", 2, 2, expectedValues, 7UZ /* 4 BPs (2 starts + 2 stops) + 3 custom diag event */); };
+    "start->stop matcher (excluding)"_test = [] {
+        const std::vector<float> expectedValues = {5, 6, 7, 8, 9, 15, 16, 17, 18, 19};
+        resetTriggerTime();
+        const std::vector<Tag> expectedTags = {
+            Tag{0, {{"sample_rate", 1000.f}}}, // out-of-range tag
+            genNoTrigger(0),                   // out-of-range tag
+            genSingle(0),                      // out-of-range tag
+            genStart(0),                       //
+            genSingle(3),                      //
+            genStop(5),                        // out-of-range tag
+            genSingle(5),                      // out-of-range tag
+            genStart(5),                       // start only; no stop published (no more chunks published after stop)
+        };
+        runTestStream(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2]", 0, 0, expectedValues, expectedTags);
+    };
 
-    expectedValues                    = {6, 7, 8, 9, 10, 11, 12, 13, 20, 21, 22, 23};
-    "single trigger (+pre/post)"_test = [&runTestStream, &expectedValues] { runTestStream(50U, "CMD_DIAG_TRIGGER1", 2, 2, expectedValues, 3UZ); };
+    "start->stop matcher (excluding +pre/post)"_test = [] {
+        const std::vector<float> expectedValues = {3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 14, 15, 16, 17, 18, 19, 20, 21};
+        resetTriggerTime();
+        const std::vector<Tag> expectedTags = {
+            Tag{0, {{"sample_rate", 1000.f}}}, // out-of-range tag
+            genNoTrigger(0),                   // out-of-range tag
+            genSingle(1),                      // history tag, correct index
+            genStart(2),                       //
+            genSingle(5),                      //
+            genStop(7),                        //
+            genSingle(9),                      // out-of-range tag
+            genStart(11),                      //
+            genStop(16),                       //
+        };
+        runTestStream(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2]", 2, 2, expectedValues, expectedTags);
+    };
+
+    "start->^stop matcher (including)"_test = [] {
+        const std::vector<float> expectedValues = {5, 6, 7, 8, 9, 10, 11, 15, 16, 17, 18, 19, 20, 21};
+        resetTriggerTime();
+        const std::vector<Tag> expectedTags = {
+            Tag{0, {{"sample_rate", 1000.f}}}, // out-of-range tag
+            genNoTrigger(0),                   // out-of-range tag
+            genSingle(0),                      // out-of-range tag
+            genStart(0),                       //
+            genSingle(3),                      //
+            genStop(5),                        //
+            genSingle(7),                      // out-of-range tag
+            genStart(7),                       //
+            genStop(12),                       //
+        };
+        runTestStream(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/^FAIR.SELECTOR.C=1:S=1:P=2]", 0, 0, expectedValues, expectedTags);
+    };
+
+    "start->^stop matcher (including. +pre/post)"_test = [] {
+        const std::vector<float> expectedValues = {3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23};
+        resetTriggerTime();
+        const std::vector<Tag> expectedTags = {
+            Tag{0, {{"sample_rate", 1000.f}}}, // out-of-range tag
+            genNoTrigger(0),                   // out-of-range tag
+            genSingle(1),                      // history tag, correct index
+            genStart(2),                       //
+            genSingle(5),                      //
+            genStop(7),                        //
+            genSingle(9),                      //
+            genStart(13),                      //
+            genStop(18),                       //
+            genSingle(20),                     //
+        };
+        runTestStream(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/^FAIR.SELECTOR.C=1:S=1:P=2]", 2, 2, expectedValues, expectedTags);
+    };
+
+    "single trigger (+pre/post)"_test = [] {
+        const std::vector<float> expectedValues = {2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 20, 21, 22, 23};
+        resetTriggerTime();
+        const std::vector<Tag> expectedTags = {
+            Tag{0, {{"sample_rate", 1000.f}}}, // out-of-range tag
+            genNoTrigger(0),                   // out-of-range tag
+            genSingle(2),                      //
+            genStart(3),                       //
+            genSingle(6),                      //
+            genStop(8),                        //
+            genSingle(10),                     //
+            genStart(12),                      // out-of-range tag
+            genStop(12),                       //
+            genSingle(14),                     //
+        };
+        runTestStream(50U, "CMD_DIAG_TRIGGER1", 2, 2, expectedValues, expectedTags);
+    };
+};
+
+void runTestDataSet(gr::Size_t nSamples, std::string filter, gr::Size_t preSamples, gr::Size_t postSamples, const std::vector<std::vector<float>>& expectedValues, const std::vector<std::vector<gr::Tag>>& expectedTags, gr::Size_t maxSamples = 100000U, std::source_location srcLocation = std::source_location::current()) {
+    using namespace boost::ut;
+    using namespace gr;
+    using namespace gr::basic;
+    using namespace gr::testing;
+
+    const auto locationStr = std::format("{}:{} ", srcLocation.file_name(), srcLocation.line());
+
+    constexpr float sampleRate = 1'000.f;
+    Graph           graph;
+
+    auto& tagSrc = graph.emplaceBlock<TagSource<float, ProcessFunction::USE_PROCESS_BULK>>({{"sample_rate", sampleRate}, //
+        {"n_samples_max", nSamples}, {"name", "TagSource"}, {"verbose_console", false}, {"repeat_tags", false}, {"mark_tag", false}});
+
+    resetTriggerTime();
+    // 'NoTrigger' and 'Single' also split processing into two iterations or act as the end trigger in "including" mode.
+    tagSrc._tags = {genNoTrigger(2), genSingle(4), genStart(5), genSingle(8), genStop(10), genSingle(12), genStart(15), genStart(20), genStop(25), genSingle(27), genStop(30), genSingle(32)};
+
+    const property_map blockSettings         = {{"filter", filter}, {"n_pre", preSamples}, {"n_post", postSamples}, {"n_max", maxSamples}};
+    auto&              filterStreamToDataSet = graph.emplaceBlock<StreamToDataSet<float>>(blockSettings);
+    auto&              dataSetSink           = graph.emplaceBlock<TagSink<DataSet<float>, ProcessFunction::USE_PROCESS_BULK>>({{"name", "dataSetSink"}, {"log_tags", true}, {"log_samples", true}, {"verbose_console", false}});
+    expect(eq(gr::ConnectionResult::SUCCESS, graph.connect<"out">(tagSrc).template to<"in">(filterStreamToDataSet))) << locationStr;
+    expect(eq(gr::ConnectionResult::SUCCESS, graph.connect<"out">(filterStreamToDataSet).template to<"in">(dataSetSink))) << locationStr;
+
+    gr::scheduler::Simple sched;
+    if (auto ret = sched.exchange(std::move(graph)); !ret) {
+        throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+    }
+    std::println("start -> Stream-to-DataSet with filter: {} n_pre:{} n_post:{}", filter, preSamples, postSamples);
+    expect(sched.runAndWait().has_value()) << std::format("runAndWait - filter {}", filter) << locationStr;
+    std::println("done -> Stream-to-DataSet with filter: {} n_pre:{} n_post:{}", filter, preSamples, postSamples);
+
+    expect(eq(tagSrc.sample_rate, sampleRate)) << locationStr;
+    expect(eq(filterStreamToDataSet.sample_rate, sampleRate)) << locationStr;
+    expect(eq(dataSetSink.sample_rate, sampleRate)) << locationStr;
+
+    expect(eq(dataSetSink._samples.size(), expectedValues.size())) << locationStr;
+    for (std::size_t i = 0; i < dataSetSink._samples.size(); i++) {
+        const DataSet<float>&          ds      = dataSetSink._samples.at(i);
+        std::expected<void, gr::Error> dsCheck = dataset::checkConsistency(ds, "TestDataSet");
+        expect(dsCheck.has_value()) << [&] { return std::format("unexpected: {}", dsCheck.error()); } << fatal << locationStr;
+        expect(std::ranges::equal(ds.signal_values, expectedValues[i])) << locationStr;
+
+        expect(fatal(eq(ds.timing_events.size(), 1UZ))) << locationStr;
+        const auto& timingEvt0 = ds.timing_events[0];
+        expect(eq(timingEvt0.size(), expectedTags[i].size())) << locationStr;
+        auto             view = timingEvt0 | std::views::transform([](const auto& p) { return Tag(static_cast<std::size_t>(p.first), p.second); });
+        std::vector<Tag> tags(std::ranges::begin(view), std::ranges::end(view));
+        // don't check trigger time tag for now because for the expected tags they are not correct, they must be set by hand
+        expect(equal_tag_lists(tags, expectedTags[i], std::vector<std::string>{gr::tag::TRIGGER_TIME.shortKey()})) << locationStr;
+    }
+
+    // check auto-forwarded tags
+    expect(le(dataSetSink._tags.size(), tagSrc._tags.size() + 1)) << locationStr; // not all src tags are auto-forwarded, because no more published DataSets
+    std::size_t counter = 0;
+    for (const Tag& tag : dataSetSink._tags) {
+        expect(le(tag.index, dataSetSink._samples.size() - 1)) << locationStr;
+        if (counter == 0) {
+            expect(tag.map == property_map{{"sample_rate", 1000.f}}) << locationStr;
+        } else {
+            expect(tag.map == tagSrc._tags[counter - 1].map) << locationStr;
+        }
+        counter++;
+    }
 };
 
 const boost::ut::suite<"StreamToDataSet test"> streamToDataSetTest = [] {
@@ -195,113 +342,147 @@ const boost::ut::suite<"StreamToDataSet test"> streamToDataSetTest = [] {
     using namespace gr::basic;
     using namespace gr::testing;
 
-    auto runTestDataSet = [](gr::Size_t nSamples, std::string filter, gr::Size_t preSamples, gr::Size_t postSamples, const std::vector<std::vector<float>>& expectedValues, const std::vector<std::size_t>& nTags, gr::Size_t maxSamples = 100000U) {
-        using namespace gr;
-        using namespace gr::basic;
-        using namespace gr::testing;
+    const std::vector<std::vector<float>> expectedValues1 = { //
+        {5, 6, 7, 8, 9},                                      //
+        {15, 16, 17, 18, 19, 20, 21, 22, 23, 24},             //
+        {20, 21, 22, 23, 24, 25, 26, 27, 28, 29}};
 
-        constexpr float sample_rate = 1'000.f;
-        Graph           graph;
-
-        auto& tagSrc = graph.emplaceBlock<TagSource<float, ProcessFunction::USE_PROCESS_BULK>>({{"sample_rate", sample_rate}, //
-            {"n_samples_max", nSamples}, {"name", "TagSource"}, {"verbose_console", false}, {"repeat_tags", false}, {"mark_tag", false}});
-        tagSrc._tags = {
-            genTrigger(5, "CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=1"),  // start
-            genTrigger(8, "CMD_DIAG_TRIGGER1", ""),                      // it is also used to split samples processing into 2 iterations
-            genTrigger(10, "CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=2"), // stop
-            genTrigger(12, "CMD_DIAG_TRIGGER1", ""),                     // it is also used as end trigger for "including" mode
-            genTrigger(15, "CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=1"), // start
-            genTrigger(20, "CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=1"), // start
-            genTrigger(25, "CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=2"), // stop
-            genTrigger(27, "CMD_DIAG_TRIGGER1", ""),                     // it is also used as end trigger for "including" mode
-            genTrigger(30, "CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=2"), // stop
-            genTrigger(32, "CMD_DIAG_TRIGGER1", "")                      // it is also used as end trigger for "including" mode
-        };
-
-        const property_map blockSettings         = {{"filter", filter}, {"n_pre", preSamples}, {"n_post", postSamples}, {"n_max", maxSamples}};
-        auto&              filterStreamToDataSet = graph.emplaceBlock<StreamToDataSet<float>>(blockSettings);
-        auto&              dataSetSink           = graph.emplaceBlock<TagSink<DataSet<float>, ProcessFunction::USE_PROCESS_BULK>>({{"name", "dataSetSink"}, {"log_tags", true}, {"log_samples", true}, {"verbose_console", false}});
-        expect(eq(gr::ConnectionResult::SUCCESS, graph.connect<"out">(tagSrc).template to<"in">(filterStreamToDataSet)));
-        expect(eq(gr::ConnectionResult::SUCCESS, graph.connect<"out">(filterStreamToDataSet).template to<"in">(dataSetSink)));
-
-        gr::scheduler::Simple sched;
-        if (auto ret = sched.exchange(std::move(graph)); !ret) {
-            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
-        }
-        std::println("start -> Stream-to-DataSet with filter: {} n_pre:{} n_post:{}", filter, preSamples, postSamples);
-        expect(sched.runAndWait().has_value()) << std::format("runAndWait - filter {}", filter);
-        std::println("done -> Stream-to-DataSet with filter: {} n_pre:{} n_post:{}", filter, preSamples, postSamples);
-
-        expect(eq(tagSrc.sample_rate, sample_rate));
-        expect(eq(filterStreamToDataSet.sample_rate, sample_rate));
-        expect(eq(dataSetSink.sample_rate, sample_rate));
-
-        expect(eq(dataSetSink._samples.size(), expectedValues.size()));
-        for (std::size_t i = 0; i < dataSetSink._samples.size(); i++) {
-            const DataSet<float>&          ds      = dataSetSink._samples.at(i);
-            std::expected<void, gr::Error> dsCheck = dataset::checkConsistency(ds, "TestDataSet");
-            expect(dsCheck.has_value()) << [&] { return std::format("unexpected: {}", dsCheck.error()); } << fatal;
-            expect(std::ranges::equal(ds.signal_values, expectedValues[i]));
-
-            expect(fatal(eq(ds.timing_events.size(), 1UZ)));
-            const auto& timingEvt0 = ds.timing_events[0];
-            expect(eq(timingEvt0.size(), nTags[i])) << [&]() {
-                std::string ret = std::format("DataSet nTags: {}\n", timingEvt0.size());
-                for (const auto& tag : timingEvt0) {
-                    ret += std::format("tag.index: {} .map: {}\n", tag.first, tag.second);
-                }
-                return ret;
-            }();
-        }
+    const std::vector<std::vector<gr::Tag>> expectedTags1 = { //
+        {genStart(0), genSingle(3)},                          //
+        {genStart(0), genStart(5)},                           //
+        {genStart(0), genStop(5), genSingle(7)}};
+    "start->stop (excluding)"_test                        = [&expectedValues1, &expectedTags1] { //
+        runTestDataSet(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2]", 0, 0, expectedValues1, expectedTags1);
+    };
+    "start->stop (excluding) n_max=0"_test = [&expectedValues1, &expectedTags1] { //
+        runTestDataSet(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2]", 0, 0, expectedValues1, expectedTags1, 0UZ);
     };
 
-    std::vector<std::vector<float>> expectedValues = {{5, 6, 7, 8, 9}, {15, 16, 17, 18, 19, 20, 21, 22, 23, 24}, {20, 21, 22, 23, 24, 25, 26, 27, 28, 29}};
-    "start->stop (excluding)"_test                 = [&runTestDataSet, &expectedValues] { runTestDataSet(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2]", 0, 0, expectedValues, {3UZ, 3UZ, 4UZ}); };
-    "start->stop (excluding) n_max=0"_test         = [&runTestDataSet, &expectedValues] { runTestDataSet(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2]", 0, 0, expectedValues, {3UZ, 3UZ, 4UZ}, 0UZ); };
+    "start->stop (excluding +pre/post)"_test = [] {
+        const std::vector<std::vector<float>>   expectedValues = {                                            //
+            {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},                                     //
+            {8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31}, //
+            {13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36}};
+        const std::vector<std::vector<gr::Tag>> expectedTags   = {                                                                                     //
+            {Tag{0, {{"sample_rate", 1000.f}}}, genNoTrigger(2), genSingle(4), genStart(5), genSingle(8), genStop(10), genSingle(12), genStart(15)}, //
+            {genSingle(0), genStop(2), genSingle(4), genStart(7), genStart(12), genStop(17), genSingle(19), genStop(22)},                            //
+            {genStart(2), genStart(7), genStop(12), genSingle(14), genStop(17), genSingle(19)}};
+        runTestDataSet(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2]", 7, 7, expectedValues, expectedTags);
+    };
 
-    expectedValues                           = {{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},                       //
-                                  {8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31}, //
-                                  {13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36}};
-    "start->stop (excluding +pre/post)"_test = [&runTestDataSet, &expectedValues] { runTestDataSet(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2]", 7, 7, expectedValues, {5UZ, 5UZ, 5UZ}); };
+    const std::vector<std::vector<float>>   expectedValues2 = { //
+        {5, 6, 7, 8, 9, 10, 11},                              //
+        {15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26},     //
+        {20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31}};
+    const std::vector<std::vector<gr::Tag>> expectedTags2   = { //
+        {genStart(0), genSingle(3), genStop(5)},              //
+        {genStart(0), genStart(5), genStop(10)},              //
+        {genStart(0), genStop(5), genSingle(7), genStop(10)}};
+    "start->^stop (including)"_test                         = [&expectedValues2, &expectedTags2] { //
+        runTestDataSet(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/^FAIR.SELECTOR.C=1:S=1:P=2]", 0, 0, expectedValues2, expectedTags2);
+    };
+    "start->^stop (including) n_max=0"_test = [&expectedValues2, &expectedTags2] { //
+        runTestDataSet(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/^FAIR.SELECTOR.C=1:S=1:P=2]", 0, 0, expectedValues2, expectedTags2, 0UZ);
+    };
 
-    expectedValues                          = {{5, 6, 7, 8, 9, 10, 11}, {15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26}, {20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31}};
-    "start->^stop (including)"_test         = [&runTestDataSet, &expectedValues] { runTestDataSet(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/^FAIR.SELECTOR.C=1:S=1:P=2]", 0, 0, expectedValues, {4UZ, 4UZ, 5UZ}); };
-    "start->^stop (including) n_max=0"_test = [&runTestDataSet, &expectedValues] { runTestDataSet(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/^FAIR.SELECTOR.C=1:S=1:P=2]", 0, 0, expectedValues, {4UZ, 4UZ, 5UZ}, 0UZ); };
+    "start->^stop (including. +pre/post)"_test = [] {
+        const std::vector<std::vector<float>>   expectedValues = {                                                    //
+            {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18},                                     //
+            {8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33}, //
+            {13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38}};
+        const std::vector<std::vector<gr::Tag>> expectedTags   = {                                                                                     //
+            {Tag{0, {{"sample_rate", 1000.f}}}, genNoTrigger(2), genSingle(4), genStart(5), genSingle(8), genStop(10), genSingle(12), genStart(15)}, //
+            {genSingle(0), genStop(2), genSingle(4), genStart(7), genStart(12), genStop(17), genSingle(19), genStop(22), genSingle(24)},             //
+            {genStart(2), genStart(7), genStop(12), genSingle(14), genStop(17), genSingle(19)}};
+        runTestDataSet(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/^FAIR.SELECTOR.C=1:S=1:P=2]", 7, 7, expectedValues, expectedTags);
+    };
 
-    expectedValues                             = {{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18},                       //
-                                    {8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33}, //
-                                    {13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38}};
-    "start->^stop (including. +pre/post)"_test = [&runTestDataSet, &expectedValues] { runTestDataSet(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/^FAIR.SELECTOR.C=1:S=1:P=2]", 7, 7, expectedValues, {5UZ, 6UZ, 5UZ}); };
+    "single trigger (+pre/post)"_test = [] {
+        const std::vector<std::vector<float>>   expectedValues = {      //
+            {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},                       //
+            {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14},          //
+            {5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18},      //
+            {20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33}, //
+            {25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38}};
+        const std::vector<std::vector<gr::Tag>> expectedTags   = {                                                        //
+            {Tag{0, {{"sample_rate", 1000.f}}}, genNoTrigger(2), genSingle(4), genStart(5), genSingle(8), genStop(10)}, //
+            {genNoTrigger(1), genSingle(3), genStart(4), genSingle(7), genStop(9), genSingle(11)},                      //
+            {genStart(0), genSingle(3), genStop(5), genSingle(7), genStart(10)},                                        //
+            {genStart(0), genStop(5), genSingle(7), genStop(10), genSingle(12)},                                        //
+            {genStop(0), genSingle(2), genStop(5), genSingle(7)}};
+        runTestDataSet(50U, "CMD_DIAG_TRIGGER1", 7, 7, expectedValues, expectedTags);
+    };
 
-    expectedValues                    = {{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14}, //
-                           {5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18},           //
-                           {20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33},      //
-                           {25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38}};
-    "single trigger (+pre/post)"_test = [&runTestDataSet, &expectedValues] { runTestDataSet(50U, "CMD_DIAG_TRIGGER1", 7, 7, expectedValues, {3UZ, 2UZ, 3UZ, 1UZ}); };
+    // n_max tests
+    "start->stop (excluding, n_max)"_test = [] {
+        const gr::Size_t                        nMaxSamples    = 6;
+        const std::vector<std::vector<float>>   expectedValues = { //
+            {5, 6, 7, 8, 9},                                     //
+            {15, 16, 17, 18, 19, 20},                            //
+            {20, 21, 22, 23, 24, 25}};
+        const std::vector<std::vector<gr::Tag>> expectedTags   = { //
+            {genStart(0), genSingle(3)},                         //
+            {genStart(0), genStart(5)},                          //
+            {genStart(0), genStop(5)}};
+        runTestDataSet(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2]", 0, 0, expectedValues, expectedTags, nMaxSamples);
+    };
 
-    // n_max test
-    gr::Size_t nMaxSamples                = 6;
-    expectedValues                        = {{5, 6, 7, 8, 9}, {15, 16, 17, 18, 19, 20}, {20, 21, 22, 23, 24, 25}};
-    "start->stop (excluding, n_max)"_test = [&runTestDataSet, &expectedValues, &nMaxSamples] { runTestDataSet(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2]", 0, 0, expectedValues, {3UZ, 2UZ, 2UZ}, nMaxSamples); };
+    "start->stop (excluding +pre/post, n_max)"_test = [] {
+        const gr::Size_t                        nMaxSamples    = 14;
+        const std::vector<std::vector<float>>   expectedValues = {    //
+            {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13},         //
+            {8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21}, //
+            {13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26}};
+        const std::vector<std::vector<gr::Tag>> expectedTags   = {                                                                       //
+            {Tag{0, {{"sample_rate", 1000.f}}}, genNoTrigger(2), genSingle(4), genStart(5), genSingle(8), genStop(10), genSingle(12)}, //
+            {genSingle(0), genStop(2), genSingle(4), genStart(7), genStart(12)},                                                       //
+            {genStart(2), genStart(7), genStop(12)}};
+        runTestDataSet(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2]", 7, 7, expectedValues, expectedTags, nMaxSamples);
+    };
 
-    nMaxSamples                                     = 14;
-    expectedValues                                  = {{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13}, {8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21}, {13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26}};
-    "start->stop (excluding +pre/post, n_max)"_test = [&runTestDataSet, &expectedValues, &nMaxSamples] { runTestDataSet(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2]", 7, 7, expectedValues, {4UZ, 2UZ, 2UZ}, nMaxSamples); };
+    "start->^stop (including, n_max)"_test = [] {
+        const gr::Size_t                        nMaxSamples    = 6;
+        const std::vector<std::vector<float>>   expectedValues = { //
+            {5, 6, 7, 8, 9, 10},                                 //
+            {15, 16, 17, 18, 19, 20},                            //
+            {20, 21, 22, 23, 24, 25}};
+        const std::vector<std::vector<gr::Tag>> expectedTags   = { //
+            {genStart(0), genSingle(3), genStop(5)},             //
+            {genStart(0), genStart(5)},                          //
+            {genStart(0), genStop(5)}};
+        runTestDataSet(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/^FAIR.SELECTOR.C=1:S=1:P=2]", 0, 0, expectedValues, expectedTags, nMaxSamples);
+    };
 
-    nMaxSamples                            = 6;
-    expectedValues                         = {{5, 6, 7, 8, 9, 10}, {15, 16, 17, 18, 19, 20}, {20, 21, 22, 23, 24, 25}};
-    "start->^stop (including, n_max)"_test = [&runTestDataSet, &expectedValues, &nMaxSamples] { runTestDataSet(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/^FAIR.SELECTOR.C=1:S=1:P=2]", 0, 0, expectedValues, {3UZ, 2UZ, 2UZ}, nMaxSamples); };
+    "start->^stop (including. +pre/post, n_max)"_test = [] {
+        const gr::Size_t                        nMaxSamples    = 14;
+        const std::vector<std::vector<float>>   expectedValues = {    //
+            {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13},         //
+            {8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21}, //
+            {13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26}};
+        const std::vector<std::vector<gr::Tag>> expectedTags   = {                                                                       //
+            {Tag{0, {{"sample_rate", 1000.f}}}, genNoTrigger(2), genSingle(4), genStart(5), genSingle(8), genStop(10), genSingle(12)}, //
+            {genSingle(0), genStop(2), genSingle(4), genStart(7), genStart(12)},                                                       //
+            {genStart(2), genStart(7), genStop(12)}};
+        runTestDataSet(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/^FAIR.SELECTOR.C=1:S=1:P=2]", 7, 7, expectedValues, expectedTags, nMaxSamples);
+    };
 
-    nMaxSamples                                       = 14;
-    expectedValues                                    = {{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13}, {8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21}, {13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26}};
-    "start->^stop (including. +pre/post, n_max)"_test = [&runTestDataSet, &expectedValues, &nMaxSamples] { runTestDataSet(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/^FAIR.SELECTOR.C=1:S=1:P=2]", 7, 7, expectedValues, {4UZ, 2UZ, 2UZ}, nMaxSamples); };
+    "single trigger (+pre/post, n_max)"_test = [] {
+        const gr::Size_t                        nMaxSamples    = 14;
+        const std::vector<std::vector<float>>   expectedValues = {      //
+            {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},                       //
+            {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14},          //
+            {5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18},      //
+            {20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33}, //
+            {25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38}};
+        const std::vector<std::vector<gr::Tag>> expectedTags   = {                                                        //
+            {Tag{0, {{"sample_rate", 1000.f}}}, genNoTrigger(2), genSingle(4), genStart(5), genSingle(8), genStop(10)}, //
+            {genNoTrigger(1), genSingle(3), genStart(4), genSingle(7), genStop(9), genSingle(11)},                      //
+            {genStart(0), genSingle(3), genStop(5), genSingle(7), genStart(10)},                                        //
+            {genStart(0), genStop(5), genSingle(7), genStop(10), genSingle(12)},                                        //
+            {genStop(0), genSingle(2), genStop(5), genSingle(7)}};
 
-    nMaxSamples                              = 14;
-    expectedValues                           = {{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14}, //
-                                  {5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18},           //
-                                  {20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33},      //
-                                  {25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38}};
-    "single trigger (+pre/post, n_max)"_test = [&runTestDataSet, &expectedValues, &nMaxSamples] { runTestDataSet(50U, "CMD_DIAG_TRIGGER1", 7, 7, expectedValues, {3UZ, 2UZ, 3UZ, 1UZ}, nMaxSamples); };
+        runTestDataSet(50U, "CMD_DIAG_TRIGGER1", 7, 7, expectedValues, expectedTags, nMaxSamples);
+    };
 };
 
 int main() { /* not needed for UT */ }

--- a/blocks/testing/include/gnuradio-4.0/testing/TagMonitors.hpp
+++ b/blocks/testing/include/gnuradio-4.0/testing/TagMonitors.hpp
@@ -104,12 +104,13 @@ struct TagSource : Block<TagSource<T, UseProcessVariant>> {
     float          sample_rate     = 1000.0f;
     std::string    signal_name     = "unknown signal";
     std::string    signal_unit     = "unknown unit";
+    std::string    signal_quantity = "unknown quantity";
     float          signal_min      = std::numeric_limits<float>::lowest();
     float          signal_max      = std::numeric_limits<float>::max();
     bool           verbose_console = false;
     bool           mark_tag        = true; // true: mark tagged samples with '1' or '0' otherwise. false: [0, 1, 2, ..., ], if values is not empty mark_tag is ignored
 
-    GR_MAKE_REFLECTABLE(TagSource, out, n_samples_max, sample_rate, signal_name, signal_unit, signal_min, signal_max, verbose_console, mark_tag, values, repeat_tags);
+    GR_MAKE_REFLECTABLE(TagSource, out, n_samples_max, sample_rate, signal_name, signal_unit, signal_quantity, signal_min, signal_max, verbose_console, mark_tag, values, repeat_tags);
 
     std::vector<Tag> _tags{};                 // It is expected that Tag.index is in ascending order
     std::size_t      _tagIndex{0};            // current index in tags array
@@ -134,7 +135,7 @@ struct TagSource : Block<TagSource<T, UseProcessVariant>> {
     T processOne() noexcept
     requires(UseProcessVariant == ProcessFunction::USE_PROCESS_ONE)
     {
-        const auto [tagGenerated, tagRepeatStarted] = generateTag(                                //
+        const auto [nGeneratedTags, tagRepeatStarted] = generateTag(                              //
             [this](const auto& map, std::size_t tagOffset) { this->publishTag(map, tagOffset); }, //
             "processOne(...)");
 
@@ -155,13 +156,13 @@ struct TagSource : Block<TagSource<T, UseProcessVariant>> {
             _valueIndex++;
             return currentValue;
         }
-        return mark_tag ? (tagGenerated ? static_cast<T>(1) : static_cast<T>(0)) : static_cast<T>(_nSamplesProduced);
+        return mark_tag ? (nGeneratedTags > 0 ? static_cast<T>(1) : static_cast<T>(0)) : static_cast<T>(_nSamplesProduced);
     }
 
     work::Status processBulk(OutputSpanLike auto& outSpan) noexcept
     requires(UseProcessVariant == ProcessFunction::USE_PROCESS_BULK)
     {
-        const auto [tagGenerated, tagRepeatStarted] = generateTag(                                //
+        const auto [nGeneratedTags, tagRepeatStarted] = generateTag(                              //
             [&outSpan](const auto& map, std::size_t offset) { outSpan.publishTag(map, offset); }, //
             "processBulk(...)");
 
@@ -193,7 +194,7 @@ struct TagSource : Block<TagSource<T, UseProcessVariant>> {
             }
         } else {
             if (mark_tag) {
-                outSpan[0] = tagGenerated ? static_cast<T>(1) : static_cast<T>(0);
+                outSpan[0] = nGeneratedTags > 0 ? static_cast<T>(1) : static_cast<T>(0);
             } else {
                 for (std::size_t i = 0; i < nSamples; ++i) {
                     outSpan[i] = static_cast<T>(_nSamplesProduced + i);
@@ -214,12 +215,21 @@ private:
     template<typename TPublishTagFunction>
     [[nodiscard]] auto generateTag(TPublishTagFunction&& publishTagFn, std::string_view processFunctionName) {
         struct {
-            bool tagGenerated     = false;
-            bool tagRepeatStarted = false;
+            std::size_t nGeneratedTags   = 0UZ;
+            bool        tagRepeatStarted = false;
         } result;
 
-        const auto nSamplesRemainder = getNProducedSamplesRemainder();
-        if (_tagIndex < _tags.size() && static_cast<gr::Size_t>(_tags[_tagIndex].index) <= nSamplesRemainder) {
+        if (_tags.empty() || _tagIndex >= _tags.size()) {
+            return result;
+        }
+
+        const std::size_t targetIndex       = _tags[_tagIndex].index;
+        const gr::Size_t  nSamplesRemainder = getNProducedSamplesRemainder();
+        if (static_cast<gr::Size_t>(targetIndex) > nSamplesRemainder) {
+            return result;
+        }
+
+        do {
             if (verbose_console) {
                 print_tag(_tags[_tagIndex], std::format("{}::{}\t publish tag at  {:6}", this->name.value, processFunctionName, _nSamplesProduced));
             }
@@ -229,12 +239,14 @@ private:
             }
             this->_outputTagsChanged = true;
             _tagIndex++;
-            if (repeat_tags && _tagIndex == _tags.size()) {
-                _tagIndex               = 0;
-                result.tagRepeatStarted = true;
-            }
-            result.tagGenerated = true;
+            result.nGeneratedTags++;
+        } while (_tagIndex < _tags.size() && _tags[_tagIndex].index == targetIndex);
+
+        if (repeat_tags && _tagIndex == _tags.size()) {
+            _tagIndex               = 0;
+            result.tagRepeatStarted = true;
         }
+
         return result;
     }
 
@@ -283,14 +295,16 @@ struct TagMonitor : public Block<TagMonitor<T, UseProcessVariant>> {
     requires(UseProcessVariant == ProcessFunction::USE_PROCESS_ONE)
     {
         if (this->inputTagsPresent()) {
-            const Tag& tag = this->mergedInputTag();
-            if (verbose_console) {
-                print_tag(tag, std::format("{}::processOne(...)\t received tag at {:6}", this->name, _nSamplesProduced));
-            }
-            if (log_tags) {
-                const auto& newTag = _tags.emplace_back(_nSamplesProduced, tag.map);
-                if (_tagCallback) {
-                    _tagCallback(newTag);
+            const auto tags = this->inputTags();
+            for (const Tag& tag : tags) {
+                if (verbose_console) {
+                    print_tag(tag, std::format("{}::processOne(...)\t received tag at {:6}", this->name, _nSamplesProduced));
+                }
+                if (log_tags) {
+                    const auto& newTag = _tags.emplace_back(_nSamplesProduced, tag.map);
+                    if (_tagCallback) {
+                        _tagCallback(newTag);
+                    }
                 }
             }
         }
@@ -305,14 +319,16 @@ struct TagMonitor : public Block<TagMonitor<T, UseProcessVariant>> {
     requires(UseProcessVariant == ProcessFunction::USE_PROCESS_BULK)
     {
         if (this->inputTagsPresent()) {
-            const Tag& tag = this->mergedInputTag();
-            if (verbose_console) {
-                print_tag(tag, std::format("{}::processBulk(...{}, ...{})\t received tag at {:6}", this->name, input.size(), output.size(), _nSamplesProduced));
-            }
-            if (log_tags) {
-                const auto& newTag = _tags.emplace_back(_nSamplesProduced, tag.map);
-                if (_tagCallback) {
-                    _tagCallback(newTag);
+            const auto tags = this->inputTags();
+            for (const Tag& tag : tags) {
+                if (verbose_console) {
+                    print_tag(tag, std::format("{}::processBulk(...{}, ...{})\t received tag at {:6}", this->name, input.size(), output.size(), _nSamplesProduced));
+                }
+                if (log_tags) {
+                    const auto& newTag = _tags.emplace_back(_nSamplesProduced, tag.map);
+                    if (_tagCallback) {
+                        _tagCallback(newTag);
+                    }
                 }
             }
         }
@@ -372,14 +388,16 @@ struct TagSink : public Block<TagSink<T, UseProcessVariant>> {
     requires(UseProcessVariant == ProcessFunction::USE_PROCESS_ONE)
     {
         if (this->inputTagsPresent()) {
-            const Tag& tag = this->mergedInputTag();
-            if (verbose_console) {
-                print_tag(tag, std::format("{}::processOne(...1)    \t received tag at {:6}", this->name, _nSamplesProduced));
-            }
-            if (log_tags) {
-                const auto& newTag = _tags.emplace_back(_nSamplesProduced, tag.map);
-                if (_tagCallback) {
-                    _tagCallback(newTag);
+            const auto tags = this->inputTags();
+            for (const Tag& tag : tags) {
+                if (verbose_console) {
+                    print_tag(tag, std::format("{}::processOne(...1)    \t received tag at {:6}", this->name, _nSamplesProduced));
+                }
+                if (log_tags) {
+                    const auto& newTag = _tags.emplace_back(_nSamplesProduced, tag.map);
+                    if (_tagCallback) {
+                        _tagCallback(newTag);
+                    }
                 }
             }
         }
@@ -397,14 +415,16 @@ struct TagSink : public Block<TagSink<T, UseProcessVariant>> {
     requires(UseProcessVariant == ProcessFunction::USE_PROCESS_BULK)
     {
         if (this->inputTagsPresent()) {
-            const Tag& tag = this->mergedInputTag();
-            if (verbose_console) {
-                print_tag(tag, std::format("{}::processBulk(...{})\t received tag at {:6}", this->name, input.size(), _nSamplesProduced));
-            }
-            if (log_tags) {
-                const auto& newTag = _tags.emplace_back(_nSamplesProduced, tag.map);
-                if (_tagCallback) {
-                    _tagCallback(newTag);
+            const auto tags = this->inputTags();
+            for (const Tag& tag : tags) {
+                if (verbose_console) {
+                    print_tag(tag, std::format("{}::processBulk(...{})\t received tag at {:6}", this->name, input.size(), _nSamplesProduced));
+                }
+                if (log_tags) {
+                    const auto& newTag = _tags.emplace_back(_nSamplesProduced, tag.map);
+                    if (_tagCallback) {
+                        _tagCallback(newTag);
+                    }
                 }
             }
         }

--- a/blocks/testing/include/gnuradio-4.0/testing/bm_test_helper.hpp
+++ b/blocks/testing/include/gnuradio-4.0/testing/bm_test_helper.hpp
@@ -53,11 +53,15 @@ struct sink : public gr::Block<sink<T, N_MIN, N_MAX>> {
     [[nodiscard]] constexpr auto processOne(T a) noexcept {
         // optional user-level tag processing
         if (this->inputTagsPresent()) {
-            if (this->inputTagsPresent() && this->mergedInputTag().map.contains("N_SAMPLES_MAX")) {
-                const auto value = this->mergedInputTag().map.at("N_SAMPLES_MAX");
-                if (std::holds_alternative<uint64_t>(value)) { // should be std::size_t but emscripten/pmtv seem to have issues with it
-                    should_receive_n_samples = std::get<uint64_t>(value);
-                    _last_tag_position       = in.streamReader().position();
+            const auto& inTags = this->inputTags();
+            for (const gr::Tag& tag : inTags) {
+                if (tag.map.contains("N_SAMPLES_MAX")) {
+                    const auto value = tag.map.at("N_SAMPLES_MAX");
+                    if (std::holds_alternative<uint64_t>(value)) { // should be std::size_t but emscripten/pmtv seem to have issues with it
+                        should_receive_n_samples = std::get<uint64_t>(value);
+                        _last_tag_position       = in.streamReader().position();
+                    }
+                    break;
                 }
             }
         }

--- a/core/include/gnuradio-4.0/BlockTraits.hpp
+++ b/core/include/gnuradio-4.0/BlockTraits.hpp
@@ -210,6 +210,7 @@ public:
     [[nodiscard]] constexpr iterator    begin() const noexcept { return internalSpan.begin(); }
     [[nodiscard]] constexpr iterator    end() const noexcept { return internalSpan.end(); }
     [[nodiscard]] constexpr std::size_t size() const noexcept { return internalSpan.size(); }
+
     operator const std::span<const T>&() const noexcept { return internalSpan; }
     operator std::span<const T>&() noexcept { return internalSpan; }
     // operator std::span<const T>&&() = delete;
@@ -224,7 +225,7 @@ struct DummyInputSpan : public DummyReaderSpan<T> {
     bool                     isConnected = true;
     bool                     isSync      = true;
     auto                     tags() { return std::views::empty<std::pair<std::size_t, const property_map&>>; }
-    [[nodiscard]] inline Tag getMergedTag(std::size_t /*untilLocalIndex*/) const { return {}; }
+    auto                     tags(std::size_t /*untilLocalIndex*/) { return std::views::empty<std::pair<std::size_t, const property_map&>>; }
     void                     consumeTags(std::size_t /*untilLocalIndex*/) {}
 };
 static_assert(ReaderSpanLike<DummyInputSpan<int>>);
@@ -249,6 +250,7 @@ public:
     [[nodiscard]] constexpr iterator    begin() const noexcept { return internalSpan.begin(); }
     [[nodiscard]] constexpr iterator    end() const noexcept { return internalSpan.end(); }
     [[nodiscard]] constexpr std::size_t size() const noexcept { return internalSpan.size(); }
+
     operator const std::span<T>&() const noexcept { return internalSpan; }
     operator std::span<T>&() noexcept { return internalSpan; }
 

--- a/core/include/gnuradio-4.0/Port.hpp
+++ b/core/include/gnuradio-4.0/Port.hpp
@@ -399,10 +399,10 @@ struct Async {};
  *     - For `Synch` ports, all samples are published by default.
  *     - For `Async` ports, no samples are published by default.
  * - Access to Tags:
- *   - Using `tags()`: Returns a `range::view` of input tags. Indices are relative to the first sample in the span and can be negative for unconsumed tags.
+ *   - Using `tags()`: Returns a `range::view` of all input tags. Indices are relative to the first sample in the span and can be negative for unconsumed tags.
+ *   - Using `tags(untilLocalIndex)`: Returns a `range::view` of input tags up to `untilLocalIndex` (exclusively). Indices are relative to the first sample in the span and can be negative for unconsumed tags.
  *   - Using `rawTags`: Provides direct access to the underlying `ReaderSpan<Tag>` for advanced manipulation.
  * - Consuming Tags: By default, tags associated with samples up to and including the first sample are consumed. One can manually consume tags up to a specific sample index using `consumeTags(streamSampleIndex)`.
- * - Merging Tags: Use `getMergedTag(untilLocalIndex)` to obtain a single tag that merges all tags up to `untilLocalIndex` (exclusively).
  */
 template<typename T>
 concept InputSpanLike = std::ranges::contiguous_range<T> && ConstSpanLike<T> && requires(T& span, std::size_t n) {
@@ -412,8 +412,8 @@ concept InputSpanLike = std::ranges::contiguous_range<T> && ConstSpanLike<T> && 
     { span.rawTags };
     requires ReaderSpanLike<std::remove_cvref_t<decltype(span.rawTags)>> && std::same_as<gr::Tag, std::ranges::range_value_t<decltype(span.rawTags)>>;
     { span.tags() } -> std::ranges::range;
+    { span.tags(n) } -> std::ranges::range;
     { span.consumeTags(n) };
-    { span.getMergedTag(n) } -> std::same_as<gr::Tag>;
 };
 
 /**
@@ -591,7 +591,7 @@ struct Port {
 
         InputSpan(std::size_t nSamples_, ReaderType& reader, TagReaderType& tagReader, bool connected, bool sync) //
             : ReaderSpanType<spanReleasePolicy>(reader.template get<spanReleasePolicy>(nSamples_)),               //
-              rawTags(getTags(nSamples_, tagReader, reader.position())),                                          //
+              rawTags(getTagsInRange(nSamples_, tagReader, reader.position())),                                   //
               streamIndex{reader.position()}, isConnected(connected), isSync(sync) {}
 
         InputSpan(const InputSpan&)            = default;
@@ -625,9 +625,15 @@ struct Port {
         }
 
         [[nodiscard]] auto tags() {
-            return std::views::transform(rawTags, [this](auto& tag) {
-                const auto relIndex = tag.index >= streamIndex ? static_cast<std::ptrdiff_t>(tag.index - streamIndex) : -static_cast<std::ptrdiff_t>(streamIndex - tag.index);
-                return std::make_pair(relIndex, std::ref(tag.map));
+            using PairRefType = std::pair<std::ptrdiff_t, std::reference_wrapper<const property_map>>;
+            return std::views::transform(rawTags, [this](const Tag& tag) -> PairRefType { return PairRefType{relIndex(tag.index, streamIndex), std::cref(tag.map)}; });
+        }
+
+        [[nodiscard]] auto tags(std::size_t untilLocalIndex) {
+            using PairRefType            = std::pair<std::ptrdiff_t, std::reference_wrapper<const property_map>>;
+            const std::size_t untilIndex = streamIndex + untilLocalIndex;
+            return rawTags | std::views::take_while([untilIndex](const Tag& t) { return t.index < untilIndex; }) | std::views::transform([this](const Tag& tag) -> PairRefType { //
+                return PairRefType{relIndex(tag.index, streamIndex), std::cref(tag.map)};
             });
         }
 
@@ -636,20 +642,10 @@ struct Port {
             std::ignore               = rawTags.tryConsume(tagsToConsume);
         }
 
-        [[nodiscard]] inline Tag getMergedTag(std::size_t untilLocalIndex = 1UZ) const {
-            auto mergeSrcMapInto = [](const property_map& sourceMap, property_map& destinationMap) {
-                assert(&sourceMap != &destinationMap);
-                for (const auto& [key, value] : sourceMap) {
-                    destinationMap.insert_or_assign(key, value);
-                }
-            };
-            Tag result{0UZ, {}};
-            std::ranges::for_each(rawTags | std::views::take_while([untilLocalIndex, this](auto& t) { return t.index < streamIndex + untilLocalIndex; }), [&mergeSrcMapInto, &result](const Tag& tag) { mergeSrcMapInto(tag.map, result.map); });
-            return result;
-        }
-
     private:
-        auto getTags(std::size_t nSamples, TagReaderType& reader, std::size_t currentStreamOffset) {
+        [[nodiscard]] static constexpr std::ptrdiff_t relIndex(std::size_t abs, std::size_t base) noexcept { return abs >= base ? static_cast<std::ptrdiff_t>(abs - base) : -static_cast<std::ptrdiff_t>(base - abs); }
+
+        auto getTagsInRange(std::size_t nSamples, TagReaderType& reader, std::size_t currentStreamOffset) {
             const auto tags = reader.get(reader.available());
             const auto it   = std::ranges::find_if_not(tags, [nSamples, currentStreamOffset](const auto& tag) { return tag.index < currentStreamOffset + nSamples; });
             const auto n    = static_cast<std::size_t>(std::distance(tags.begin(), it));
@@ -693,19 +689,14 @@ struct Port {
             }
         }
 
-        inline constexpr void publishTag(property_map&& tagData, std::size_t tagOffset = 0UZ) noexcept { processPublishTag(std::move(tagData), tagOffset); }
-
-        inline constexpr void publishTag(const property_map& tagData, std::size_t tagOffset = 0UZ) noexcept { processPublishTag(tagData, tagOffset); }
-
-    private:
-        template<PropertyMapType PropertyMap>
-        inline constexpr void processPublishTag(PropertyMap&& tagData, std::size_t tagOffset) noexcept {
+        template<PropertyMapType TPropertyMap>
+        inline constexpr void publishTag(TPropertyMap&& tagData, std::size_t tagOffset = 0UZ) noexcept {
             // Do not publish tags if port is not connected, as it can lead to a tag buffer overflow.
             if (!isConnected) {
                 return;
             }
 
-            if (tagsPublished + 1 >= tags.size()) {
+            if (tagsPublished > tags.size()) {
                 // TODO(error handling): Decide how to surface failures.
                 // Option A: throw an exception, but this function is marked noexcept—either remove noexcept or avoid throwing.
                 // Option B: return an error (or set a port-status flag) that the Scheduler can observe and handle accordingly.
@@ -714,25 +705,16 @@ struct Port {
             }
             const auto index = streamIndex + tagOffset;
 
+#ifndef NDEBUG
             if (tagsPublished > 0) {
                 auto& lastTag = tags[tagsPublished - 1];
-#ifndef NDEBUG
-
                 if (lastTag.index > index) { // check the order of published Tags.index
                     std::println(stderr, "Tag indices are not in the correct order, tagsPublished:{}, lastTag.index:{}, index:{}", tagsPublished, lastTag.index, index);
-                    // std::abort();
+                    std::abort();
                 }
-#endif
-                if (lastTag.index == index) { // -> merge tags with the same index
-                    for (auto&& [key, value] : tagData) {
-                        lastTag.map.insert_or_assign(std::forward<decltype(key)>(key), std::forward<decltype(value)>(value));
-                    }
-                } else {
-                    tags[tagsPublished++] = {index, std::forward<PropertyMap>(tagData)};
-                }
-            } else {
-                tags[tagsPublished++] = {index, std::forward<PropertyMap>(tagData)};
             }
+#endif
+            tags[tagsPublished++] = {index, std::forward<TPropertyMap>(tagData)};
         }
     }; // end of PortOutputSpan
     static_assert(WriterSpanLike<OutputSpan<gr::SpanReleasePolicy::ProcessAll, WriterSpanReservePolicy::Reserve>>);
@@ -741,21 +723,20 @@ struct Port {
 private:
     IoType    _ioHandler    = newIoHandler();
     TagIoType _tagIoHandler = newTagIoHandler();
-    Tag       _cachedTag{}; // todo: for now this is only used in the output ports
 
-    [[nodiscard]] constexpr auto newIoHandler(std::size_t buffer_size = kDefaultBufferSize) const noexcept {
+    [[nodiscard]] constexpr auto newIoHandler(std::size_t bufferSize = kDefaultBufferSize) const noexcept {
         if constexpr (kIsInput) {
-            return BufferType(buffer_size).new_reader();
+            return BufferType(bufferSize).new_reader();
         } else {
-            return BufferType(buffer_size).new_writer();
+            return BufferType(bufferSize).new_writer();
         }
     }
 
-    [[nodiscard]] constexpr auto newTagIoHandler(std::size_t buffer_size = kDefaultBufferSize) const noexcept {
+    [[nodiscard]] constexpr auto newTagIoHandler(std::size_t bufferSize = kDefaultBufferSize) const noexcept {
         if constexpr (kIsInput) {
-            return TagBufferType(buffer_size).new_reader();
+            return TagBufferType(bufferSize).new_reader();
         } else {
-            return TagBufferType(buffer_size).new_writer();
+            return TagBufferType(bufferSize).new_writer();
         }
     }
 
@@ -984,63 +965,23 @@ public:
         return OutputSpan<spanReleasePolicy, WriterSpanReservePolicy::TryReserve>(nSamples, streamWriter(), tagWriter(), streamWriter().position(), this->isConnected(), this->isSynchronous());
     }
 
-    inline constexpr void publishTag(property_map&& tag_data, std::size_t tagOffset = 0UZ) noexcept
+    template<PropertyMapType TPropertyMap>
+    inline constexpr void publishTag(TPropertyMap&& tagData, std::size_t tagOffset = 0UZ) noexcept
     requires(kIsOutput)
     {
-        processPublishTag(std::move(tag_data), tagOffset);
-    }
-
-    inline constexpr void publishTag(const property_map& tag_data, std::size_t tagOffset = 0UZ) noexcept
-    requires(kIsOutput)
-    {
-        processPublishTag(tag_data, tagOffset);
-    }
-
-    [[maybe_unused]] inline constexpr bool publishPendingTags() noexcept
-    requires(kIsOutput)
-    {
-        if (_cachedTag.map.empty() /*|| streamWriter().buffer().n_readers() == 0UZ*/) {
-            return false;
-        }
-        {
+        if (isConnected()) {
             WriterSpanLike auto outTags = tagWriter().tryReserve(1UZ);
             if (!outTags.empty()) {
-                outTags[0].index = _cachedTag.index;
-                outTags[0].map   = _cachedTag.map;
+                outTags[0].index = streamWriter().position() + tagOffset;
+                outTags[0].map   = std::forward<TPropertyMap>(tagData);
                 outTags.publish(1UZ);
             } else {
-                return false;
+                // TODO(error handling): Decide how to surface failures. Function is noexcept now
             }
         }
-
-        _cachedTag.reset();
-        return true;
     }
 
 private:
-    template<PropertyMapType PropertyMap>
-    inline constexpr void processPublishTag(PropertyMap&& tag_data, std::size_t tagOffset) noexcept
-    requires(kIsOutput)
-    {
-        const auto newTagIndex = streamWriter().position() + tagOffset;
-        if (isConnected() && _cachedTag.index != newTagIndex) {
-            publishPendingTags();
-        }
-        _cachedTag.index = newTagIndex;
-        if constexpr (std::is_rvalue_reference_v<PropertyMap&&>) { // -> move semantics
-            for (auto& [key, value] : tag_data) {
-                _cachedTag.map.insert_or_assign(std::move(key), std::move(value));
-            }
-        } else { // -> copy semantics
-            for (const auto& [key, value] : tag_data) {
-                _cachedTag.map.insert_or_assign(key, value);
-            }
-        }
-        if (isConnected()) {
-            publishPendingTags();
-        }
-    }
-
     friend class DynamicPort;
 };
 
@@ -1173,7 +1114,6 @@ private:
             } else {
                 static_assert(requires { arg.writerHandlerInternal(); }, "'private void* writerHandlerInternal()' not implemented");
             }
-            arg.metaInfo.data_type = gr::meta::type_name<typename T::value_type>();
         }
 
         explicit constexpr PortWrapper(T&& arg) noexcept : _value{std::move(arg)} {
@@ -1182,7 +1122,6 @@ private:
             } else {
                 static_assert(requires { arg.writerHandlerInternal(); }, "'private void* writerHandlerInternal()' not implemented");
             }
-            arg.metaInfo.data_type = gr::meta::type_name<typename T::value_type>();
         }
 
         ~PortWrapper() override = default;

--- a/core/include/gnuradio-4.0/Tag.hpp
+++ b/core/include/gnuradio-4.0/Tag.hpp
@@ -84,6 +84,19 @@ struct alignas(hardware_constructive_interference_size) Tag {
 
 } // namespace gr
 
+template<>
+struct std::formatter<gr::Tag> {
+    template<typename ParseContext>
+    constexpr auto parse(ParseContext& ctx) {
+        return ctx.begin();
+    }
+
+    template<typename FormatContext>
+    constexpr auto format(const gr::Tag& tag, FormatContext& ctx) const {
+        return std::format_to(ctx.out(), "{}->{{ {} }}", tag.index, tag.map);
+    }
+};
+
 namespace gr {
 using meta::fixed_string;
 


### PR DESCRIPTION
* remove Port::getMergedTag(), introduce Port::tags(untilLocalIndex),
* adjust unit tests accordingly

Update `TagSource`
- add possibility to generated several tags with the same index

Update SyncBlock and qa_SyncBlock to support several tags with the same index.

Update `bm_test_hekper` to support Block::inputTags()

Update `ImCharMonitor` block
- Use `processBulk` instead of `processOne`

Update `StreamToDataSet` block to support multiple Tags.
- Add tags for all pre-samples with correct position
- 'stop' tag is not included in the output if `n_post == 0`
- Extend unit test to check also all arrived tags (index + map) to the sink
- `StreamToDataSet` is now attributed `NoDefaultTagForwarding` and tags are consumed/published manually to ensure correct index of published tags.
- publish auto-forwarded tags in Stream->DataSet mode


Update `DataSink` to support multiple tags.
- Extend unit test to cover more cases (polling + callbacks in one test)
- Fix several problem with listeners

