### PR TITLE
Better handling of moved-from destruction

### DIFF
--- a/core/include/gnuradio-4.0/CircularBuffer.hpp
+++ b/core/include/gnuradio-4.0/CircularBuffer.hpp
@@ -651,7 +651,7 @@ class CircularBuffer {
         Reader(Reader&& other) noexcept
             : _readIndex(std::move(other._readIndex)),                                      //
               _readIndexCached(std::exchange(other._readIndexCached, _readIndex->value())), //
-              _buffer(other._buffer),                                                       //
+              _buffer(std::move(other._buffer)),                                            //
               _nSamplesFirstGet(other._nSamplesFirstGet),                                   //
               _instanceCount(other._instanceCount),                                         //
               _nRequestedSamplesToConsume(other._nRequestedSamplesToConsume),               //
@@ -668,8 +668,10 @@ class CircularBuffer {
             return *this;
         };
         ~Reader() {
-            gr::detail::removeSequence(_buffer->_claimStrategy._readSequences, _readIndex);
-            _buffer->_reader_count.fetch_sub(1UZ, std::memory_order_relaxed);
+            if (_buffer) {
+                gr::detail::removeSequence(_buffer->_claimStrategy._readSequences, _readIndex);
+                _buffer->_reader_count.fetch_sub(1UZ, std::memory_order_relaxed);
+            }
         }
 
         [[nodiscard]] constexpr BufferType  buffer() const noexcept { return CircularBuffer(_buffer); };


### PR DESCRIPTION
- moved-from ~Block was running a lot of code related to active state, so move state to stopped when moved-from

- Remove code duplication between StateMachine move-ctor and move-assign

- moved-from ~Reader was decrementing the _reader_count while move-ctor didn't increment it. Instead, don't do anything.