### PR TITLE
Fix Mac OS Clang/libc++ compilation errors

### DIFF
--- a/blocks/basic/include/gnuradio-4.0/basic/FunctionGenerator.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/FunctionGenerator.hpp
@@ -281,7 +281,7 @@ Operating modes:
         const double dur = static_cast<double>(duration);
 
         double value{};
-        switch (signal_type) {
+        switch (signal_type.value) {
         case Const: value = sv; break;
         case LinearRamp: value = _currentTime > dur ? fv : sv + (fv - sv) * (_currentTime / dur); break;
         case ParabolicRamp: value = calculateParabolicRamp(); break;

--- a/blocks/filter/include/gnuradio-4.0/filter/FrequencyEstimator.hpp
+++ b/blocks/filter/include/gnuradio-4.0/filter/FrequencyEstimator.hpp
@@ -479,7 +479,7 @@ Typical application: RF cavity field measurement at 0.1–5 MHz carriers, 62.5 M
 
         // configure derivative kernel (stored time-reversed for direct inner_product)
         // gain factor = lim_{ω→0} |H(ω)|/sin(ω), used for frequency estimation
-        switch (derivative_method) {
+        switch (derivative_method.value) {
         case DerivativeMethod::SymmetricDifference:
             // H(ω) = 2j·sin(ω), |H(ω)| = 2·sin(ω)
             _derivative_kernel      = {T(1), T(0), T(-1)};

--- a/core/include/gnuradio-4.0/Block.hpp
+++ b/core/include/gnuradio-4.0/Block.hpp
@@ -1898,7 +1898,7 @@ public:
 
             retMessage->cmd             = Final; // N.B. could enable/allow for partial if we return multiple messages (e.g. using coroutines?)
             retMessage->serviceName     = unique_name;
-            WriterSpanLike auto msgSpan = msgOut.streamWriter().tryReserve<SpanReleasePolicy::ProcessAll>(1UZ);
+            WriterSpanLike auto msgSpan = msgOut.streamWriter().template tryReserve<SpanReleasePolicy::ProcessAll>(1UZ);
             if (msgSpan.empty()) {
                 throw gr::exception(std::format("{}::processMessages() can not reserve span for message\n", name));
             } else {

--- a/core/include/gnuradio-4.0/Scheduler.hpp
+++ b/core/include/gnuradio-4.0/Scheduler.hpp
@@ -359,7 +359,7 @@ public:
         // Forward any messages to children that were received before the scheduler was initialised
         _messagePortsConnected = true;
 
-        WriterSpanLike auto msgSpan = _toChildMessagePort.streamWriter().reserve<SpanReleasePolicy::ProcessAll>(_pendingMessagesToChildren.size());
+        WriterSpanLike auto msgSpan = _toChildMessagePort.streamWriter().template reserve<SpanReleasePolicy::ProcessAll>(_pendingMessagesToChildren.size());
         std::ranges::move(_pendingMessagesToChildren, msgSpan.begin());
         _pendingMessagesToChildren.clear();
     }
@@ -371,7 +371,7 @@ public:
             if (msg.serviceName != this->unique_name && msg.serviceName != this->name && msg.endpoint != block::property::kLifeCycleState) {
                 // only forward wildcard, non-scheduler messages, and non-lifecycle messages (N.B. the latter is exclusively handled by the scheduler)
                 if (_messagePortsConnected) {
-                    WriterSpanLike auto msgSpan = _toChildMessagePort.streamWriter().reserve<SpanReleasePolicy::ProcessAll>(1UZ);
+                    WriterSpanLike auto msgSpan = _toChildMessagePort.streamWriter().template reserve<SpanReleasePolicy::ProcessAll>(1UZ);
                     msgSpan[0]                  = msg;
                 } else {
                     // if not yet connected, keep messages to children in cache and forward when connecting

--- a/core/test/qa_YamlPmt.cpp
+++ b/core/test/qa_YamlPmt.cpp
@@ -4,6 +4,7 @@
 #include <limits>
 #include <variant>
 
+#include <gnuradio-4.0/meta/UnitTestHelper.hpp>
 #include <gnuradio-4.0/meta/formatter.hpp>
 
 #include <gnuradio-4.0/Value.hpp>

--- a/core/test/qa_thread_pool.cpp
+++ b/core/test/qa_thread_pool.cpp
@@ -1,5 +1,6 @@
 #include <boost/ut.hpp>
 
+#include <gnuradio-4.0/meta/UnitTestHelper.hpp>
 #include <gnuradio-4.0/thread/thread_pool.hpp>
 
 const boost::ut::suite<"gr::thread_pool GR4 default"> defaultThreadPool = [] {

--- a/meta/include/gnuradio-4.0/meta/UnitTestHelper.hpp
+++ b/meta/include/gnuradio-4.0/meta/UnitTestHelper.hpp
@@ -46,6 +46,16 @@ auto eq(const RangeLHS& lhs, const RangeRHS& rhs, T tolerance);
 template<typename Enum>
 requires std::is_enum_v<Enum>
 auto eq(Enum lhs, Enum rhs);
+
+// Boost.UT uses its own source_location fallback on Apple libc++, so bridge
+// std::source_location call sites only when the two types differ.
+#if defined(_LIBCPP_APPLE_CLANG_VER)
+template<class TExpr>
+requires(!std::same_as<reflection::source_location, std::source_location> && (type_traits::is_op<TExpr> || concepts::explicitly_convertible_to<TExpr, bool>))
+constexpr auto expect(const TExpr& expr, const std::source_location& sl) {
+    return boost::ut::expect(expr, reflection::source_location::current(sl.file_name(), static_cast<int>(sl.line())));
+}
+#endif
 } // namespace boost::ut
 
 namespace gr::test {

--- a/meta/test/qa_fixed_string.cpp
+++ b/meta/test/qa_fixed_string.cpp
@@ -1,5 +1,6 @@
 #include <boost/ut.hpp>
 
+#include <gnuradio-4.0/meta/UnitTestHelper.hpp>
 #include <gnuradio-4.0/meta/utils.hpp>
 
 #include <atomic>


### PR DESCRIPTION
Fix Mac OS Clang/libc++ compilation errors:
- use `.value` for annotated enums
- add missing dependent `template`
- bridge Boost.UT source_location on Apple libc++