### PR TITLE
Add namespaced alias to exported targets

### DIFF
--- a/.github/workflows/cpack.yml
+++ b/.github/workflows/cpack.yml
@@ -15,12 +15,12 @@ jobs:
       CCACHE_DIR: ${{ github.workspace }}/.ccache
       CCACHE_BASEDIR: ${{ github.workspace }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Cache ccache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/.ccache
           key: ccache-cpack-gcc14-relwithdebinfo-${{ github.sha }}
@@ -28,7 +28,7 @@ jobs:
             ccache-cpack-gcc14-relwithdebinfo
 
       - name: Cache fetchContent
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/build/_deps
           key: fetchContent-cpack-gcc14-relwithdebinfo-${{ hashFiles('CMakeLists.txt') }}
@@ -72,7 +72,7 @@ jobs:
         run: sudo apt install ./build/*.deb ./build/*.ddeb -y
 
       - name: Upload packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ubuntu-gcc14-relwithdebinfo-deb-${{ github.run_number }}
           path: |
@@ -99,12 +99,12 @@ jobs:
       CCACHE_DIR: ${{ github.workspace }}/.ccache
       CCACHE_BASEDIR: ${{ github.workspace }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Cache ccache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/.ccache
           key: ccache-cpack-emscripten-relwithdebinfo-${{ github.sha }}
@@ -112,7 +112,7 @@ jobs:
             ccache-cpack-emscripten-relwithdebinfo
 
       - name: Cache fetchContent
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/build/_deps
           key: fetchContent-cpack-emscripten-relwithdebinfo-${{ hashFiles('CMakeLists.txt') }}
@@ -160,7 +160,7 @@ jobs:
           cmake --build build --target package
 
       - name: Upload packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: emscripten-relwithdebinfo-deb-${{ github.run_number }}
           path: build/*.deb

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,9 +179,9 @@ option(ENABLE_TESTING "Enable Test Builds" ${GR_TOPLEVEL_PROJECT})
 option(MIT_ONLY "Exclude modules with non-MIT/Apache-compatible licences" OFF)
 
 if(NOT DEFINED GR_DATA_CACHE_DIR)
-    set(GR_DATA_CACHE_DIR "${CMAKE_CURRENT_BINARY_DIR}/gnuradio_cache" 
-        CACHE PATH 
-        "Writeable system path where GR should store its cached data (for example, /var/lib/gnuradio4/cache)")
+  set(GR_DATA_CACHE_DIR
+      "${CMAKE_CURRENT_BINARY_DIR}/gnuradio_cache"
+      CACHE PATH "Writeable system path where GR should store its cached data (for example, /var/lib/gnuradio4/cache)")
 endif()
 
 set(GR_MAX_WASM_THREAD_COUNT
@@ -257,6 +257,7 @@ include(cmake/CompilerWarnings.cmake)
 add_subdirectory(blocklib_generator)
 
 add_library(gnuradio-options INTERFACE)
+add_library(gnuradio4::gnuradio-options ALIAS gnuradio-options)
 install(TARGETS gnuradio-options EXPORT gnuradio4Targets)
 
 message(
@@ -415,6 +416,7 @@ endif()
 # include header-only libraries that have been inlined to simplify builds w/o requiring access to the internet
 if(NOT (TARGET magic_enum))
   add_library(magic_enum INTERFACE)
+  add_library(gnuradio4::magic_enum ALIAS magic_enum)
   target_include_directories(
     magic_enum ${CMAKE_EXT_DEP_WARNING_GUARD} INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/third_party/magic_enum/>
                                                         $<INSTALL_INTERFACE:include>)
@@ -432,14 +434,17 @@ add_library(
   exprtk STATIC "${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk.hpp"
                 "${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk.cpp" # dummy source file
 )
-target_include_directories(exprtk PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/third_party"
-                                         "${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk")
+add_library(gnuradio4::exprtk ALIAS exprtk)
+target_include_directories(exprtk PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/third_party>
+                                         $<INSTALL_INTERFACE:include>)
 if(EMSCRIPTEN)
   target_compile_options(exprtk PRIVATE -O1 -g0)
 else()
   target_compile_options(exprtk PRIVATE -O1 -g0 -fvisibility=hidden)
 endif()
 set_source_files_properties(third_party/exprtk.cpp PROPERTIES COMPILE_OPTIONS "-fvisibility=hidden")
+install(TARGETS exprtk EXPORT gnuradio4Targets)
+install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/third_party/exprtk.hpp" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 # include exprtk header-only - END
 
 include(FetchContent)
@@ -543,6 +548,7 @@ if(NOT EMSCRIPTEN)
   target_include_directories(
     libsoundio_static ${CMAKE_EXT_DEP_WARNING_GUARD} PUBLIC $<BUILD_INTERFACE:${libsoundio_SOURCE_DIR}>
                                                             $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+  add_library(gnuradio4::libsoundio_static ALIAS libsoundio_static)
   if(APPLE)
     find_library(GR_LIBSOUNDIO_COREAUDIO_LIBRARY CoreAudio REQUIRED)
     find_library(GR_LIBSOUNDIO_COREFOUNDATION_LIBRARY CoreFoundation REQUIRED)
@@ -569,6 +575,7 @@ if(NOT EMSCRIPTEN)
   install(TARGETS libsoundio_static EXPORT gnuradio4Targets)
 
   add_library(gr-libsoundio INTERFACE)
+  add_library(gnuradio4::gr-libsoundio ALIAS gr-libsoundio)
   target_link_libraries(gr-libsoundio INTERFACE libsoundio_static)
   install(TARGETS gr-libsoundio EXPORT gnuradio4Targets)
 endif()
@@ -613,6 +620,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)") # WIP
 endif()
 
 add_library(vir INTERFACE)
+add_library(gnuradio4::vir ALIAS vir)
 target_include_directories(vir INTERFACE $<BUILD_INTERFACE:${vir-simd_SOURCE_DIR}/>
                                          $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 install(TARGETS vir EXPORT gnuradio4Targets)
@@ -747,6 +755,14 @@ install(
   FILE gnuradio4Targets.cmake
   NAMESPACE gnuradio4::
   DESTINATION "${GR_CMAKECONFIG_INSTALL_DIR}")
+
+if(TARGET gnuradio-plugin)
+  install(
+    EXPORT gnuradio4PluginTargets
+    FILE gnuradio4PluginTargets.cmake
+    NAMESPACE gnuradio4::
+    DESTINATION "${GR_CMAKECONFIG_INSTALL_DIR}")
+endif()
 
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/gnuradio4Config.cmake"
               "${CMAKE_CURRENT_BINARY_DIR}/gnuradio4ConfigVersion.cmake" DESTINATION "${GR_CMAKECONFIG_INSTALL_DIR}")

--- a/algorithm/CMakeLists.txt
+++ b/algorithm/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library(gnuradio-algorithm INTERFACE)
+add_library(gnuradio4::gnuradio-algorithm ALIAS gnuradio-algorithm)
 target_include_directories(gnuradio-algorithm INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
                                                         $<INSTALL_INTERFACE:include/>)
 install(TARGETS gnuradio-algorithm EXPORT gnuradio4Targets)
@@ -7,10 +8,10 @@ install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/gnuradio-4.0/algorithm"
 
 target_link_libraries(
   gnuradio-algorithm
-  INTERFACE gnuradio-options
-            gnuradio-meta
-            vir
-            magic_enum)
+  INTERFACE gnuradio4::gnuradio-options
+            gnuradio4::gnuradio-meta
+            gnuradio4::vir
+            gnuradio4::magic_enum)
 
 if(GR_HTTP_ENABLED AND NOT EMSCRIPTEN)
   target_link_libraries(gnuradio-algorithm INTERFACE cpr::cpr)

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -1,5 +1,9 @@
 add_library(ut-benchmark INTERFACE benchmark.hpp)
-target_include_directories(ut-benchmark INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+add_library(gnuradio4::ut-benchmark ALIAS ut-benchmark)
+target_include_directories(ut-benchmark INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+                                                  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+install(TARGETS ut-benchmark EXPORT gnuradio4Targets)
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/benchmark.hpp DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 function(append_compiler_flags TARGET_NAME)
   set(FLAGS_COMMON -Wall)
@@ -20,7 +24,7 @@ endfunction()
 function(add_benchmark BM_NAME)
   add_executable(${BM_NAME} ${BM_NAME}.cpp)
   append_compiler_flags(${BM_NAME})
-  target_link_libraries(${BM_NAME} PRIVATE gnuradio-options ut ut-benchmark)
+  target_link_libraries(${BM_NAME} PRIVATE gnuradio4::gnuradio-options ut gnuradio4::ut-benchmark)
 endfunction()
 
 add_benchmark(bm_example)

--- a/blocklib_generator/GnuRadioBlockLibConfig.cmake.in
+++ b/blocklib_generator/GnuRadioBlockLibConfig.cmake.in
@@ -1,5 +1,9 @@
 @PACKAGE_INIT@
 
+include(CMakeFindDependencyMacro)
+
+find_dependency(gnuradio4 CONFIG)
+
 set(PARSER_EXECUTABLE ${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_BINDIR@/gnuradio_4_0_parse_registrations)
 
 include("${CMAKE_CURRENT_LIST_DIR}/GnuRadioBlockLibTargets.cmake")

--- a/blocklib_generator/GnuRadioBlockLibMacros.cmake.in
+++ b/blocklib_generator/GnuRadioBlockLibMacros.cmake.in
@@ -60,9 +60,10 @@ function(gr_generate_block_instantiations LIB_NAME)
     endif()
 
     # directory where gnuradio_4_0_parse_registrations will output .cpp files.
-    set(GEN_DIR "${CMAKE_BINARY_DIR}/generated_plugins/${MODULE_NAME_BASE}")
+    set(GEN_DIR "${CMAKE_BINARY_DIR}/plugins/${MODULE_NAME_BASE}")
     file(MAKE_DIRECTORY "${GEN_DIR}")
     target_include_directories(${LIB_NAME} PUBLIC ${GEN_DIR})
+    target_include_directories(${LIB_NAME} PUBLIC ${CMAKE_BINARY_DIR}/include)
 
     set(GEN_CPP_LIST "${GEN_DIR}/integrator.cpp")
 
@@ -154,6 +155,14 @@ function(gr_generate_block_instantiations LIB_NAME)
             gr_detail_merge_files_into(${GEN_DIR}/raw_calls.hpp "${RAW_CALLS_FILES}")
         endif()
 
+        set(GENERATED_PUBLIC_HEADER_SOURCE "${GEN_DIR}/${MODULE_NAME_BASE}.hpp")
+        if(EXISTS "${GENERATED_PUBLIC_HEADER_SOURCE}")
+            set(GENERATED_PUBLIC_HEADER_BUILD_DIR "${CMAKE_BINARY_DIR}/include/gnuradio-4.0")
+            set(GENERATED_PUBLIC_HEADER_BUILD_PATH "${GENERATED_PUBLIC_HEADER_BUILD_DIR}/${MODULE_NAME_BASE}.hpp")
+            file(MAKE_DIRECTORY "${GENERATED_PUBLIC_HEADER_BUILD_DIR}")
+            configure_file("${GENERATED_PUBLIC_HEADER_SOURCE}" "${GENERATED_PUBLIC_HEADER_BUILD_PATH}" COPYONLY)
+        endif()
+
     target_sources(${LIB_NAME} PRIVATE ${GEN_CPP_LIST})
 endfunction()
 
@@ -180,26 +189,45 @@ function(gr_add_block_library LIB_NAME)
         HEADERS ${CBL_HEADERS}
         MODULE_NAME_BASE ${LIB_NAME}
         ${SPLIT_BLOCK_INSTANTIATIONS_ARG})
-    target_link_libraries(${OBJECT_LIB_NAME} PUBLIC gnuradio-core gnuradio-blocklib-core ${CBL_LINK_LIBRARIES})
+
+    target_link_libraries(${OBJECT_LIB_NAME} PUBLIC gnuradio4::gnuradio-core gnuradio4::gnuradio-blocklib-core ${CBL_LINK_LIBRARIES})
 
     if(CBL_MAKE_SHARED_LIBRARY)
         set(SHARED_LIB_NAME "${LIB_NAME}Shared")
         message(STATUS "[BlockLibMacros] Creating a shared library target ${SHARED_LIB_NAME}")
         add_library(${SHARED_LIB_NAME} SHARED)
-        target_link_libraries(${SHARED_LIB_NAME} ${OBJECT_LIB_NAME})
-        install(TARGETS ${SHARED_LIB_NAME} LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/gnuradio-4/plugins)
+        if(NOT TARGET gnuradio4::${SHARED_LIB_NAME})
+            add_library(gnuradio4::${SHARED_LIB_NAME} ALIAS ${SHARED_LIB_NAME})
+        endif()
+        target_include_directories(${SHARED_LIB_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
+                                                          $<INSTALL_INTERFACE:include>)
+        target_sources(${SHARED_LIB_NAME} PRIVATE $<TARGET_OBJECTS:${OBJECT_LIB_NAME}>)
+        target_link_libraries(${SHARED_LIB_NAME} PUBLIC gnuradio4::gnuradio-core gnuradio4::gnuradio-blocklib-core ${CBL_LINK_LIBRARIES})
+        install(
+            TARGETS ${SHARED_LIB_NAME}
+            EXPORT gnuradio4Targets
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/gnuradio-4/plugins)
     endif()
 
     if(CBL_MAKE_STATIC_LIBRARY)
         set(STATIC_LIB_NAME "${LIB_NAME}Static")
         message(STATUS "[BlockLibMacros] Creating a static library target ${STATIC_LIB_NAME}")
         add_library(${STATIC_LIB_NAME} STATIC)
-        target_link_libraries(${STATIC_LIB_NAME} ${OBJECT_LIB_NAME})
-        install(TARGETS ${STATIC_LIB_NAME} LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/gnuradio-4/plugins)
+        if(NOT TARGET gnuradio4::${STATIC_LIB_NAME})
+            add_library(gnuradio4::${STATIC_LIB_NAME} ALIAS ${STATIC_LIB_NAME})
+        endif()
+        target_include_directories(${STATIC_LIB_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
+                                  $<INSTALL_INTERFACE:include>)
+        target_sources(${STATIC_LIB_NAME} PRIVATE $<TARGET_OBJECTS:${OBJECT_LIB_NAME}>)
+        target_link_libraries(${STATIC_LIB_NAME} PUBLIC gnuradio4::gnuradio-core gnuradio4::gnuradio-blocklib-core ${CBL_LINK_LIBRARIES})
+        install(
+            TARGETS ${STATIC_LIB_NAME}
+            EXPORT gnuradio4Targets
+            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/gnuradio-4/plugins)
     endif()
 
-    install(FILES "${CMAKE_BINARY_DIR}/generated_plugins/${LIB_NAME}/${LIB_NAME}.hpp"
-            DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/gnuradio-4.0")
+    install(FILES "${CMAKE_BINARY_DIR}/include/gnuradio-4.0/${LIB_NAME}.hpp"
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/gnuradio-4.0")
 
     # TODO Install pkgconfig files, CMake files for finding the package,
     # header for blocklib init
@@ -241,7 +269,7 @@ function(gr_add_block_plugin LIB_NAME)
         gnuradio-4.0/Plugin.hpp
         REGISTRY_INSTANCE
         grPluginInstance)
-    target_link_libraries(${OBJECT_LIB_NAME} PUBLIC gnuradio-core gnuradio-blocklib-core gnuradio-plugin ${CBL_LINK_LIBRARIES})
+    target_link_libraries(${OBJECT_LIB_NAME} PUBLIC gnuradio4::gnuradio-core gnuradio4::gnuradio-blocklib-core gnuradio4::gnuradio-plugin ${CBL_LINK_LIBRARIES})
 
     set(PLUGIN_LIB_NAME "${LIB_NAME}Plugin")
     message(STATUS "[BlockLibMacros] Creating a plugin target ${PLUGIN_LIB_NAME}")

--- a/blocks/audio/CMakeLists.txt
+++ b/blocks/audio/CMakeLists.txt
@@ -1,12 +1,13 @@
 add_library(gr-audio INTERFACE)
+add_library(gnuradio4::gr-audio ALIAS gr-audio)
 target_link_libraries(
   gr-audio
-  INTERFACE gnuradio-core
-            gnuradio-algorithm
-            gr-common
-            gr-fileio)
+  INTERFACE gnuradio4::gnuradio-core
+            gnuradio4::gnuradio-algorithm
+            gnuradio4::gr-common
+            gnuradio4::gr-fileio)
 if(NOT EMSCRIPTEN)
-  target_link_libraries(gr-audio INTERFACE gr-libsoundio)
+  target_link_libraries(gr-audio INTERFACE gnuradio4::gr-libsoundio)
 endif()
 if(EMSCRIPTEN)
   target_link_options(
@@ -30,9 +31,9 @@ gr_add_block_library(
   include/gnuradio-4.0/audio/EmscriptenAudioBackend.hpp
   include/gnuradio-4.0/audio/SoundIoBackend.hpp
   LINK_LIBRARIES
-  gr-audio)
+  gnuradio4::gr-audio)
 
-if(TARGET GrAudioBlocksShared AND ENABLE_TESTING)
+if(TARGET gnuradio4::GrAudioBlocksShared AND ENABLE_TESTING)
   add_subdirectory(test)
 endif()
 

--- a/blocks/basic/CMakeLists.txt
+++ b/blocks/basic/CMakeLists.txt
@@ -10,7 +10,7 @@ set(GrBasicBlocks_HDRS
     include/gnuradio-4.0/basic/SyncBlock.hpp
     include/gnuradio-4.0/basic/Trigger.hpp)
 
-set(GrBasicBlocks_LIBS gr-basic gr-testing)
+set(GrBasicBlocks_LIBS gnuradio4::gr-basic gnuradio4::gr-testing)
 
 if(PYTHON_AVAILABLE)
   list(
@@ -26,9 +26,11 @@ if(PYTHON_AVAILABLE)
 endif()
 
 add_library(gr-basic INTERFACE ${GrBasicBlocks_HDRS})
-target_link_libraries(gr-basic INTERFACE gnuradio-core gnuradio-algorithm ${GrBasicBlocks_LIBS})
+add_library(gnuradio4::gr-basic ALIAS gr-basic)
+target_link_libraries(gr-basic INTERFACE gnuradio4::gnuradio-core gnuradio4::gnuradio-algorithm)
 target_include_directories(gr-basic INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
                                               $<INSTALL_INTERFACE:include/>)
+install(TARGETS gr-basic EXPORT gnuradio4Targets)
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/gnuradio-4.0/basic"
         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/gnuradio-4.0")
 
@@ -41,6 +43,6 @@ gr_add_block_library(
   LINK_LIBRARIES
   ${GrBasicBlocks_LIBS})
 
-if(TARGET GrBasicBlocksShared AND ENABLE_TESTING)
+if(TARGET gnuradio4::GrBasicBlocksShared AND ENABLE_TESTING)
   add_subdirectory(test)
 endif()

--- a/blocks/basic/test/CMakeLists.txt
+++ b/blocks/basic/test/CMakeLists.txt
@@ -6,7 +6,7 @@ add_ut_test(qa_TriggerBlocks)
 
 if(GR_ENABLE_BLOCK_REGISTRY AND INTERNAL_ENABLE_BLOCK_PLUGINS)
   add_ut_test(qa_BasicAvailableBlocks)
-  target_link_libraries(qa_BasicAvailableBlocks PRIVATE GrBasicBlocksShared)
+  target_link_libraries(qa_BasicAvailableBlocks PRIVATE gnuradio4::GrBasicBlocksShared)
 endif()
 add_ut_test(qa_StreamToDataSet)
 add_ut_test(qa_SyncBlock)

--- a/blocks/basic/test/qa_BasicAvailableBlocks.cpp
+++ b/blocks/basic/test/qa_BasicAvailableBlocks.cpp
@@ -6,7 +6,7 @@
 #include <gnuradio-4.0/basic/Selector.hpp>
 #include <gnuradio-4.0/basic/SignalGenerator.hpp>
 
-#include <GrBasicBlocks.hpp>
+#include <gnuradio-4.0/GrBasicBlocks.hpp>
 
 const boost::ut::suite AvailableBlockTests = [] {
     using namespace boost::ut;

--- a/blocks/common/CMakeLists.txt
+++ b/blocks/common/CMakeLists.txt
@@ -1,7 +1,8 @@
 add_library(gr-common INTERFACE)
+add_library(gnuradio4::gr-common ALIAS gr-common)
 target_include_directories(gr-common INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
                                                $<INSTALL_INTERFACE:include/>)
-target_link_libraries(gr-common INTERFACE gnuradio-core)
+target_link_libraries(gr-common INTERFACE gnuradio4::gnuradio-core)
 install(TARGETS gr-common EXPORT gnuradio4Targets)
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/gnuradio-4.0/common"
         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/gnuradio-4.0")

--- a/blocks/electrical/CMakeLists.txt
+++ b/blocks/electrical/CMakeLists.txt
@@ -1,7 +1,9 @@
 add_library(gr-electrical INTERFACE)
-target_link_libraries(gr-electrical INTERFACE gnuradio-core gnuradio-algorithm)
+add_library(gnuradio4::gr-electrical ALIAS gr-electrical)
+target_link_libraries(gr-electrical INTERFACE gnuradio4::gnuradio-core gnuradio4::gnuradio-algorithm)
 target_include_directories(gr-electrical INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
                                                    $<INSTALL_INTERFACE:include/>)
+install(TARGETS gr-electrical EXPORT gnuradio4Targets)
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/gnuradio-4.0/electrical"
         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/gnuradio-4.0")
 
@@ -11,9 +13,9 @@ gr_add_block_library(
   HEADERS
   include/gnuradio-4.0/electrical/PowerEstimators.hpp
   LINK_LIBRARIES
-  gr-basic
+  gnuradio4::gr-basic
   gr-electrical)
 
-if(TARGET GrElectricalBlocksShared AND ENABLE_TESTING)
+if(TARGET gnuradio4::GrElectricalBlocksShared AND ENABLE_TESTING)
   add_subdirectory(test)
 endif()

--- a/blocks/fileio/CMakeLists.txt
+++ b/blocks/fileio/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(gr-fileio INTERFACE)
-target_link_libraries(gr-fileio INTERFACE gnuradio-core gnuradio-algorithm)
+add_library(gnuradio4::gr-fileio ALIAS gr-fileio)
+target_link_libraries(gr-fileio INTERFACE gnuradio4::gnuradio-core gnuradio4::gnuradio-algorithm)
 target_include_directories(gr-fileio INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
                                                $<INSTALL_INTERFACE:include/>)
 install(TARGETS gr-fileio EXPORT gnuradio4Targets)
@@ -14,8 +15,8 @@ gr_add_block_library(
   include/gnuradio-4.0/fileio/BasicFileIo.hpp
   include/gnuradio-4.0/fileio/WavBlocks.hpp
   LINK_LIBRARIES
-  gr-fileio)
+  gnuradio4::gr-fileio)
 
-if(TARGET GrFileIoBlocksShared AND ENABLE_TESTING)
+if(TARGET gnuradio4::GrFileIoBlocksShared AND ENABLE_TESTING)
   add_subdirectory(test)
 endif()

--- a/blocks/filter/CMakeLists.txt
+++ b/blocks/filter/CMakeLists.txt
@@ -1,7 +1,9 @@
 add_library(gr-filter INTERFACE)
-target_link_libraries(gr-filter INTERFACE gnuradio-core)
+add_library(gnuradio4::gr-filter ALIAS gr-filter)
+target_link_libraries(gr-filter INTERFACE gnuradio4::gnuradio-core)
 target_include_directories(gr-filter INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
                                                $<INSTALL_INTERFACE:include/>)
+install(TARGETS gr-filter EXPORT gnuradio4Targets)
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/gnuradio-4.0/filter"
         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/gnuradio-4.0")
 
@@ -15,8 +17,8 @@ gr_add_block_library(
   include/gnuradio-4.0/filter/time_domain_filter.hpp
   LINK_LIBRARIES
   gr-filter
-  gnuradio-algorithm)
+  gnuradio4::gnuradio-algorithm)
 
-if(TARGET GrFilterBlocksShared AND ENABLE_TESTING)
+if(TARGET gnuradio4::GrFilterBlocksShared AND ENABLE_TESTING)
   add_subdirectory(test)
 endif()

--- a/blocks/fourier/CMakeLists.txt
+++ b/blocks/fourier/CMakeLists.txt
@@ -1,7 +1,9 @@
 add_library(gr-fourier INTERFACE)
-target_link_libraries(gr-fourier INTERFACE gnuradio-core gnuradio-algorithm)
+add_library(gnuradio4::gr-fourier ALIAS gr-fourier)
+target_link_libraries(gr-fourier INTERFACE gnuradio4::gnuradio-core gnuradio4::gnuradio-algorithm)
 target_include_directories(gr-fourier INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
                                                 $<INSTALL_INTERFACE:include/>)
+install(TARGETS gr-fourier EXPORT gnuradio4Targets)
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/gnuradio-4.0/fourier"
         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/gnuradio-4.0")
 
@@ -11,10 +13,10 @@ gr_add_block_library(
   HEADERS
   include/gnuradio-4.0/fourier/fft.hpp
   LINK_LIBRARIES
-  gr-basic
+  gnuradio4::gr-basic
   gr-fourier)
 
-if(TARGET GrFourierBlocksShared AND ENABLE_TESTING)
+if(TARGET gnuradio4::GrFourierBlocksShared AND ENABLE_TESTING)
   add_subdirectory(test)
 endif()
 

--- a/blocks/http/CMakeLists.txt
+++ b/blocks/http/CMakeLists.txt
@@ -1,10 +1,12 @@
 add_library(gr-http INTERFACE)
-target_link_libraries(gr-http INTERFACE gnuradio-core gnuradio-algorithm)
+add_library(gnuradio4::gr-http ALIAS gr-http)
+target_link_libraries(gr-http INTERFACE gnuradio4::gnuradio-core gnuradio4::gnuradio-algorithm)
 if(APPLE)
   target_link_libraries(gr-http INTERFACE "-framework CFNetwork")
 endif()
 target_include_directories(gr-http INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
                                              $<INSTALL_INTERFACE:include/>)
+install(TARGETS gr-http EXPORT gnuradio4Targets)
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/gnuradio-4.0/http"
         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/gnuradio-4.0")
 
@@ -14,8 +16,8 @@ gr_add_block_library(
   HEADERS
   include/gnuradio-4.0/http/HttpBlock.hpp
   LINK_LIBRARIES
-  gr-http)
+  gnuradio4::gr-http)
 
-if(TARGET GrHttpBlocksShared AND ENABLE_TESTING)
+if(TARGET gnuradio4::GrHttpBlocksShared AND ENABLE_TESTING)
   add_subdirectory(test)
 endif()

--- a/blocks/libs/test/CMakeLists.txt
+++ b/blocks/libs/test/CMakeLists.txt
@@ -1,20 +1,20 @@
-if(NOT EMSCRIPTEN AND TARGET GrBasicBlocksShared)
+if(NOT EMSCRIPTEN AND TARGET gnuradio4::GrBasicBlocksShared)
   add_ut_test(qa_KnownSharedLibBlocks)
   target_link_libraries(
     qa_KnownSharedLibBlocks
     PRIVATE gnuradio-core
-            GrAudioBlocksShared
-            GrTestingBlocksShared
-            GrFileIoBlocksShared
-            GrBasicBlocksShared
-            GrElectricalBlocksShared
-            GrHttpBlocksShared
-            GrFilterBlocksShared
-            GrFourierBlocksShared)
+            gnuradio4::GrAudioBlocksShared
+            gnuradio4::GrTestingBlocksShared
+            gnuradio4::GrFileIoBlocksShared
+            gnuradio4::GrBasicBlocksShared
+            gnuradio4::GrElectricalBlocksShared
+            gnuradio4::GrHttpBlocksShared
+            gnuradio4::GrFilterBlocksShared
+            gnuradio4::GrFourierBlocksShared)
 
   add_executable(qa_apptest_KnownStaticLibBlocks qa_apptest_KnownStaticLibBlocks.cpp)
   setup_test(qa_apptest_KnownStaticLibBlocks)
-  target_link_libraries(qa_apptest_KnownStaticLibBlocks PRIVATE gnuradio-core GrBasicBlocksStatic)
+  target_link_libraries(qa_apptest_KnownStaticLibBlocks PRIVATE gnuradio-core gnuradio4::GrBasicBlocksStatic)
 
   add_executable(qa_apptest_LoadingPlainBlocklibs qa_apptest_LoadingPlainBlocklibs.cpp)
   setup_test(qa_apptest_LoadingPlainBlocklibs)

--- a/blocks/libs/test/qa_KnownSharedLibBlocks.cpp
+++ b/blocks/libs/test/qa_KnownSharedLibBlocks.cpp
@@ -9,14 +9,14 @@ using namespace boost::ut;
 
 using namespace std::string_view_literals;
 
-#include <GrAudioBlocks.hpp>
-#include <GrBasicBlocks.hpp>
-#include <GrElectricalBlocks.hpp>
-#include <GrFileIoBlocks.hpp>
-#include <GrFilterBlocks.hpp>
-#include <GrFourierBlocks.hpp>
-#include <GrHttpBlocks.hpp>
-#include <GrTestingBlocks.hpp>
+#include <gnuradio-4.0/GrAudioBlocks.hpp>
+#include <gnuradio-4.0/GrBasicBlocks.hpp>
+#include <gnuradio-4.0/GrElectricalBlocks.hpp>
+#include <gnuradio-4.0/GrFileIoBlocks.hpp>
+#include <gnuradio-4.0/GrFilterBlocks.hpp>
+#include <gnuradio-4.0/GrFourierBlocks.hpp>
+#include <gnuradio-4.0/GrHttpBlocks.hpp>
+#include <gnuradio-4.0/GrTestingBlocks.hpp>
 
 const boost::ut::suite TagTests = [] {
     auto&       registry = gr::globalBlockRegistry();

--- a/blocks/libs/test/qa_apptest_KnownStaticLibBlocks.cpp
+++ b/blocks/libs/test/qa_apptest_KnownStaticLibBlocks.cpp
@@ -4,7 +4,7 @@
 #include <cassert>
 #include <iostream>
 
-#include <GrBasicBlocks.hpp>
+#include <gnuradio-4.0/GrBasicBlocks.hpp>
 
 using namespace std::string_literals;
 

--- a/blocks/math/CMakeLists.txt
+++ b/blocks/math/CMakeLists.txt
@@ -1,7 +1,9 @@
 add_library(gr-math INTERFACE)
-target_link_libraries(gr-math INTERFACE gnuradio-core gnuradio-algorithm exprtk)
+add_library(gnuradio4::gr-math ALIAS gr-math)
+target_link_libraries(gr-math INTERFACE gnuradio4::gnuradio-core gnuradio4::gnuradio-algorithm gnuradio4::exprtk)
 target_include_directories(gr-math INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
                                              $<INSTALL_INTERFACE:include/>)
+install(TARGETS gr-math EXPORT gnuradio4Targets)
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/gnuradio-4.0/math"
         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/gnuradio-4.0")
 
@@ -15,6 +17,6 @@ gr_add_block_library(
   LINK_LIBRARIES
   gr-math)
 
-if(TARGET GrMathBlocksShared AND ENABLE_TESTING)
+if(TARGET gnuradio4::GrMathBlocksShared AND ENABLE_TESTING)
   add_subdirectory(test)
 endif()

--- a/blocks/testing/CMakeLists.txt
+++ b/blocks/testing/CMakeLists.txt
@@ -1,7 +1,9 @@
 add_library(gr-testing INTERFACE)
-target_link_libraries(gr-testing INTERFACE gnuradio-core ut-benchmark)
+add_library(gnuradio4::gr-testing ALIAS gr-testing)
+target_link_libraries(gr-testing INTERFACE gnuradio4::gnuradio-core gnuradio4::ut-benchmark)
 target_include_directories(gr-testing INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
                                                 $<INSTALL_INTERFACE:include/>)
+install(TARGETS gr-testing EXPORT gnuradio4Targets)
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/gnuradio-4.0/testing"
         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/gnuradio-4.0")
 
@@ -16,9 +18,9 @@ gr_add_block_library(
   include/gnuradio-4.0/testing/PerformanceMonitor.hpp
   include/gnuradio-4.0/testing/SettingsChangeRecorder.hpp
   LINK_LIBRARIES
-  gr-testing
-  gnuradio-algorithm)
+  gnuradio4::gr-testing
+  gnuradio4::gnuradio-algorithm)
 
-if(TARGET GrTestingBlocksShared AND ENABLE_TESTING)
+if(TARGET gnuradio4::GrTestingBlocksShared AND ENABLE_TESTING)
   add_subdirectory(test)
 endif()

--- a/cmake/gnuradio4Config.cmake.in
+++ b/cmake/gnuradio4Config.cmake.in
@@ -14,4 +14,8 @@ endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/gnuradio4Targets.cmake")
 
+if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/gnuradio4PluginTargets.cmake")
+  include("${CMAKE_CURRENT_LIST_DIR}/gnuradio4PluginTargets.cmake")
+endif()
+
 check_required_components(gnuradio4)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -49,6 +49,7 @@ set(public_headers
     include/gnuradio-4.0/YamlPmt.hpp)
 
 set_target_properties(gnuradio-core PROPERTIES PUBLIC_HEADER "${public_headers}")
+add_library(gnuradio4::gnuradio-core ALIAS gnuradio-core)
 target_include_directories(
   gnuradio-core
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
@@ -67,6 +68,7 @@ target_link_libraries(
 add_library(gnuradio-blocklib-core SHARED src/BlockRegistry.cpp)
 set(blocklib_public_headers include/gnuradio-4.0/BlockRegistry.hpp include/gnuradio-4.0/Plugin.hpp)
 set_target_properties(gnuradio-blocklib-core PROPERTIES PUBLIC_HEADER "${blocklib_public_headers}")
+add_library(gnuradio4::gnuradio-blocklib-core ALIAS gnuradio-blocklib-core)
 message(INFO "PATH include " $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/>)
 target_include_directories(gnuradio-blocklib-core PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/>
                                                          $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)

--- a/core/include/gnuradio-4.0/Scheduler.hpp
+++ b/core/include/gnuradio-4.0/Scheduler.hpp
@@ -656,7 +656,12 @@ protected:
                 currentProgress = progress->value();
             }
 
-            bool hasMessagesToProcess = msgToCount == 0UZ;
+            // Process messages either when the ratio gate opens, or immediately when any entry-point port has
+            // pending traffic. This keeps the ratio's amortisation of empty-queue checks while giving arriving
+            // messages single-iteration latency (important for multi-hop sub-scheduler message paths).
+            const bool hasMessagesToProcess = msgToCount == 0UZ                //
+                                              || this->msgIn.available() > 0UZ //
+                                              || _fromChildMessagePort.available() > 0UZ;
             if (hasMessagesToProcess) {
                 if (runnerID == 0UZ || nRunningJobs->value() == 0UZ) {
                     this->processScheduledMessages(); // execute the scheduler- and Graph-specific message handler only once globally
@@ -1255,15 +1260,16 @@ protected:
     std::optional<Message> propertyCallbackSchedulerInspect([[maybe_unused]] std::string_view propertyName, Message message) {
         assert(propertyName == scheduler::property::kSchedulerInspect);
 
-        if (const bool yamlSerialize = [&] {
-                if (!message.data) {
+        if (const bool yamlSerialize =
+                [&] {
+                    if (!message.data) {
+                        return false;
+                    }
+                    if (const auto it = message.data->find("serialization_format"); it != message.data->cend()) {
+                        return it->second == "yaml";
+                    }
                     return false;
-                }
-                if (const auto it = message.data->find("serialization_format"); it != message.data->cend()) {
-                    return it->second == "yaml";
-                }
-                return false;
-            }();
+                }();
             !yamlSerialize) {
             message.data = [&] {
                 property_map result;

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -5,6 +5,7 @@ endif()
 
 if(NOT EMSCRIPTEN)
   add_library(gnuradio-plugin SHARED plugin.cpp)
+  add_library(gnuradio4::gnuradio-plugin ALIAS gnuradio-plugin)
   set_target_properties(gnuradio-plugin PROPERTIES BUILD_WITH_INSTALL_RPATH ON)
   target_include_directories(
     gnuradio-plugin PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -92,40 +92,50 @@ add_ut_test(qa_SubGraphAssets)
 set(_QA_SUBGRAPH_HTTP_PORT 18765)
 target_compile_definitions(qa_SubGraphAssets PRIVATE HTTP_SERVER_PORT=${_QA_SUBGRAPH_HTTP_PORT})
 if(EMSCRIPTEN)
-    set(ASSETS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/assets")
-    set(HTTP_SERVER_PORT ${_QA_SUBGRAPH_HTTP_PORT})
-    configure_file(subgraph_assets_pre.js.in subgraph_assets_pre.js @ONLY)
-    target_link_options(qa_SubGraphAssets PRIVATE
-        --pre-js=${CMAKE_CURRENT_BINARY_DIR}/subgraph_assets_pre.js
-        "SHELL:-s PROXY_TO_PTHREAD=1")
-    set_property(TARGET qa_SubGraphAssets APPEND PROPERTY LINK_DEPENDS
-        ${CMAKE_CURRENT_BINARY_DIR}/subgraph_assets_pre.js)
+  set(ASSETS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/assets")
+  set(HTTP_SERVER_PORT ${_QA_SUBGRAPH_HTTP_PORT})
+  configure_file(subgraph_assets_pre.js.in subgraph_assets_pre.js @ONLY)
+  target_link_options(
+    qa_SubGraphAssets
+    PRIVATE
+    --pre-js=${CMAKE_CURRENT_BINARY_DIR}/subgraph_assets_pre.js
+    "SHELL:-s PROXY_TO_PTHREAD=1")
+  set_property(
+    TARGET qa_SubGraphAssets
+    APPEND
+    PROPERTY LINK_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/subgraph_assets_pre.js)
 else()
-    target_link_libraries(qa_SubGraphAssets PRIVATE httplib::httplib)
+  target_link_libraries(qa_SubGraphAssets PRIVATE httplib::httplib)
 endif()
-if (GR_ENABLE_BLOCK_REGISTRY AND INTERNAL_ENABLE_BLOCK_PLUGINS)
-  add_dependencies(qa_SubGraphAssets GoodBasePlugin good_math_plugin good_conversion_plugin bad_plugin)
-endif ()
+if(GR_ENABLE_BLOCK_REGISTRY AND INTERNAL_ENABLE_BLOCK_PLUGINS)
+  add_dependencies(
+    qa_SubGraphAssets
+    GoodBasePlugin
+    good_math_plugin
+    good_conversion_plugin
+    bad_plugin)
+endif()
 
 if(GR_ENABLE_BLOCK_REGISTRY AND INTERNAL_ENABLE_BLOCK_PLUGINS)
   add_ut_test(qa_Settings)
 
   add_app_test(qa_grc)
   gr_generate_block_instantiations(qa_grc HEADERS CollectionTestBlocks.hpp)
-  target_link_libraries(qa_grc PUBLIC GrBasicBlocksShared GrTestingBlocksShared)
+  target_link_libraries(qa_grc PUBLIC gnuradio4::GrBasicBlocksShared gnuradio4::GrTestingBlocksShared)
 
   add_ut_test(qa_GraphMessages)
-  target_link_libraries(qa_GraphMessages PUBLIC GrBasicBlocksShared GrTestingBlocksShared)
+  target_link_libraries(qa_GraphMessages PUBLIC gnuradio4::GrBasicBlocksShared gnuradio4::GrTestingBlocksShared)
 
   add_ut_test(qa_SchedulerMessages)
-  target_link_libraries(qa_SchedulerMessages PUBLIC GrBasicBlocksShared GrTestingBlocksShared)
+  target_link_libraries(qa_SchedulerMessages PUBLIC gnuradio4::GrBasicBlocksShared gnuradio4::GrTestingBlocksShared)
 
   add_subdirectory(plugins)
   add_app_test(qa_plugins_test)
-  target_link_libraries(qa_plugins_test PUBLIC GrBasicBlocksShared GrTestingBlocksShared)
+  target_link_libraries(qa_plugins_test PUBLIC gnuradio4::GrBasicBlocksShared gnuradio4::GrTestingBlocksShared)
 
   add_app_test(qa_plugin_schedulers_test)
-  target_link_libraries(qa_plugin_schedulers_test PUBLIC GrBasicBlocksShared GrTestingBlocksShared)
+  target_link_libraries(qa_plugin_schedulers_test PUBLIC gnuradio4::GrBasicBlocksShared
+                                                         gnuradio4::GrTestingBlocksShared)
 endif()
 
 if(GR_USE_ADAPTIVE_CPP)

--- a/core/test/qa_GraphMessages.cpp
+++ b/core/test/qa_GraphMessages.cpp
@@ -3,8 +3,8 @@
 #include <gnuradio-4.0/Scheduler.hpp>
 #include <gnuradio-4.0/testing/NullSources.hpp>
 
-#include <GrBasicBlocks.hpp>
-#include <GrTestingBlocks.hpp>
+#include <gnuradio-4.0/GrBasicBlocks.hpp>
+#include <gnuradio-4.0/GrTestingBlocks.hpp>
 
 #include "TestBlockRegistryContext.hpp"
 

--- a/core/test/qa_SchedulerMessages.cpp
+++ b/core/test/qa_SchedulerMessages.cpp
@@ -4,14 +4,13 @@
 #include <gnuradio-4.0/meta/UnitTestHelper.hpp>
 #include <gnuradio-4.0/testing/NullSources.hpp>
 
-#include <GrBasicBlocks.hpp>
-#include <GrTestingBlocks.hpp>
+#include <gnuradio-4.0/GrBasicBlocks.hpp>
+#include <gnuradio-4.0/GrTestingBlocks.hpp>
 
 #include "TestBlockRegistryContext.hpp"
 
 #include "magic_enum.hpp"
 #include "message_utils.hpp"
-#include <magic_enum/magic_enum.hpp>
 
 using namespace std::chrono_literals;
 using namespace std::string_literals;

--- a/core/test/qa_grc.cpp
+++ b/core/test/qa_grc.cpp
@@ -15,12 +15,12 @@
 
 #include "CollectionTestBlocks.hpp"
 
-#include <GrBasicBlocks.hpp>
-#include <GrTestingBlocks.hpp>
-#include <qa_grc.hpp>
+#include <gnuradio-4.0/GrBasicBlocks.hpp>
+#include <gnuradio-4.0/GrTestingBlocks.hpp>
+#include <gnuradio-4.0/qa_grc.hpp>
 
 #include "TestBlockRegistryContext.hpp"
-#include "gnuradio-4.0/BlockModel.hpp"
+#include <gnuradio-4.0/BlockModel.hpp>
 
 #include <gnuradio-4.0/meta/UnitTestHelper.hpp>
 

--- a/core/test/qa_plugins_test.cpp
+++ b/core/test/qa_plugins_test.cpp
@@ -9,8 +9,8 @@
 #include <gnuradio-4.0/Graph.hpp>
 #include <gnuradio-4.0/basic/CommonBlocks.hpp>
 
-#include <GrBasicBlocks.hpp>
-#include <GrTestingBlocks.hpp>
+#include <gnuradio-4.0/GrBasicBlocks.hpp>
+#include <gnuradio-4.0/GrTestingBlocks.hpp>
 
 #include "TestBlockRegistryContext.hpp"
 

--- a/meta/CMakeLists.txt
+++ b/meta/CMakeLists.txt
@@ -1,7 +1,8 @@
 add_library(gnuradio-meta INTERFACE)
+add_library(gnuradio4::gnuradio-meta ALIAS gnuradio-meta)
 target_include_directories(gnuradio-meta INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
                                                    $<INSTALL_INTERFACE:include/>)
-target_link_libraries(gnuradio-meta INTERFACE gnuradio-options vir)
+target_link_libraries(gnuradio-meta INTERFACE gnuradio4::gnuradio-options gnuradio4::vir)
 
 set(meta_public_headers
     include/gnuradio-4.0/meta/CacheLineSize.hpp


### PR DESCRIPTION
Namespaced targets allow for better CMake checking of target dependencies, allowing it to fail at
configure time rather than silently or at link time.

Use namespaced aliases to link in tree.