### PR TITLE
Fix CMake typo in linking for qa_apptest_LoadingPlainBlocklibs

### DIFF
--- a/blocks/libs/test/CMakeLists.txt
+++ b/blocks/libs/test/CMakeLists.txt
@@ -17,7 +17,7 @@ if(NOT EMSCRIPTEN AND TARGET GrBasicBlocksShared)
 
   add_executable(qa_apptest_LoadingPlainBlocklibs qa_apptest_LoadingPlainBlocklibs.cpp)
   setup_test(qa_apptest_LoadingPlainBlocklibs)
-  target_link_libraries(qa_apptest_KnownStaticLibBlocks PRIVATE gnuradio-core gnuradio-blocklib-core)
+  target_link_libraries(qa_apptest_LoadingPlainBlocklibs PRIVATE gnuradio-core gnuradio-blocklib-core)
   set_property(
     TEST qa_apptest_LoadingPlainBlocklibs
     PROPERTY ENVIRONMENT_MODIFICATION


### PR DESCRIPTION
Correct a target_link_libraries() typo where gnuradio-blocklib-core was linked to qa_apptest_KnownStaticLibBlocks instead of qa_apptest_LoadingPlainBlocklibs.

The change only corrects the target name; there are no functional
changes beyond fixing the test build configuration.