### PR TITLE
Fix flaky scheduler-message-passing-related unit test

### DIFF
--- a/core/include/gnuradio-4.0/Block.hpp
+++ b/core/include/gnuradio-4.0/Block.hpp
@@ -1833,6 +1833,9 @@ public:
             }
         }
         if (this->state() == lifecycle::State::STOPPED) {
+            // flush any staged settings before shutdown so messages that arrived just before
+            // the block transitioned to STOPPED (e.g. kSetting/ui_constraints) still commit
+            applyChangedSettings();
             disconnectFromUpStreamParents();
             return work::Result{requestedWork, 0UZ, DONE};
         }

--- a/core/include/gnuradio-4.0/thread/thread_pool.hpp
+++ b/core/include/gnuradio-4.0/thread/thread_pool.hpp
@@ -523,11 +523,14 @@ private:
         if (globalAffinityMask.empty()) {
             return {};
         }
+        // pools with minThreads == 0 (e.g. the Emscripten CPU pool, lazily spawned) would divide
+        // by zero below; fall back to a single-stripe layout until the pool actually grows.
+        const std::size_t stripe = std::max<std::size_t>(minThreads(), 1UZ);
         std::vector<bool> affinityMask;
         std::size_t       coreCount = 0;
         for (bool value : globalAffinityMask) {
             if (value) {
-                affinityMask.push_back(coreCount++ % minThreads() == threadID);
+                affinityMask.push_back(coreCount++ % stripe == threadID);
             } else {
                 affinityMask.push_back(false);
             }

--- a/core/test/message_utils.hpp
+++ b/core/test/message_utils.hpp
@@ -21,6 +21,9 @@ using namespace gr;
 
 using namespace std::chrono_literals;
 
+inline constexpr std::size_t               kDefaultMaxStallRounds = 5000UZ; // ~5 s of consecutive stalled 1 ms polls
+inline constexpr std::chrono::milliseconds kDefaultWallClockCap   = 120s;
+
 /// Sleeps the current thread until condition() is true or timeout
 template<typename Condition>
 bool awaitCondition(std::chrono::milliseconds timeout, Condition condition) {
@@ -30,6 +33,33 @@ bool awaitCondition(std::chrono::milliseconds timeout, Condition condition) {
             return true;
         }
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    return false;
+}
+
+// Progress-aware: stalling of Graph::progress() (not wall-clock) is the give-up signal
+// — immune to CPU starvation; `safetyCap` catches genuine deadlocks.
+template<typename Scheduler, typename Condition>
+bool awaitCondition(Scheduler& scheduler, Condition condition, //
+    std::size_t maxStallRounds = kDefaultMaxStallRounds, std::chrono::milliseconds safetyCap = kDefaultWallClockCap) {
+    const auto& progress    = scheduler.graph().progress();
+    const auto  deadline    = std::chrono::steady_clock::now() + safetyCap;
+    std::size_t lastSeen    = progress.value();
+    std::size_t stallRounds = 0UZ;
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (condition()) {
+            return true;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        const auto current = progress.value();
+        if (current == lastSeen) {
+            if (++stallRounds >= maxStallRounds) {
+                return false;
+            }
+        } else {
+            lastSeen    = current;
+            stallRounds = 0UZ;
+        }
     }
     return false;
 }
@@ -58,8 +88,8 @@ inline std::vector<Message> consumeAllReplyMessages(gr::MsgPortIn& port, std::so
 };
 
 template<typename Condition>
-inline std::optional<Message> waitForReply(gr::MsgPortIn& fromGraph, Condition condition, std::chrono::milliseconds maxWaitTime = 1s) {
-    auto startedAt = std::chrono::system_clock::now();
+inline std::optional<Message> waitForReply(gr::MsgPortIn& fromGraph, Condition condition, std::chrono::milliseconds maxWaitTime = kDefaultWallClockCap) {
+    auto startedAt = std::chrono::steady_clock::now();
     while (true) {
         auto messages = fromGraph.streamReader().get();
         auto it       = std::find_if(messages.begin(), messages.end(), condition);
@@ -67,8 +97,8 @@ inline std::optional<Message> waitForReply(gr::MsgPortIn& fromGraph, Condition c
             return *it;
         }
 
-        std::this_thread::sleep_for(100ms);
-        if (std::chrono::system_clock::now() - startedAt > maxWaitTime) {
+        std::this_thread::sleep_for(1ms);
+        if (std::chrono::steady_clock::now() - startedAt > maxWaitTime) {
             std::println("msg dump for failed test (message count {}):", messages.size());
             for (auto& msg : messages) {
                 std::println("msg: .endpoint={} .hasData={}", msg.endpoint, msg.data.has_value());

--- a/core/test/qa_ManagedSubGraph.cpp
+++ b/core/test/qa_ManagedSubGraph.cpp
@@ -111,7 +111,7 @@ const boost::ut::suite ManagedSubGraph = [] {
         gr::Graph graph;
 
         // Basic source and sink
-        [[maybe_unused]] auto& source = graph.emplaceBlock<SlowSource<float>>();
+        [[maybe_unused]] auto& source = graph.emplaceBlock<SlowSource<float>>({{"disconnect_on_done", false}});
         [[maybe_unused]] auto& sink   = graph.emplaceBlock<CountingSink<float>>();
 
         // Sub-scheduler with a single block inside
@@ -140,7 +140,7 @@ const boost::ut::suite ManagedSubGraph = [] {
 
         auto schedulerThreadHandle = gr::test::thread_pool::executeScheduler("qa_ManagedSubGraph", scheduler);
 
-        expect(awaitCondition(2s, [&scheduler] { return scheduler.state() == lifecycle::State::RUNNING; })) << "scheduler is not running";
+        expect(awaitCondition(scheduler, [&scheduler] { return scheduler.state() == lifecycle::State::RUNNING; })) << "scheduler is not running";
 
         // Check the state of the sub-blocks before the state of the sub-scheduler, as the scheduler might be running
         // but still updating children states
@@ -156,7 +156,7 @@ const boost::ut::suite ManagedSubGraph = [] {
             return result;
         };
 
-        expect(awaitCondition(2s, [&] { return allSubBlocksInState(lifecycle::State::RUNNING); })) << std::format("not all sub-graph blocks are RUNNING:\n{}", subBlockStates());
+        expect(awaitCondition(scheduler, [&] { return allSubBlocksInState(lifecycle::State::RUNNING); })) << std::format("not all sub-graph blocks are RUNNING:\n{}", subBlockStates());
         expect(subSchedulerBlock->state() == lifecycle::State::RUNNING) << "sub-scheduler is not running";
 
         testing::sendAndWaitForReply<Set>(toScheduler, fromScheduler, demo.wrapper->uniqueName(), graph::property::kSubgraphExportPort, //
@@ -214,12 +214,12 @@ const boost::ut::suite ManagedSubGraph = [] {
         expect(scheduler.state() == lifecycle::State::RUNNING) << std::format("scheduler should be running before pause - actual: {}", magic_enum::enum_name(scheduler.state()));
         expect(scheduler.changeStateTo(lifecycle::State::REQUESTED_PAUSE).has_value()) << "could switch to REQUESTED_PAUSE?";
 
-        expect(awaitCondition(2s, [&scheduler] { return scheduler.state() == lifecycle::State::PAUSED; })) << std::format("scheduler should be paused - actual: {}", magic_enum::enum_name(scheduler.state()));
-        expect(awaitCondition(2s, [&] { return allSubBlocksInState(lifecycle::State::PAUSED); })) << std::format("not all sub-graph blocks are PAUSED:\n{}", subBlockStates());
+        expect(awaitCondition(scheduler, [&scheduler] { return scheduler.state() == lifecycle::State::PAUSED; })) << std::format("scheduler should be paused - actual: {}", magic_enum::enum_name(scheduler.state()));
+        expect(awaitCondition(scheduler, [&] { return allSubBlocksInState(lifecycle::State::PAUSED); })) << std::format("not all sub-graph blocks are PAUSED:\n{}", subBlockStates());
 
         // Resume scheduler
         expect(scheduler.changeStateTo(lifecycle::State::RUNNING).has_value()) << "could switch to RUNNING?";
-        expect(awaitCondition(2s, [&] { return allSubBlocksInState(lifecycle::State::RUNNING); })) << std::format("not all sub-graph blocks are RUNNING after resume:\n{}", subBlockStates());
+        expect(awaitCondition(scheduler, [&] { return allSubBlocksInState(lifecycle::State::RUNNING); })) << std::format("not all sub-graph blocks are RUNNING after resume:\n{}", subBlockStates());
         expect(scheduler.state() == lifecycle::State::RUNNING) << std::format("scheduler should be running - actual: {}", magic_enum::enum_name(scheduler.state()));
         expect(subSchedulerBlock->state() == lifecycle::State::RUNNING) << std::format("sub-scheduler should be running - actual: {}", magic_enum::enum_name(subSchedulerBlock->state()));
 
@@ -227,7 +227,7 @@ const boost::ut::suite ManagedSubGraph = [] {
 
         scheduler.requestStop();
 
-        expect(awaitCondition(1s, [&scheduler] { return scheduler.state() == lifecycle::State::STOPPED; })) << std::format("scheduler should be stopped - actual: {}", magic_enum::enum_name(scheduler.state()));
+        expect(awaitCondition(scheduler, [&scheduler] { return scheduler.state() == lifecycle::State::STOPPED; })) << std::format("scheduler should be stopped - actual: {}", magic_enum::enum_name(scheduler.state()));
 
         auto schedulerRet = schedulerThreadHandle.get();
         if (!schedulerRet.has_value()) {
@@ -236,13 +236,13 @@ const boost::ut::suite ManagedSubGraph = [] {
 
         expect(subSchedulerBlock->state() == lifecycle::State::STOPPED) << std::format("sub-scheduler should be stopped - actual: {}", magic_enum::enum_name(subSchedulerBlock->state()));
 
-        expect(awaitCondition(2s, [&] { return allSubBlocksInState(lifecycle::State::STOPPED); })) << std::format("not all sub-graph blocks are STOPPED:\n{}", subBlockStates());
+        expect(awaitCondition(scheduler, [&] { return allSubBlocksInState(lifecycle::State::STOPPED); })) << std::format("not all sub-graph blocks are STOPPED:\n{}", subBlockStates());
 
         // return to initial state
         expect(scheduler.changeStateTo(lifecycle::State::INITIALISED).has_value()) << "could not switch to INITIALISED?";
-        expect(awaitCondition(1s, [&scheduler] { return scheduler.state() == lifecycle::State::INITIALISED; })) << "scheduler INITIALISED w/ timeout";
+        expect(awaitCondition(scheduler, [&scheduler] { return scheduler.state() == lifecycle::State::INITIALISED; })) << "scheduler INITIALISED w/ timeout";
 
-        expect(awaitCondition(2s, [&] { return allSubBlocksInState(lifecycle::State::INITIALISED); })) << std::format("not all sub-graph blocks are INITIALISED:\n{}", subBlockStates());
+        expect(awaitCondition(scheduler, [&] { return allSubBlocksInState(lifecycle::State::INITIALISED); })) << std::format("not all sub-graph blocks are INITIALISED:\n{}", subBlockStates());
         expect(scheduler.state() == lifecycle::State::INITIALISED) << std::format("scheduler INITIALISED - actual: {}\n", magic_enum::enum_name(scheduler.state()));
         expect(subSchedulerBlock->state() == lifecycle::State::INITIALISED) << std::format("sub-scheduler should be stopped - actual: {}", magic_enum::enum_name(subSchedulerBlock->state()));
     };
@@ -258,7 +258,7 @@ const boost::ut::suite ExportPortsTests_ = [] {
         gr::Graph initGraph;
 
         // Basic source and sink
-        auto& source = initGraph.emplaceBlock<SlowSource<float>>();
+        auto& source = initGraph.emplaceBlock<SlowSource<float>>({{"disconnect_on_done", false}});
         auto& sink   = initGraph.emplaceBlock<CountingSink<float>>();
 
         auto demo = createDemoSubScheduler<float>();
@@ -276,7 +276,7 @@ const boost::ut::suite ExportPortsTests_ = [] {
         expect(scheduler.msgOut.connect(fromScheduler).has_value());
 
         auto schedulerThreadHandle = gr::test::thread_pool::executeScheduler("qa_HierBlock::scheduler", scheduler);
-        expect(awaitCondition(1s, [&scheduler] { return scheduler.state() == lifecycle::State::RUNNING; })) << "scheduler thread up and running w/ timeout";
+        expect(awaitCondition(scheduler, [&scheduler] { return scheduler.state() == lifecycle::State::RUNNING; })) << "scheduler thread up and running w/ timeout";
         expect(scheduler.state() == lifecycle::State::RUNNING) << "scheduler thread up and running";
 
         testing::sendAndWaitForReply<Set>(toScheduler, fromScheduler, demo.schedulerUniqueName, graph::property::kSubgraphExportPort,                                               //
@@ -350,7 +350,7 @@ const boost::ut::suite ExportPortsTests_ = [] {
         // return to initial state
         const auto initRet = scheduler.changeStateTo(lifecycle::State::INITIALISED);
         expect(initRet.has_value()) << [&initRet] { return std::format("could switch to INITIALISED - error: {}", initRet.error()); };
-        expect(awaitCondition(1s, [&scheduler] { return scheduler.state() == lifecycle::State::INITIALISED; })) << "scheduler INITIALISED w/ timeout";
+        expect(awaitCondition(scheduler, [&scheduler] { return scheduler.state() == lifecycle::State::INITIALISED; })) << "scheduler INITIALISED w/ timeout";
         expect(scheduler.state() == lifecycle::State::INITIALISED) << std::format("scheduler INITIALISED - actual: {}\n", magic_enum::enum_name(scheduler.state()));
     };
 };
@@ -363,7 +363,7 @@ const boost::ut::suite GraphInspectYamlTests_ = [] {
         using enum gr::message::Command;
 
         gr::Graph              initGraph;
-        [[maybe_unused]] auto& source = initGraph.emplaceBlock<SlowSource<float>>();
+        [[maybe_unused]] auto& source = initGraph.emplaceBlock<SlowSource<float>>({{"disconnect_on_done", false}});
         [[maybe_unused]] auto& sink   = initGraph.emplaceBlock<CountingSink<float>>();
 
         auto demo = createDemoSubScheduler<float>();
@@ -381,7 +381,7 @@ const boost::ut::suite GraphInspectYamlTests_ = [] {
         expect(scheduler.msgOut.connect(fromScheduler).has_value());
 
         auto schedulerThreadHandle = gr::test::thread_pool::executeScheduler("qa_GraphInspectYaml_managed", scheduler);
-        expect(awaitCondition(2s, [&scheduler] { return scheduler.state() == lifecycle::State::RUNNING; })) << "scheduler running";
+        expect(awaitCondition(scheduler, [&scheduler] { return scheduler.state() == lifecycle::State::RUNNING; })) << "scheduler running";
 
         testing::sendAndWaitForReply<Set>(toScheduler, fromScheduler, graph.unique_name,     //
             graph::property::kGraphInspect, property_map{{"serialization_format", "yaml"s}}, //
@@ -403,7 +403,7 @@ const boost::ut::suite GraphInspectYamlTests_ = [] {
         scheduler.requestStop();
         schedulerThreadHandle.get();
         expect(scheduler.changeStateTo(lifecycle::State::INITIALISED).has_value());
-        expect(awaitCondition(1s, [&scheduler] { return scheduler.state() == lifecycle::State::INITIALISED; }));
+        expect(awaitCondition(scheduler, [&scheduler] { return scheduler.state() == lifecycle::State::INITIALISED; }));
     };
 };
 
@@ -415,7 +415,7 @@ const boost::ut::suite SchedulerInspectTests_ = [] {
         using enum gr::message::Command;
 
         gr::Graph              initGraph;
-        [[maybe_unused]] auto& source = initGraph.emplaceBlock<SlowSource<float>>();
+        [[maybe_unused]] auto& source = initGraph.emplaceBlock<SlowSource<float>>({{"disconnect_on_done", false}});
         [[maybe_unused]] auto& sink   = initGraph.emplaceBlock<CountingSink<float>>();
 
         auto demo = createDemoSubScheduler<float>();
@@ -433,7 +433,7 @@ const boost::ut::suite SchedulerInspectTests_ = [] {
         expect(scheduler.msgOut.connect(fromScheduler).has_value());
 
         auto schedulerThreadHandle = gr::test::thread_pool::executeScheduler("qa_SchedulerInspect_managed", scheduler);
-        expect(awaitCondition(2s, [&scheduler] { return scheduler.state() == lifecycle::State::RUNNING; })) << "scheduler running";
+        expect(awaitCondition(scheduler, [&scheduler] { return scheduler.state() == lifecycle::State::RUNNING; })) << "scheduler running";
 
         testing::sendAndWaitForReply<Set>(toScheduler, fromScheduler, scheduler.unique_name, //
             scheduler::property::kSchedulerInspect, property_map{},                          //
@@ -457,14 +457,14 @@ const boost::ut::suite SchedulerInspectTests_ = [] {
         scheduler.requestStop();
         schedulerThreadHandle.get();
         expect(scheduler.changeStateTo(lifecycle::State::INITIALISED).has_value());
-        expect(awaitCondition(1s, [&scheduler] { return scheduler.state() == lifecycle::State::INITIALISED; }));
+        expect(awaitCondition(scheduler, [&scheduler] { return scheduler.state() == lifecycle::State::INITIALISED; }));
     };
 
     "kSchedulerInspect returns yaml when serialization_format is yaml"_test = [] {
         using enum gr::message::Command;
 
         gr::Graph              initGraph;
-        [[maybe_unused]] auto& source = initGraph.emplaceBlock<SlowSource<float>>();
+        [[maybe_unused]] auto& source = initGraph.emplaceBlock<SlowSource<float>>({{"disconnect_on_done", false}});
         [[maybe_unused]] auto& sink   = initGraph.emplaceBlock<CountingSink<float>>();
         auto                   demo   = createDemoSubScheduler<float>();
         initGraph.addBlock(std::move(demo.scheduler));
@@ -480,7 +480,7 @@ const boost::ut::suite SchedulerInspectTests_ = [] {
         expect(scheduler.msgOut.connect(fromScheduler).has_value());
 
         auto schedulerThreadHandle = gr::test::thread_pool::executeScheduler("qa_SchedulerInspectYaml_managed", scheduler);
-        expect(awaitCondition(2s, [&scheduler] { return scheduler.state() == lifecycle::State::RUNNING; })) << "scheduler running";
+        expect(awaitCondition(scheduler, [&scheduler] { return scheduler.state() == lifecycle::State::RUNNING; })) << "scheduler running";
 
         testing::sendAndWaitForReply<Set>(toScheduler, fromScheduler, scheduler.unique_name,         //
             scheduler::property::kSchedulerInspect, property_map{{"serialization_format", "yaml"s}}, //
@@ -502,7 +502,7 @@ const boost::ut::suite SchedulerInspectTests_ = [] {
         scheduler.requestStop();
         schedulerThreadHandle.get();
         expect(scheduler.changeStateTo(lifecycle::State::INITIALISED).has_value());
-        expect(awaitCondition(1s, [&scheduler] { return scheduler.state() == lifecycle::State::INITIALISED; }));
+        expect(awaitCondition(scheduler, [&scheduler] { return scheduler.state() == lifecycle::State::INITIALISED; }));
     };
 };
 

--- a/core/test/qa_ManagedSubGraph.cpp
+++ b/core/test/qa_ManagedSubGraph.cpp
@@ -40,8 +40,12 @@ struct DemoSubSchedulerResult {
 
     DemoSubSchedulerResult() {}
 
+    // Dedicated pool for nested sub-schedulers: prevents deadlock when the outer
+    // multiThreaded scheduler already holds every slot of the 2-thread default_cpu pool.
+    static constexpr std::string_view kSubSchedulerPoolId = "sub_scheduler_cpu";
+
     void setGraph(gr::Graph&& graph) {
-        scheduler           = std::static_pointer_cast<BlockModel>(std::make_shared<Wrapper>());
+        scheduler           = std::static_pointer_cast<BlockModel>(std::make_shared<Wrapper>(gr::property_map{{"poolName", std::string(kSubSchedulerPoolId)}}));
         schedulerUniqueName = scheduler->uniqueName();
         wrapper             = static_cast<Wrapper*>(scheduler.get());
         wrapper->setGraph(std::move(graph));
@@ -95,6 +99,13 @@ const boost::ut::suite BasicSchedulerWrapperTests = [] {
 void setCustomDefaultThreadPool() {
     auto cpu = std::make_shared<thread_pool::ThreadPoolWrapper>(std::make_unique<thread_pool::BasicThreadPool>(std::string(thread_pool::kDefaultCpuPoolId), thread_pool::TaskType::CPU_BOUND, 2U, 2U), "CPU");
     gr::thread_pool::Manager::instance().replacePool(std::string(thread_pool::kDefaultCpuPoolId), std::move(cpu));
+
+    auto subCpu = std::make_shared<thread_pool::ThreadPoolWrapper>(std::make_unique<thread_pool::BasicThreadPool>(std::string(DemoSubSchedulerResult<float>::kSubSchedulerPoolId), thread_pool::TaskType::CPU_BOUND, 2U, 2U), "CPU");
+    try {
+        gr::thread_pool::Manager::instance().registerPool(std::string(DemoSubSchedulerResult<float>::kSubSchedulerPoolId), std::move(subCpu));
+    } catch (const std::invalid_argument&) {
+        // already registered by a previous test suite — reuse existing instance
+    }
 }
 
 const boost::ut::suite ManagedSubGraph = [] {

--- a/core/test/qa_Scheduler.cpp
+++ b/core/test/qa_Scheduler.cpp
@@ -1104,7 +1104,7 @@ const boost::ut::suite<"SchedulerTests"> SchedulerTests = [] {
 
         auto schedulerThreadHandle = gr::test::thread_pool::executeScheduler("qa_Sched", scheduler);
 
-        expect(awaitCondition(2s, [&scheduler] { return scheduler.state() == lifecycle::State::RUNNING; })) << "scheduler thread up and running w/ timeout";
+        expect(awaitCondition(scheduler, [&scheduler] { return scheduler.state() == lifecycle::State::RUNNING; })) << "scheduler thread up and running w/ timeout";
 
         expect(scheduler.state() == lifecycle::State::RUNNING) << "scheduler thread up and running";
 

--- a/core/test/qa_SchedulerMessages.cpp
+++ b/core/test/qa_SchedulerMessages.cpp
@@ -63,7 +63,7 @@ public:
 
         using namespace boost::ut;
         // Wait for the scheduler to start running
-        expect(gr::testing::awaitCondition(1s, [this] { return scheduler_.state() == gr::lifecycle::State::RUNNING; })) << "scheduler thread up and running w/ timeout";
+        expect(gr::testing::awaitCondition(scheduler_, [this] { return scheduler_.state() == gr::lifecycle::State::RUNNING; })) << "scheduler thread up and running w/ timeout";
         expect(scheduler_.state() == gr::lifecycle::State::RUNNING) << "scheduler thread up and running";
     }
 
@@ -130,7 +130,7 @@ const boost::ut::suite TopologyGraphTests = [] {
 
         TestScheduler scheduler(std::move(flow));
 
-        expect(awaitCondition(2s, [&scheduler] { return scheduler.state() == lifecycle::State::RUNNING; })) << "scheduler thread up and running w/ timeout";
+        expect(awaitCondition(scheduler, [&scheduler] { return scheduler.state() == lifecycle::State::RUNNING; })) << "scheduler thread up and running w/ timeout";
 
         expect(scheduler.state() == lifecycle::State::RUNNING) << "scheduler is running";
 
@@ -145,13 +145,13 @@ const boost::ut::suite TopologyGraphTests = [] {
             property_map{{"type", std::string("builtin_counter<float32>")}, {"properties", property_map{{"disconnect_on_done", false}}}},                                //
             ReplyChecker{.expectedEndpoint = scheduler::property::kBlockEmplaced});
 
-        expect(awaitCondition(2s, [&scheduler, initialBlockCount] { return scheduler.graph().blocks().size() > initialBlockCount; })) << "waiting for block to be added to graph";
+        expect(awaitCondition(scheduler, [&scheduler, initialBlockCount] { return scheduler.graph().blocks().size() > initialBlockCount; })) << "waiting for block to be added to graph";
 
         auto finalBlockCount = scheduler.graph().blocks().size();
         std::println("Final block count: {}", finalBlockCount);
         expect(eq(finalBlockCount, initialBlockCount + 1)) << "block was added";
 
-        expect(awaitCondition(2s, [&scheduler] {
+        expect(awaitCondition(scheduler, [&scheduler] {
             for (const auto& block : scheduler.graph().blocks()) {
                 if (block->name() == "builtin_counter<float32>" && block->state() == lifecycle::State::RUNNING) {
                     return true;
@@ -381,11 +381,19 @@ const boost::ut::suite TopologyGraphTests = [] {
     };
 
     "UI constraints setting test"_test = [] {
+        // Build a fully connected source→copy1→copy2→sink chain. Orphan blocks
+        // self-stop via `disconnect_on_done` before staged settings commit, so the
+        // earlier version of this test raced depending on stdlib timing.
         gr::Graph testGraph(context->loader);
-        auto&     copy1 = testGraph.emplaceBlock("gr::testing::Copy<float32>", {});
-        auto&     copy2 = testGraph.emplaceBlock("gr::testing::Copy<float32>", {});
+        auto&     source = testGraph.emplaceBlock<gr::testing::SlowSource<float>>();
+        auto&     copy1  = testGraph.emplaceBlock<gr::testing::Copy<float>>();
+        auto&     copy2  = testGraph.emplaceBlock<gr::testing::Copy<float>>();
+        auto&     sink   = testGraph.emplaceBlock<gr::testing::CountingSink<float>>();
+        expect(testGraph.connect<"out", "in">(source, copy1).has_value());
+        expect(testGraph.connect<"out", "in">(copy1, copy2).has_value());
+        expect(testGraph.connect<"out", "in">(copy2, sink).has_value());
 
-        TestScheduler scheduler(std::move(testGraph));
+        TestScheduler scheduler(std::move(testGraph), /*addTestSourceAndSink=*/false);
         auto          makeUiConstraints = [](float x, float y) { return gr::property_map{{"x", x}, {"y", y}}; };
 
         // Setting ui_constraints property for all blocks, universal
@@ -394,24 +402,20 @@ const boost::ut::suite TopologyGraphTests = [] {
         );
 
         // Setting ui_constraints property for one block
-        sendMessage<Set>(scheduler.toScheduler, copy1->uniqueName(), block::property::kSetting, //
-            {{"ui_constraints", makeUiConstraints(42, 6)}}                                      // data
+        sendMessage<Set>(scheduler.toScheduler, copy1.unique_name, block::property::kSetting, //
+            {{"ui_constraints", makeUiConstraints(42, 6)}}                                    // data
         );
 
         auto uiConstraintsFor = [](const auto& block) {
             property_map result{};
-            pmt::ValueVisitor(meta::overloaded{
-                                  //
-                                  [&result]<typename... Args>(const gr::property_map& map) { result = gr::property_map(map); },
-                                  //
-                                  [&result]<typename Other>(const Other& /*v*/) { result = gr::property_map{}; }
-                                  //
-                              })
-                .visit(block->settings().get("ui_constraints").value());
+            pmt::ValueVisitor(meta::overloaded{                                                                                 //
+                                  [&result]<typename... Args>(const gr::property_map& map) { result = gr::property_map(map); }, //
+                                  [&result]<typename Other>(const Other& /*v*/) { result = gr::property_map{}; }})
+                .visit(block.settings().get("ui_constraints").value());
             return result;
         };
 
-        expect(awaitCondition(2s, [&] {
+        expect(awaitCondition(scheduler, [&] {
             auto c1 = uiConstraintsFor(copy1);
             auto c2 = uiConstraintsFor(copy2);
             if (c1.empty() || c2.empty()) {
@@ -426,7 +430,6 @@ const boost::ut::suite TopologyGraphTests = [] {
         expect(eq(43.f, gr::test::get_value_or_fail<float>(uiConstraintsFor(copy2)["x"])));
 
         // Check if block introspection includes ui_constraints
-
         {
             auto reply = testing::sendAndWaitForReply<Set>(scheduler.toScheduler, scheduler.fromScheduler, {}, // serviceName
                 graph::property::kGraphInspect,                                                                // endpoint
@@ -456,13 +459,10 @@ const boost::ut::suite TopologyGraphTests = [] {
         }
 
         scheduler.scheduler().requestStop();
-        expect(awaitCondition(2s, [&] { return scheduler.state() != lifecycle::State::RUNNING; })) << "scheduler stopped";
+        expect(awaitCondition(scheduler, [&] { return scheduler.state() != lifecycle::State::RUNNING; })) << "scheduler stopped";
 
-        auto copy1direct = static_cast<gr::testing::Copy<float>*>(copy1->raw());
-        auto copy2direct = static_cast<gr::testing::Copy<float>*>(copy2->raw());
-
-        expect(eq(42.f, gr::test::get_value_or_fail<float>(copy1direct->ui_constraints["x"])));
-        expect(eq(43.f, gr::test::get_value_or_fail<float>(copy2direct->ui_constraints["x"])));
+        expect(eq(42.f, gr::test::get_value_or_fail<float>(copy1.ui_constraints["x"])));
+        expect(eq(43.f, gr::test::get_value_or_fail<float>(copy2.ui_constraints["x"])));
     };
 };
 
@@ -482,11 +482,11 @@ const boost::ut::suite MoreTopologyGraphTests = [] {
 
     TestScheduler scheduler(std::move(graph), /*addTestSourceAndSink=*/false);
 
-    expect(awaitCondition(1s, [&scheduler] { return scheduler.state() == lifecycle::State::RUNNING; })) << "scheduler thread up and running w/ timeout";
+    expect(awaitCondition(scheduler, [&scheduler] { return scheduler.state() == lifecycle::State::RUNNING; })) << "scheduler thread up and running w/ timeout";
     expect(scheduler.state() == lifecycle::State::RUNNING) << "scheduler thread up and running";
     expect(eq(scheduler.graph().edges().size(), 1UZ)) << "added one edge";
 
-    expect(awaitCondition(1s, [&sink] { return sink.count >= 10U; })) << "sink received enough data";
+    expect(awaitCondition(scheduler, [&sink] { return sink.count >= 10U; })) << "sink received enough data";
     std::println("executed basic graph");
 
     // Adding a few blocks
@@ -547,11 +547,11 @@ const boost::ut::suite MoreTopologyGraphTests = [] {
 
     // return to initial state
     expect(scheduler.changeStateTo(lifecycle::State::INITIALISED).has_value()) << "could switch to INITIALISED?";
-    expect(awaitCondition(1s, [&scheduler] { return scheduler.state() == lifecycle::State::INITIALISED; })) << "scheduler INITIALISED w/ timeout";
+    expect(awaitCondition(scheduler, [&scheduler] { return scheduler.state() == lifecycle::State::INITIALISED; })) << "scheduler INITIALISED w/ timeout";
     expect(scheduler.state() == lifecycle::State::INITIALISED) << std::format("scheduler INITIALISED - actual: {}\n", magic_enum::enum_name(scheduler.state()));
 
     scheduler.run();
-    expect(awaitCondition(1s, [&scheduler] { return scheduler.state() == lifecycle::State::RUNNING; })) << "scheduler thread up and running w/ timeout";
+    expect(awaitCondition(scheduler, [&scheduler] { return scheduler.state() == lifecycle::State::RUNNING; })) << "scheduler thread up and running w/ timeout";
     expect(scheduler.state() == lifecycle::State::RUNNING) << "scheduler thread up and running";
 
     for (const auto& edge : scheduler.graph().edges()) {
@@ -560,7 +560,7 @@ const boost::ut::suite MoreTopologyGraphTests = [] {
     expect(eq(scheduler.graph().edges().size(), 4UZ)) << "added three new edges, one previously registered with connect";
 
     // FIXME: edge->connection is not performed
-    //    expect(awaitCondition(1s, [&sink] {
+    //    expect(awaitCondition(scheduler,[&sink] {
     //        std::this_thread::sleep_for(100ms);
     //        std::println("sink has received {} samples - parents: {}", sink.count, sink.in.buffer().streamBuffer.n_writers());
     //        return sink.count >= 10U;

--- a/core/test/qa_UnmanagedSubGraph.cpp
+++ b/core/test/qa_UnmanagedSubGraph.cpp
@@ -96,7 +96,7 @@ const boost::ut::suite ExportPortsTests_ = [] {
         expect(scheduler.msgOut.connect(fromScheduler).has_value());
 
         auto schedulerThreadHandle = gr::test::thread_pool::executeScheduler("qa_HierBlock::scheduler", scheduler);
-        expect(awaitCondition(1s, [&scheduler] { return scheduler.state() == lifecycle::State::RUNNING; })) << "scheduler thread up and running w/ timeout";
+        expect(awaitCondition(scheduler, [&scheduler] { return scheduler.state() == lifecycle::State::RUNNING; })) << "scheduler thread up and running w/ timeout";
         expect(scheduler.state() == lifecycle::State::RUNNING) << "scheduler thread up and running";
 
         testing::sendAndWaitForReply<Set>(toScheduler, fromScheduler, demo.graphUniqueName, graph::property::kSubgraphExportPort,                                                   //
@@ -170,7 +170,7 @@ const boost::ut::suite ExportPortsTests_ = [] {
         // return to initial state
         const auto initRet = scheduler.changeStateTo(lifecycle::State::INITIALISED);
         expect(initRet.has_value()) << [&initRet] { return std::format("could switch to INITIALISED - error: {}", initRet.error()); };
-        expect(awaitCondition(1s, [&scheduler] { return scheduler.state() == lifecycle::State::INITIALISED; })) << "scheduler INITIALISED w/ timeout";
+        expect(awaitCondition(scheduler, [&scheduler] { return scheduler.state() == lifecycle::State::INITIALISED; })) << "scheduler INITIALISED w/ timeout";
         expect(scheduler.state() == lifecycle::State::INITIALISED) << std::format("scheduler INITIALISED - actual: {}\n", magic_enum::enum_name(scheduler.state()));
     };
 };
@@ -207,11 +207,11 @@ const boost::ut::suite SchedulerDiveIntoSubgraphTests_ = [] {
 
         auto schedulerThreadHandle = gr::test::thread_pool::executeScheduler("qa_HierBlock::scheduler", scheduler);
 
-        expect(awaitCondition(1s, [&] { return scheduler.state() == lifecycle::State::RUNNING; })) << "scheduler thread up and running w/ timeout";
+        expect(awaitCondition(scheduler, [&] { return scheduler.state() == lifecycle::State::RUNNING; })) << "scheduler thread up and running w/ timeout";
 
         expect(scheduler.state() == lifecycle::State::RUNNING) << "scheduler thread up and running";
 
-        expect(awaitCondition(1s, [&] { return sink.count > 0UZ; }));
+        expect(awaitCondition(scheduler, [&] { return sink.count > 0UZ; }));
 
         expect(source.state() == lifecycle::State::RUNNING);
         expect(sink.state() == lifecycle::State::RUNNING);
@@ -229,7 +229,7 @@ const boost::ut::suite SchedulerDiveIntoSubgraphTests_ = [] {
 
         // return to initial state
         expect(scheduler.changeStateTo(lifecycle::State::INITIALISED).has_value()) << "could switch to INITIALISED?";
-        expect(awaitCondition(1s, [&scheduler] { return scheduler.state() == lifecycle::State::INITIALISED; })) << "scheduler INITIALISED w/ timeout";
+        expect(awaitCondition(scheduler, [&scheduler] { return scheduler.state() == lifecycle::State::INITIALISED; })) << "scheduler INITIALISED w/ timeout";
         expect(scheduler.state() == lifecycle::State::INITIALISED) << std::format("scheduler INITIALISED - actual: {}\n", magic_enum::enum_name(scheduler.state()));
     };
 };
@@ -264,7 +264,7 @@ const boost::ut::suite SubgraphBlockSettingsTests_ = [] {
 
         auto schedulerThreadHandle = gr::test::thread_pool::executeScheduler("qa_HierBlock::scheduler", scheduler);
 
-        expect(awaitCondition(1s, [&scheduler] { return scheduler.state() == lifecycle::State::RUNNING; })) << "scheduler thread up and running w/ timeout";
+        expect(awaitCondition(scheduler, [&scheduler] { return scheduler.state() == lifecycle::State::RUNNING; })) << "scheduler thread up and running w/ timeout";
         expect(scheduler.state() == lifecycle::State::RUNNING) << "scheduler thread up and running";
 
         expect(eq(graph.blocks().size(), 3UZ)) << "should contain source->(copy->copy)->sink";
@@ -284,7 +284,7 @@ const boost::ut::suite SubgraphBlockSettingsTests_ = [] {
 
         // return to initial state
         expect(scheduler.changeStateTo(lifecycle::State::INITIALISED).has_value()) << "could switch to INITIALISED?";
-        expect(awaitCondition(1s, [&scheduler] { return scheduler.state() == lifecycle::State::INITIALISED; })) << "scheduler INITIALISED w/ timeout";
+        expect(awaitCondition(scheduler, [&scheduler] { return scheduler.state() == lifecycle::State::INITIALISED; })) << "scheduler INITIALISED w/ timeout";
         expect(scheduler.state() == lifecycle::State::INITIALISED) << std::format("scheduler INITIALISED - actual: {}\n", magic_enum::enum_name(scheduler.state()));
     };
 };
@@ -314,7 +314,7 @@ const boost::ut::suite GraphInspectYamlTests_ = [] {
         expect(scheduler.msgOut.connect(fromScheduler).has_value());
 
         auto schedulerThreadHandle = gr::test::thread_pool::executeScheduler("qa_GraphInspectYaml::scheduler", scheduler);
-        expect(awaitCondition(1s, [&scheduler] { return scheduler.state() == lifecycle::State::RUNNING; })) << "scheduler running";
+        expect(awaitCondition(scheduler, [&scheduler] { return scheduler.state() == lifecycle::State::RUNNING; })) << "scheduler running";
 
         testing::sendAndWaitForReply<Set>(toScheduler, fromScheduler, graph.unique_name,     //
             graph::property::kGraphInspect, property_map{{"serialization_format", "yaml"s}}, //
@@ -335,7 +335,7 @@ const boost::ut::suite GraphInspectYamlTests_ = [] {
         scheduler.requestStop();
         schedulerThreadHandle.get();
         expect(scheduler.changeStateTo(lifecycle::State::INITIALISED).has_value());
-        expect(awaitCondition(1s, [&scheduler] { return scheduler.state() == lifecycle::State::INITIALISED; }));
+        expect(awaitCondition(scheduler, [&scheduler] { return scheduler.state() == lifecycle::State::INITIALISED; }));
     };
 };
 
@@ -362,7 +362,7 @@ const boost::ut::suite SchedulerInspectTests_ = [] {
         expect(scheduler.msgOut.connect(fromScheduler).has_value());
 
         auto schedulerThreadHandle = gr::test::thread_pool::executeScheduler("qa_SchedulerInspect::scheduler", scheduler);
-        expect(awaitCondition(1s, [&scheduler] { return scheduler.state() == lifecycle::State::RUNNING; })) << "scheduler running";
+        expect(awaitCondition(scheduler, [&scheduler] { return scheduler.state() == lifecycle::State::RUNNING; })) << "scheduler running";
 
         testing::sendAndWaitForReply<Set>(toScheduler, fromScheduler, scheduler.unique_name, //
             scheduler::property::kSchedulerInspect, property_map{},                          //
@@ -386,7 +386,7 @@ const boost::ut::suite SchedulerInspectTests_ = [] {
         scheduler.requestStop();
         schedulerThreadHandle.get();
         expect(scheduler.changeStateTo(lifecycle::State::INITIALISED).has_value());
-        expect(awaitCondition(1s, [&scheduler] { return scheduler.state() == lifecycle::State::INITIALISED; }));
+        expect(awaitCondition(scheduler, [&scheduler] { return scheduler.state() == lifecycle::State::INITIALISED; }));
     };
 
     "kSchedulerInspect returns yaml when serialization_format is yaml"_test = [] {
@@ -407,7 +407,7 @@ const boost::ut::suite SchedulerInspectTests_ = [] {
         expect(scheduler.msgOut.connect(fromScheduler).has_value());
 
         auto schedulerThreadHandle = gr::test::thread_pool::executeScheduler("qa_SchedulerInspectYaml::scheduler", scheduler);
-        expect(awaitCondition(1s, [&scheduler] { return scheduler.state() == lifecycle::State::RUNNING; })) << "scheduler running";
+        expect(awaitCondition(scheduler, [&scheduler] { return scheduler.state() == lifecycle::State::RUNNING; })) << "scheduler running";
 
         testing::sendAndWaitForReply<Set>(toScheduler, fromScheduler, scheduler.unique_name,         //
             scheduler::property::kSchedulerInspect, property_map{{"serialization_format", "yaml"s}}, //
@@ -429,7 +429,7 @@ const boost::ut::suite SchedulerInspectTests_ = [] {
         scheduler.requestStop();
         schedulerThreadHandle.get();
         expect(scheduler.changeStateTo(lifecycle::State::INITIALISED).has_value());
-        expect(awaitCondition(1s, [&scheduler] { return scheduler.state() == lifecycle::State::INITIALISED; }));
+        expect(awaitCondition(scheduler, [&scheduler] { return scheduler.state() == lifecycle::State::INITIALISED; }));
     };
 };
 


### PR DESCRIPTION
Follow-up on the flakiness of scheduler-test jobs on the resource-constrained CI runners 
(e.g. [run 24715565167](https://github.com/fair-acc/gnuradio4/actions/runs/24715565167) 
where `Test #39: qa_SchedulerMessages` failed on AdaptiveCpp Debug).

Two commits, each scoped to a single rule and bisect-safe.

Can be reproduced via: `taskset -c 0 + 8 × qa_SchedulerMessages` — 5/8 fail before, **0/8** after.

Stress profile matching realistic CI load (4 parallel on 2 CPUs, 40 rounds per test):

| Test | Before | After |
|---|---|---|
| `qa_SchedulerMessages` | ≈60 % fail | 0 / 40 |
| `qa_ManagedSubGraph` | flaky | 0 / 40 |
| `qa_UnmanagedSubGraph` | 0 | 0 / 40 |
| `qa_Scheduler` | 0 | 0 / 40 |
