### PR TITLE
IQDemodulator - real-valued amplitude, phase, and frequency detector

### DIFF
--- a/blocks/filter/include/gnuradio-4.0/filter/FrequencyEstimator.hpp
+++ b/blocks/filter/include/gnuradio-4.0/filter/FrequencyEstimator.hpp
@@ -3,7 +3,9 @@
 
 #include <algorithm>
 #include <cmath>
+#include <execution>
 #include <numbers>
+#include <numeric>
 #include <ranges>
 #include <stdexcept>
 #include <vector>
@@ -350,6 +352,305 @@ private:
 
 template<typename T>
 using FrequencyEstimatorFrequencyDomainDecimating = FrequencyEstimatorFrequencyDomain<T, Resampling<1U>, Stride<0U>>;
+
+// ============================================================================
+// IQDemodulator - Digital Vector Detector / Lock-In Amplifier
+// ============================================================================
+
+enum class PhaseUnit : int { Radians = 0, Degrees = 1 };
+
+enum class DerivativeMethod : int {
+    SymmetricDifference = 0, /// [-1, 0, +1] kernel
+    SavitzkyGolay5      = 1, /// 5-point SG derivative
+    SavitzkyGolay7      = 2  /// 7-point SG derivative
+};
+
+template<DerivativeMethod method = DerivativeMethod::SymmetricDifference, bool isConst = false>
+struct Derivative {
+    static constexpr DerivativeMethod kMethod  = method;
+    static constexpr bool             kIsConst = isConst;
+};
+
+namespace detail {
+template<typename T>
+struct is_derivative : std::false_type {};
+
+template<DerivativeMethod M, bool C>
+struct is_derivative<Derivative<M, C>> : std::true_type {};
+
+template<typename T>
+inline constexpr bool is_derivative_v = is_derivative<T>::value;
+} // namespace detail
+
+GR_REGISTER_BLOCK("gr::filter::IQDemodulator", gr::filter::IQDemodulator, ([T], gr::Resampling<1024U, 1U, false>), [ float, double ])
+
+template<typename T, typename... Args>
+requires std::floating_point<T>
+struct IQDemodulator : Block<IQDemodulator<T, Args...>, Args...> {
+    using Description = Doc<R""(@brief Digital vector detector for coherent signal demodulation (lock-in amplifier).
+
+Signal model:
+  ref(t)  = A_r · cos(ωt) + DC (ADC)-- reference oscillator (DDS)
+  resp(t) = A_x · cos(ωt + φ) + DC  -- response signal with phase shift φ
+
+Signal chain:
+  1. HP filter (DC blocking):     y[n] = α·(y[n-1] + x[n] - x[n-1]),  α = exp(-2π·f_hp/f_s)
+  2. Quadrature via derivative:   Q = d/dt{ref},  |H(ω)| varies by method
+  3. Lock-in mixer:               I = resp·ref,   Q_mix = resp·Q
+  4. LP filter (averaging):       y[n] = y[n-1] + α·(x[n] - y[n-1]),  α = 1 - exp(-2π·f_lp/f_s)
+
+Output extraction (after LP averaging):
+  amplitude = √(P_x / P_r)                          -- ratio of response to reference power
+  phase     = atan2(Q_mix, I · √(P_d/P_r))          -- with automatic gain compensation
+  frequency = solved iteratively from |H(ω)| = √(P_d/P_r) using method-specific G(ω)
+
+Derivative methods (G(ω) = |H(ω)|/sin(ω), used for frequency estimation):
+  SymmetricDifference: h = [-1, 0, +1],        G(ω) = 2,                          delay = 1
+  SavitzkyGolay5:      h = [-2,-1,0,+1,+2]/10, G(ω) = 0.8·cos(ω) + 0.2,           delay = 2
+  SavitzkyGolay7:      h = [-3..+3]/28,        G(ω) = (6cos²ω + 2cosω - 1)/7,     delay = 3
+
+Limitations:
+  - Carrier frequency must satisfy: f_hp < f_carrier < f_s/2 (Nyquist)
+  - Settling time ≈ 5/(2π·f_lp) samples after transient
+
+Typical application: RF cavity field measurement at 0.1–5 MHz carriers, 62.5 MHz ADC rate.
+)"">;
+
+    using TParent           = Block<IQDemodulator<T, Args...>, Args...>;
+    using ArgumentsTypeList = typename TParent::ArgumentsTypeList;
+    using DerivativeControl = typename ArgumentsTypeList::template find_or_default<detail::is_derivative, Derivative<DerivativeMethod::SymmetricDifference, false>>;
+
+    PortIn<T>  ref;       // reference/DDS signal
+    PortIn<T>  resp;      // response signal (e.g., cavity pickup)
+    PortOut<T> amplitude; // A_resp / A_ref (dimensionless)
+    PortOut<T> phase;     // phase of response relative to reference
+    PortOut<T> frequency; // estimated carrier frequency
+
+    // settings
+    Annotated<float, "sample_rate", Doc<"input sample rate">, Unit<"Hz">>                 sample_rate{62.5e6f};
+    Annotated<float, "f_high_pass", Doc<"high-pass cutoff for DC blocking">, Unit<"Hz">>  f_high_pass{100.f};
+    Annotated<float, "f_low_pass", Doc<"low-pass cutoff for averaging">, Unit<"Hz">>      f_low_pass{10000.f};
+    Annotated<PhaseUnit, "phase_unit", Doc<"output phase unit">>                          phase_unit{PhaseUnit::Radians};
+    Annotated<bool, "invert_phase", Doc<"invert phase sign (swap lead/lag)">>             invert_phase{false};
+    Annotated<DerivativeMethod, "derivative_method", Doc<"quadrature generation method">> derivative_method{DerivativeControl::kMethod};
+    Annotated<T, "epsilon", Doc<"numerical threshold for division safety">>               epsilon{T(1e-12)};
+
+    GR_MAKE_REFLECTABLE(IQDemodulator, ref, resp, amplitude, phase, frequency, sample_rate, f_high_pass, f_low_pass, phase_unit, invert_phase, derivative_method, epsilon);
+
+    // filter state variables
+    T _hp_ref_state{}, _hp_ref_prev{};
+    T _hp_resp_state{}, _hp_resp_prev{};
+    T _lp_I{}, _lp_Q{}, _lp_Pr{}, _lp_Pd{}, _lp_Px{};
+    T _alpha_hp{}, _alpha_lp{};
+
+    // delay line for derivative and time alignment
+    HistoryBuffer<T> _ref_history{8UZ};
+    HistoryBuffer<T> _resp_history{8UZ};
+
+    std::vector<T> _derivative_kernel; // time-reversed for direct inner_product
+    std::size_t    _derivative_delay{};
+    T              _derivative_gain_factor{T(2)}; // DC gain: |H(ω)|/sin(ω) as ω→0
+
+    void settingsChanged(const property_map& /*oldSettings*/, const property_map& newSettings) {
+        if constexpr (DerivativeControl::kIsConst) {
+            if (newSettings.contains("derivative_method")) {
+                throw gr::exception("derivative_method is compile-time fixed and cannot be changed at runtime");
+            }
+        }
+        if (newSettings.contains("sample_rate") || newSettings.contains("f_high_pass") || newSettings.contains("f_low_pass") || newSettings.contains("derivative_method")) {
+            if (f_high_pass <= 0.f || f_low_pass <= 0.f || f_high_pass >= f_low_pass || f_low_pass >= sample_rate / 2.f) {
+                throw gr::exception(std::format("invalid filter frequencies: 0 < f_hp({}) < f_lp({}) < fs/2({})", f_high_pass.value, f_low_pass.value, sample_rate / 2.f));
+            }
+            initialiseFilters();
+        }
+    }
+
+    void initialiseFilters() {
+        const T fs = static_cast<T>(sample_rate);
+
+        // compute filter coefficients
+        _alpha_hp = std::exp(T(-2) * std::numbers::pi_v<T> * static_cast<T>(f_high_pass) / fs);
+        _alpha_lp = T(1) - std::exp(T(-2) * std::numbers::pi_v<T> * static_cast<T>(f_low_pass) / fs);
+
+        // reset filter states
+        _hp_ref_state = _hp_ref_prev = T(0);
+        _hp_resp_state = _hp_resp_prev = T(0);
+        _lp_I = _lp_Q = _lp_Pr = _lp_Pd = _lp_Px = T(0);
+
+        // configure derivative kernel (stored time-reversed for direct inner_product)
+        // gain factor = lim_{ω→0} |H(ω)|/sin(ω), used for frequency estimation
+        switch (derivative_method) {
+        case DerivativeMethod::SymmetricDifference:
+            // H(ω) = 2j·sin(ω), |H(ω)| = 2·sin(ω)
+            _derivative_kernel      = {T(1), T(0), T(-1)};
+            _derivative_delay       = 1UZ;
+            _derivative_gain_factor = T(2);
+            break;
+        case DerivativeMethod::SavitzkyGolay5:
+            // H(ω) = j·(0.4·sin(2ω) + 0.2·sin(ω)), |H(ω)| ≈ sin(ω)·(0.8·cos(ω) + 0.2) ≈ sin(ω) at DC
+            _derivative_kernel      = {T(0.2), T(0.1), T(0), T(-0.1), T(-0.2)};
+            _derivative_delay       = 2UZ;
+            _derivative_gain_factor = T(1);
+            break;
+        case DerivativeMethod::SavitzkyGolay7:
+            // H(ω) = j·(6·sin(3ω) + 4·sin(2ω) + 2·sin(ω))/28, |H(ω)| ≈ sin(ω) at DC
+            _derivative_kernel      = {T(3) / T(28), T(2) / T(28), T(1) / T(28), T(0), T(-1) / T(28), T(-2) / T(28), T(-3) / T(28)};
+            _derivative_delay       = 3UZ;
+            _derivative_gain_factor = T(1);
+            break;
+        }
+
+        const std::size_t histSize = std::bit_ceil(_derivative_kernel.size() + 1UZ);
+        _ref_history               = HistoryBuffer<T>(histSize);
+        _resp_history              = HistoryBuffer<T>(histSize);
+    }
+
+    void reset() { initialiseFilters(); }
+    void start() { initialiseFilters(); }
+
+    [[nodiscard]] work::Status processBulk(std::span<const T> inRef, std::span<const T> inResp, std::span<T> outAmp, std::span<T> outPhase, std::span<T> outFreq) noexcept {
+        const auto chunkSize = static_cast<std::size_t>(this->input_chunk_size);
+        const auto nChunks   = std::min({inRef.size(), inResp.size()}) / chunkSize;
+        const auto nOutputs  = std::min({outAmp.size(), outPhase.size(), outFreq.size()});
+
+        if (nOutputs < nChunks) {
+            return work::Status::INSUFFICIENT_OUTPUT_ITEMS;
+        }
+
+        // HP filter: y[n] = α·(y[n-1] + x[n] - x[n-1])
+        auto processHP = [alpha_hp = _alpha_hp](T x, T& state, T& x_prev) noexcept -> T {
+            state  = alpha_hp * (state + x - x_prev);
+            x_prev = x;
+            return state;
+        };
+
+        // LP filter: y[n] = y[n-1] + α·(x[n] - y[n-1])
+        auto processLP = [alpha_lp = _alpha_lp](T x, T& state) noexcept -> T {
+            state += alpha_lp * (x - state);
+            return state;
+        };
+
+        for (std::size_t chunk = 0; chunk < nChunks; ++chunk) {
+            const auto refChunk  = inRef.subspan(chunk * chunkSize, chunkSize);
+            const auto respChunk = inResp.subspan(chunk * chunkSize, chunkSize);
+
+            for (std::size_t i = 0; i < chunkSize; ++i) {
+                // step 1: high-pass filter inputs (DC blocking)
+                const T r_hp = processHP(refChunk[i], _hp_ref_state, _hp_ref_prev);
+                const T x_hp = processHP(respChunk[i], _hp_resp_state, _hp_resp_prev);
+
+                // push to history buffers (most recent at front)
+                _ref_history.push_front(r_hp);
+                _resp_history.push_front(x_hp);
+
+                // step 2: compute derivative via kernel convolution (kernel is pre-reversed)
+                T r_Q = T(0);
+                if (_ref_history.size() >= _derivative_kernel.size()) {
+                    r_Q = std::transform_reduce(std::execution::unseq, _derivative_kernel.cbegin(), _derivative_kernel.cend(), _ref_history.cbegin(), T(0), std::plus<>{}, std::multiplies<>{});
+                }
+
+                // extract time-aligned reference and response (at derivative center)
+                const T r_I = (_ref_history.size() > _derivative_delay) ? _ref_history[_derivative_delay] : T(0);
+                const T x_I = (_resp_history.size() > _derivative_delay) ? _resp_history[_derivative_delay] : T(0);
+
+                // step 3: lock-in products (time-aligned at derivative center)
+                const T I_raw  = x_I * r_I;
+                const T Q_raw  = x_I * r_Q;
+                const T Pr_raw = r_I * r_I;
+                const T Pd_raw = r_Q * r_Q;
+                const T Px_raw = x_I * x_I;
+
+                // step 4: low-pass filter all products
+                processLP(I_raw, _lp_I);
+                processLP(Q_raw, _lp_Q);
+                processLP(Pr_raw, _lp_Pr);
+                processLP(Pd_raw, _lp_Pd);
+                processLP(Px_raw, _lp_Px);
+            }
+
+            // step 5: extract amplitude, phase, frequency from filtered values
+            const T I  = _lp_I;
+            const T Q  = _lp_Q;
+            const T Pr = _lp_Pr;
+            const T Pd = _lp_Pd;
+            const T Px = _lp_Px;
+
+            // amplitude ratio: √(P_x / P_r)
+            const T amp = (Pr > epsilon && Px > epsilon) ? std::sqrt(Px / Pr) : T(0);
+
+            // frequency from derivative power ratio with iterative gain correction
+            // solve: G(ω)·sin(ω) = √(P_d/P_r) where G(ω) is method-specific
+            T freq = T(0);
+            if (Pr > epsilon && Pd > epsilon) {
+                const T measured_ratio = std::sqrt(Pd / Pr);
+                const T fs             = static_cast<T>(sample_rate);
+
+                // compute frequency-dependent gain: G(ω) = |H(ω)|/sin(ω)
+                auto computeGainFactor = [this](T omega) -> T {
+                    const T c = std::cos(omega);
+                    switch (derivative_method.value) {
+                    case DerivativeMethod::SymmetricDifference: return T(2);                               // |H(ω)| = 2·sin(ω)
+                    case DerivativeMethod::SavitzkyGolay5: return T(0.8) * c + T(0.2);                     // |H(ω)| = sin(ω)·(0.8c + 0.2)
+                    case DerivativeMethod::SavitzkyGolay7: return (T(6) * c * c + T(2) * c - T(1)) / T(7); // |H(ω)| = sin(ω)·(6c²+2c-1)/7
+                    default: return _derivative_gain_factor;
+                    }
+                };
+
+                // initial estimate using DC gain factor
+                T omega = std::asin(std::clamp(measured_ratio / _derivative_gain_factor, T(-1), T(1)));
+
+                // iterative refinement with Aitken acceleration for faster convergence
+                T omega0 = omega, omega1, omega2;
+                for (int iter = 0; iter < 3; ++iter) {
+                    // three standard iterations
+                    omega1         = std::asin(std::clamp(measured_ratio / computeGainFactor(omega0), T(-1), T(1)));
+                    omega2         = std::asin(std::clamp(measured_ratio / computeGainFactor(omega1), T(-1), T(1)));
+                    const T omega3 = std::asin(std::clamp(measured_ratio / computeGainFactor(omega2), T(-1), T(1)));
+
+                    // Aitken's delta-squared acceleration
+                    const T denom = omega3 - T(2) * omega2 + omega1;
+                    if (std::abs(denom) > epsilon) {
+                        const T delta = omega2 - omega1;
+                        omega0        = omega1 - (delta * delta) / denom;
+                    } else {
+                        omega0 = omega3;
+                    }
+                }
+                omega = omega0;
+                freq  = omega * fs / (T(2) * std::numbers::pi_v<T>);
+            }
+
+            // phase: atan2(Q, I·√(P_d/P_r)) with gain compensation
+            T ph = T(0);
+            if (Pr > epsilon && Pd > epsilon && (std::abs(I) > epsilon || std::abs(Q) > epsilon)) {
+                const T sqrt_ratio = std::sqrt(Pd / Pr);
+                ph                 = std::atan2(Q, I * sqrt_ratio);
+            }
+
+            // apply phase sign convention
+            if (invert_phase) {
+                ph = -ph;
+            }
+
+            // convert to degrees if requested
+            if (phase_unit == PhaseUnit::Degrees) {
+                ph *= T(180) / std::numbers::pi_v<T>;
+            }
+
+            outAmp[chunk]   = amp;
+            outPhase[chunk] = ph;
+            outFreq[chunk]  = freq;
+        }
+
+        return work::Status::OK;
+    }
+};
+
+template<typename T>
+using IQDemodulatorDecimating = IQDemodulator<T, Resampling<1024U, 1U, false>>;
+
+template<typename T, DerivativeMethod M>
+using IQDemodulatorFixed = IQDemodulator<T, Resampling<1024U, 1U, false>, Derivative<M, true>>;
 
 } // namespace gr::filter
 

--- a/blocks/filter/test/qa_FrequencyEstimator.cpp
+++ b/blocks/filter/test/qa_FrequencyEstimator.cpp
@@ -1,9 +1,13 @@
 #include <boost/ut.hpp>
 #include <cmath>
+#include <limits>
+#include <numeric>
+#include <print>
 #include <random>
 #include <span>
 #include <vector>
 
+#include <gnuradio-4.0/algorithm/ImChart.hpp>
 #include <gnuradio-4.0/filter/FrequencyEstimator.hpp>
 
 namespace {
@@ -191,6 +195,541 @@ const boost::ut::suite<"FrequencyEstimatorTests"> FrequencyEstimatorTests = [] {
         };
 
         testFrequencyEstimator(estimator, processFunc, testFrequencies, sample_rate, numSamples, noiseAmp, tolerance);
+    };
+};
+
+template<typename T = float>
+auto generateIQTestSignals(float freq, float fs, T ampRatio, T phaseShift, T dcOffset, T noise, std::size_t numSamples) {
+    std::vector<T>                    ref(numSamples), resp(numSamples);
+    std::mt19937                      gen(42);
+    std::uniform_real_distribution<T> dist(T(-0.5), T(0.5));
+
+    const T omega = T(2) * std::numbers::pi_v<T> * static_cast<T>(freq) / static_cast<T>(fs);
+    for (std::size_t i = 0UZ; i < numSamples; ++i) {
+        const T t = static_cast<T>(i);
+        ref[i]    = std::sin(omega * t) + dcOffset + noise * dist(gen);
+        resp[i]   = ampRatio * std::sin(omega * t + phaseShift) + dcOffset + noise * dist(gen);
+    }
+    return std::make_pair(ref, resp);
+}
+
+const boost::ut::suite<"IQDemodulator"> iqDemodulatorTests = [] {
+    using namespace boost::ut;
+    using namespace gr::filter;
+
+    // test parameters: {carrier_freq, sample_rate} - must satisfy Nyquist: freq < fs/2
+    struct TestCase {
+        float freq;
+        float fs;
+    };
+
+    "IQDemodulator basic amplitude/phase extraction"_test = []<typename T> {
+        "frequency sweep"_test =
+            [](TestCase tc) {
+                "phase unit"_test = [tc](PhaseUnit phaseUnit) {
+                    const float           fs         = tc.fs;
+                    const float           freq       = tc.freq;
+                    constexpr T           ampRatio   = T(0.8);  // response 80% of reference
+                    constexpr T           phaseShift = T(0.5);  // ~28.6 degrees leading
+                    constexpr T           dcOffset   = T(0.1);  // 10% DC offset
+                    constexpr T           noise      = T(0.01); // 1% noise
+                    constexpr std::size_t chunkSize  = 1024U;
+                    constexpr std::size_t numChunks  = 100U;
+                    constexpr std::size_t numSamples = chunkSize * numChunks;
+
+                    auto [refSignal, respSignal] = generateIQTestSignals<T>(freq, fs, ampRatio, phaseShift, dcOffset, noise, numSamples);
+
+                    IQDemodulator<T, Resampling<1024U, 1U, false>> demod;
+                    demod.sample_rate      = fs;
+                    demod.f_high_pass      = 100.f;
+                    demod.f_low_pass       = 10000.f;
+                    demod.phase_unit       = phaseUnit;
+                    demod.invert_phase     = false;
+                    demod.input_chunk_size = chunkSize;
+                    demod.start();
+
+                    std::vector<T> ampOut(numChunks);
+                    std::vector<T> phaseOut(numChunks);
+                    std::vector<T> freqOut(numChunks);
+
+                    auto status = demod.processBulk(std::span{refSignal}, std::span{respSignal}, std::span{ampOut}, std::span{phaseOut}, std::span{freqOut});
+                    expect(status == work::Status::OK);
+
+                    constexpr std::size_t settleChunks = 20UZ; // skip first ~20 samples to allow HP and LP to settle
+                    T                     ampSum       = T{0};
+                    T                     phaseSum     = T{0};
+                    T                     freqSum      = T{0};
+                    std::size_t           count        = 0UZ;
+                    for (std::size_t i = settleChunks; i < numChunks; ++i) {
+                        ampSum += ampOut[i];
+                        phaseSum += phaseOut[i];
+                        freqSum += freqOut[i];
+                        ++count;
+                    }
+                    const T ampMean   = ampSum / static_cast<T>(count);
+                    const T phaseMean = phaseSum / static_cast<T>(count);
+                    const T freqMean  = freqSum / static_cast<T>(count);
+
+                    // tolerances: amplitude within 5%, phase within 0.1 rad (~6 deg), frequency within 5%
+                    expect(approx(ampMean, ampRatio, T(0.05))) << std::format("amplitude deviation: {} vs. expected {}", ampMean, ampRatio);
+                    if (phaseUnit == PhaseUnit::Degrees) {
+                        const T expectedDeg = phaseShift * T(180) / std::numbers::pi_v<T>;
+                        expect(approx(phaseMean, expectedDeg, T(3.0))) << std::format("phase deviation: {}° vs. expected {}°", phaseMean, expectedDeg);
+                    } else {
+                        expect(approx(phaseMean, phaseShift, T(0.1))) << std::format("phase deviation: {} rad vs. expected {} rad", phaseMean, phaseShift);
+                    }
+                    expect(approx(freqMean, static_cast<T>(freq), T(0.05) * static_cast<T>(freq))) << std::format("frequency deviation: {} vs. expected {}", freqMean, freq);
+                } | std::vector{PhaseUnit::Radians, PhaseUnit::Degrees};
+            } |
+            std::vector<TestCase>{
+                {100e3f, 1e6f}, // 100 kHz carrier at 1 MHz sample rate (10x oversampling)
+                {5e6f, 62.5e6f} // 5 MHz carrier at 62.5 MHz sample rate (12.5x oversampling)
+            };
+    } | std::tuple<float, double>{};
+
+    "IQDemodulator phase inversion"_test = [] {
+        constexpr float       fs         = 1e6f;
+        constexpr float       freq       = 150e3f;
+        constexpr float       phaseShift = 0.3f;
+        constexpr std::size_t chunkSize  = 256U;
+        constexpr std::size_t numChunks  = 300U;
+        constexpr std::size_t numSamples = chunkSize * numChunks;
+
+        auto [refSignal, respSignal] = [=] {
+            std::vector<float> ref(numSamples), resp(numSamples);
+            const float        omega = 2.f * std::numbers::pi_v<float> * freq / fs;
+            for (std::size_t i = 0UZ; i < numSamples; ++i) {
+                const float t = static_cast<float>(i);
+                ref[i]        = std::sin(omega * t);
+                resp[i]       = std::sin(omega * t + phaseShift);
+            }
+            return std::make_pair(ref, resp);
+        }();
+
+        // test with invert_phase = false
+        IQDemodulator<float, Resampling<256U, 1U, false>> demodNormal;
+        demodNormal.sample_rate      = fs;
+        demodNormal.f_high_pass      = 50.f;
+        demodNormal.f_low_pass       = 15000.f;
+        demodNormal.invert_phase     = false;
+        demodNormal.input_chunk_size = chunkSize;
+        demodNormal.start();
+
+        std::vector<float> amp1(numChunks), phase1(numChunks), freq1(numChunks);
+        std::ignore = demodNormal.processBulk(refSignal, respSignal, amp1, phase1, freq1);
+
+        // test with invert_phase = true
+        IQDemodulator<float, Resampling<256U, 1U, false>> demodInverted;
+        demodInverted.sample_rate      = fs;
+        demodInverted.f_high_pass      = 50.f;
+        demodInverted.f_low_pass       = 15000.f;
+        demodInverted.invert_phase     = true;
+        demodInverted.input_chunk_size = chunkSize;
+        demodInverted.start();
+
+        std::vector<float> amp2(numChunks), phase2(numChunks), freq2(numChunks);
+        std::ignore = demodInverted.processBulk(refSignal, respSignal, amp2, phase2, freq2);
+
+        // after settling, phases should be negatives of each other
+        const float phaseMean1 = std::accumulate(phase1.begin() + 100, phase1.end(), 0.f) / static_cast<float>(numChunks - 100);
+        const float phaseMean2 = std::accumulate(phase2.begin() + 100, phase2.end(), 0.f) / static_cast<float>(numChunks - 100);
+        expect(std::abs(phaseMean1 + phaseMean2) < 0.05f) << "inverted phases should sum to ~0:" << phaseMean1 << "+" << phaseMean2;
+    };
+
+    "IQDemodulator settings change resets filters"_test = [] {
+        constexpr float       fs         = 1e6f;
+        constexpr float       freq       = 100e3f;
+        constexpr std::size_t chunkSize  = 256U;
+        constexpr std::size_t numChunks  = 50U;
+        constexpr std::size_t numSamples = chunkSize * numChunks;
+
+        std::vector<float> ref(numSamples), resp(numSamples);
+        const float        omega = 2.f * std::numbers::pi_v<float> * freq / fs;
+        for (std::size_t i = 0UZ; i < numSamples; ++i) {
+            ref[i]  = std::sin(omega * static_cast<float>(i));
+            resp[i] = std::sin(omega * static_cast<float>(i) + 0.2f);
+        }
+
+        IQDemodulator<float, Resampling<256U, 1U, false>> demod;
+        demod.sample_rate      = fs;
+        demod.f_high_pass      = 100.f;
+        demod.f_low_pass       = 10000.f;
+        demod.input_chunk_size = chunkSize;
+        demod.start();
+
+        std::vector<float> amp1(numChunks), phase1(numChunks), freq1(numChunks);
+        std::ignore = demod.processBulk(ref, resp, amp1, phase1, freq1);
+
+        // change LP cutoff - should trigger filter reset
+        property_map oldSettings, newSettings;
+        newSettings["f_low_pass"] = 5000.f;
+        demod.f_low_pass          = 5000.f;
+        demod.settingsChanged(oldSettings, newSettings);
+
+        // process again - filter states should have been reset
+        std::vector<float> amp2(numChunks), phase2(numChunks), freq2(numChunks);
+        std::ignore = demod.processBulk(ref, resp, amp2, phase2, freq2);
+
+        // just verify no crash and outputs are valid (not NaN/inf)
+        expect(std::isfinite(amp2.back()));
+        expect(std::isfinite(phase2.back()));
+        expect(std::isfinite(freq2.back()));
+    };
+
+    "IQDemodulator derivative methods"_test = [] {
+        constexpr float       fs         = 1e6f;
+        constexpr float       freq       = 100e3f;
+        constexpr std::size_t chunkSize  = 512U;
+        constexpr std::size_t numChunks  = 100U;
+        constexpr std::size_t numSamples = chunkSize * numChunks;
+
+        auto [refSignal, respSignal] = generateIQTestSignals<float>(freq, fs, 0.8f, 0.3f, 0.f, 0.01f, numSamples);
+
+        for (auto method : {DerivativeMethod::SymmetricDifference, DerivativeMethod::SavitzkyGolay5, DerivativeMethod::SavitzkyGolay7}) {
+            IQDemodulator<float, Resampling<512U, 1U, false>> demod;
+            demod.sample_rate       = fs;
+            demod.f_high_pass       = 50.f;
+            demod.f_low_pass        = 20000.f;
+            demod.derivative_method = method;
+            demod.input_chunk_size  = chunkSize;
+            demod.start();
+
+            std::vector<float> ampOut(numChunks), phaseOut(numChunks), freqOut(numChunks);
+            auto               status = demod.processBulk(refSignal, respSignal, ampOut, phaseOut, freqOut);
+            expect(status == work::Status::OK);
+
+            // verify outputs are finite after settling
+            const float ampMean = std::accumulate(ampOut.begin() + 30, ampOut.end(), 0.f) / static_cast<float>(numChunks - 30);
+            expect(std::isfinite(ampMean) && ampMean > 0.f) << "derivative method " << static_cast<int>(method) << " amplitude:" << ampMean;
+        }
+    };
+
+    "IQDemodulator zero/near-zero amplitude inputs"_test = [] {
+        // simulates ADC failure mode or disconnected signal
+        constexpr float       fs         = 1e6f;
+        constexpr std::size_t chunkSize  = 256U;
+        constexpr std::size_t numChunks  = 50U;
+        constexpr std::size_t numSamples = chunkSize * numChunks;
+
+        // generate zero-amplitude signals
+        std::vector<float> ref(numSamples, 0.f);
+        std::vector<float> resp(numSamples, 0.f);
+
+        IQDemodulator<float, Resampling<256U, 1U, false>> demod;
+        demod.sample_rate      = fs;
+        demod.f_high_pass      = 100.f;
+        demod.f_low_pass       = 10000.f;
+        demod.input_chunk_size = chunkSize;
+        demod.start();
+
+        std::vector<float> ampOut(numChunks), phaseOut(numChunks), freqOut(numChunks);
+        auto               status = demod.processBulk(ref, resp, ampOut, phaseOut, freqOut);
+        expect(status == work::Status::OK);
+
+        // all outputs should be zero (no signal) and finite (no NaN/inf)
+        for (std::size_t i = 10; i < numChunks; ++i) {
+            expect(std::isfinite(ampOut[i])) << "amplitude should be finite at chunk" << i;
+            expect(std::isfinite(phaseOut[i])) << "phase should be finite at chunk" << i;
+            expect(std::isfinite(freqOut[i])) << "frequency should be finite at chunk" << i;
+            expect(ampOut[i] == 0.f) << "amplitude should be zero for zero input";
+        }
+    };
+
+    "IQDemodulator DC-only input (no carrier)"_test = [] {
+        // DC offset without any AC component
+        // HP filter blocks DC on both ref and resp, leaving only numerical noise
+        // ratio of two small noise values is unstable, so we check for bounded output
+        constexpr float       fs         = 1e6f;
+        constexpr float       dcLevel    = 0.5f;
+        constexpr std::size_t chunkSize  = 256U;
+        constexpr std::size_t numChunks  = 100U;
+        constexpr std::size_t numSamples = chunkSize * numChunks;
+
+        std::vector<float> ref(numSamples, dcLevel);
+        std::vector<float> resp(numSamples, dcLevel * 0.8f);
+
+        IQDemodulator<float, Resampling<256U, 1U, false>> demod;
+        demod.sample_rate      = fs;
+        demod.f_high_pass      = 100.f;
+        demod.f_low_pass       = 10000.f;
+        demod.input_chunk_size = chunkSize;
+        demod.start();
+
+        std::vector<float> ampOut(numChunks), phaseOut(numChunks), freqOut(numChunks);
+        auto               status = demod.processBulk(ref, resp, ampOut, phaseOut, freqOut);
+        expect(status == work::Status::OK);
+
+        // after HP filter settles, outputs should be finite (HP blocks DC, leaving noise)
+        for (std::size_t i = 50; i < numChunks; ++i) {
+            expect(std::isfinite(ampOut[i])) << "amplitude should be finite for DC input";
+            expect(std::isfinite(phaseOut[i])) << "phase should be finite for DC input";
+            expect(std::isfinite(freqOut[i])) << "frequency should be finite for DC input";
+        }
+    };
+
+    "IQDemodulator frequency at HP cutoff boundary"_test = [] {
+        // carrier frequency equal to HP cutoff
+        // HP attenuates both ref and resp equally, so amplitude RATIO should be preserved
+        constexpr float       fs         = 1e6f;
+        constexpr float       f_hp       = 1000.f;
+        constexpr float       freq       = 1000.f; // exactly at HP cutoff
+        constexpr float       ampRatio   = 0.8f;
+        constexpr std::size_t chunkSize  = 1024U;
+        constexpr std::size_t numChunks  = 200U;
+        constexpr std::size_t numSamples = chunkSize * numChunks;
+
+        auto [refSignal, respSignal] = generateIQTestSignals<float>(freq, fs, ampRatio, 0.3f, 0.f, 0.f, numSamples);
+
+        IQDemodulator<float, Resampling<1024U, 1U, false>> demod;
+        demod.sample_rate      = fs;
+        demod.f_high_pass      = f_hp;
+        demod.f_low_pass       = 10000.f;
+        demod.input_chunk_size = chunkSize;
+        demod.start();
+
+        std::vector<float> ampOut(numChunks), phaseOut(numChunks), freqOut(numChunks);
+        auto               status = demod.processBulk(refSignal, respSignal, ampOut, phaseOut, freqOut);
+        expect(status == work::Status::OK);
+
+        // HP attenuates both signals equally, so ratio should be preserved
+        const float ampMean = std::accumulate(ampOut.begin() + 100, ampOut.end(), 0.f) / static_cast<float>(numChunks - 100);
+        expect(std::isfinite(ampMean)) << "amplitude should be finite at HP boundary";
+        // ratio should still be close to input ampRatio (both attenuated equally)
+        expect(approx(ampMean, ampRatio, 0.15f)) << "amplitude ratio at HP cutoff:" << ampMean << "vs expected" << ampRatio;
+    };
+
+    "IQDemodulator frequency near Nyquist"_test = [] {
+        // carrier close to Nyquist limit
+        // frequency estimation has fundamental limitation: arcsin(x) only valid for |x| <= 1
+        // at high frequencies, sin(ω) → 1, limiting frequency estimate to fs/4
+        constexpr float       fs         = 1e6f;
+        constexpr float       freq       = 200e3f; // 40% of Nyquist - more reasonable test
+        constexpr std::size_t chunkSize  = 512U;
+        constexpr std::size_t numChunks  = 200U;
+        constexpr std::size_t numSamples = chunkSize * numChunks;
+
+        auto [refSignal, respSignal] = generateIQTestSignals<float>(freq, fs, 0.9f, 0.4f, 0.f, 0.f, numSamples);
+
+        IQDemodulator<float, Resampling<512U, 1U, false>> demod;
+        demod.sample_rate      = fs;
+        demod.f_high_pass      = 100.f;
+        demod.f_low_pass       = 50000.f;
+        demod.input_chunk_size = chunkSize;
+        demod.start();
+
+        std::vector<float> ampOut(numChunks), phaseOut(numChunks), freqOut(numChunks);
+        auto               status = demod.processBulk(refSignal, respSignal, ampOut, phaseOut, freqOut);
+        expect(status == work::Status::OK);
+
+        const float ampMean   = std::accumulate(ampOut.begin() + 50, ampOut.end(), 0.f) / static_cast<float>(numChunks - 50);
+        const float phaseMean = std::accumulate(phaseOut.begin() + 50, phaseOut.end(), 0.f) / static_cast<float>(numChunks - 50);
+        const float freqMean  = std::accumulate(freqOut.begin() + 50, freqOut.end(), 0.f) / static_cast<float>(numChunks - 50);
+
+        expect(approx(ampMean, 0.9f, 0.05f)) << "amplitude at 40% Nyquist:" << ampMean;
+        expect(approx(phaseMean, 0.4f, 0.1f)) << "phase at 40% Nyquist:" << phaseMean;
+        expect(approx(freqMean, freq, 0.1f * freq)) << "frequency at 40% Nyquist:" << freqMean << "vs" << freq;
+    };
+
+    "IQDemodulator frequency sweep 0.1-5 MHz"_test = [](DerivativeMethod derivative_method) {
+        constexpr float       fs           = 62.5e6f; // 62.5 MHz sample rate
+        constexpr float       f_start      = 0.1e6f;  // 0.1 MHz start
+        constexpr float       f_end        = 5.0e6f;  // 5 MHz end
+        constexpr float       sweepTime    = 0.5f;    // 0.5 second sweep
+        constexpr float       ampRatio     = 0.85f;   // response amplitude
+        constexpr float       phaseShift   = 0.4f;    // phase shift (radians)
+        constexpr float       noise        = 0.01f;   // 1% noise
+        constexpr std::size_t chunkSize    = 1024U;
+        constexpr std::size_t numSamples   = static_cast<std::size_t>(fs * sweepTime);
+        constexpr std::size_t numChunks    = numSamples / chunkSize;
+        constexpr std::size_t settleChunks = 500UZ; // ~8 ms settling
+
+        std::mt19937                          gen(42);
+        std::uniform_real_distribution<float> dist(-0.5f, 0.5f);
+
+        // generate linear frequency sweep with noise
+        std::vector<float> refSignal(numSamples), respSignal(numSamples);
+        std::vector<float> trueFreq(numChunks); // true frequency at each chunk
+
+        float phase = 0.f;
+        for (std::size_t i = 0UZ; i < numSamples; ++i) {
+            const float t     = static_cast<float>(i) / fs;
+            const float freq  = f_start + (f_end - f_start) * t / sweepTime; // linear chirp
+            const float omega = 2.f * std::numbers::pi_v<float> * freq;
+
+            phase += omega / fs; // instantaneous phase increment
+            if (phase > 2.f * std::numbers::pi_v<float>) {
+                phase -= 2.f * std::numbers::pi_v<float>;
+            }
+
+            refSignal[i]  = std::sin(phase) + noise * dist(gen);
+            respSignal[i] = ampRatio * std::sin(phase + phaseShift) + noise * dist(gen);
+
+            // record true frequency at chunk boundaries
+            if (i % chunkSize == 0 && i / chunkSize < numChunks) {
+                trueFreq[i / chunkSize] = freq;
+            }
+        }
+
+        IQDemodulator<float, Resampling<1024U, 1U, false>> demod;
+        demod.sample_rate       = fs;
+        demod.f_high_pass       = 1000.f;  // low HP for 0.1 MHz carrier
+        demod.f_low_pass        = 10000.f; // 10 kHz LP bandwidth
+        demod.input_chunk_size  = chunkSize;
+        demod.derivative_method = derivative_method;
+        demod.start();
+
+        std::vector<float> ampOut(numChunks), phaseOut(numChunks), freqOut(numChunks);
+        auto               status = demod.processBulk(refSignal, respSignal, ampOut, phaseOut, freqOut);
+        expect(status == work::Status::OK);
+
+        // compute statistics after settling
+        float       ampSum = 0.f, ampMin = std::numeric_limits<float>::max(), ampMax = std::numeric_limits<float>::lowest();
+        float       phaseSum = 0.f, phaseMin = std::numeric_limits<float>::max(), phaseMax = std::numeric_limits<float>::lowest();
+        float       freqErrMax = 0.f, freqErrSum = 0.f;
+        std::size_t count = 0UZ;
+
+        for (std::size_t i = settleChunks; i < numChunks; ++i) {
+            ampSum += ampOut[i];
+            ampMin = std::min(ampMin, ampOut[i]);
+            ampMax = std::max(ampMax, ampOut[i]);
+
+            phaseSum += phaseOut[i];
+            phaseMin = std::min(phaseMin, phaseOut[i]);
+            phaseMax = std::max(phaseMax, phaseOut[i]);
+
+            // frequency error (relative to true instantaneous frequency)
+            const float freqErr = std::abs(freqOut[i] - trueFreq[i]);
+            freqErrSum += freqErr;
+            freqErrMax = std::max(freqErrMax, freqErr);
+            ++count;
+        }
+
+        const float ampMean     = ampSum / static_cast<float>(count);
+        const float phaseMean   = phaseSum / static_cast<float>(count);
+        const float freqErrMean = freqErrSum / static_cast<float>(count);
+
+        // prepare time and reference vectors for plotting
+        std::vector<float> timeMs(numChunks);
+        std::vector<float> ampMeasured(numChunks), ampExpected(numChunks);
+        std::vector<float> phaseMeasured(numChunks), phaseExpected(numChunks);
+        std::vector<float> freqMeasured(numChunks), freqReference(numChunks);
+
+        for (std::size_t i = 0; i < numChunks; ++i) {
+            timeMs[i]        = static_cast<float>(i * chunkSize) / fs * 1e3f; // time in ms
+            ampMeasured[i]   = ampOut[i];
+            ampExpected[i]   = ampRatio;
+            phaseMeasured[i] = phaseOut[i];
+            phaseExpected[i] = phaseShift;
+            freqMeasured[i]  = freqOut[i] / 1e6f;  // MHz
+            freqReference[i] = trueFreq[i] / 1e6f; // MHz
+        }
+
+        std::println("\n=== IQDemodulator Frequency Sweep Statistics (0.1-5 MHz, 62.5 MHz fs) derivative_method: {} ===", demod.derivative_method);
+        // plots
+        {
+            auto chart = gr::graphs::ImChart<130UZ, 16UZ>({{0., timeMs.back()}, {0., 5.5}});
+            chart.draw(timeMs, freqMeasured, "f_meas");
+            chart.draw(timeMs, freqReference, "f_ref [MHz]");
+            chart.draw();
+        }
+        {
+            auto chart = gr::graphs::ImChart<130UZ, 16UZ>({{0., timeMs.back()}, {static_cast<double>(ampMin) * 0.95, static_cast<double>(ampMax) * 1.05}});
+            chart.draw(timeMs, ampMeasured, "A_meas");
+            chart.draw(timeMs, ampExpected, "A_ref");
+            chart.draw();
+        }
+
+        {
+            auto chart = gr::graphs::ImChart<130UZ, 16UZ>({{0., timeMs.back()}, {static_cast<double>(phaseMin) * 0.95, static_cast<double>(phaseMax) * 1.05}});
+            chart.draw(timeMs, phaseMeasured, "meas");
+            chart.draw(timeMs, phaseExpected, "phase-ref [rad]");
+            chart.draw();
+        }
+
+        // print statistics
+        std::println("Amplitude:  mean={:.4f}, min={:.4f}, max={:.4f}, expected={:.4f}", ampMean, ampMin, ampMax, ampRatio);
+        std::println("Phase:      mean={:.4f} rad, min={:.4f}, max={:.4f}, expected={:.4f} rad", phaseMean, phaseMin, phaseMax, phaseShift);
+        std::println("Freq error: mean={:.1f} Hz, max={:.1f} Hz", freqErrMean, freqErrMax);
+        std::println("Phase lag:  {:.4f} rad ({:.2f}°)", phaseMean - phaseShift, (phaseMean - phaseShift) * 180.f / std::numbers::pi_v<float>);
+        std::println("============================================================================\n");
+
+        // amplitude should track input ratio within 10%
+        expect(approx(ampMean, ampRatio, 0.1f)) << "sweep amplitude mean:" << ampMean;
+        expect(ampMin > 0.6f * ampRatio) << "sweep amplitude min:" << ampMin;
+        expect(ampMax < 1.4f * ampRatio) << "sweep amplitude max:" << ampMax;
+
+        // phase should track within 0.2 rad (~11°)
+        expect(approx(phaseMean, phaseShift, 0.2f)) << "sweep phase mean:" << phaseMean;
+
+        // frequency tracking: all methods should achieve similar accuracy after gain correction
+        const float f_center = (f_start + f_end) / 2.f;
+        expect(freqErrMean < 0.02f * f_center) << "sweep freq mean error:" << freqErrMean;
+        expect(freqErrMax < 0.05f * f_center) << "sweep freq max error:" << freqErrMax;
+    } | std::vector<DerivativeMethod>{DerivativeMethod::SymmetricDifference, DerivativeMethod::SavitzkyGolay5, DerivativeMethod::SavitzkyGolay7};
+
+    "IQDemodulator static decimation"_test = [] {
+        constexpr float       fs         = 1e6f;
+        constexpr float       freq       = 100e3f;
+        constexpr std::size_t chunkSize  = 512U;
+        constexpr std::size_t numChunks  = 100U;
+        constexpr std::size_t numSamples = chunkSize * numChunks;
+
+        auto [refSignal, respSignal] = generateIQTestSignals<float>(freq, fs, 0.8f, 0.5f, 0.1f, 0.01f, numSamples);
+
+        // static decimation: Resampling<512U, 1U, true> - compile-time fixed
+        IQDemodulator<float, Resampling<512U, 1U, true>> demod;
+        demod.sample_rate = fs;
+        demod.f_high_pass = 100.f;
+        demod.f_low_pass  = 10000.f;
+        // input_chunk_size should be set from NTTP, but we verify it's correct
+        expect(demod.input_chunk_size == 512U) << "static decimation chunk size should be 512";
+        demod.start();
+
+        std::vector<float> ampOut(numChunks), phaseOut(numChunks), freqOut(numChunks);
+        auto               status = demod.processBulk(refSignal, respSignal, ampOut, phaseOut, freqOut);
+        expect(status == work::Status::OK);
+
+        // verify results are valid
+        const float ampMean   = std::accumulate(ampOut.begin() + 20, ampOut.end(), 0.f) / static_cast<float>(numChunks - 20);
+        const float phaseMean = std::accumulate(phaseOut.begin() + 20, phaseOut.end(), 0.f) / static_cast<float>(numChunks - 20);
+        const float freqMean  = std::accumulate(freqOut.begin() + 20, freqOut.end(), 0.f) / static_cast<float>(numChunks - 20);
+
+        expect(approx(ampMean, 0.8f, 0.05f)) << "static decimation amplitude:" << ampMean;
+        expect(approx(phaseMean, 0.5f, 0.1f)) << "static decimation phase:" << phaseMean;
+        expect(approx(freqMean, freq, 0.05f * freq)) << "static decimation frequency:" << freqMean;
+    };
+
+    "IQDemodulator fixed derivative NTTP"_test = [] {
+        constexpr float       fs         = 1e6f;
+        constexpr float       freq       = 100e3f;
+        constexpr std::size_t chunkSize  = 256U;
+        constexpr std::size_t numChunks  = 100U;
+        constexpr std::size_t numSamples = chunkSize * numChunks;
+
+        auto [refSignal, respSignal] = generateIQTestSignals<float>(freq, fs, 0.8f, 0.3f, 0.f, 0.01f, numSamples);
+
+        // use IQDemodulatorFixed alias with compile-time fixed SavitzkyGolay5
+        IQDemodulatorFixed<float, DerivativeMethod::SavitzkyGolay5> demod;
+        demod.sample_rate      = fs;
+        demod.f_high_pass      = 100.f;
+        demod.f_low_pass       = 10000.f;
+        demod.input_chunk_size = chunkSize;
+        demod.start();
+
+        // verify derivative_method is set correctly from NTTP
+        expect(demod.derivative_method == DerivativeMethod::SavitzkyGolay5) << "derivative method should be SG5 from NTTP";
+
+        std::vector<float> ampOut(numChunks), phaseOut(numChunks), freqOut(numChunks);
+        auto               status = demod.processBulk(refSignal, respSignal, ampOut, phaseOut, freqOut);
+        expect(status == work::Status::OK);
+
+        const float ampMean = std::accumulate(ampOut.begin() + 30, ampOut.end(), 0.f) / static_cast<float>(numChunks - 30);
+        expect(approx(ampMean, 0.8f, 0.05f)) << "fixed derivative amplitude:" << ampMean;
+
+        // verify that changing derivative_method at runtime throws
+        property_map oldSettings, newSettings;
+        newSettings["derivative_method"] = static_cast<int>(DerivativeMethod::SymmetricDifference);
+        expect(throws([&] { demod.settingsChanged(oldSettings, newSettings); })) << "changing fixed derivative_method should throw";
     };
 };
 


### PR DESCRIPTION
This PR adds the `IQDemodulator` block, which implements a digital vector detector (lock-in amplifier) for coherent demodulation of real-valued DDS and RF response signals. This technique extracts amplitude, phase, and frequency from an RF response signal relative to a known real-valued reference. N.B. this works not only for a (semi-)static DDS frequency but also when the frequency changes by large factors, for example,  >25 (e.g 0.2 -> 5 MHz).*

This is an alternative to the broadband Hilbert transform-based method, which has higher numerical complexity (~ 50x) and higher latency (~ +50 samples).

## What it does:

- **Signal extraction**: Amplitude ratio, phase difference, and carrier frequency from response signal relative to reference oscillator
- **Signal chain**: HP filter (DC blocking) → quadrature via derivative → lock-in mixer → LP filter (averaging)
- **Derivative methods**: 
  - `SymmetricDifference`: `[-1, 0, +1]`, `|H(ω)| = 2·sin(ω)`
  - `SavitzkyGolay5`: 5-point smoothed derivative, `|H(ω)| ≈ sin(ω)`
  - `SavitzkyGolay7`: 7-point smoothed derivative, `|H(ω)| ≈ sin(ω)`
- **Automatic gain compensation**: Frequency-dependent gain correction using `√(P_d/P_r)` ratio


**Example output :**
```
=== IQDemodulator Frequency Sweep Statistics (0.2-5 MHz, 62.5 MHz fs) derivative_method: SymmetricDifference ===
Amplitude:  mean=0.8500, min=0.8212, max=0.8806, expected=0.8500
Phase:      mean=0.3999 rad, min=0.3235, max=0.4640, expected=0.4000 rad
Freq error: mean=16740.1 Hz, max=28958.0 Hz
Phase lag:  -0.0001 rad (-0.01°)
============================================================================

=== IQDemodulator Frequency Sweep Statistics (0.2-5 MHz, 62.5 MHz fs) derivative_method: SavitzkyGolay5 ===
Amplitude:  mean=0.8500, min=0.8214, max=0.8808, expected=0.8500
Phase:      mean=0.3999 rad, min=0.3248, max=0.4651, expected=0.4000 rad
Freq error: mean=18254.7 Hz, max=37640.5 Hz
Phase lag:  -0.0001 rad (-0.00°)
============================================================================

=== IQDemodulator Frequency Sweep Statistics (0.2-5 MHz, 62.5 MHz fs) derivative_method: SavitzkyGolay7 ===
Amplitude:  mean=0.8500, min=0.8217, max=0.8808, expected=0.8500
Phase:      mean=0.3999 rad, min=0.3255, max=0.4651, expected=0.4000 rad
Freq error: mean=22368.8 Hz, max=77661.5 Hz
Phase lag:  -0.0001 rad (-0.00°)
============================================================================
```

<img width="1182" height="890" alt="image" src="https://github.com/user-attachments/assets/b61b4691-f5ab-4eda-ab1d-14564033b960" />
