### PR TITLE
Sonar fixes

### DIFF
--- a/algorithm/include/gnuradio-4.0/algorithm/filter/FilterTool.hpp
+++ b/algorithm/include/gnuradio-4.0/algorithm/filter/FilterTool.hpp
@@ -377,7 +377,7 @@ template<typename... Coeffs>
 enum class ResponseType { Magnitude, MagnitudeDB, Phase, PhaseDegrees };
 
 template<Frequency frequencyType, ResponseType responseType, std::floating_point T, typename... TFilterCoefficients>
-[[nodiscard]] inline T calculateResponse(T normalisedDigitalFrequency, TFilterCoefficients... filterCoefficients) {
+[[nodiscard]] inline T calculateResponse(T normalisedDigitalFrequency, TFilterCoefficients&&... filterCoefficients) {
     using C = std::complex<T>;
     static_assert(frequencyType == Frequency::Normalised, "Frequency::Hertz not applicable for digital filters");
     std::vector<FilterCoefficients<T>> filterCoefficients_{std::forward<TFilterCoefficients>(filterCoefficients)...};
@@ -626,7 +626,7 @@ std::vector<std::complex<T>> sortComplexWithConjugates(const std::vector<std::co
 } // namespace details
 
 template<typename T, std::ranges::input_range Range>
-[[nodiscard]] std::vector<T> expandRootsToPolynomial(Range&& roots, std::size_t desiredOrder) {
+[[nodiscard]] std::vector<T> expandRootsToPolynomial(Range&& roots, std::size_t desiredOrder) { // NOSONAR (S5425) — forwarding-ref kept for non-const-iterable views
     if (roots.empty()) {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wnull-dereference" // gcc13 false positive

--- a/blocks/timing/include/gnuradio-4.0/GpsSource.hpp
+++ b/blocks/timing/include/gnuradio-4.0/GpsSource.hpp
@@ -44,6 +44,11 @@ for synchronising otherwise undisciplined SDRs using their PPS)">;
 
     struct IoThreadGuard { // must be last member — destroyed first, ensuring IO thread exits before _serialPort/_parser
         bool& done;
+        explicit IoThreadGuard(bool& done_) noexcept : done(done_) {}
+        IoThreadGuard(const IoThreadGuard&)            = delete;
+        IoThreadGuard(IoThreadGuard&&)                 = delete;
+        IoThreadGuard& operator=(const IoThreadGuard&) = delete;
+        IoThreadGuard& operator=(IoThreadGuard&&)      = delete;
         ~IoThreadGuard() { gr::atomic_ref(done).wait(false); }
     };
     IoThreadGuard _ioGuard{_ioThreadDone};

--- a/core/include/gnuradio-4.0/Block.hpp
+++ b/core/include/gnuradio-4.0/Block.hpp
@@ -488,21 +488,21 @@ struct isBlockDependent {
 
 namespace block::property {
 // [[maybe_unused]]: names referenced only from Block.cpp (initStandardPropertyCallbacks) and user code — silences -Werror=unused-variable on TUs that include only the header.
-[[maybe_unused]] inline static const char* kHeartbeat      = "Heartbeat";      ///< heartbeat property - the canary in the coal mine (supports block-specific subscribe/unsubscribe)
-[[maybe_unused]] inline static const char* kEcho           = "Echo";           ///< basic property that receives any matching message and sends a mirror with it's serviceName/unique_name
-[[maybe_unused]] inline static const char* kLifeCycleState = "LifecycleState"; ///< basic property that sets the block's @see lifecycle::StateMachine
-[[maybe_unused]] inline static const char* kSetting        = "Settings";       ///< asynchronous message-based setting handling,
-                                                                               // N.B. 'Set' Settings are first staged before being applied within the work(...) function (real-time/non-real-time decoupling)
-[[maybe_unused]] inline static const char* kStagedSetting = "StagedSettings";  ///< asynchronous message-based staging of settings
+[[maybe_unused]] inline static const char* const kHeartbeat      = "Heartbeat";      ///< heartbeat property - the canary in the coal mine (supports block-specific subscribe/unsubscribe)
+[[maybe_unused]] inline static const char* const kEcho           = "Echo";           ///< basic property that receives any matching message and sends a mirror with it's serviceName/unique_name
+[[maybe_unused]] inline static const char* const kLifeCycleState = "LifecycleState"; ///< basic property that sets the block's @see lifecycle::StateMachine
+[[maybe_unused]] inline static const char* const kSetting        = "Settings";       ///< asynchronous message-based setting handling,
+                                                                                     // N.B. 'Set' Settings are first staged before being applied within the work(...) function (real-time/non-real-time decoupling)
+[[maybe_unused]] inline static const char* const kStagedSetting = "StagedSettings";  ///< asynchronous message-based staging of settings
 
-[[maybe_unused]] inline static const char* kMetaInformation = "MetaInformation"; ///< asynchronous message-based retrieval of the static meta-information (i.e. Annotated<> interfaces, constraints, etc...)
-[[maybe_unused]] inline static const char* kUiConstraints   = "UiConstraints";   ///< asynchronous message-based retrieval of user-defined UI constraints
+[[maybe_unused]] inline static const char* const kMetaInformation = "MetaInformation"; ///< asynchronous message-based retrieval of the static meta-information (i.e. Annotated<> interfaces, constraints, etc...)
+[[maybe_unused]] inline static const char* const kUiConstraints   = "UiConstraints";   ///< asynchronous message-based retrieval of user-defined UI constraints
 
-[[maybe_unused]] inline static const char* kStoreDefaults    = "StoreDefaults";    ///< store present settings as default, for counterpart @see kResetDefaults
-[[maybe_unused]] inline static const char* kResetDefaults    = "ResetDefaults";    ///< retrieve and reset to default setting, for counterpart @see kStoreDefaults
-[[maybe_unused]] inline static const char* kActiveContext    = "ActiveContext";    ///< retrieve and set active context
-[[maybe_unused]] inline static const char* kSettingsCtx      = "SettingsCtx";      ///< retrieve/creates/remove a new stored context
-[[maybe_unused]] inline static const char* kSettingsContexts = "SettingsContexts"; ///< retrieve/creates/remove a new stored context
+[[maybe_unused]] inline static const char* const kStoreDefaults    = "StoreDefaults";    ///< store present settings as default, for counterpart @see kResetDefaults
+[[maybe_unused]] inline static const char* const kResetDefaults    = "ResetDefaults";    ///< retrieve and reset to default setting, for counterpart @see kStoreDefaults
+[[maybe_unused]] inline static const char* const kActiveContext    = "ActiveContext";    ///< retrieve and set active context
+[[maybe_unused]] inline static const char* const kSettingsCtx      = "SettingsCtx";      ///< retrieve/creates/remove a new stored context
+[[maybe_unused]] inline static const char* const kSettingsContexts = "SettingsContexts"; ///< retrieve/creates/remove a new stored context
 
 } // namespace block::property
 

--- a/core/include/gnuradio-4.0/Block.hpp
+++ b/core/include/gnuradio-4.0/Block.hpp
@@ -909,7 +909,7 @@ public:
         // Set names of port member variables
         // TODO: Refactor the library not to assign names to ports. The
         // block and the graph are the only things that need the port name
-        auto setPortName = [&](std::size_t, auto* t) {
+        auto setPortName = [this](std::size_t, auto* t) {
             using Description = std::remove_pointer_t<decltype(t)>;
             auto& port        = Description::getPortObject(self());
             if constexpr (Description::kIsDynamicCollection || Description::kIsStaticCollection) {
@@ -1139,7 +1139,7 @@ public:
             // MergeTagPropagation: all auto-forward keys → one output tag at position 0
             property_map merged;
             for_each_reader_span(
-                [&](auto& in) {
+                [&tagWindow, &filterAndSubstitute, &merged](auto& in) {
                     if (!in.isSync || !in.isConnected) {
                         return;
                     }
@@ -1159,7 +1159,7 @@ public:
 
         if constexpr (kNInputPorts <= 1) {
             for_each_reader_span(
-                [&](auto& in) {
+                [&tagWindow, &publishFiltered](auto& in) {
                     if (!in.isSync || !in.isConnected) {
                         return;
                     }
@@ -1175,7 +1175,7 @@ public:
             std::size_t                           nSeen = 0;
 
             for_each_reader_span(
-                [&](auto& in) {
+                [&tagWindow, &publishFiltered, &seen, &nSeen, kDedupCapacity](auto& in) {
                     if (!in.isSync || !in.isConnected) {
                         return;
                     }
@@ -1346,7 +1346,7 @@ public:
 
     void rebindFieldsTo(std::pmr::memory_resource* mr) {
         _allocResource = mr;
-        refl::for_each_data_member_index<Derived>([&](auto kIdx) {
+        refl::for_each_data_member_index<Derived>([this, mr](auto kIdx) {
             auto& field     = refl::data_member<kIdx>(self());
             using F         = std::remove_cvref_t<decltype(field)>;
             using Unwrapped = unwrap_if_wrapped_t<F>;
@@ -1612,12 +1612,12 @@ public:
     work::Status invokeProcessOneSimd(auto& inputSpans, auto& outputSpans, auto width, std::size_t nSamplesToProcess) {
         std::size_t i = 0UZ;
         for (; i + width <= nSamplesToProcess; i += width) {
-            const auto& results = simdize_tuple_load_and_apply(width, inputSpans, i, [&](const auto&... input_simds) { return invoke_processOne_simd(width, input_simds...); });
+            const auto& results = simdize_tuple_load_and_apply(width, inputSpans, i, [this, width](const auto&... input_simds) { return this->invoke_processOne_simd(width, input_simds...); });
             meta::tuple_for_each([i](auto& output_range, const auto& result) { result.copy_to(output_range.data() + i, stdx::element_aligned); }, outputSpans, results);
         }
-        simd_epilogue(width, [&](auto w) {
+        simd_epilogue(width, [this, &i, &nSamplesToProcess, &inputSpans, &outputSpans](auto w) {
             if (i + w <= nSamplesToProcess) {
-                const auto results = simdize_tuple_load_and_apply(w, inputSpans, i, [&](auto&&... input_simds) { return invoke_processOne_simd(w, input_simds...); });
+                const auto results = simdize_tuple_load_and_apply(w, inputSpans, i, [this, w](auto&&... input_simds) { return this->invoke_processOne_simd(w, input_simds...); });
                 meta::tuple_for_each([i](auto& output_range, auto& result) { result.copy_to(output_range.data() + i, stdx::element_aligned); }, outputSpans, results);
                 i += w;
             }
@@ -2230,13 +2230,13 @@ template<BlockLike TBlock>
     // re-enable once all compilers support string and constexpr static
     /*constexpr*/ std::string ret = std::format("# {}\n{}\n**supported data types:**", //
         gr::meta::type_name<DerivedBlock>(), TBlock::description);
-    gr::meta::typelist<SupportedTypes>::for_each([&](std::size_t index, auto&& t) {
+    gr::meta::typelist<SupportedTypes>::for_each([&ret](std::size_t index, auto&& t) {
         std::string type_name = gr::meta::type_name<decltype(t)>();
         ret += std::format("{}:{} ", index, type_name);
     });
     ret += std::format("\n**Parameters:**\n");
     if constexpr (refl::reflectable<DerivedBlock>) {
-        refl::for_each_data_member_index<DerivedBlock>([&](auto kIdx) {
+        refl::for_each_data_member_index<DerivedBlock>([&ret](auto kIdx) {
             using RawType = std::remove_cvref_t<refl::data_member_type<DerivedBlock, kIdx>>;
             using Type    = unwrap_if_wrapped_t<RawType>;
             if constexpr ((std::integral<Type> || std::floating_point<Type> || std::is_same_v<Type, std::string>)) {
@@ -2352,7 +2352,7 @@ int registerBlock(auto& registerInstance) {
  */
 template<template<typename...> typename TBlock, typename... Tuples>
 inline constexpr int registerBlockTT(auto& registerInstance) {
-    meta::outer_product<meta::to_typelist<Tuples>...>::for_each([&]<typename Types>(std::size_t, Types*) { registerBlock<TBlock, typename Types::template apply<BlockParameters>>(registerInstance); });
+    meta::outer_product<meta::to_typelist<Tuples>...>::for_each([&registerInstance]<typename Types>(std::size_t, Types*) { registerBlock<TBlock, typename Types::template apply<BlockParameters>>(registerInstance); });
     return {};
 }
 
@@ -2369,7 +2369,7 @@ inline constexpr int registerBlockTT(auto& registerInstance) {
 // (yet). And in principle, there's always another overload missing.
 template<template<typename, auto> typename TBlock, auto Value0, typename... TBlockParameters, typename TRegisterInstance>
 inline constexpr int registerBlock(TRegisterInstance& registerInstance) {
-    auto addBlockType = [&]<typename Type> {
+    auto addBlockType = [&registerInstance]<typename Type> {
         static_assert(!meta::is_instantiation_of<Type, BlockParameters>);
         using ThisBlock = TBlock<Type, Value0>;
         registerInstance.template addBlockType<ThisBlock>();
@@ -2380,7 +2380,7 @@ inline constexpr int registerBlock(TRegisterInstance& registerInstance) {
 
 template<template<typename, typename, auto> typename TBlock, auto Value0, typename... TBlockParameters, typename TRegisterInstance>
 inline constexpr int registerBlock(TRegisterInstance& registerInstance) {
-    auto addBlockType = [&]<typename Type> {
+    auto addBlockType = [&registerInstance]<typename Type> {
         static_assert(meta::is_instantiation_of<Type, BlockParameters>);
         static_assert(Type::size == 2);
         using ThisBlock = TBlock<typename Type::template at<0>, typename Type::template at<1>, Value0>;
@@ -2392,7 +2392,7 @@ inline constexpr int registerBlock(TRegisterInstance& registerInstance) {
 
 template<template<typename, auto, auto> typename TBlock, auto Value0, auto Value1, typename... TBlockParameters, typename TRegisterInstance>
 inline constexpr int registerBlock(TRegisterInstance& registerInstance) {
-    auto addBlockType = [&]<typename Type> {
+    auto addBlockType = [&registerInstance]<typename Type> {
         static_assert(!meta::is_instantiation_of<Type, BlockParameters>);
         using ThisBlock = TBlock<Type, Value0, Value1>;
         registerInstance.template addBlockType<ThisBlock>();
@@ -2403,7 +2403,7 @@ inline constexpr int registerBlock(TRegisterInstance& registerInstance) {
 
 template<template<typename, typename, auto, auto> typename TBlock, auto Value0, auto Value1, typename... TBlockParameters, typename TRegisterInstance>
 inline constexpr int registerBlock(TRegisterInstance& registerInstance) {
-    auto addBlockType = [&]<typename Type> {
+    auto addBlockType = [&registerInstance]<typename Type> {
         static_assert(meta::is_instantiation_of<Type, BlockParameters>);
         static_assert(Type::size == 2);
         using ThisBlock = TBlock<typename Type::template at<0>, typename Type::template at<1>, Value0, Value1>;

--- a/core/include/gnuradio-4.0/BlockMerging.hpp
+++ b/core/include/gnuradio-4.0/BlockMerging.hpp
@@ -160,7 +160,7 @@ public:
     MergeByIndex& operator=(MergeByIndex& other)  = delete;
     MergeByIndex& operator=(MergeByIndex&& other) = delete;
 
-    MergeByIndex(MergeByIndex&& other) : _leftBlock(std::move(other._leftBlock)), _rightBlock(std::move(other._rightBlock)) {}
+    MergeByIndex(MergeByIndex&& other) noexcept(std::is_nothrow_move_constructible_v<Left> && std::is_nothrow_move_constructible_v<Right>) : _leftBlock(std::move(other._leftBlock)), _rightBlock(std::move(other._rightBlock)) {}
 
     // copy-paste from above, keep in sync
     using base = Block<MergeByIndex<Left, OutId, Right, InId>>;
@@ -415,7 +415,7 @@ struct SplitMergeCombine<Paths...> : Block<SplitMergeCombine<Paths...>> {
     SplitMergeCombine& operator=(const SplitMergeCombine&) = delete;
     SplitMergeCombine& operator=(SplitMergeCombine&&)      = delete;
 
-    SplitMergeCombine(SplitMergeCombine&& other) : _paths(std::move(other._paths)) {}
+    SplitMergeCombine(SplitMergeCombine&& other) noexcept(std::is_nothrow_move_constructible_v<std::tuple<Paths...>>) : _paths(std::move(other._paths)) {}
 
     explicit constexpr SplitMergeCombine(gr::property_map init = {}) {
         [&]<std::size_t... Is>(std::index_sequence<Is...>) {
@@ -513,7 +513,7 @@ struct SplitMergeCombine<OutputSigns<Vs...>, Paths...> : Block<SplitMergeCombine
     SplitMergeCombine& operator=(const SplitMergeCombine&) = delete;
     SplitMergeCombine& operator=(SplitMergeCombine&&)      = delete;
 
-    SplitMergeCombine(SplitMergeCombine&& other) : _paths(std::move(other._paths)) {}
+    SplitMergeCombine(SplitMergeCombine&& other) noexcept(std::is_nothrow_move_constructible_v<std::tuple<Paths...>>) : _paths(std::move(other._paths)) {}
 
     explicit constexpr SplitMergeCombine(gr::property_map init = {}) {
         [&]<std::size_t... Is>(std::index_sequence<Is...>) {

--- a/core/include/gnuradio-4.0/BlockMerging.hpp
+++ b/core/include/gnuradio-4.0/BlockMerging.hpp
@@ -159,6 +159,7 @@ public:
     MergeByIndex(const MergeByIndex& other)       = delete;
     MergeByIndex& operator=(MergeByIndex& other)  = delete;
     MergeByIndex& operator=(MergeByIndex&& other) = delete;
+    ~MergeByIndex()                               = default;
 
     MergeByIndex(MergeByIndex&& other) noexcept(std::is_nothrow_move_constructible_v<Left> && std::is_nothrow_move_constructible_v<Right>) : _leftBlock(std::move(other._leftBlock)), _rightBlock(std::move(other._rightBlock)) {}
 

--- a/core/include/gnuradio-4.0/BlockModel.hpp
+++ b/core/include/gnuradio-4.0/BlockModel.hpp
@@ -111,6 +111,7 @@ struct Edge {
     }
     Edge(Edge&&) noexcept            = default;
     Edge& operator=(Edge&&) noexcept = default;
+    ~Edge()                          = default;
 
     explicit Edge(std::shared_ptr<BlockModel> sourceBlock, PortDefinition sourcePortDefinition,               //
         std::shared_ptr<BlockModel> destinationBlock, PortDefinition destinationPortDefinition,               //

--- a/core/include/gnuradio-4.0/BlockRegistry.hpp
+++ b/core/include/gnuradio-4.0/BlockRegistry.hpp
@@ -68,6 +68,7 @@ public:
         std::swap(_blockTypeHandlers, tmp._blockTypeHandlers);
         return *this;
     }
+    ~GeneralRegistry() = default;
 
 #ifdef GR_ENABLE_BLOCK_REGISTRY
     template<BlockLike TBlock>

--- a/core/include/gnuradio-4.0/BlockTraits.hpp
+++ b/core/include/gnuradio-4.0/BlockTraits.hpp
@@ -237,7 +237,6 @@ public:
 
     operator const std::span<const T>&() const noexcept { return internalSpan; }
     operator std::span<const T>&() noexcept { return internalSpan; }
-    // operator std::span<const T>&&() = delete;
 
     [[nodiscard]] bool consume(std::size_t /* nSamples */) noexcept { return true; }
 };

--- a/core/include/gnuradio-4.0/CircularBuffer.hpp
+++ b/core/include/gnuradio-4.0/CircularBuffer.hpp
@@ -548,7 +548,6 @@ private:
 #endif
         }
     }; // class Writer
-    // static_assert(BufferWriterLike<Writer<T>>);
 
     template<typename U = T>
     class Reader;
@@ -622,7 +621,6 @@ private:
         const T&                                 operator[](std::size_t i) noexcept { return _internalSpan[i]; }
         explicit(false) operator const std::span<const T>&() const noexcept { return _internalSpan; }
         explicit(false) operator std::span<const T>&() noexcept { return _internalSpan; }
-        // operator std::span<const T>&&() = delete;
 
         template<bool strict_check = true>
         [[nodiscard]] bool consume(std::size_t nSamples) noexcept {
@@ -769,7 +767,6 @@ private:
 
         [[nodiscard]] constexpr std::size_t available() const noexcept { return _buffer->_claimStrategy._publishCursor.value() - _readIndexCached; }
     }; // class Reader
-    // static_assert(BufferReaderLike<Reader<T>>);
 
     [[nodiscard]] constexpr static Allocator DefaultAllocator() {
         if constexpr (has_posix_mmap_interface && std::is_trivially_copyable_v<T>) {

--- a/core/include/gnuradio-4.0/CircularBuffer.hpp
+++ b/core/include/gnuradio-4.0/CircularBuffer.hpp
@@ -789,10 +789,10 @@ public:
 
     // CircularBuffer is just a shared pointer over BufferImpl,
     // it is Ok to have copy and move operations.
-    CircularBuffer(const CircularBuffer&)            = default;
-    CircularBuffer(CircularBuffer&&)                 = default;
-    CircularBuffer& operator=(const CircularBuffer&) = default;
-    CircularBuffer& operator=(CircularBuffer&&)      = default;
+    CircularBuffer(const CircularBuffer&)                = default;
+    CircularBuffer(CircularBuffer&&) noexcept            = default;
+    CircularBuffer& operator=(const CircularBuffer&)     = default;
+    CircularBuffer& operator=(CircularBuffer&&) noexcept = default;
 
     [[nodiscard]] std::size_t           size() const noexcept { return _sharedBufferPtr->_size; }
     [[nodiscard]] BufferWriterLike auto new_writer() { return Writer<T>(_sharedBufferPtr); }

--- a/core/include/gnuradio-4.0/CircularBuffer.hpp
+++ b/core/include/gnuradio-4.0/CircularBuffer.hpp
@@ -465,7 +465,10 @@ private:
               _offset(std::exchange(other._offset, 0)),                                           //
               _internalSpan(std::exchange(other._internalSpan, std::span<T>{})) {};
 
-        Writer& operator=(Writer tmp) noexcept {
+        Writer(const Writer&)            = delete;
+        Writer& operator=(const Writer&) = delete;
+
+        Writer& operator=(Writer&& tmp) noexcept {
             std::swap(_buffer, tmp._buffer);
             std::swap(_nRequestedSamplesToPublish, tmp._nRequestedSamplesToPublish);
             std::swap(_index, tmp._index);
@@ -719,7 +722,10 @@ private:
               _nRequestedSamplesToConsume(other._nRequestedSamplesToConsume),               //
               _nSamplesConsumed(other._nSamplesConsumed) {}
 
-        Reader& operator=(Reader tmp) noexcept {
+        Reader(const Reader&)            = delete;
+        Reader& operator=(const Reader&) = delete;
+
+        Reader& operator=(Reader&& tmp) noexcept {
             std::swap(_readIndex, tmp._readIndex);
             std::swap(_readIndexCached, tmp._readIndexCached);
             std::swap(_buffer, tmp._buffer);

--- a/core/include/gnuradio-4.0/Graph.hpp
+++ b/core/include/gnuradio-4.0/Graph.hpp
@@ -722,7 +722,6 @@ public:
                 }
             }
         });
-        // assert(maxSize != 0UZ);
         assert(maxSize != undefined_size);
         return maxSize;
     }

--- a/core/include/gnuradio-4.0/Graph.hpp
+++ b/core/include/gnuradio-4.0/Graph.hpp
@@ -412,7 +412,7 @@ public:
     }
 
     [[maybe_unused]] bool removeEdge(const Edge& edge) {
-        return std::erase_if(_edges, [&](const Edge& e) { return e == edge; });
+        return std::erase_if(_edges, [&edge](const Edge& e) { return e == edge; });
     }
 
     std::optional<Message> propertyCallbackInspectBlock([[maybe_unused]] std::string_view propertyName, Message message);
@@ -562,7 +562,7 @@ public:
             std::expected<Result, Error> result       = std::unexpected(Error("Not found"));
 
             gr::meta::tuple_for_each(
-                [&]<typename PortOrCollection>(const PortOrCollection& portOrCollection) {
+                [&currentIndex, &result, &info]<typename PortOrCollection>(const PortOrCollection& portOrCollection) {
                     if constexpr (traits::port::is_port_v<PortOrCollection>) {
                         if (portOrCollection.metaInfo.name == info.portName) {
                             if (info.portIndex != meta::invalid_index) {
@@ -714,7 +714,7 @@ public:
         }
 
         std::size_t maxSize = 0UZ;
-        graph::forEachEdge<block::Category::All>(*this, [&](const Edge& e) {
+        graph::forEachEdge<block::Category::All>(*this, [&refEdge, &maxSize](const Edge& e) {
             if (refEdge.hasSameSourcePort(e)) {
                 std::size_t minBufferSize = e.minBufferSize();
                 if (minBufferSize != undefined_size) {
@@ -806,7 +806,7 @@ template<block::Category traverseCategory, typename Fn>
 void forEachBlock(GraphLike auto const& root, Fn&& function, block::Category filter = block::Category::All) {
     using enum block::Category;
 
-    detail::traverseSubgraphs<traverseCategory>(root, [&](const GraphLike auto& graph) {
+    detail::traverseSubgraphs<traverseCategory>(root, [&function, filter](const GraphLike auto& graph) {
         for (auto& block : graph.blocks()) {
             const block::Category cat = block->blockCategory();
             if (filter == All || cat == filter) {
@@ -819,7 +819,7 @@ void forEachBlock(GraphLike auto const& root, Fn&& function, block::Category fil
 template<block::Category traverseCategory>
 [[nodiscard]] std::size_t countBlocks(GraphLike auto const& root, block::Category filter = block::Category::All) {
     std::size_t n = 0;
-    forEachBlock<traverseCategory>(root, [&](auto const&) { n++; }, filter);
+    forEachBlock<traverseCategory>(root, [&n](auto const&) { n++; }, filter);
     return n;
 }
 
@@ -827,7 +827,7 @@ template<block::Category traverseCategory, typename Fn>
 void forEachEdge(GraphLike auto const& root, Fn&& function, Edge::EdgeState filter) {
     using enum Edge::EdgeState;
 
-    detail::traverseSubgraphs<traverseCategory>(root, [&](const GraphLike auto& graph) {
+    detail::traverseSubgraphs<traverseCategory>(root, [&function, filter](const GraphLike auto& graph) {
         for (auto& edge : graph.edges()) {
             if (filter == Unknown || edge._state == filter) {
                 function(edge);
@@ -839,7 +839,7 @@ void forEachEdge(GraphLike auto const& root, Fn&& function, Edge::EdgeState filt
 template<block::Category traverseCategory>
 [[nodiscard]] std::size_t countEdges(GraphLike auto const& root, Edge::EdgeState filter = Edge::EdgeState::Unknown) {
     std::size_t n = 0;
-    forEachEdge<traverseCategory>(root, [&](auto const&) { n++; }, filter);
+    forEachEdge<traverseCategory>(root, [&n](auto const&) { n++; }, filter);
     return n;
 }
 
@@ -848,11 +848,11 @@ gr::Graph flatten(GraphLike auto const& root, std::source_location location = st
     using enum block::Category;
 
     gr::Graph flattenedGraph;
-    gr::graph::forEachBlock<traverseCategory>(root, [&](const std::shared_ptr<BlockModel>& block) { flattenedGraph.addBlock(block, false); });
-    std::ranges::for_each(root.edges(), [&](const Edge& edge) { std::ignore = flattenedGraph.addEdge(edge, location); }); // add edges from root graph
+    gr::graph::forEachBlock<traverseCategory>(root, [&flattenedGraph](const std::shared_ptr<BlockModel>& block) { flattenedGraph.addBlock(block, false); });
+    std::ranges::for_each(root.edges(), [&flattenedGraph, &location](const Edge& edge) { std::ignore = flattenedGraph.addEdge(edge, location); }); // add edges from root graph
 
     // add edges related to blocks in flattened Graph
-    gr::graph::forEachBlock<traverseCategory>(root, [&](const std::shared_ptr<BlockModel>& block) { std::ranges::for_each(block->edges(), [&](const Edge& edge) { std::ignore = flattenedGraph.addEdge(edge, location); }); });
+    gr::graph::forEachBlock<traverseCategory>(root, [&flattenedGraph, &location](const std::shared_ptr<BlockModel>& block) { std::ranges::for_each(block->edges(), [&flattenedGraph, &location](const Edge& edge) { std::ignore = flattenedGraph.addEdge(edge, location); }); });
 
     return flattenedGraph;
 }
@@ -1005,7 +1005,7 @@ std::vector<FeedbackLoop> detectFeedbackLoops(const GraphLike auto& graph) {
 
     const AdjacencyList adjList = computeAdjacencyList(graph);
 
-    forEachBlock<block::Category::All>(graph, [&](const auto& block) { visited[block] = VisitState::Unvisited; });
+    forEachBlock<block::Category::All>(graph, [&visited](const auto& block) { visited[block] = VisitState::Unvisited; });
 
     auto dfs = [&](this auto&& self, auto& current) -> void {
         visited[current] = VisitState::Gray;
@@ -1040,7 +1040,7 @@ std::vector<FeedbackLoop> detectFeedbackLoops(const GraphLike auto& graph) {
         visited[current] = VisitState::Black;
     };
 
-    forEachBlock<block::Category::All>(graph, [&](auto& block) {
+    forEachBlock<block::Category::All>(graph, [&visited, &dfs](auto& block) {
         if (visited[block] == VisitState::Unvisited) {
             dfs(block);
         }

--- a/core/include/gnuradio-4.0/Graph.hpp
+++ b/core/include/gnuradio-4.0/Graph.hpp
@@ -43,16 +43,16 @@ using namespace std::string_literals;
 class PluginLoader;
 
 namespace graph::property {
-inline const char* kInspectBlock   = "InspectBlock";
-inline const char* kBlockInspected = "BlockInspected";
-inline const char* kGraphInspect   = "GraphInspect";
-inline const char* kGraphInspected = "GraphInspected";
+inline const char* const kInspectBlock   = "InspectBlock";
+inline const char* const kBlockInspected = "BlockInspected";
+inline const char* const kGraphInspect   = "GraphInspect";
+inline const char* const kGraphInspected = "GraphInspected";
 
-inline const char* kRegistryBlockTypes     = "RegistryBlockTypes";
-inline const char* kRegistrySchedulerTypes = "RegistrySchedulerTypes";
+inline const char* const kRegistryBlockTypes     = "RegistryBlockTypes";
+inline const char* const kRegistrySchedulerTypes = "RegistrySchedulerTypes";
 
-inline const char* kSubgraphExportPort   = "SubgraphExportPort";
-inline const char* kSubgraphExportedPort = "SubgraphExportedPort";
+inline const char* const kSubgraphExportPort   = "SubgraphExportPort";
+inline const char* const kSubgraphExportedPort = "SubgraphExportedPort";
 } // namespace graph::property
 
 namespace detail {

--- a/core/include/gnuradio-4.0/Graph.hpp
+++ b/core/include/gnuradio-4.0/Graph.hpp
@@ -352,7 +352,7 @@ public:
 
     Graph(gr::PluginLoader& pluginLoader, property_map settings = property_map{}) : Graph(std::move(settings)) { _pluginLoader = std::addressof(pluginLoader); }
 
-    Graph(Graph&& other)
+    Graph(Graph&& other) noexcept
         : gr::Block<gr::Graph>(std::move(other)),                             //
           _edges(std::move(other._edges)), _blocks(std::move(other._blocks)), //
           _progress(std::move(other._progress)),                              //

--- a/core/include/gnuradio-4.0/Graph.hpp
+++ b/core/include/gnuradio-4.0/Graph.hpp
@@ -361,6 +361,7 @@ public:
     Graph(Graph&)                   = delete; // there can be only one owner of Graph
     Graph& operator=(Graph&)        = delete; // there can be only one owner of Graph
     Graph& operator=(Graph&& other) = delete;
+    ~Graph()                        = default;
 
     [[nodiscard]] std::span<const std::shared_ptr<BlockModel>> blocks() const noexcept { return _blocks; }
     [[nodiscard]] std::span<std::shared_ptr<BlockModel>>       blocks() noexcept { return _blocks; }

--- a/core/include/gnuradio-4.0/Graph_yaml_importer.hpp
+++ b/core/include/gnuradio-4.0/Graph_yaml_importer.hpp
@@ -299,7 +299,7 @@ inline gr::property_map saveGraphToMap(PluginLoader& loader, const gr::Graph& ro
         const std::size_t  nBlocks = gr::graph::countBlocks<gr::block::Category::NormalBlock>(rootGraph);
         Tensor<pmt::Value> serializedBlocks;
         serializedBlocks.reserve(nBlocks);
-        gr::graph::forEachBlock<gr::block::Category::NormalBlock>(rootGraph, [&](const std::shared_ptr<BlockModel>& block) { serializedBlocks.emplace_back(serializeBlock(loader, block, BlockSerializationFlags::All & (~BlockSerializationFlags::Ports))); });
+        gr::graph::forEachBlock<gr::block::Category::NormalBlock>(rootGraph, [&serializedBlocks, &loader](const std::shared_ptr<BlockModel>& block) { serializedBlocks.emplace_back(serializeBlock(loader, block, BlockSerializationFlags::All & (~BlockSerializationFlags::Ports))); });
         result["blocks"] = std::move(serializedBlocks);
     }
 
@@ -307,7 +307,7 @@ inline gr::property_map saveGraphToMap(PluginLoader& loader, const gr::Graph& ro
         const std::size_t  nEdges = gr::graph::countEdges<block::Category::NormalBlock>(rootGraph);
         Tensor<pmt::Value> serializedConnections;
         serializedConnections.reserve(nEdges);
-        graph::forEachEdge<block::Category::NormalBlock>(rootGraph, [&](const Edge& edge) { // NormalBlock -> perhaps can be modelled to 'ALL' for a cleaner sub-graph handling
+        graph::forEachEdge<block::Category::NormalBlock>(rootGraph, [&serializedConnections](const Edge& edge) { // NormalBlock -> perhaps can be modelled to 'ALL' for a cleaner sub-graph handling
             Tensor<pmt::Value> seq;
             seq.reserve(7);
 

--- a/core/include/gnuradio-4.0/LifeCycle.hpp
+++ b/core/include/gnuradio-4.0/LifeCycle.hpp
@@ -191,6 +191,9 @@ public:
     }
 
     StateMachine(StateMachine&& other) noexcept { *this = std::move(other); }
+    ~StateMachine()                              = default;
+    StateMachine(const StateMachine&)            = delete;
+    StateMachine& operator=(const StateMachine&) = delete;
 
     StateMachine& operator=(StateMachine&& other) noexcept {
         // _other's state is put in STOPPED, so that a moved-from ~Block() becomes a no-op

--- a/core/include/gnuradio-4.0/Message.hpp
+++ b/core/include/gnuradio-4.0/Message.hpp
@@ -82,8 +82,8 @@ std::string commandName() noexcept {
     return std::string(gr::meta::enumName(command).value_or(""));
 }
 
-inline static std::string defaultBlockProtocol  = "MDPW03";
-inline static std::string defaultClientProtocol = "MDPC03";
+inline static const std::string defaultBlockProtocol  = "MDPW03";
+inline static const std::string defaultClientProtocol = "MDPC03";
 
 } // namespace message
 

--- a/core/include/gnuradio-4.0/Port.hpp
+++ b/core/include/gnuradio-4.0/Port.hpp
@@ -1197,6 +1197,7 @@ public:
 
     DynamicPort(const DynamicPort& arg)            = delete;
     DynamicPort& operator=(const DynamicPort& arg) = delete;
+    ~DynamicPort()                                 = default;
 
     DynamicPort(DynamicPort&& other) noexcept : priority(other.priority), min_samples(other.min_samples), max_samples(other.max_samples), metaInfo(other.metaInfo), _accessor(std::move(other._accessor)) {}
     auto& operator=(DynamicPort&& other) noexcept {

--- a/core/include/gnuradio-4.0/Port.hpp
+++ b/core/include/gnuradio-4.0/Port.hpp
@@ -217,7 +217,7 @@ Follows the ISO 80000-1:2022 Quantities and Units conventions:
             if (!auto_update.contains(convert_string_domain(key))) {
                 continue;
             }
-            refl::for_each_data_member_index<PortMetaInfo>([&](auto kIdx) {
+            refl::for_each_data_member_index<PortMetaInfo>([&key, &value, &maybeError, &location, this](auto kIdx) {
                 using MemberType = refl::data_member_type<PortMetaInfo, kIdx>;
                 using Type       = unwrap_if_wrapped_t<std::remove_cvref_t<MemberType>>;
 
@@ -253,7 +253,7 @@ Follows the ISO 80000-1:2022 Quantities and Units conventions:
 
     [[nodiscard]] property_map get() const noexcept {
         property_map metaInfo;
-        refl::for_each_data_member_index<PortMetaInfo>([&](auto kIdx) { //
+        refl::for_each_data_member_index<PortMetaInfo>([&metaInfo, this](auto kIdx) { //
             metaInfo.insert_or_assign(std::pmr::string(refl::data_member_name<PortMetaInfo, kIdx>.view()), refl::data_member<kIdx>(*this).value);
         });
 

--- a/core/include/gnuradio-4.0/Port.hpp
+++ b/core/include/gnuradio-4.0/Port.hpp
@@ -589,10 +589,10 @@ struct Port {
               rawTags(getTagsInRange(nSamples_, tagReader, reader.position())),                                   //
               streamIndex{reader.position()}, isConnected(connected), isSync(sync) {}
 
-        InputSpan(const InputSpan&)            = delete;
-        InputSpan& operator=(const InputSpan&) = delete;
-        InputSpan(InputSpan&&) noexcept        = default;
-        InputSpan& operator=(InputSpan&&)      = default;
+        InputSpan(const InputSpan&)                = delete;
+        InputSpan& operator=(const InputSpan&)     = delete;
+        InputSpan(InputSpan&&) noexcept            = default;
+        InputSpan& operator=(InputSpan&&) noexcept = default;
 
         ~InputSpan() {
             if (ReaderSpanType<spanReleasePolicy>::instanceCount() == 1UZ) { // has to be one, because the parent destructor which decrements it to zero is only called afterward
@@ -671,10 +671,10 @@ struct Port {
               tags(tagsWriter.template tryReserve<SpanReleasePolicy::ProcessNone>(tagsWriter.available())),      //
               streamIndex{streamOffset}, isConnected(connected), isSync(sync) {}
 
-        OutputSpan(const OutputSpan&)            = delete;
-        OutputSpan& operator=(const OutputSpan&) = delete;
-        OutputSpan(OutputSpan&&) noexcept        = default;
-        OutputSpan& operator=(OutputSpan&&)      = default;
+        OutputSpan(const OutputSpan&)                = delete;
+        OutputSpan& operator=(const OutputSpan&)     = delete;
+        OutputSpan(OutputSpan&&) noexcept            = default;
+        OutputSpan& operator=(OutputSpan&&) noexcept = default;
 
         ~OutputSpan() {
             if (WriterSpanType<spanReleasePolicy>::instanceCount() == 1UZ) { // has to be one, because the parent destructor which decrements it to zero is only called afterward

--- a/core/include/gnuradio-4.0/Scheduler.hpp
+++ b/core/include/gnuradio-4.0/Scheduler.hpp
@@ -495,7 +495,7 @@ public:
 protected:
     void disconnectAllEdges() {
         _graph->disconnectAllEdges();
-        graph::forEachBlock<TransparentBlockGroup>(*_graph, [&](auto& block) {
+        graph::forEachBlock<TransparentBlockGroup>(*_graph, [](auto& block) {
             if (block->blockCategory() == TransparentBlockGroup) {
                 auto* graph = static_cast<GraphWrapper<gr::Graph>*>(block.get());
                 graph->blockRef().disconnectAllEdges();
@@ -519,7 +519,7 @@ protected:
 
         bool result = _graph->connectPendingEdges();
         primeFeedbackPorts(gr::graph::flatten(*_graph)); // need to flatten graph due to potential loops from within the subgraph to blocks in the parents.
-        graph::forEachBlock<TransparentBlockGroup>(*_graph, [&](auto& block) {
+        graph::forEachBlock<TransparentBlockGroup>(*_graph, [&result, &primeFeedbackPorts](auto& block) {
             if (block->blockCategory() == TransparentBlockGroup) {
                 auto* graph = static_cast<GraphWrapper<gr::Graph>*>(block.get());
                 result      = result && graph->blockRef().connectPendingEdges();

--- a/core/include/gnuradio-4.0/Scheduler.hpp
+++ b/core/include/gnuradio-4.0/Scheduler.hpp
@@ -625,7 +625,7 @@ protected:
         }
     }
 
-    void poolWorker(const std::size_t runnerID, std::shared_ptr<std::vector<std::vector<std::shared_ptr<BlockModel>>>> jobList) noexcept {
+    void poolWorker(const std::size_t runnerID, std::shared_ptr<std::vector<std::vector<std::shared_ptr<BlockModel>>>> jobList) {
         using enum lifecycle::State;
         std::shared_ptr<gr::Sequence> progress     = _graph->_progress; // life-time guaranteed
         std::shared_ptr<gr::Sequence> nRunningJobs = _nRunningJobs;

--- a/core/include/gnuradio-4.0/Scheduler.hpp
+++ b/core/include/gnuradio-4.0/Scheduler.hpp
@@ -54,21 +54,21 @@ using namespace gr::message;
 
 namespace property {
 
-inline static const char* kEmplaceBlock = "EmplaceBlock";
-inline static const char* kRemoveBlock  = "RemoveBlock";
-inline static const char* kReplaceBlock = "ReplaceBlock";
-inline static const char* kEmplaceEdge  = "EmplaceEdge";
-inline static const char* kRemoveEdge   = "RemoveEdge";
+inline static const char* const kEmplaceBlock = "EmplaceBlock";
+inline static const char* const kRemoveBlock  = "RemoveBlock";
+inline static const char* const kReplaceBlock = "ReplaceBlock";
+inline static const char* const kEmplaceEdge  = "EmplaceEdge";
+inline static const char* const kRemoveEdge   = "RemoveEdge";
 
-inline static const char* kBlockEmplaced = "BlockEmplaced";
-inline static const char* kBlockRemoved  = "BlockRemoved";
-inline static const char* kBlockReplaced = "BlockReplaced";
-inline static const char* kEdgeEmplaced  = "EdgeEmplaced";
-inline static const char* kEdgeRemoved   = "EdgeRemoved";
+inline static const char* const kBlockEmplaced = "BlockEmplaced";
+inline static const char* const kBlockRemoved  = "BlockRemoved";
+inline static const char* const kBlockReplaced = "BlockReplaced";
+inline static const char* const kEdgeEmplaced  = "EdgeEmplaced";
+inline static const char* const kEdgeRemoved   = "EdgeRemoved";
 
-inline static const char* kGraphGRC           = "GraphGRC";
-inline static const char* kSchedulerInspect   = "SchedulerInspect";
-inline static const char* kSchedulerInspected = "SchedulerInspected";
+inline static const char* const kGraphGRC           = "GraphGRC";
+inline static const char* const kSchedulerInspect   = "SchedulerInspect";
+inline static const char* const kSchedulerInspected = "SchedulerInspected";
 } // namespace property
 
 enum class ExecutionPolicy {

--- a/core/include/gnuradio-4.0/Settings.hpp
+++ b/core/include/gnuradio-4.0/Settings.hpp
@@ -152,7 +152,7 @@ constexpr std::size_t hash_combine(std::size_t seed, const T& v) noexcept {
     return seed;
 }
 
-inline auto computeValueHash = meta::overloaded([](const std::string_view& sv) { return std::hash<std::string_view>()(sv); }, //
+inline const auto computeValueHash = meta::overloaded([](const std::string_view& sv) { return std::hash<std::string_view>()(sv); }, //
     []<typename T>(const gr::Tensor<T>& tensor) {
         std::size_t seed = 9UZ;
         for (const auto& v : tensor) {

--- a/core/include/gnuradio-4.0/Settings.hpp
+++ b/core/include/gnuradio-4.0/Settings.hpp
@@ -193,7 +193,7 @@ inline auto computeValueHash = meta::overloaded([](const std::string_view& sv) {
 
 inline std::size_t computeHash(const pmt::Value& value) {
     std::size_t result = 0UZ;
-    pmt::ValueVisitor([&](const auto& v) { result = computeValueHash(v); }).visit(value);
+    pmt::ValueVisitor([&result](const auto& v) { result = computeValueHash(v); }).visit(value);
     return result;
 }
 
@@ -645,7 +645,7 @@ public:
         static const std::set<std::string> members = [] {
             std::set<std::string> result;
             if constexpr (refl::reflectable<TBlock>) {
-                refl::for_each_data_member_index<TBlock>([&](auto kIdx) {
+                refl::for_each_data_member_index<TBlock>([&result](auto kIdx) {
                     using MemberType = refl::data_member_type<TBlock, kIdx>;
                     using RawType    = std::remove_cvref_t<MemberType>;
                     using Type       = unwrap_if_wrapped_t<RawType>;
@@ -774,7 +774,7 @@ public:
         static const std::unordered_map<std::string_view, ParameterSetter> setters = [] {
             std::unordered_map<std::string_view, ParameterSetter> result;
             if constexpr (refl::reflectable<TBlock>) {
-                refl::for_each_data_member_index<TBlock>([&](auto kIdx) {
+                refl::for_each_data_member_index<TBlock>([&result](auto kIdx) {
                     using MemberType = refl::data_member_type<TBlock, kIdx>;
                     using RawType    = std::remove_cvref_t<MemberType>;
                     using Type       = unwrap_if_wrapped_t<RawType>;
@@ -794,7 +794,7 @@ public:
         static const std::unordered_map<std::string_view, AutoUpdateHandler> handlers = [] {
             std::unordered_map<std::string_view, AutoUpdateHandler> result;
             if constexpr (refl::reflectable<TBlock>) {
-                refl::for_each_data_member_index<TBlock>([&](auto kIdx) {
+                refl::for_each_data_member_index<TBlock>([&result](auto kIdx) {
                     using MemberType = refl::data_member_type<TBlock, kIdx>;
                     using Type       = unwrap_if_wrapped_t<std::remove_cvref_t<MemberType>>;
                     if constexpr (settings::isWritableMember<Type, MemberType>()) {
@@ -813,7 +813,7 @@ public:
         static const std::unordered_map<std::string_view, StagedApplier> appliers = [] {
             std::unordered_map<std::string_view, StagedApplier> result;
             if constexpr (refl::reflectable<TBlock>) {
-                refl::for_each_data_member_index<TBlock>([&](auto kIdx) {
+                refl::for_each_data_member_index<TBlock>([&result](auto kIdx) {
                     using MemberType = refl::data_member_type<TBlock, kIdx>;
                     using RawType    = std::remove_cvref_t<MemberType>;
                     using Type       = unwrap_if_wrapped_t<RawType>;
@@ -833,7 +833,7 @@ public:
         static const std::vector<ParameterReader> readers = [] {
             std::vector<ParameterReader> result;
             if constexpr (refl::reflectable<TBlock>) {
-                refl::for_each_data_member_index<TBlock>([&](auto kIdx) {
+                refl::for_each_data_member_index<TBlock>([&result](auto kIdx) {
                     using MemberType = refl::data_member_type<TBlock, kIdx>;
                     using Type       = unwrap_if_wrapped_t<std::remove_cvref_t<MemberType>>;
                     if constexpr (settings::isReadableMember<Type>()) {
@@ -851,7 +851,7 @@ public:
         static const std::vector<ActiveParameterReader> readers = [] {
             std::vector<ActiveParameterReader> result;
             if constexpr (refl::reflectable<TBlock>) {
-                refl::for_each_data_member_index<TBlock>([&](auto kIdx) {
+                refl::for_each_data_member_index<TBlock>([&result](auto kIdx) {
                     using MemberType = refl::data_member_type<TBlock, kIdx>;
                     using RawType    = std::remove_cvref_t<MemberType>;
                     using Type       = unwrap_if_wrapped_t<RawType>;
@@ -912,7 +912,7 @@ public:
             }
 
             // handle meta-information for UI and other non-processing-related purposes
-            refl::for_each_data_member_index<TBlock>([&](auto kIdx) {
+            refl::for_each_data_member_index<TBlock>([this](auto kIdx) {
                 using MemberType = refl::data_member_type<TBlock, kIdx>;
                 using RawType    = std::remove_cvref_t<MemberType>;
                 using Type       = unwrap_if_wrapped_t<RawType>;

--- a/core/include/gnuradio-4.0/Settings.hpp
+++ b/core/include/gnuradio-4.0/Settings.hpp
@@ -36,7 +36,6 @@ constexpr bool isSupportedVectorOrTensorType() {
     if constexpr (gr::meta::vector_type<T> || gr::meta::array_type<T> || is_tensor<T>) {
         using ValueType = typename T::value_type;
         // TODO(follow-up PR): remove pmt::Value as collection element — it bypasses C++ type safety and breaks settings introspection
-        // return std::is_arithmetic_v<ValueType> || std::is_same_v<ValueType, std::string> || std::is_same_v<ValueType, std::pmr::string> || std::is_same_v<ValueType, std::complex<double>> || std::is_same_v<ValueType, std::complex<float>> || std::is_enum_v<ValueType>;
         return std::is_arithmetic_v<ValueType> || std::is_same_v<ValueType, std::string> || std::is_same_v<ValueType, std::pmr::string> || std::is_same_v<ValueType, std::complex<double>> || std::is_same_v<ValueType, std::complex<float>> || std::is_enum_v<ValueType> || std::is_same_v<ValueType, pmt::Value>;
     } else {
         return false;
@@ -56,7 +55,6 @@ constexpr bool isReadableMember() {
         }
     };
     // TODO(follow-up PR): remove pmt::Value as settings type — it erases type information, prevents validation, and complicates GRC YAML serialisation
-    // return std::is_arithmetic_v<T> || std::is_same_v<T, std::string> || isSupportedVectorOrTensorType<T>() || std::is_same_v<T, property_map> || std::is_same_v<T, std::complex<double>> || std::is_same_v<T, std::complex<float>> || std::is_enum_v<T> || isReadableImmutable();
     return std::is_arithmetic_v<T> || std::is_same_v<T, std::string> || std::is_same_v<T, std::pmr::string> || isSupportedVectorOrTensorType<T>() || std::is_same_v<T, property_map> //
            || std::is_same_v<T, std::complex<double>> || std::is_same_v<T, std::complex<float>> || std::is_enum_v<T> || std::is_same_v<T, pmt::Value> || isReadableImmutable();
 }

--- a/core/include/gnuradio-4.0/Tensor.hpp
+++ b/core/include/gnuradio-4.0/Tensor.hpp
@@ -1078,7 +1078,7 @@ struct Tensor<T, Ex...> : TensorBase<T, true, Ex...> { // fully or partially dyn
 
         // move data
         base_t::_data.reserve(other._data.size());
-        for (auto&& elem : other._data) {
+        for (auto& elem : other._data) {
             base_t::_data.push_back(static_cast<T>(std::move(elem)));
         }
     }

--- a/core/include/gnuradio-4.0/Tensor.hpp
+++ b/core/include/gnuradio-4.0/Tensor.hpp
@@ -1051,6 +1051,7 @@ struct Tensor<T, Ex...> : TensorBase<T, true, Ex...> { // fully or partially dyn
     using base_t::strides;
 
     Tensor(Tensor&& other) noexcept = default;
+    ~Tensor()                       = default;
     explicit Tensor(const T& v, std::pmr::memory_resource* mr = std::pmr::get_default_resource()) {
         base_t::_data = make_container(mr);
         base_t::fill(v);

--- a/core/include/gnuradio-4.0/ValueHelper.hpp
+++ b/core/include/gnuradio-4.0/ValueHelper.hpp
@@ -638,7 +638,7 @@ std::expected<std::vector<DstT>, ConversionError> valueToVector(const Value& v) 
 #undef DISPATCH_CASE
 
     case Value::ValueType::Value:
-        if (auto* t = const_cast<Value&>(v).get_if<Tensor<Value>>()) return tensorOfValueToVector<DstT, CP, RP>(*t);
+        if (const auto* t = v.get_if<Tensor<Value>>()) return tensorOfValueToVector<DstT, CP, RP>(*t);
         return std::unexpected(ConversionError{.kind = ConversionError::Kind::TypeMismatch});
 
     default: return std::unexpected(ConversionError{.kind = ConversionError::Kind::TypeMismatch});
@@ -678,7 +678,7 @@ std::expected<std::array<DstT, N>, ConversionError> valueToArray(const Value& v)
 #undef DISPATCH_CASE
 
     case Value::ValueType::Value:
-        if (auto* t = const_cast<Value&>(v).get_if<Tensor<Value>>()) return tensorOfValueToArray<DstT, N, CP, RP>(*t);
+        if (const auto* t = v.get_if<Tensor<Value>>()) return tensorOfValueToArray<DstT, N, CP, RP>(*t);
         return std::unexpected(ConversionError{.kind = ConversionError::Kind::TypeMismatch});
 
     default: return std::unexpected(ConversionError{.kind = ConversionError::Kind::TypeMismatch});
@@ -718,7 +718,7 @@ std::expected<DstTensor, ConversionError> valueToTensor(const Value& v, std::pmr
 #undef DISPATCH_CASE
 
     case Value::ValueType::Value:
-        if (auto* t = const_cast<Value&>(v).get_if<Tensor<Value>>()) return tensorOfValueToTensor<DstTensor, CP, RP>(*t, mr);
+        if (const auto* t = v.get_if<Tensor<Value>>()) return tensorOfValueToTensor<DstTensor, CP, RP>(*t, mr);
         return std::unexpected(ConversionError{.kind = ConversionError::Kind::TypeMismatch});
 
     default: return std::unexpected(ConversionError{.kind = ConversionError::Kind::TypeMismatch});
@@ -866,7 +866,7 @@ std::expected<void, ConversionError> assignTo(TensorT& dst, const Value& value) 
     using T = typename gr::tensor_traits<TensorT>::value_type;
     if constexpr (!gr::tensor_traits<TensorT>::all_static) {
         if (value.value_type() == detail::valueTypeFor<T>() && value.is_tensor()) {
-            if (auto* srcTensor = const_cast<Value&>(value).get_if<Tensor<T>>()) {
+            if (const auto* srcTensor = value.get_if<Tensor<T>>()) {
                 if constexpr (RP == RankPolicy::Strict && gr::tensor_traits<TensorT>::static_rank) {
                     if (srcTensor->rank() != dst.rank()) {
                         return std::unexpected(ConversionError{.kind = ConversionError::Kind::RankMismatch});

--- a/core/include/gnuradio-4.0/ValueHelper.hpp
+++ b/core/include/gnuradio-4.0/ValueHelper.hpp
@@ -928,8 +928,6 @@ std::expected<void, ConversionError> assignTo(TensorT& dst, Value&& value) {
     return assignTo<CP, RP>(dst, static_cast<const Value&>(value));
 }
 
-// public API: assignTo unordered_map<string, Value>
-
 template<ConversionPolicy CP = ConversionPolicy::Safe, RankPolicy RP = RankPolicy::Strict>
 std::expected<void, ConversionError> assignTo(std::unordered_map<std::string, Value>& dst, const Value& value) {
     auto result = convertTo<std::unordered_map<std::string, Value>, CP, RP>(value);
@@ -945,8 +943,6 @@ std::expected<void, ConversionError> assignTo(std::unordered_map<std::string, Va
     return assignTo<CP, RP>(dst, static_cast<const Value&>(value));
 }
 
-// public API: assignTo std::map<string, Value>
-
 template<ConversionPolicy CP = ConversionPolicy::Safe, RankPolicy RP = RankPolicy::Strict>
 std::expected<void, ConversionError> assignTo(std::map<std::string, Value>& dst, const Value& value) {
     auto result = convertTo<std::map<std::string, Value>, CP, RP>(value);
@@ -961,8 +957,6 @@ template<ConversionPolicy CP = ConversionPolicy::Safe, RankPolicy RP = RankPolic
 std::expected<void, ConversionError> assignTo(std::map<std::string, Value>& dst, Value&& value) {
     return assignTo<CP, RP>(dst, static_cast<const Value&>(value));
 }
-
-// public API: assignTo typed unordered_map<string, V>
 
 template<ConversionPolicy CP = ConversionPolicy::Safe, RankPolicy RP = RankPolicy::Strict, typename V>
 requires(!std::same_as<V, Value>)
@@ -980,8 +974,6 @@ requires(!std::same_as<V, Value>)
 std::expected<void, ConversionError> assignTo(std::unordered_map<std::string, V>& dst, Value&& value) {
     return assignTo<CP, RP>(dst, static_cast<const Value&>(value));
 }
-
-// public API: assignTo typed std::map<string, V>
 
 template<ConversionPolicy CP = ConversionPolicy::Safe, RankPolicy RP = RankPolicy::Strict, typename V>
 requires(!std::same_as<V, Value>)

--- a/core/include/gnuradio-4.0/YamlPmt.hpp
+++ b/core/include/gnuradio-4.0/YamlPmt.hpp
@@ -716,7 +716,7 @@ inline std::expected<pmt::Value, ParseError> parsePlainScalar(ParseContext& ctx,
     }
 
     // fallback for parsing without a YAML tag
-    return parseNextString(ctx, extraDelimiters, [&](std::size_t quoteOffset, std::string_view sv) -> std::expected<pmt::Value, ValueParseError> {
+    return parseNextString(ctx, extraDelimiters, [](std::size_t quoteOffset, std::string_view sv) -> std::expected<pmt::Value, ValueParseError> {
         if (quoteOffset > 0) { // quoted, treat as string
             return resolveYamlEscapes_quoted(sv).transform(value_construct);
         }
@@ -744,7 +744,7 @@ inline std::expected<pmt::Value, ParseError> parsePlainScalar(ParseContext& ctx,
         }
 
         // Anything else: string
-        return parseAs<std::string>(sv).transform_error([&](ValueParseError error) { return ValueParseError{quoteOffset + error.offset, error.message}; }).transform(value_construct);
+        return parseAs<std::string>(sv).transform_error([quoteOffset](ValueParseError error) { return ValueParseError{quoteOffset + error.offset, error.message}; }).transform(value_construct);
     });
 }
 

--- a/core/include/gnuradio-4.0/thread/thread_pool.hpp
+++ b/core/include/gnuradio-4.0/thread/thread_pool.hpp
@@ -503,8 +503,6 @@ private:
 
     void updateThreadConstraints() {
         std::scoped_lock lock(_threadListMutex);
-        // std::erase_if(_threads, [](auto &thread) { return !thread.joinable(); });
-
         std::for_each(_threads.begin(), _threads.end(), [this, threadID = std::size_t{0}](auto& thread) mutable { this->updateThreadConstraints(threadID++, thread); });
     }
 

--- a/core/src/main.cpp
+++ b/core/src/main.cpp
@@ -106,9 +106,9 @@ void reflectBlock(const TBlock& obj) {
                "# output streams: {}\n",
         gr::refl::type_name<TBlock>.view(), gr::refl::data_member_count<TBlock>, inputs::size(), outputs::size());
     std::print("-- input streams:\n");
-    inputs::for_each([&]<typename P>(auto idx, P*) { reflectPort<P>(idx, P::getPortObject(obj)); });
+    inputs::for_each([&obj]<typename P>(auto idx, P*) { reflectPort<P>(idx, P::getPortObject(obj)); });
     std::print("-- output streams:\n");
-    outputs::for_each([&]<typename P>(auto idx, P*) { reflectPort<P>(idx, P::getPortObject(obj)); });
+    outputs::for_each([&obj]<typename P>(auto idx, P*) { reflectPort<P>(idx, P::getPortObject(obj)); });
 }
 
 int main() {

--- a/meta/include/gnuradio-4.0/meta/RangesHelper.hpp
+++ b/meta/include/gnuradio-4.0/meta/RangesHelper.hpp
@@ -173,10 +173,7 @@ struct MergeView : std::ranges::view_interface<MergeView<R, TComp>> {
             }
         }
 
-        reference operator*() const {
-            // assert(_chosen < _its.size());
-            return *_its[_chosen];
-        }
+        reference operator*() const { return *_its[_chosen]; }
 
         Iterator& operator++() {
             ++_its[_chosen];

--- a/meta/include/gnuradio-4.0/meta/immutable.hpp
+++ b/meta/include/gnuradio-4.0/meta/immutable.hpp
@@ -25,7 +25,7 @@ public:
     immutable(Args&&... args) : _value(std::forward<Args>(args)...) {}
 
     // Only construction is allowed
-    immutable(immutable<T>&& other) : _value(std::move(other._value)) { other._value = T{}; }
+    immutable(immutable<T>&& other) noexcept(std::is_nothrow_move_constructible_v<T> && std::is_nothrow_default_constructible_v<T> && std::is_nothrow_move_assignable_v<T>) : _value(std::move(other._value)) { other._value = T{}; }
     immutable(const immutable<T>& other) : _value(other._value) {}
 
     // No assignment, these are const values

--- a/meta/include/gnuradio-4.0/meta/immutable.hpp
+++ b/meta/include/gnuradio-4.0/meta/immutable.hpp
@@ -32,6 +32,8 @@ public:
     immutable<T>& operator=(const immutable<T>& other) = delete;
     immutable<T>& operator=(immutable<T>&& other)      = delete;
 
+    ~immutable() = default;
+
     const T& value() const { return _value; }
 
     operator const T&() const { return _value; }

--- a/meta/include/gnuradio-4.0/meta/indirect.hpp
+++ b/meta/include/gnuradio-4.0/meta/indirect.hpp
@@ -25,7 +25,7 @@ public:
     requires std::is_copy_constructible_v<T> && std::is_copy_assignable_v<T>
         : _value(std::make_unique<T>(*other)) {}
 
-    indirect(indirect<T>&& other) : _value(std::move(other._value)) {}
+    indirect(indirect<T>&& other) noexcept : _value(std::move(other._value)) {}
 
     indirect<T>& operator=(const indirect<T>& other)
     requires std::is_copy_constructible_v<T> && std::is_copy_assignable_v<T>
@@ -35,7 +35,7 @@ public:
         return *this;
     }
 
-    indirect<T>& operator=(indirect<T>&& other) {
+    indirect<T>& operator=(indirect<T>&& other) noexcept {
         _value = std::exchange(other._value, nullptr);
         return *this;
     }

--- a/meta/include/gnuradio-4.0/meta/utils.hpp
+++ b/meta/include/gnuradio-4.0/meta/utils.hpp
@@ -715,9 +715,6 @@ consteval std::size_t indexForName() {
     return helper(std::make_index_sequence<PortList::size>());
 }
 
-// template<template<typename...> typename Type, typename... Items>
-// using find_type = decltype(std::tuple_cat(std::declval<std::conditional_t<is_instantiation_of<Items, Type>, std::tuple<Items>, std::tuple<>>>()...));
-
 template<template<typename> typename Pred, typename... Items>
 struct find_type;
 

--- a/meta/include/gnuradio-4.0/meta/utils.hpp
+++ b/meta/include/gnuradio-4.0/meta/utils.hpp
@@ -886,6 +886,10 @@ template<typename Fn>
 struct on_scope_exit {
     Fn function;
     on_scope_exit(Fn fn) : function(std::move(fn)) {}
+    on_scope_exit(const on_scope_exit&)            = delete;
+    on_scope_exit(on_scope_exit&&)                 = delete;
+    on_scope_exit& operator=(const on_scope_exit&) = delete;
+    on_scope_exit& operator=(on_scope_exit&&)      = delete;
     ~on_scope_exit() { function(); }
 };
 


### PR DESCRIPTION
## Summary

Follow-up on the [SonarCloud static-analysis report](https://sonarcloud.io/summary/overall?id=fair-acc_graph-prototype&branch=main).
Claude-assisted, human-reviewed cleanup of all BLOCKERs and the highest-signal CRITICAL/MAJOR clusters.

## Rules addressed (one rule per commit, ordered mechanical → judgement)

| Rule(s)               | What                                                 |
|-----------------------|------------------------------------------------------|
| `S5018`               | `noexcept` on move ctors / assignments               |
| `S5417`, `S5425`      | `std::forward` / `std::move` correctness fixes       |
| `S3608`               | explicit lambda captures in place of `[&]` / `[=]`   |
| `S3743`, `S3624`      | drop misleading `noexcept`; round out `Edge` dtor    |
| `S5421`               | deep-const on global property-name pointers          |
| `S859`                | remove redundant `const_cast`s in `ValueHelper`      |
| `S125`                | remove commented-out code                            |
| `S3624` (remainder)   | complete rule-of-five on flagged types               |

Each commit is scoped to a single rule and is bisect-safe.

## Deliberately out of scope

- `std::atomic<bool> stopRequested` signal flags in 3 example `.cpp`s — needed mutable by design.
- `Port.hpp:1216` `const_cast` — already tagged `TODO` for Ivan.
- `Value.hpp:445`, `Tensor.hpp:1743`, `USBDevice.hpp:229` — non-mechanical refactors or C-API boundary.
- `indirect.hpp`, `Port.hpp` `S3624` hits — false positives (dtor already `= default`).
- `InputSpan` / `OutputSpan` move ops — defaulted intentionally; dtor uses an `instanceCount` guard.