### PR TITLE
Export CPR in pkg-config when HTTP support is enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -544,6 +544,7 @@ if(NOT
       PATCH_COMMAND ${cpr_patch_command} || true)
 
     set(GR_HTTP_ENABLED TRUE)
+    string(APPEND GR4_PKGCONFIG_EXTRA_LIBS " -lcpr")
   endif()
 elseif(GR_ENABLE_HTTP STREQUAL "OFF")
   set(GR_HTTP_ENABLED FALSE)


### PR DESCRIPTION
This updates the generated gnuradio4.pc so builds that consume gnuradio4 through pkg-config also pick up cpr when GR_ENABLE_HTTP is enabled.

Today libgnuradio-core.a can contain HTTP/file I/O code paths that reference cpr, but the pkg-config export only advertises the core GNU Radio libraries. Downstream projects using pkg_check_modules(gnuradio4 ...) can therefore compile successfully and then fail at link time with unresolved cpr::... symbols.

This change appends -lcpr to GR4_PKGCONFIG_EXTRA_LIBS when HTTP support is active, so the generated gnuradio4.pc reflects the actual link requirements of the installed static archive.


  - Fixes downstream link failures for pkg-config consumers of gnuradio4
  - Makes the pkg-config export consistent with the enabled feature set
  - Brings the pkg-config contract closer to the effective CMake link interface
  - No change when HTTP support is disabled
  - When HTTP support is enabled, pkg-config --libs gnuradio4 now includes -lcpr so downstream consumers link cleanly
