### PR TITLE
Bump emscripten to v5

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -46,7 +46,7 @@ To be able to natively compile some prerequisites have to be installed:
 - ninja (or GNU make)
 - optional for python block support: python3
 - optional for soapy (limesdr,rtlsdr) blocks: soapysdr
-- optional for compiling to webassembly: emscripten >= 3.1.50
+- optional for compiling to webassembly: emscripten >= 5.0.0
 
 To apply the project's formatting rules, you'll also need the correct formatters, `clang-format-18` and `cmake-format`. With these installed you can use the scripts in the repository to reformat your changes. For smaller changes, the CI will provide you with a patch which will fix the formatting (click on the "Details" link on the failed Restyled.io check), but for bigger changes it's useful to have local formatting.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 [![CI](https://github.com/fair-acc/gnuradio4/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/fair-acc/gnuradio4/actions/workflows/ci.yml)
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-17-orange.svg?style=flat-square)](#contributors-)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 # GNU Radio 4.0 prototype
@@ -31,7 +33,7 @@ GNU Radio 4.0 uses modern C++ (C++23), and is tested for
 - CMake (>= 3.25),
 - GCC (>=13.3, better: >=14.2)
 - Clang (>=18, recommended), and
-- Emscripten (3.1.66).
+- Emscripten (5.0.2).
 
 **To build**:
 
@@ -109,13 +111,12 @@ describe how to set up a local development environment.
 ## License and Copyright
 
 Unless otherwise noted: SPDX-License-Identifier: MIT<br>
-All code contributions to GNU Radio core and runtime will be integrated into a library under the MIT, ensuring it remains free/libre (FLOSS) for both personal and commercial use, without further constraints on either.  GNU Radio also allows for individual block libraries to be licensed as GPLv3.
+All code contributions to GNU Radio core and runtime will be integrated into a library under the MIT, ensuring it remains free/libre (FLOSS) for both personal and commercial use, without further constraints on either. GNU Radio also allows for individual block libraries to be licensed as GPLv3.
 For details on these distinctions and how to contribute, please consult: [CONTRIBUTING.md](CONTRIBUTING.md)
 
 Copyright (C) The GNU Radio Authors<br>
 Copyright (C) Contributors to the GNU Radio Project<br>
 Copyright (C) FAIR - Facility for Antiproton & Ion Research, Darmstadt, Germany<br>
-
 
 ## Acknowledgements
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,7 +18,7 @@ ENV JAVA_HOME=/opt/java/openjdk \
     LC_ALL=en_US.UTF-8 \
     CMAKE_MAKE_PROGRAM=ninja \
     EMSDK_HOME=/opt/emsdk \
-    EMSDK_VERSION=4.0.8
+    EMSDK_VERSION=5.0.2
 
 # Install compilers, package managers and build-tools
 # As we are using the the ubuntu prerelease llvm and cmake are fresh enough, readd these if the version is not sufficient anymore
@@ -64,6 +64,7 @@ RUN apt-get update -y \
     && ./emsdk install $EMSDK_VERSION \
     && ./emsdk activate $EMSDK_VERSION \
     && npm install --ignore-scripts -g xhr2 \
+    && ./upstream/emscripten/embuilder build sdl3 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && chown -R root:users $EMSDK_HOME && chmod -R 777 $EMSDK_HOME

--- a/third_party/exprtk.hpp
+++ b/third_party/exprtk.hpp
@@ -45,6 +45,9 @@
 #if defined(__clang__) || defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
+#ifdef __EMSCRIPTEN__
+#pragma GCC diagnostic ignored "-Wunnecessary-virtual-specifier"
+#endif
 #pragma GCC diagnostic ignored "-Wdouble-promotion"
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #pragma GCC diagnostic ignored "-Wshadow"


### PR DESCRIPTION
Bumps emscripten to 5.0.1 in the Dockerfile.

Needs to add a warning suppression guard to the exprtk header.

Note that the sdl3 cmake logic for emscripten has changed. Before, it was automatically fetched if it was used in the cmake file, now it is necessary to run `embuilder build sld3` to install the sdl3 emscripten port (since gr4 itself is not using any ui code, this is only relevant for downstream projects).