### PR TITLE
refactor(core): cleanup + GCC-16 support + C++26 reflection prep

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,19 +81,46 @@ if(NOT MSVC)
     set(_USE_ICF FALSE)
   endif()
 
+  # user-facing override: USE_MOLD_LINKER=OFF forces fall-through to lld/default even if mold is installed.
+  option(USE_MOLD_LINKER "Use mold as the linker when available (falls back to lld, then default)" ON)
+
   if(NOT
      CMAKE_SYSTEM_NAME
      STREQUAL
      "Emscripten"
      AND NOT APPLE)
-    find_program(MOLD_BIN ld.mold)
-    if(MOLD_BIN)
+    set(_mold_usable FALSE)
+    if(USE_MOLD_LINKER)
+      find_program(MOLD_BIN ld.mold)
+      if(MOLD_BIN)
+        # mold < 3.0 does not parse the AS_NEEDED() directive used by some modern libatomic stubs (observed with GCC
+        # 16's libatomic_asneeded.so; affects any compiler toolchain whose runtime ships an AS_NEEDED linker-script
+        # stub). Auto-fall-through to lld / default in that case.
+        execute_process(
+          COMMAND "${MOLD_BIN}" --version
+          OUTPUT_VARIABLE _mold_version_out
+          OUTPUT_STRIP_TRAILING_WHITESPACE)
+        if(_mold_version_out MATCHES "mold ([0-9]+)\\.([0-9]+)")
+          if(CMAKE_MATCH_1 VERSION_LESS 3)
+            message(
+              STATUS "Skipping mold ${CMAKE_MATCH_1}.${CMAKE_MATCH_2} (AS_NEEDED() support requires mold >= 3.0).")
+          else()
+            set(_mold_usable TRUE)
+          endif()
+        else()
+          # unknown format — assume usable, user can override via -DUSE_MOLD_LINKER=OFF
+          set(_mold_usable TRUE)
+        endif()
+      endif()
+    endif()
+
+    if(_mold_usable)
       set(_LD_GC_SECTIONS "${_LD_GC_SECTIONS} -fuse-ld=mold")
       if(_USE_ICF)
         string(APPEND _LD_GC_SECTIONS " -Wl,--icf=safe")
       endif()
       message(STATUS "Using mold @ ${MOLD_BIN} as the linker.")
-    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    else()
       find_program(LLD_BIN ld.lld)
       if(LLD_BIN)
         set(_LD_GC_SECTIONS "${_LD_GC_SECTIONS} -fuse-ld=lld")
@@ -101,6 +128,8 @@ if(NOT MSVC)
           string(APPEND _LD_GC_SECTIONS " -Wl,--icf=safe")
         endif()
         message(STATUS "Using lld @ ${LLD_BIN} as the linker.")
+      else()
+        message(STATUS "Using default system linker (mold and lld unavailable).")
       endif()
     endif()
   endif()

--- a/core/benchmarks/bm_Scheduler.cpp
+++ b/core/benchmarks/bm_Scheduler.cpp
@@ -203,7 +203,7 @@ void printGraphTopology(const gr::Graph& graph, GraphTopology topology, bool det
     for (auto& loop : gr::graph::detectFeedbackLoops(flatGraph)) {
         gr::graph::colour(loop.edges.back(), gr::utf8::color::palette::Default::Cyan); // colour feedback edges
     }
-    std::println("Graph Topology: {}{}:\n{}", magic_enum::enum_name(topology), neededFlattening ? "-flattened" : "", gr::graph::draw(flatGraph));
+    std::println("Graph Topology: {}{}:\n{}", gr::meta::enumName(topology).value_or(""), neededFlattening ? "-flattened" : "", gr::graph::draw(flatGraph));
     std::println("blocks in order of definition: {}", //
         [&] -> std::string {
             std::string s;
@@ -322,7 +322,7 @@ gr::Graph createInstrumentalisedGraph(GraphTopology topology = GraphTopology::LI
     using namespace benchmark;
 
     "scheduler topology loop"_test = [](GraphTopology topology) {
-        const std::string topologyName(magic_enum::enum_name(topology));
+        const std::string topologyName(gr::meta::enumName(topology).value_or(""));
 
         gr::scheduler::Simple simple;
         if (auto ret = simple.exchange(createInstrumentalisedGraph<T>(topology)); !ret) {

--- a/core/include/gnuradio-4.0/Block.hpp
+++ b/core/include/gnuradio-4.0/Block.hpp
@@ -460,6 +460,24 @@ inline std::size_t computePerformedWork(Status status, std::size_t processedIn, 
 
 } // namespace work
 
+} // namespace gr
+
+// Compile-time performance override; phased out with C++26 reflection.
+namespace gr::meta::detail {
+template<>
+struct EnumTraits<gr::work::Status> {
+    static constexpr std::array<std::pair<gr::work::Status, std::string_view>, 5> entries = {{
+        {gr::work::Status::ERROR, "ERROR"},
+        {gr::work::Status::INSUFFICIENT_OUTPUT_ITEMS, "INSUFFICIENT_OUTPUT_ITEMS"},
+        {gr::work::Status::INSUFFICIENT_INPUT_ITEMS, "INSUFFICIENT_INPUT_ITEMS"},
+        {gr::work::Status::DONE, "DONE"},
+        {gr::work::Status::OK, "OK"},
+    }};
+};
+} // namespace gr::meta::detail
+
+namespace gr {
+
 template<typename TBlock, typename TDecayedBlock = std::remove_cvref_t<TBlock>>
 inline void checkBlockContracts();
 
@@ -753,7 +771,7 @@ public:
         property_map ret;
         if constexpr (!std::is_same_v<NotDrawable, DrawableControl>) {
             property_map info;
-            info.insert_or_assign("Category", std::string(magic_enum::enum_name(DrawableControl::kCategory)));
+            info.insert_or_assign("Category", std::string(gr::meta::enumName(DrawableControl::kCategory).value_or("")));
             info.insert_or_assign("Toolkit", std::string(DrawableControl::kToolkit));
 
             ret.insert_or_assign("Drawable", info);
@@ -2484,7 +2502,7 @@ struct std::formatter<gr::work::Result, char> {
 
     template<typename FormatContext>
     auto format(const gr::work::Result& result, FormatContext& ctx) const {
-        return std::format_to(ctx.out(), "requested_work: {}, performed_work: {}, status: {}", result.requested_work, result.performed_work, magic_enum::enum_name(result.status));
+        return std::format_to(ctx.out(), "requested_work: {}, performed_work: {}, status: {}", result.requested_work, result.performed_work, gr::meta::enumName(result.status).value_or(""));
     }
 };
 

--- a/core/include/gnuradio-4.0/Block.hpp
+++ b/core/include/gnuradio-4.0/Block.hpp
@@ -937,7 +937,9 @@ public:
                 }
             }
         });
-        checkBlockParameterConsistency();
+        if constexpr (gr::meta::kDebugBuild) {
+            checkBlockParameterConsistency();
+        }
         // store default settings -> can be recovered with 'resetDefaults()'
         settings().storeDefaults();
         emitErrorMessageIfAny("init(..) -> INITIALISED", this->changeStateTo(lifecycle::State::INITIALISED));
@@ -1233,7 +1235,9 @@ public:
             std::ignore      = publishForwardTags;
             std::ignore      = capturedForwardParams;
             auto applyResult = settings().applyStagedParameters();
-            checkBlockParameterConsistency();
+            if constexpr (gr::meta::kDebugBuild) {
+                checkBlockParameterConsistency();
+            }
 
             if constexpr (!noTagPropagation) {
                 if (publishForwardTags && !applyResult.forwardParameters.empty()) {

--- a/core/include/gnuradio-4.0/Block.hpp
+++ b/core/include/gnuradio-4.0/Block.hpp
@@ -469,21 +469,22 @@ struct isBlockDependent {
 };
 
 namespace block::property {
-inline static const char* kHeartbeat      = "Heartbeat";      ///< heartbeat property - the canary in the coal mine (supports block-specific subscribe/unsubscribe)
-inline static const char* kEcho           = "Echo";           ///< basic property that receives any matching message and sends a mirror with it's serviceName/unique_name
-inline static const char* kLifeCycleState = "LifecycleState"; ///< basic property that sets the block's @see lifecycle::StateMachine
-inline static const char* kSetting        = "Settings";       ///< asynchronous message-based setting handling,
-                                                              // N.B. 'Set' Settings are first staged before being applied within the work(...) function (real-time/non-real-time decoupling)
-inline static const char* kStagedSetting = "StagedSettings";  ///< asynchronous message-based staging of settings
+// [[maybe_unused]]: names referenced only from Block.cpp (initStandardPropertyCallbacks) and user code — silences -Werror=unused-variable on TUs that include only the header.
+[[maybe_unused]] inline static const char* kHeartbeat      = "Heartbeat";      ///< heartbeat property - the canary in the coal mine (supports block-specific subscribe/unsubscribe)
+[[maybe_unused]] inline static const char* kEcho           = "Echo";           ///< basic property that receives any matching message and sends a mirror with it's serviceName/unique_name
+[[maybe_unused]] inline static const char* kLifeCycleState = "LifecycleState"; ///< basic property that sets the block's @see lifecycle::StateMachine
+[[maybe_unused]] inline static const char* kSetting        = "Settings";       ///< asynchronous message-based setting handling,
+                                                                               // N.B. 'Set' Settings are first staged before being applied within the work(...) function (real-time/non-real-time decoupling)
+[[maybe_unused]] inline static const char* kStagedSetting = "StagedSettings";  ///< asynchronous message-based staging of settings
 
-inline static const char* kMetaInformation = "MetaInformation"; ///< asynchronous message-based retrieval of the static meta-information (i.e. Annotated<> interfaces, constraints, etc...)
-inline static const char* kUiConstraints   = "UiConstraints";   ///< asynchronous message-based retrieval of user-defined UI constraints
+[[maybe_unused]] inline static const char* kMetaInformation = "MetaInformation"; ///< asynchronous message-based retrieval of the static meta-information (i.e. Annotated<> interfaces, constraints, etc...)
+[[maybe_unused]] inline static const char* kUiConstraints   = "UiConstraints";   ///< asynchronous message-based retrieval of user-defined UI constraints
 
-inline static const char* kStoreDefaults    = "StoreDefaults";    ///< store present settings as default, for counterpart @see kResetDefaults
-inline static const char* kResetDefaults    = "ResetDefaults";    ///< retrieve and reset to default setting, for counterpart @see kStoreDefaults
-inline static const char* kActiveContext    = "ActiveContext";    ///< retrieve and set active context
-inline static const char* kSettingsCtx      = "SettingsCtx";      ///< retrieve/creates/remove a new stored context
-inline static const char* kSettingsContexts = "SettingsContexts"; ///< retrieve/creates/remove a new stored context
+[[maybe_unused]] inline static const char* kStoreDefaults    = "StoreDefaults";    ///< store present settings as default, for counterpart @see kResetDefaults
+[[maybe_unused]] inline static const char* kResetDefaults    = "ResetDefaults";    ///< retrieve and reset to default setting, for counterpart @see kStoreDefaults
+[[maybe_unused]] inline static const char* kActiveContext    = "ActiveContext";    ///< retrieve and set active context
+[[maybe_unused]] inline static const char* kSettingsCtx      = "SettingsCtx";      ///< retrieve/creates/remove a new stored context
+[[maybe_unused]] inline static const char* kSettingsContexts = "SettingsContexts"; ///< retrieve/creates/remove a new stored context
 
 } // namespace block::property
 
@@ -520,6 +521,9 @@ struct BlockBase {
 
     std::map<std::string, PropertyCallback>      propertyCallbacks;
     std::map<std::string, std::set<std::string>> propertySubscriptions;
+
+    // out-of-line so the 12-entry map literal is compiled once, not per Block<T>::Block body.
+    void initStandardPropertyCallbacks() noexcept;
 
     // accessor helpers (delegate to function pointers, using _blockSelf for correct Block* address)
     SettingsBase&              cbSettings() { return _cbSettings(_blockSelf); }
@@ -835,21 +839,7 @@ public:
         _cbMetaInformation = &Block::cbMetaInformationImpl;
         _cbUiConstraints   = &Block::cbUiConstraintsImpl;
 
-        // initialize inherited BlockBase::propertyCallbacks
-        propertyCallbacks = {
-            {block::property::kHeartbeat, &BlockBase::propertyCallbackHeartbeat},
-            {block::property::kEcho, &BlockBase::propertyCallbackEcho},
-            {block::property::kLifeCycleState, &BlockBase::propertyCallbackLifecycleState},
-            {block::property::kSetting, &BlockBase::propertyCallbackSettings},
-            {block::property::kStagedSetting, &BlockBase::propertyCallbackStagedSettings},
-            {block::property::kStoreDefaults, &BlockBase::propertyCallbackStoreDefaults},
-            {block::property::kResetDefaults, &BlockBase::propertyCallbackResetDefaults},
-            {block::property::kActiveContext, &BlockBase::propertyCallbackActiveContext},
-            {block::property::kSettingsCtx, &BlockBase::propertyCallbackSettingsCtx},
-            {block::property::kSettingsContexts, &BlockBase::propertyCallbackSettingsContexts},
-            {block::property::kMetaInformation, &BlockBase::propertyCallbackMetaInformation},
-            {block::property::kUiConstraints, &BlockBase::propertyCallbackUiConstraints},
-        };
+        initStandardPropertyCallbacks();
 
         // check Block<T> contracts
         checkBlockContracts<decltype(*static_cast<Derived*>(this))>();

--- a/core/include/gnuradio-4.0/BlockMerging.hpp
+++ b/core/include/gnuradio-4.0/BlockMerging.hpp
@@ -33,7 +33,8 @@ concept MergedBlock = requires(const T& t) {
 
 template<BlockLike T>
 std::shared_ptr<BlockModel> makeNonOwningWrapper(T& block) {
-    return std::make_shared<BlockWrapper<T, std::false_type>>(block);
+    BlockModel* raw = new BlockWrapper<T, std::false_type>(block);
+    return std::shared_ptr<BlockModel>{raw};
 }
 
 template<typename T>
@@ -345,9 +346,9 @@ struct SplitMergeDisplayBlock : gr::Block<SplitMergeDisplayBlock<T>> {
 
 template<typename T>
 std::shared_ptr<BlockModel> makeSplitMergeDisplayNode(const std::string& label) {
-    auto node             = std::make_shared<BlockWrapper<SplitMergeDisplayBlock<T>>>();
-    node->blockRef().name = label;
-    return node;
+    auto* wrapper            = new BlockWrapper<SplitMergeDisplayBlock<T>>();
+    wrapper->blockRef().name = label;
+    return std::shared_ptr<BlockModel>{static_cast<BlockModel*>(wrapper)};
 }
 
 template<BlockLike... Paths>

--- a/core/include/gnuradio-4.0/BlockModel.hpp
+++ b/core/include/gnuradio-4.0/BlockModel.hpp
@@ -625,10 +625,10 @@ property_map serializeEdge(const auto& edge) {
     result.emplace(serialization_fields::EDGE_NAME, std::string(edge.name()));
 
     result.emplace(serialization_fields::EDGE_BUFFER_SIZE, static_cast<gr::Size_t>(edge.bufferSize()));
-    result.emplace(serialization_fields::EDGE_EDGE_STATE, std::string(magic_enum::enum_name(edge.state())));
+    result.emplace(serialization_fields::EDGE_EDGE_STATE, std::string(gr::meta::enumName(edge.state()).value_or("")));
     result.emplace(serialization_fields::EDGE_N_READERS, static_cast<gr::Size_t>(edge.nReaders()));
     result.emplace(serialization_fields::EDGE_N_WRITERS, static_cast<gr::Size_t>(edge.nWriters()));
-    result.emplace(serialization_fields::EDGE_TYPE, std::string(magic_enum::enum_name(edge.edgeType())));
+    result.emplace(serialization_fields::EDGE_TYPE, std::string(gr::meta::enumName(edge.edgeType()).value_or("")));
 
     return result;
 }
@@ -1009,7 +1009,7 @@ struct std::formatter<gr::Edge> {
 
         return std::format_to(ctx.out(), "{}/{} ⟶ (name: '{}', size: {:2}, weight: {:2}, state: {}) ⟶ {}/{}", //
             getName(e._sourceBlock), e._sourcePortDefinition,                                                 // src
-            e._name, e._minBufferSize, e._weight, magic_enum::enum_name(e._state),                            // edge
+            e._name, e._minBufferSize, e._weight, gr::meta::enumName(e._state).value_or(""),                  // edge
             getName(e._destinationBlock), e._destinationPortDefinition);                                      // dst
     }
 };

--- a/core/include/gnuradio-4.0/Graph.hpp
+++ b/core/include/gnuradio-4.0/Graph.hpp
@@ -389,7 +389,8 @@ public:
     requires std::is_constructible_v<TBlock, property_map>
     TBlock& emplaceBlock(gr::property_map initialSettings = gr::property_map()) {
         static_assert(std::is_same_v<TBlock, std::remove_reference_t<TBlock>>);
-        const std::shared_ptr<BlockModel>& newBlock    = _blocks.emplace_back(std::make_shared<BlockWrapper<TBlock>>(std::move(initialSettings)));
+        BlockModel*                        raw         = new BlockWrapper<TBlock>(std::move(initialSettings));
+        const std::shared_ptr<BlockModel>& newBlock    = _blocks.emplace_back(std::shared_ptr<BlockModel>{raw});
         TBlock*                            rawBlockRef = static_cast<TBlock*>(newBlock->raw());
         rawBlockRef->init(_progress);
         return *rawBlockRef;

--- a/core/include/gnuradio-4.0/LifeCycle.hpp
+++ b/core/include/gnuradio-4.0/LifeCycle.hpp
@@ -74,6 +74,27 @@ namespace gr::lifecycle {
 enum class State : char { IDLE, INITIALISED, RUNNING, REQUESTED_PAUSE, PAUSED, REQUESTED_STOP, STOPPED, ERROR };
 using enum State;
 
+} // namespace gr::lifecycle
+
+// Compile-time performance override; phased out with C++26 reflection.
+namespace gr::meta::detail {
+template<>
+struct EnumTraits<gr::lifecycle::State> {
+    static constexpr std::array<std::pair<gr::lifecycle::State, std::string_view>, 8> entries = {{
+        {gr::lifecycle::State::IDLE, "IDLE"},
+        {gr::lifecycle::State::INITIALISED, "INITIALISED"},
+        {gr::lifecycle::State::RUNNING, "RUNNING"},
+        {gr::lifecycle::State::REQUESTED_PAUSE, "REQUESTED_PAUSE"},
+        {gr::lifecycle::State::PAUSED, "PAUSED"},
+        {gr::lifecycle::State::REQUESTED_STOP, "REQUESTED_STOP"},
+        {gr::lifecycle::State::STOPPED, "STOPPED"},
+        {gr::lifecycle::State::ERROR, "ERROR"},
+    }};
+};
+} // namespace gr::meta::detail
+
+namespace gr::lifecycle {
+
 inline constexpr bool isActive(lifecycle::State state) noexcept { return state == RUNNING || state == REQUESTED_PAUSE || state == PAUSED; }
 
 inline constexpr bool isShuttingDown(lifecycle::State state) noexcept { return state == REQUESTED_STOP || state == STOPPED; }
@@ -199,7 +220,7 @@ public:
         if (!isValidTransition(oldState, newState)) {
             return std::unexpected(Error{std::format("Block '{}' invalid state transition in {} from {} -> to {}", //
                                              getBlockName(), gr::meta::type_name<TDerived>(),                      //
-                                             magic_enum::enum_name(state()), magic_enum::enum_name(newState)),
+                                             gr::meta::enumName(state()).value_or(""), gr::meta::enumName(newState).value_or("")),
                 location});
         }
 

--- a/core/include/gnuradio-4.0/Message.hpp
+++ b/core/include/gnuradio-4.0/Message.hpp
@@ -79,7 +79,7 @@ enum class Command : unsigned char {
 
 template<Command command>
 std::string commandName() noexcept {
-    return std::string(magic_enum::enum_name<command>());
+    return std::string(gr::meta::enumName(command).value_or(""));
 }
 
 inline static std::string defaultBlockProtocol  = "MDPW03";
@@ -186,11 +186,11 @@ struct std::formatter<gr::message::Command> {
     // Formats the source_location, using 'f' for file and 'l' for line
     template<typename FormatContext>
     auto format(const gr::message::Command& command, FormatContext& ctx) const -> decltype(ctx.out()) {
-        return std::format_to(ctx.out(), "{}", magic_enum::enum_name(command));
+        return std::format_to(ctx.out(), "{}", gr::meta::enumName(command).value_or(""));
     }
 };
 
-inline std::ostream& operator<<(std::ostream& os, const gr::message::Command& command) { return os << magic_enum::enum_name(command); }
+inline std::ostream& operator<<(std::ostream& os, const gr::message::Command& command) { return os << gr::meta::enumName(command).value_or(""); }
 
 template<>
 struct std::formatter<gr::Message> {

--- a/core/include/gnuradio-4.0/PmtTypeHelpers.hpp
+++ b/core/include/gnuradio-4.0/PmtTypeHelpers.hpp
@@ -295,15 +295,15 @@ template<class T, bool strictCheck = false, typename From>
     else if constexpr (std::is_same_v<S, std::string>) {
         // 6a) string->enum
         if constexpr (std::is_enum_v<T>) {
-            if (auto maybeEnum = magic_enum::enum_cast<T>(srcValue)) {
+            if (auto maybeEnum = gr::meta::parseEnum<T>(srcValue)) {
                 return *maybeEnum;
             }
             auto possibleEnumValues = []<typename U>(const U&) -> std::string {
-                constexpr auto vals  = magic_enum::enum_values<U>();
-                auto           names = vals | std::views::transform(magic_enum::enum_name<U>);
+                constexpr auto vals  = gr::meta::enumValues<U>();
+                auto           names = vals | std::views::transform([](U v) { return gr::meta::enumName(v).value_or(""); });
                 return std::format("{}", gr::join(names, ", "));
             };
-            return std::unexpected(std::format("'{}' is not a valid enum '{}' value: [{}]", srcValue, magic_enum::enum_type_name<T>(), possibleEnumValues(T{})));
+            return std::unexpected(std::format("'{}' is not a valid enum '{}' value: [{}]", srcValue, gr::meta::type_name<T>(), possibleEnumValues(T{})));
         }
         // 6b) string->integral (excluding bool)
         else if constexpr (std::is_integral_v<T> && !std::is_same_v<T, bool>) {
@@ -347,9 +347,9 @@ template<class T, bool strictCheck = false, typename From>
     // 7) source is enum
     else if constexpr (std::is_enum_v<S>) {
         if constexpr (std::is_same_v<T, std::string>) {
-            return std::string(magic_enum::enum_name(srcValue));
+            return std::string(gr::meta::enumName(srcValue).value_or(""));
         }
-        return std::unexpected(std::format("no safe conversion for {} src = {} -> <{}>", magic_enum::enum_type_name<S>(), magic_enum::enum_name(srcValue), typeid(T).name()));
+        return std::unexpected(std::format("no safe conversion for {} src = {} -> <{}>", gr::meta::type_name<S>(), gr::meta::enumName(srcValue).value_or(""), typeid(T).name()));
     }
 
     // fallback

--- a/core/include/gnuradio-4.0/Scheduler.hpp
+++ b/core/include/gnuradio-4.0/Scheduler.hpp
@@ -348,7 +348,7 @@ public:
         }
     }
 
-    void stateChanged(lifecycle::State newState) { this->notifyListeners(block::property::kLifeCycleState, {{"state", std::string(magic_enum::enum_name(newState))}}); }
+    void stateChanged(lifecycle::State newState) { this->notifyListeners(block::property::kLifeCycleState, {{"state", std::string(gr::meta::enumName(newState).value_or(""))}}); }
 
     [[nodiscard]] std::span<std::shared_ptr<BlockModel>>       blocks() noexcept { return _graph->blocks(); }
     [[nodiscard]] std::span<const std::shared_ptr<BlockModel>> blocks() const noexcept { return _graph->blocks(); }
@@ -852,7 +852,7 @@ protected:
         case INITIALISED: //
             this->emitErrorMessageIfAny("adoptBlock -> INITIALIZED", newBlock->changeStateTo(RUNNING));
             break;
-        default: this->emitErrorMessage("propertyCallbackEmplaceBlock", std::format("Unexpected block state during emplacement: {}", magic_enum::enum_name(newBlock->state())));
+        default: this->emitErrorMessage("propertyCallbackEmplaceBlock", std::format("Unexpected block state during emplacement: {}", gr::meta::enumName(newBlock->state()).value_or("")));
         }
     }
 
@@ -1275,7 +1275,7 @@ protected:
                 property_map result;
                 result[std::pmr::string(serialization_fields::BLOCK_NAME)]        = std::string(this->name);
                 result[std::pmr::string(serialization_fields::BLOCK_UNIQUE_NAME)] = std::string(this->unique_name);
-                result[std::pmr::string(serialization_fields::BLOCK_CATEGORY)]    = std::string(magic_enum::enum_name(blockCategory));
+                result[std::pmr::string(serialization_fields::BLOCK_CATEGORY)]    = std::string(gr::meta::enumName(blockCategory).value_or(""));
 
                 // Requesting graph serialization
                 property_map serializedChildren;

--- a/core/include/gnuradio-4.0/Settings.hpp
+++ b/core/include/gnuradio-4.0/Settings.hpp
@@ -332,6 +332,71 @@ template<typename T>
 
 } // namespace settings
 
+namespace detail {
+// Free templates (not CtxSettings<TBlock>::) so the bodies instantiate once per Type
+// instead of once per (TBlock, Type).
+template<typename Type>
+inline std::optional<std::string> setParameterImpl(std::string_view key, const pmt::Value& value, property_map& newParameters) {
+    if (auto convertedValue = settings::convertParameter<Type>(key, value); convertedValue) [[likely]] {
+        const auto keyStr = std::pmr::string(key);
+        if constexpr (detail::isEnumOrAnnotatedEnum<Type>) {
+            newParameters.insert_or_assign(keyStr, detail::enumToString(convertedValue.value()));
+        } else if constexpr (meta::array_or_vector_type<Type>) {
+            newParameters.insert_or_assign(keyStr, pmt::Value(detail::collectionToTensor(*convertedValue)));
+        } else {
+            newParameters.insert_or_assign(keyStr, detail::castToGrSizeIfNeeded(convertedValue.value()));
+        }
+        return std::nullopt;
+    } else {
+        return convertedValue.error();
+    }
+}
+
+template<typename Type>
+inline bool autoUpdateImpl(std::string_view key, const pmt::Value& value, const std::set<std::string>& autoUpdateParams, property_map& stagedParameters) {
+    const auto keyStr = std::string(key);
+    if (!autoUpdateParams.contains(keyStr)) {
+        return false;
+    }
+    const auto keyPmr = std::pmr::string(key);
+    if constexpr (std::is_enum_v<Type>) {
+        if (value.holds<std::string>()) {
+            stagedParameters.insert_or_assign(keyPmr, value);
+            return true;
+        }
+#ifdef __EMSCRIPTEN__
+    } else if constexpr (std::is_same_v<Type, std::size_t> && !std::is_same_v<std::size_t, gr::Size_t>) {
+        if (value.holds<gr::Size_t>()) {
+            stagedParameters.insert_or_assign(keyPmr, value);
+            return true;
+        }
+#endif
+    } else if constexpr (std::is_same_v<Type, std::string> || std::is_same_v<Type, std::pmr::string>) {
+        if (value.holds<std::pmr::string>()) {
+            stagedParameters.insert_or_assign(keyPmr, value);
+            return true;
+        }
+    } else if constexpr (meta::array_or_vector_type<Type>) {
+        using TValue      = typename Type::value_type;
+        using TTensorElem = std::conditional_t<std::is_same_v<TValue, std::string> || std::is_same_v<TValue, std::pmr::string>, std::pmr::string, TValue>;
+        if (value.holds<Tensor<TTensorElem>>()) {
+            auto converted = pmt::convertTo<Tensor<TTensorElem>>(value);
+            if (converted.has_value()) {
+                stagedParameters.insert_or_assign(keyPmr, std::move(*converted));
+                return true;
+            }
+            return false;
+        }
+    } else {
+        if (value.holds<Type>()) {
+            stagedParameters.insert_or_assign(keyPmr, value);
+            return true;
+        }
+    }
+    return false;
+}
+} // namespace detail
+
 struct SettingsBase {
     struct CtxSettingsPair {
         SettingsCtx  context;
@@ -605,69 +670,6 @@ public:
     using ActiveParameterReader = void (*)(const TBlock* block, property_map& activeParameters);
 
 private:
-    // Helper template for parameter setting (set method) - instantiated once per member type
-    template<typename Type>
-    static std::optional<std::string> setParameterImpl(std::string_view key, const pmt::Value& value, property_map& newParameters) {
-        if (auto convertedValue = settings::convertParameter<Type>(key, value); convertedValue) [[likely]] {
-            const auto keyStr = std::pmr::string(key);
-            if constexpr (detail::isEnumOrAnnotatedEnum<Type>) {
-                newParameters.insert_or_assign(keyStr, detail::enumToString(convertedValue.value()));
-            } else if constexpr (meta::array_or_vector_type<Type>) {
-                newParameters.insert_or_assign(keyStr, pmt::Value(detail::collectionToTensor(*convertedValue)));
-            } else {
-                newParameters.insert_or_assign(keyStr, detail::castToGrSizeIfNeeded(convertedValue.value()));
-            }
-            return std::nullopt; // success
-        } else {
-            return convertedValue.error(); // error message
-        }
-    }
-
-    // Helper template for autoUpdate - checks type compatibility and updates staged parameters
-    template<typename Type>
-    static bool autoUpdateImpl(std::string_view key, const pmt::Value& value, const std::set<std::string>& autoUpdateParams, property_map& stagedParameters) {
-        const auto keyStr = std::string(key);
-        if (!autoUpdateParams.contains(keyStr)) {
-            return false;
-        }
-        const auto keyPmr = std::pmr::string(key);
-        if constexpr (std::is_enum_v<Type>) {
-            if (value.holds<std::string>()) {
-                stagedParameters.insert_or_assign(keyPmr, value);
-                return true;
-            }
-#ifdef __EMSCRIPTEN__
-        } else if constexpr (std::is_same_v<Type, std::size_t> && !std::is_same_v<std::size_t, gr::Size_t>) {
-            if (value.holds<gr::Size_t>()) {
-                stagedParameters.insert_or_assign(keyPmr, value);
-                return true;
-            }
-#endif
-        } else if constexpr (std::is_same_v<Type, std::string> || std::is_same_v<Type, std::pmr::string>) {
-            if (value.holds<std::pmr::string>()) {
-                stagedParameters.insert_or_assign(keyPmr, value);
-                return true;
-            }
-        } else if constexpr (meta::array_or_vector_type<Type>) {
-            using TValue      = typename Type::value_type;
-            using TTensorElem = std::conditional_t<std::is_same_v<TValue, std::string> || std::is_same_v<TValue, std::pmr::string>, std::pmr::string, TValue>;
-            if (value.holds<Tensor<TTensorElem>>()) {
-                auto converted = pmt::convertTo<Tensor<TTensorElem>>(value);
-                if (converted.has_value()) {
-                    stagedParameters.insert_or_assign(keyPmr, std::move(*converted));
-                    return true;
-                }
-                return false;
-            }
-        } else {
-            if (value.holds<Type>()) {
-                stagedParameters.insert_or_assign(keyPmr, value);
-                return true;
-            }
-        }
-        return false;
-    }
-
     // Helper template for applyStagedParameters - applies value to block member
     template<std::size_t kIdx, typename RawType, typename Type>
     static bool applyStagedImpl(TBlock* block, std::string_view key, const pmt::Value& stagedValue, property_map& applied, property_map& staged, bool hasCallback) {
@@ -778,7 +780,7 @@ public:
                     using Type       = unwrap_if_wrapped_t<RawType>;
                     if constexpr (settings::isWritableMember<Type, MemberType>()) {
                         constexpr auto fieldName = refl::data_member_name<TBlock, kIdx>;
-                        result[fieldName.view()] = &setParameterImpl<Type>;
+                        result[fieldName.view()] = &detail::setParameterImpl<Type>;
                     }
                 });
             }
@@ -797,7 +799,7 @@ public:
                     using Type       = unwrap_if_wrapped_t<std::remove_cvref_t<MemberType>>;
                     if constexpr (settings::isWritableMember<Type, MemberType>()) {
                         constexpr auto fieldName = refl::data_member_name<TBlock, kIdx>;
-                        result[fieldName.view()] = &autoUpdateImpl<Type>;
+                        result[fieldName.view()] = &detail::autoUpdateImpl<Type>;
                     }
                 });
             }

--- a/core/include/gnuradio-4.0/Settings.hpp
+++ b/core/include/gnuradio-4.0/Settings.hpp
@@ -218,7 +218,7 @@ std::expected<T, std::string> tryExtractEnumValue(const pmt::Value& pmt, std::st
         return std::unexpected(std::format("Field '{}' expects enum string, got different type", key));
     }
 
-    if (auto opt = magic_enum::enum_cast<T>(str); opt.has_value()) {
+    if (auto opt = gr::meta::parseEnum<T>(str); opt.has_value()) {
         return *opt;
     }
 
@@ -229,9 +229,9 @@ template<typename T, typename U = std::remove_cvref_t<T>>
 requires isEnumOrAnnotatedEnum<U>
 std::string enumToString(T&& enum_value) {
     if constexpr (is_annotated<U>()) {
-        return std::string(magic_enum::enum_name(enum_value.value));
+        return std::string(gr::meta::enumName(enum_value.value).value_or(""));
     } else {
-        return std::string(magic_enum::enum_name(enum_value));
+        return std::string(gr::meta::enumName(enum_value).value_or(""));
     }
 }
 
@@ -921,14 +921,17 @@ public:
                     auto  memberName                                               = std::string(refl::data_member_name<TBlock, kIdx>.view());
                     auto& meta_info                                                = _block->meta_information;
                     meta_info[convert_string_domain(memberName) + "::enum_values"] = [] {
+                        constexpr auto           values = gr::meta::enumValues<Type>();
                         std::vector<std::string> result;
-                        result.reserve(magic_enum::enum_count<Type>());
-                        for (auto [_, name] : magic_enum::enum_entries<Type>()) {
-                            result.emplace_back(name);
+                        result.reserve(values.size());
+                        for (auto v : values) {
+                            if (auto name = gr::meta::enumName(v); name.has_value()) {
+                                result.emplace_back(*name);
+                            }
                         }
                         return result;
                     }();
-                    meta_info[convert_string_domain(memberName) + "::enum_type"] = std::string(magic_enum::enum_type_name<Type>());
+                    meta_info[convert_string_domain(memberName) + "::enum_type"] = std::string(gr::meta::type_name<Type>());
                 }
 
                 if constexpr (hasMetaInfo && AnnotatedType<RawType>) {

--- a/core/include/gnuradio-4.0/TriggerMatcher.hpp
+++ b/core/include/gnuradio-4.0/TriggerMatcher.hpp
@@ -353,7 +353,7 @@ struct std::formatter<gr::trigger::MatchResult> {
     // Formats the source_location, using 'f' for file and 'l' for line
     template<typename FormatContext>
     auto format(const gr::trigger::MatchResult& ret, FormatContext& ctx) const -> decltype(ctx.out()) {
-        return std::format_to(ctx.out(), "{}", magic_enum::enum_name(ret));
+        return std::format_to(ctx.out(), "{}", gr::meta::enumName(ret).value_or(""));
     }
 };
 

--- a/core/include/gnuradio-4.0/ValueHelper.hpp
+++ b/core/include/gnuradio-4.0/ValueHelper.hpp
@@ -95,7 +95,7 @@ template<typename From, typename To, ConversionPolicy P>
 inline constexpr bool conversion_allowed_v = is_same_type_v<From, To> || (P >= ConversionPolicy::Widening && is_widening_v<From, To>) || (P >= ConversionPolicy::Narrowing && is_narrowing_v<From, To>) || (P == ConversionPolicy::Unchecked && is_static_castable_v<From, To>);
 
 template<typename F, typename T>
-concept FallbackFactory = std::invocable<F> && std::convertible_to<std::invoke_result_t<F>, T>;
+concept FallbackFactory = std::invocable<F> && std::convertible_to<gr::meta::invoke_result_t<F>, T>;
 
 template<typename F, typename T>
 concept FallbackValue = std::convertible_to<F, T> && !FallbackFactory<F, T>;

--- a/core/include/gnuradio-4.0/annotated.hpp
+++ b/core/include/gnuradio-4.0/annotated.hpp
@@ -202,6 +202,29 @@ enum class UICategory {
     Notification /// Transient non-modal feedback (toast/banner).
 };
 
+} // namespace gr
+
+// Compile-time performance override; phased out with C++26 reflection.
+namespace gr::meta::detail {
+template<>
+struct EnumTraits<gr::UICategory> {
+    static constexpr std::array<std::pair<gr::UICategory, std::string_view>, 10> entries = {{
+        {gr::UICategory::None, "None"},
+        {gr::UICategory::MenuBar, "MenuBar"},
+        {gr::UICategory::Toolbar, "Toolbar"},
+        {gr::UICategory::StatusBar, "StatusBar"},
+        {gr::UICategory::Content, "Content"},
+        {gr::UICategory::Panel, "Panel"},
+        {gr::UICategory::Overlay, "Overlay"},
+        {gr::UICategory::ContextMenu, "ContextMenu"},
+        {gr::UICategory::Dialog, "Dialog"},
+        {gr::UICategory::Notification, "Notification"},
+    }};
+};
+} // namespace gr::meta::detail
+
+namespace gr {
+
 /**
  * @brief Annotates block, indicating that it is drawable and provides a  mandatory `void draw()` method.
  *

--- a/core/include/gnuradio-4.0/formatter/ValueHelperFormatter.hpp
+++ b/core/include/gnuradio-4.0/formatter/ValueHelperFormatter.hpp
@@ -3,11 +3,11 @@
 
 #include <gnuradio-4.0/formatter/ValueFormatter.hpp>
 
-#include <magic_enum.hpp>
+#include <gnuradio-4.0/meta/reflection.hpp>
 #include <ostream>
 
 namespace gr::pmt {
-inline std::ostream& operator<<(std::ostream& os, ConversionError::Kind k) { return os << magic_enum::enum_name(k); }
+inline std::ostream& operator<<(std::ostream& os, ConversionError::Kind k) { return os << gr::meta::enumName(k).value_or(""); }
 } // namespace gr::pmt
 
 #endif // GNURADIO_VALUEHELPERFORMAT_HPP

--- a/core/include/gnuradio-4.0/thread/thread_pool.hpp
+++ b/core/include/gnuradio-4.0/thread/thread_pool.hpp
@@ -439,7 +439,7 @@ public:
         updateThreadConstraints();
     }
 
-    template<const detail::basic_fixed_string taskName = "", uint32_t priority = 0, int32_t cpuID = -1, std::invocable Callable, typename... Args, typename R = std::invoke_result_t<Callable, Args...>>
+    template<const detail::basic_fixed_string taskName = "", uint32_t priority = 0, int32_t cpuID = -1, std::invocable Callable, typename... Args, typename R = gr::meta::invoke_result_t<Callable, Args...>>
     requires(std::is_same_v<R, void>)
     void execute(Callable&& func, Args&&... args, const std::source_location& location = std::source_location::current()) {
         static thread_local gr::SpinWait spinWait;
@@ -466,7 +466,7 @@ public:
         spinWait.reset();
     }
 
-    template<const detail::basic_fixed_string taskName = "", uint32_t priority = 0, int32_t cpuID = -1, std::invocable Callable, typename... Args, typename R = std::invoke_result_t<Callable, Args...>>
+    template<const detail::basic_fixed_string taskName = "", uint32_t priority = 0, int32_t cpuID = -1, std::invocable Callable, typename... Args, typename R = gr::meta::invoke_result_t<Callable, Args...>>
     requires(!std::is_same_v<R, void>)
     [[nodiscard]] std::future<R> execute(Callable&& func, Args&&... funcArgs) {
         if constexpr (cpuID >= 0) {

--- a/core/src/Block.cpp
+++ b/core/src/Block.cpp
@@ -71,7 +71,7 @@ std::optional<Message> BlockBase::propertyCallbackLifecycleState(std::string_vie
             throw gr::exception(std::format("propertyCallbackLifecycleState - state is not a string, msg: {}", message));
         }
 
-        auto state = magic_enum::enum_cast<lifecycle::State>(stateStr);
+        auto state = gr::meta::parseEnum<lifecycle::State>(stateStr);
         if (!state.has_value()) {
             throw gr::exception(std::format("propertyCallbackLifecycleState - invalid lifecycle::State conversion from {}, msg: {}", stateStr, message));
         }
@@ -84,7 +84,7 @@ std::optional<Message> BlockBase::propertyCallbackLifecycleState(std::string_vie
     }
 
     if (message.cmd == Get) {
-        message.data = pmt::Value::Map{{"state", std::string(magic_enum::enum_name(cbState()))}};
+        message.data = pmt::Value::Map{{"state", std::string(gr::meta::enumName(cbState()).value_or(""))}};
         return message;
     }
 

--- a/core/src/Block.cpp
+++ b/core/src/Block.cpp
@@ -2,6 +2,23 @@
 
 namespace gr {
 
+void BlockBase::initStandardPropertyCallbacks() noexcept {
+    propertyCallbacks = {
+        {block::property::kHeartbeat, &BlockBase::propertyCallbackHeartbeat},
+        {block::property::kEcho, &BlockBase::propertyCallbackEcho},
+        {block::property::kLifeCycleState, &BlockBase::propertyCallbackLifecycleState},
+        {block::property::kSetting, &BlockBase::propertyCallbackSettings},
+        {block::property::kStagedSetting, &BlockBase::propertyCallbackStagedSettings},
+        {block::property::kStoreDefaults, &BlockBase::propertyCallbackStoreDefaults},
+        {block::property::kResetDefaults, &BlockBase::propertyCallbackResetDefaults},
+        {block::property::kActiveContext, &BlockBase::propertyCallbackActiveContext},
+        {block::property::kSettingsCtx, &BlockBase::propertyCallbackSettingsCtx},
+        {block::property::kSettingsContexts, &BlockBase::propertyCallbackSettingsContexts},
+        {block::property::kMetaInformation, &BlockBase::propertyCallbackMetaInformation},
+        {block::property::kUiConstraints, &BlockBase::propertyCallbackUiConstraints},
+    };
+}
+
 std::optional<Message> BlockBase::propertyCallbackHeartbeat(std::string_view propertyName, Message message) {
     using enum gr::message::Command;
     assert(propertyName == block::property::kHeartbeat);

--- a/core/src/BlockModel.cpp
+++ b/core/src/BlockModel.cpp
@@ -11,7 +11,7 @@ property_map serializeBlockImpl(gr::PluginLoader& pluginLoader, const std::share
     property_map result;
     result.emplace(serialization_fields::BLOCK_ID, pluginLoader.registry().typeName(block));
     result.emplace(serialization_fields::BLOCK_UNIQUE_NAME, std::string(block->uniqueName()));
-    result.emplace(serialization_fields::BLOCK_CATEGORY, std::string(magic_enum::enum_name(block->blockCategory())));
+    result.emplace(serialization_fields::BLOCK_CATEGORY, std::string(gr::meta::enumName(block->blockCategory()).value_or("")));
 
     if (!block->metaInformation().empty()) {
         result.emplace(serialization_fields::BLOCK_META_INFORMATION, block->metaInformation());

--- a/core/src/Graph.cpp
+++ b/core/src/Graph.cpp
@@ -114,15 +114,16 @@ std::optional<Message> Graph::propertyCallbackInspectBlock([[maybe_unused]] std:
 std::optional<Message> Graph::propertyCallbackGraphInspect([[maybe_unused]] std::string_view propertyName, Message message) {
     assert(propertyName == graph::property::kGraphInspect);
 
-    if (const bool yamlSerialize = [&] {
-            if (!message.data) {
+    if (const bool yamlSerialize =
+            [&] {
+                if (!message.data) {
+                    return false;
+                }
+                if (const auto it = message.data->find("serialization_format"); it != message.data->cend()) {
+                    return it->second == "yaml";
+                }
                 return false;
-            }
-            if (const auto it = message.data->find("serialization_format"); it != message.data->cend()) {
-                return it->second == "yaml";
-            }
-            return false;
-        }();
+            }();
         !yamlSerialize) {
         message.data = [&] {
             property_map _result;
@@ -130,7 +131,7 @@ std::optional<Message> Graph::propertyCallbackGraphInspect([[maybe_unused]] std:
 
             result[std::pmr::string(serialization_fields::BLOCK_NAME)]        = std::string(name);
             result[std::pmr::string(serialization_fields::BLOCK_UNIQUE_NAME)] = std::string(unique_name);
-            result[std::pmr::string(serialization_fields::BLOCK_CATEGORY)]    = std::string(magic_enum::enum_name(blockCategory));
+            result[std::pmr::string(serialization_fields::BLOCK_CATEGORY)]    = std::string(gr::meta::enumName(blockCategory).value_or(""));
 
             property_map serializedChildren;
             for (const auto& child : blocks()) {

--- a/meta/include/gnuradio-4.0/meta/UnitTestHelper.hpp
+++ b/meta/include/gnuradio-4.0/meta/UnitTestHelper.hpp
@@ -255,10 +255,8 @@ auto boost::ut::eq(Enum lhs, Enum rhs) {
 template<typename Enum>
 requires std::is_enum_v<Enum>
 std::ostream& operator<<(std::ostream& os, Enum e) {
-    if constexpr (std::is_enum_v<Enum>) {
-        if (auto name = magic_enum::enum_name(e); !name.empty()) {
-            return os << name;
-        }
+    if (auto name = gr::meta::enumName(e); name.has_value()) {
+        return os << *name;
     }
     return os << static_cast<std::underlying_type_t<Enum>>(e);
 }

--- a/meta/include/gnuradio-4.0/meta/formatter.hpp
+++ b/meta/include/gnuradio-4.0/meta/formatter.hpp
@@ -7,19 +7,12 @@
 #include <expected>
 #include <format>
 #include <source_location>
+#include <utility>
 #include <vector>
 
-#if defined(__GNUC__) && !defined(__clang__) && !defined(__EMSCRIPTEN__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wuseless-cast"
-#endif
-#include <magic_enum.hpp>
-
 #include <gnuradio-4.0/meta/UncertainValue.hpp>
+#include <gnuradio-4.0/meta/reflection.hpp>
 #include <gnuradio-4.0/meta/utils.hpp>
-#if defined(__GNUC__) && !defined(__clang__) && !defined(__EMSCRIPTEN__)
-#pragma GCC diagnostic pop
-#endif
 
 namespace gr {
 namespace time {
@@ -395,11 +388,10 @@ struct std::formatter<E, char> {
 
     template<typename FormatContext>
     auto format(E e, FormatContext& ctx) const {
-        if (auto name = magic_enum::enum_name(e); !name.empty()) {
-            return _strFormatter.format(name, ctx); // delegate string formatting
-        } else {
-            return std::format_to(ctx.out(), "{}", std::to_underlying(e)); // fallback to underlying type
+        if (auto name = gr::meta::enumName(e); name.has_value()) {
+            return _strFormatter.format(*name, ctx);
         }
+        return std::format_to(ctx.out(), "{}", std::to_underlying(e));
     }
 };
 #endif

--- a/meta/include/gnuradio-4.0/meta/reflection.hpp
+++ b/meta/include/gnuradio-4.0/meta/reflection.hpp
@@ -4,10 +4,14 @@
 #include <gnuradio-4.0/meta/typelist.hpp>
 #include <gnuradio-4.0/meta/utils.hpp>
 
+#include <algorithm>
 #include <array>
 #include <memory_resource>
-// #include <string> // for type_name specialization
+#include <optional>
+#include <string_view>
 #include <tuple>
+#include <type_traits>
+#include <utility>
 #ifdef _MSC_VER
 #include <vector> // for type_name specialization
 #endif
@@ -491,8 +495,58 @@ using make_typelist_from_index_sequence = typename detail::make_typelist_from_in
 
 } // namespace gr::refl
 
+// gr::meta:: enum reflection — C++26 std::meta when available, magic_enum fallback.
+// The std::meta branch (__cpp_impl_reflection >= 202506L, GCC 16+ with -std=c++26 -freflection)
+// pulls no external dependency. On every other compiler the branch falls back to magic_enum;
+// hot enums may provide gr::meta::detail::EnumTraits<E> to bypass its per-enum fan-out.
+#if defined(__cpp_impl_reflection) && __cpp_impl_reflection >= 202506L
+
+#include <meta>
+
+namespace gr::meta {
+
+template<typename E>
+requires std::is_enum_v<E>
+[[nodiscard]] constexpr std::optional<std::string_view> enumName(E value) noexcept {
+    constexpr std::meta::info enums = std::meta::reflect_constant_array(std::meta::enumerators_of(^^E));
+    template for (constexpr std::meta::info I : [:enums:]) {
+        if (value == [:I:]) {
+            return std::string_view{std::meta::identifier_of(I)};
+        }
+    }
+    return std::nullopt;
+}
+
+template<typename E>
+requires std::is_enum_v<E>
+[[nodiscard]] constexpr std::optional<E> parseEnum(std::string_view s) noexcept {
+    constexpr std::meta::info enums = std::meta::reflect_constant_array(std::meta::enumerators_of(^^E));
+    template for (constexpr std::meta::info I : [:enums:]) {
+        if (s == std::meta::identifier_of(I)) {
+            return [:I:];
+        }
+    }
+    return std::nullopt;
+}
+
+template<typename E>
+requires std::is_enum_v<E>
+[[nodiscard]] consteval auto enumValues() noexcept {
+    constexpr auto              enums = std::meta::enumerators_of(^^E);
+    std::array<E, enums.size()> result{};
+    std::size_t                 i = 0;
+    template for (constexpr std::meta::info I : std::meta::reflect_constant_array(enums)) { result[i++] = [:I:]; }
+    return result;
+}
+
+[[nodiscard]] constexpr std::string_view reflectionBackendProvider() noexcept { return "std::meta"; }
+
+} // namespace gr::meta
+
+#else // fallback: magic_enum with optional gr::meta::detail::EnumTraits<E> override for hot enums
+
 #ifdef __GNUC__
-#pragma GCC diagnostic push // ignore warning of external libraries that from this lib-context we do not have any control over
+#pragma GCC diagnostic push // ignore warnings from external lib we can't control
 #ifndef __clang__
 #pragma GCC diagnostic ignored "-Wuseless-cast"
 #endif
@@ -503,5 +557,74 @@ using make_typelist_from_index_sequence = typename detail::make_typelist_from_in
 #ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif
+
+namespace gr::meta {
+
+namespace detail {
+// Opt-in compile-time override: specialise for hot enums to bypass magic_enum's
+// per-enum template instantiation cascade. Phased out with C++26 reflection.
+template<typename E>
+struct EnumTraits;
+} // namespace detail
+
+template<typename E>
+requires std::is_enum_v<E>
+[[nodiscard]] constexpr std::optional<std::string_view> enumName(E value) noexcept {
+    if constexpr (requires { detail::EnumTraits<E>::entries; }) {
+        for (const auto& [v, s] : detail::EnumTraits<E>::entries) {
+            if (v == value) {
+                return s;
+            }
+        }
+        return std::nullopt;
+    } else {
+        if (auto name = magic_enum::enum_name(value); !name.empty()) {
+            return std::string_view{name};
+        }
+        return std::nullopt;
+    }
+}
+
+template<typename E>
+requires std::is_enum_v<E>
+[[nodiscard]] constexpr std::optional<E> parseEnum(std::string_view s) noexcept {
+    if constexpr (requires { detail::EnumTraits<E>::entries; }) {
+        for (const auto& [v, name] : detail::EnumTraits<E>::entries) {
+            if (s == name) {
+                return v;
+            }
+        }
+        return std::nullopt;
+    } else {
+        if (auto v = magic_enum::enum_cast<E>(s); v.has_value()) {
+            return *v;
+        }
+        return std::nullopt;
+    }
+}
+
+template<typename E>
+requires std::is_enum_v<E>
+[[nodiscard]] consteval auto enumValues() noexcept {
+    if constexpr (requires { detail::EnumTraits<E>::entries; }) {
+        constexpr auto&               entries = detail::EnumTraits<E>::entries;
+        std::array<E, entries.size()> result{};
+        for (std::size_t i = 0; i < entries.size(); ++i) {
+            result[i] = entries[i].first;
+        }
+        return result;
+    } else {
+        constexpr auto               values = magic_enum::enum_values<E>();
+        std::array<E, values.size()> result{};
+        std::ranges::copy(values, result.begin());
+        return result;
+    }
+}
+
+[[nodiscard]] constexpr std::string_view reflectionBackendProvider() noexcept { return "magic_enum"; }
+
+} // namespace gr::meta
+
+#endif // __cpp_impl_reflection
 
 #endif // GNURADIO_REFLECTION_HPP

--- a/meta/include/gnuradio-4.0/meta/utils.hpp
+++ b/meta/include/gnuradio-4.0/meta/utils.hpp
@@ -72,6 +72,11 @@ T cast(U value) { /// gcc/clang warning suppressing cast
 
 namespace meta {
 
+// Shallow alternative to std::invoke_result_t that avoids the libstdc++
+// __invoke_result cascade. No member-function-pointer support — use std::invoke_result_t there.
+template<typename F, typename... Args>
+using invoke_result_t = decltype(std::declval<F>()(std::declval<Args>()...));
+
 struct null_type {};
 
 template<typename... Ts>

--- a/meta/include/gnuradio-4.0/meta/utils.hpp
+++ b/meta/include/gnuradio-4.0/meta/utils.hpp
@@ -72,6 +72,12 @@ T cast(U value) { /// gcc/clang warning suppressing cast
 
 namespace meta {
 
+#if defined(NDEBUG)
+inline constexpr bool kDebugBuild = false;
+#else
+inline constexpr bool kDebugBuild = true;
+#endif
+
 // Shallow alternative to std::invoke_result_t that avoids the libstdc++
 // __invoke_result cascade. No member-function-pointer support — use std::invoke_result_t there.
 template<typename F, typename... Args>

--- a/meta/test/qa_reflection.cpp
+++ b/meta/test/qa_reflection.cpp
@@ -272,4 +272,44 @@ std::string_view string_test2() { return gr::refl::class_name<ns::Type<float>>; 
 
 const char* member_name_string0() { return gr::refl::data_member_name<ns::Type<char>, 0>.data(); }
 
+// verifies parity between std::meta (C++26, GCC 16+) and magic_enum fallback branches
+namespace enum_reflection_test {
+
+enum class Color : int { Red, Green, Blue, Yellow };
+
+// basic name resolution
+static_assert(gr::meta::enumName(Color::Red).has_value());
+static_assert(gr::meta::enumName(Color::Red).value() == "Red");
+static_assert(gr::meta::enumName(Color::Green).value() == "Green");
+static_assert(gr::meta::enumName(Color::Blue).value() == "Blue");
+static_assert(gr::meta::enumName(Color::Yellow).value() == "Yellow");
+
+// unknown value → nullopt
+static_assert(!gr::meta::enumName(static_cast<Color>(99)).has_value());
+
+// round-trip parseEnum(enumName(v)) == v for every enumerator
+static_assert(gr::meta::parseEnum<Color>("Red") == Color::Red);
+static_assert(gr::meta::parseEnum<Color>("Green") == Color::Green);
+static_assert(gr::meta::parseEnum<Color>("Blue") == Color::Blue);
+static_assert(gr::meta::parseEnum<Color>("Yellow") == Color::Yellow);
+static_assert(gr::meta::parseEnum<Color>("Magenta") == std::nullopt);
+static_assert(gr::meta::parseEnum<Color>("") == std::nullopt);
+
+// enumValues<E>() — consteval array of all enumerators
+static_assert(gr::meta::enumValues<Color>().size() == 4);
+static_assert(gr::meta::enumValues<Color>()[0] == Color::Red);
+static_assert(gr::meta::enumValues<Color>()[3] == Color::Yellow);
+
+// non-contiguous values — mirrors gr::work::Status shape
+enum class Status : int { Error = -100, InsufficientInput = -2, Done = -1, Ok = 0 };
+static_assert(gr::meta::enumName(Status::Error).value() == "Error");
+static_assert(gr::meta::enumName(Status::Ok).value() == "Ok");
+static_assert(gr::meta::parseEnum<Status>("Done") == Status::Done);
+static_assert(gr::meta::enumValues<Status>().size() == 4);
+
+// reflectionBackendProvider returns a non-empty identifier
+static_assert(!gr::meta::reflectionBackendProvider().empty());
+
+} // namespace enum_reflection_test
+
 int main() { /* tests are statically executed */ }


### PR DESCRIPTION
## Summary

A cleanup branch:
- unblocks GCC 16 builds (mold / `AS_NEEDED` linker issue)
- prepares migration to C++26 `std::meta` reflection — no external dependency when the compiler provides it
- modest per-TU compile-time reduction on all currently shipping compilers

No user-API or ABI changes; test suite unchanged.

### Measured compile-time impact

Per-TU `-j1` median (3 reps), `USE_CCACHE=OFF`, Debug build.

| Compiler | qa_Math | qa_Block | qa_Scheduler |
|----------|--------:|---------:|-------------:|
| clang-21 | **−10.1 %** | **−6.6 %** | **−6.3 %** |
| gcc-15   | −5.7 % | −1.1 % | −3.7 % |
| clang-20 | −2.2 % | −4.8 % | −4.0 % |
| gcc-16¹  | −1.3 % | — | — |

¹ `main` alone does not build with gcc-16; baseline here is `main` + the cmake-only linker fix commit.

Runtime neutral on the hot path; binary size is expected to be neutral-to-negative (per-T `__shared_ptr_emplace<BlockWrapper<T>>` bodies no longer emitted).

### `-ftime-trace` top-10 template sets

clang-21, aggregated across all 79 TUs via `ClangBuildAnalyzer --analyze`.

**Before** (main)

| # | Template set | Time | Count | Avg |
|:-:|---|------:|-----:|----:|
| 1 | `gr::Graph::emplaceBlock<$>` | 45 186 ms | 109 | 414 ms |
| 2 | `test_block<$>` (qa_Math only) | 32 762 ms | 48 | 682 ms |
| 3 | `gr::Block<$>::Block` | 29 328 ms | 188 | 156 ms |
| 4 | `std::make_shared<$>` | 26 920 ms | 302 | 89 ms |
| 5 | `std::allocate_shared<$>` | 26 807 ms | 302 | 88 ms |
| 6 | `std::__shared_ptr_emplace<$>::__shared_ptr_emplace<$>` | 25 812 ms | 302 | 85 ms |
| 7 | `gr::BlockWrapper<$>::BlockWrapper` | 25 071 ms | 117 | 214 ms |
| 8 | `gr::Block<$>::work<$>` | 16 916 ms | 112 | 151 ms |
| 9 | `gr::Block<$>::workInternal` | 16 897 ms | 112 | 150 ms |
| 10 | `gr::pmt::yaml::detail::applyTag<$>` | 14 285 ms | 12 | 1 190 ms |

**After** (coreOptimisation)

Four of the ten — **the entire shared_ptr-construction cascade plus `BlockWrapper<T>::BlockWrapper`** — disappear from the top-10 (≈ 105 s of aggregate template instantiation eliminated). `Block<T>::Block` drops from #3 to outside the top-10 (hoist of `propertyCallbacks`).

| # | Template set | Time | Count | Avg | vs main |
|:-:|---|------:|-----:|----:|---:|
| 1 | `gr::Graph::emplaceBlock<$>` | 41 460 ms | 109 | 380 ms | −8 % |
| 2 | `gr::Block<$>::~Block` | 30 801 ms | 182 | 169 ms | **+143 %** |
| 3 | `test_block<$>` (qa_Math only) | 30 084 ms | 48 | 626 ms | −8 % |
| 4 | `gr::Block<$>::work<$>` | 18 174 ms | 112 | 162 ms | +7 % |
| 5 | `gr::Block<$>::workInternal` | 18 154 ms | 112 | 162 ms | +7 % |
| 6 | `gr::pmt::yaml::detail::applyTag<$>` | 14 138 ms | 12 | 1 178 ms | −1 % |
| 7 | `gr::CtxSettings<$>::applyStagedParameters` | 13 080 ms | 186 | 70 ms | −5 % |
| 8 | `gr::refl::for_each_data_member_index<$>` | 11 243 ms | 1 320 | 8 ms | +8 % |
| 9 | `magic_enum::enum_name<$>` | 9 116 ms | 65 | 140 ms | **−26 %** (82→65 instantiations) |
| 10 | `gr::meta::enumName<$>` | 9 107 ms | 81 | 112 ms | new (wrapper, cold-enum pass-through) |

**One regression worth flagging**: `gr::Block<$>::~Block` grows +143 % (row 2). The aliasing-deleter routes destruction through the virtual `~BlockModel` chain, and the compiler cannot fully devirtualise through `BlockWrapper<T>` because `GraphWrapper<TSelf>` derives from it — destructor bodies are synthesised with more fallback-dispatch shape. Net across the shared_ptr reorganisation is still **≈ −75 s aggregate**. A `BlockWrapper` / `BlockWrapperImpl` split would recover the regression; deferred to a follow-up.