### PR TITLE
Fix tag propagation

### DIFF
--- a/core/include/gnuradio-4.0/Block.hpp
+++ b/core/include/gnuradio-4.0/Block.hpp
@@ -1660,6 +1660,7 @@ public:
             nOutSamplesBeforeRequestedStop++;
             if (_outputTagPending) [[unlikely]] {
                 for_each_writer_span([this, i](auto& out) { out.publishTag(_pendingOutputTag, i); }, outputSpans);
+                _pendingOutputTag.clear();
                 _outputTagPending = false;
                 break;
             }
@@ -2028,6 +2029,7 @@ public:
         if constexpr (HasProcessOneFunction<Derived> && !HasProcessBulkFunction<Derived>) {
             _inputTagPresent      = false;
             _outputTagPending     = false;
+            _pendingOutputTag.clear();
             _inProcessOneDispatch = false;
         }
         work::sanitiseProcessStatus(userReturnStatus, processedIn, processedOut);

--- a/core/include/gnuradio-4.0/Block.hpp
+++ b/core/include/gnuradio-4.0/Block.hpp
@@ -1145,7 +1145,9 @@ public:
                     }
                     for (const auto& [relIndex, tagMapRef] : in.tags(tagWindow)) {
                         auto filtered = filterAndSubstitute(tagMapRef.get());
-                        merged.merge(std::move(filtered));
+                        for (auto& [key, value] : filtered) {
+                            merged.insert_or_assign(key, std::move(value));
+                        }
                     }
                 },
                 inputSpans);
@@ -2027,8 +2029,8 @@ public:
         work::Status userReturnStatus = dispatchProcessing(inputSpans, outputSpans, processedIn, processedOut);
 
         if constexpr (HasProcessOneFunction<Derived> && !HasProcessBulkFunction<Derived>) {
-            _inputTagPresent      = false;
-            _outputTagPending     = false;
+            _inputTagPresent  = false;
+            _outputTagPending = false;
             _pendingOutputTag.clear();
             _inProcessOneDispatch = false;
         }

--- a/core/test/qa_Tags.cpp
+++ b/core/test/qa_Tags.cpp
@@ -1,6 +1,11 @@
 #include <boost/ut.hpp>
 
+#include <algorithm>
 #include <format>
+#include <iterator>
+#include <ranges>
+#include <string>
+#include <vector>
 
 #include <gnuradio-4.0/Block.hpp>
 #include <gnuradio-4.0/Buffer.hpp>
@@ -601,18 +606,21 @@ struct NoForwardBlock : gr::Block<NoForwardBlock<T>, gr::NoTagPropagation> {
 
 template<typename T>
 struct ProcessOnePublisher : gr::Block<ProcessOnePublisher<T>> {
-    using Description = gr::Doc<"processOne block that publishes a tag at a specific sample">;
+    using Description = gr::Doc<"processOne block that publishes tags at selected samples">;
     gr::PortIn<T>  in;
     gr::PortOut<T> out;
 
     GR_MAKE_REFLECTABLE(ProcessOnePublisher, in, out);
 
-    std::size_t _nSamples       = 0;
-    std::size_t publishAtSample = 5;
+    std::size_t              _nSamples = 0;
+    std::vector<std::size_t> publishAtSamples{};
 
     [[nodiscard]] T processOne(T x) noexcept {
-        if (_nSamples == publishAtSample) {
-            this->publishTag(gr::property_map{{"published_at", static_cast<std::uint64_t>(_nSamples)}});
+        if (std::ranges::find(publishAtSamples, _nSamples) != publishAtSamples.end()) {
+            const auto       key = std::format("published_at_{}", _nSamples);
+            gr::property_map tag;
+            tag.insert_or_assign(std::pmr::string(key.data(), key.size()), static_cast<std::uint64_t>(_nSamples));
+            this->publishTag(tag);
         }
         _nSamples++;
         return x;
@@ -725,12 +733,12 @@ const boost::ut::suite<"CustomForwardTests"> _CustomForwardTests = [] {
         expect(eq(nofw.sample_rate, 42.f)) << "settings still auto-updated from input tags";
     };
 
-    "processOne publishTag positions tag at correct sample"_test = [] {
+    "processOne publishTag with multiple tags"_test = [] {
         Graph testGraph;
-        auto& src           = testGraph.emplaceBlock<TagSource<float, ProcessFunction::USE_PROCESS_BULK>>({{"n_samples_max", gr::Size_t(30)}, {"verbose_console", false}});
-        auto& pub           = testGraph.emplaceBlock<ProcessOnePublisher<float>>();
-        pub.publishAtSample = 5;
-        auto& sink          = testGraph.emplaceBlock<TagSink<float, ProcessFunction::USE_PROCESS_BULK>>({{"verbose_console", false}});
+        auto& src            = testGraph.emplaceBlock<TagSource<float, ProcessFunction::USE_PROCESS_BULK>>({{"n_samples_max", gr::Size_t(30)}, {"verbose_console", false}});
+        auto& pub            = testGraph.emplaceBlock<ProcessOnePublisher<float>>();
+        pub.publishAtSamples = {3UZ, 7UZ, 11UZ};
+        auto& sink           = testGraph.emplaceBlock<TagSink<float, ProcessFunction::USE_PROCESS_BULK>>({{"verbose_console", false}});
 
         expect(testGraph.connect<"out", "in">(src, pub).has_value());
         expect(testGraph.connect<"out", "in">(pub, sink).has_value());
@@ -739,15 +747,21 @@ const boost::ut::suite<"CustomForwardTests"> _CustomForwardTests = [] {
         expect(sched.exchange(std::move(testGraph)).has_value());
         expect(sched.runAndWait().has_value());
 
-        expect(ge(sink._tags.size(), 1UZ)) << "tag must be forwarded";
-        bool found = false;
-        for (const auto& tag : sink._tags) {
-            if (tag.map.contains("published_at")) {
-                expect(eq(tag.index, 5UZ)) << "tag must be at sample 5";
-                found = true;
+        for (const auto index : pub.publishAtSamples) {
+            const auto expectedKey = std::format("published_at_{}", index);
+            const auto found       = std::ranges::find_if(sink._tags, [&expectedKey](const gr::Tag& tag) { return tag.map.contains(expectedKey); });
+
+            expect(found != sink._tags.end()) << std::format("processOne tag at sample {} must be forwarded", index);
+            if (found != sink._tags.end()) {
+                expect(eq(found->index, index)) << std::format("tag must be at sample {}", index);
+
+                auto                     forbiddenKeys = pub.publishAtSamples | std::views::filter([index](auto i) { return i != index; }) | std::views::transform([](auto i) { return std::format("published_at_{}", i); });
+                std::vector<std::string> staleKeys;
+                std::ranges::copy_if(forbiddenKeys, std::back_inserter(staleKeys), [&found](const auto& key) { return found->map.contains(key); });
+
+                expect(staleKeys.empty()) << std::format("tag at sample {} contains stale keys: {}", index, gr::join(staleKeys, ", "));
             }
         }
-        expect(found) << "published_at tag must exist in sink";
     };
 
     "processOne mergedInputTag receives tag and clears flag"_test = [] {

--- a/core/test/qa_Tags.cpp
+++ b/core/test/qa_Tags.cpp
@@ -970,6 +970,33 @@ const boost::ut::suite<"CustomForwardTests"> _CustomForwardTests = [] {
         expect(foundMerged) << "merged tag must contain both sample_rate and signal_name";
     };
 
+    "MergeTagPropagation overlapping keys use last value"_test = [] {
+        Graph testGraph;
+        auto& src0  = testGraph.emplaceBlock<TagSource<float, ProcessFunction::USE_PROCESS_BULK>>({{"n_samples_max", gr::Size_t(10)}, {"verbose_console", false}});
+        auto& src1  = testGraph.emplaceBlock<TagSource<float, ProcessFunction::USE_PROCESS_BULK>>({{"n_samples_max", gr::Size_t(10)}, {"verbose_console", false}});
+        src0._tags  = {{0, {{tag::SIGNAL_NAME.shortKey(), "first"}}}, {0, {{tag::SIGNAL_NAME.shortKey(), "second"}}}};
+        src1._tags  = {{0, {{tag::SIGNAL_NAME.shortKey(), "third"}}}, {0, {{tag::SIGNAL_NAME.shortKey(), "fourth"}}}};
+        auto& merge = testGraph.emplaceBlock<MergePropTwoInput<float>>();
+        auto& sink  = testGraph.emplaceBlock<TagSink<float, ProcessFunction::USE_PROCESS_BULK>>({{"verbose_console", false}});
+
+        expect(testGraph.connect<"out", "in0">(src0, merge).has_value());
+        expect(testGraph.connect<"out", "in1">(src1, merge).has_value());
+        expect(testGraph.connect<"out", "in">(merge, sink).has_value());
+
+        scheduler::Simple<> sched;
+        expect(sched.exchange(std::move(testGraph)).has_value());
+        expect(sched.runAndWait().has_value());
+
+        const auto signalNameKey = tag::SIGNAL_NAME.shortKey();
+        const auto found         = std::ranges::find_if(sink._tags, [&signalNameKey](const gr::Tag& tag) { return tag.map.contains(signalNameKey); });
+
+        expect(found != sink._tags.end());
+        if (found != sink._tags.end()) {
+            expect(eq(found->index, 0UZ));
+            expect(eq(found->map.at(signalNameKey).value_or(std::string{}), std::string{"fourth"})) << "last overlapping key wins";
+        }
+    };
+
     "MergeTagPropagation with multi-input deduplicates and merges"_test = [] {
         // fan-out: same source → both inputs of merge block
         // identical tags from fan-out should be deduped, then merged into one output tag


### PR DESCRIPTION
Fixes two tag propagation issues in `processOne()` and `MergeTagPropagation`.

- `processOne()` tags now clear the saved pending tag map after publishing. This prevents later tags from reusing keys from earlier tags.

- `MergeTagPropagation` now matches the documented last-key-wins behavior. When multiple forwarded tags contain the same key, later values overwrite earlier values.

Added regression tests for:
- multiple tags published from `processOne()`
- overlapping merge keys across multiple input ports

