### PR TITLE
Multi tags support for StreamToDataSet and DataSink

### DIFF
--- a/blocks/basic/include/gnuradio-4.0/basic/DataSink.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/DataSink.hpp
@@ -11,8 +11,10 @@
 
 #include <any>
 #include <chrono>
+#include <cstdlib>
 #include <deque>
 #include <limits>
+#include <print>
 
 namespace gr::basic {
 
@@ -73,15 +75,16 @@ inline std::size_t calculateNSamplesToProcess(std::size_t available, std::size_t
 template<typename T>
 struct StreamingPoller {
     // TODO consider whether reusing port<T> here makes sense
-    gr::CircularBuffer<T>            buffer      = gr::CircularBuffer<T>(detail::data_sink_buffer_size);
-    decltype(buffer.new_reader())    reader      = buffer.new_reader();
-    decltype(buffer.new_writer())    writer      = buffer.new_writer();
-    gr::CircularBuffer<Tag>          tagBuffer   = gr::CircularBuffer<Tag>(detail::data_sink_tag_buffer_size);
-    decltype(tagBuffer.new_reader()) tagReader   = tagBuffer.new_reader();
-    decltype(tagBuffer.new_writer()) tagWriter   = tagBuffer.new_writer();
-    std::size_t                      samplesRead = 0; // reader thread
-    std::atomic<bool>                finished    = false;
-    std::atomic<std::size_t>         dropCount   = 0;
+    gr::CircularBuffer<T>            buffer             = gr::CircularBuffer<T>(detail::data_sink_buffer_size);
+    decltype(buffer.new_reader())    reader             = buffer.new_reader();
+    decltype(buffer.new_writer())    writer             = buffer.new_writer();
+    gr::CircularBuffer<Tag>          tagBuffer          = gr::CircularBuffer<Tag>(detail::data_sink_tag_buffer_size);
+    decltype(tagBuffer.new_reader()) tagReader          = tagBuffer.new_reader();
+    decltype(tagBuffer.new_writer()) tagWriter          = tagBuffer.new_writer();
+    std::size_t                      samplesRead        = 0; // reader thread
+    std::atomic<bool>                finished           = false;
+    std::atomic<std::size_t>         droppedSampleCount = 0;
+    std::atomic<std::size_t>         droppedTagCount    = 0;
     std::size_t                      minRequiredSamples; // the number of samples to process must be in a range [minRequiredSamples, maxRequiredSamples]
     std::size_t                      maxRequiredSamples;
 
@@ -383,24 +386,8 @@ struct Metadata {
     }
 };
 
-inline std::optional<property_map> tagAndMetadata(const std::optional<property_map>& tagData, const std::optional<Metadata>& metadata) {
-    if (!tagData && !metadata) {
-        return std::nullopt;
-    }
-
-    property_map merged;
-    if (metadata) {
-        merged = metadata->toTagMap();
-    }
-    if (tagData) {
-        merged.insert(tagData->begin(), tagData->end());
-    }
-
-    return merged;
-}
-
 template<typename T>
-[[nodiscard]] inline DataSet<T> createDataset(const Metadata& metadata) {
+[[nodiscard]] inline DataSet<T> createDataset(const Metadata& metadata, std::size_t reserveSize = 0UZ) {
     DataSet<T> ds;
     ds.signal_names      = {metadata.signalName};
     ds.signal_quantities = {metadata.signalQuantity};
@@ -420,7 +407,21 @@ template<typename T>
 
     ds.meta_information.resize(1UZ);
 
+    if (reserveSize != 0UZ) {
+        ds.signal_values.reserve(reserveSize);
+        ds.axis_values[0UZ].reserve(reserveSize);
+    }
+
     return ds;
+}
+
+inline constexpr void checkTag([[maybe_unused]] const Tag& tag) {
+#ifndef NDEBUG
+    if (tag.index != 0UZ) {
+        std::println(stderr, "DataSink always has input_chunk_size == 1 and only tags with index == 0 are available; tag.index:{}, tag.map:{}", tag.index, tag.map);
+        std::abort();
+    }
+#endif
 }
 } // namespace detail
 
@@ -549,58 +550,58 @@ public:
         return handler;
     }
 
-    template<trigger::Matcher M>
-    std::shared_ptr<DataSetPoller<T>> getTriggerPoller(M&& matcher, PollerConfig config = {}) {
+    template<trigger::Matcher TMatcher>
+    std::shared_ptr<DataSetPoller<T>> getTriggerPoller(TMatcher&& matcher, PollerConfig config = {}) {
         const auto      withBackpressure = config.overflowPolicy == OverflowPolicy::Backpressure;
         auto            handler          = std::make_shared<DataSetPoller<T>>(config.minRequiredSamples, config.maxRequiredSamples);
         std::lock_guard lg(_listener_mutex);
         handler->finished = _listeners_finished;
-        addListener(std::make_unique<TriggerListener<gr::meta::null_type, M>>(std::forward<M>(matcher), handler, config.preSamples, config.postSamples, withBackpressure), withBackpressure);
+        addListener(std::make_unique<TriggerListener<TMatcher>>(std::forward<TMatcher>(matcher), handler, config.preSamples, config.postSamples, withBackpressure), withBackpressure);
         ensureHistorySize(config.preSamples);
         return handler;
     }
 
-    template<trigger::Matcher M>
-    std::shared_ptr<DataSetPoller<T>> getMultiplexedPoller(M&& matcher, PollerConfig config = {}) {
+    template<trigger::Matcher TMatcher>
+    std::shared_ptr<DataSetPoller<T>> getMultiplexedPoller(TMatcher&& matcher, PollerConfig config = {}) {
         std::lock_guard lg(_listener_mutex);
         const auto      withBackpressure = config.overflowPolicy == OverflowPolicy::Backpressure;
         auto            handler          = std::make_shared<DataSetPoller<T>>(config.minRequiredSamples, config.maxRequiredSamples);
-        addListener(std::make_unique<MultiplexedListener<gr::meta::null_type, M>>(std::forward<M>(matcher), config.maximumWindowSize, handler, withBackpressure), withBackpressure);
+        addListener(std::make_unique<MultiplexedListener<TMatcher>>(std::forward<TMatcher>(matcher), config.maximumWindowSize, handler, withBackpressure), withBackpressure);
         return handler;
     }
 
-    template<trigger::Matcher M>
-    std::shared_ptr<DataSetPoller<T>> getSnapshotPoller(M&& matcher, PollerConfig config = {}) {
+    template<trigger::Matcher TMatcher>
+    std::shared_ptr<DataSetPoller<T>> getSnapshotPoller(TMatcher&& matcher, PollerConfig config = {}) {
         const auto      withBackpressure = config.overflowPolicy == OverflowPolicy::Backpressure;
         auto            handler          = std::make_shared<DataSetPoller<T>>(config.minRequiredSamples, config.maxRequiredSamples);
         std::lock_guard lg(_listener_mutex);
-        addListener(std::make_unique<SnapshotListener<gr::meta::null_type, M>>(std::forward<M>(matcher), config.delay, handler, withBackpressure), withBackpressure);
+        addListener(std::make_unique<SnapshotListener<TMatcher>>(std::forward<TMatcher>(matcher), config.delay, handler, withBackpressure), withBackpressure);
         return handler;
     }
 
-    template<StreamCallback<T> Callback>
-    void registerStreamingCallback(std::size_t maxChunkSize, Callback&& callback) {
+    template<StreamCallback<T> TCallback>
+    void registerStreamingCallback(std::size_t maxChunkSize, TCallback&& callback) {
         std::lock_guard lg(_listener_mutex);
-        addListener(std::make_unique<ContinuousListener<Callback>>(maxChunkSize, std::forward<Callback>(callback), *this), false);
+        addListener(std::make_unique<ContinuousListener<TCallback>>(maxChunkSize, std::forward<TCallback>(callback), *this), false);
     }
 
-    template<trigger::Matcher M, DataSetCallback<T> Callback>
-    void registerTriggerCallback(M&& matcher, std::size_t preSamples, std::size_t postSamples, Callback&& callback) {
+    template<trigger::Matcher TMatcher, DataSetCallback<T> TCallback>
+    void registerTriggerCallback(TMatcher&& matcher, std::size_t preSamples, std::size_t postSamples, TCallback&& callback) {
         std::lock_guard lg(_listener_mutex);
-        addListener(std::make_unique<TriggerListener<Callback, M>>(std::forward<M>(matcher), preSamples, postSamples, std::forward<Callback>(callback)), false);
+        addListener(std::make_unique<TriggerListener<TMatcher, TCallback>>(std::forward<TMatcher>(matcher), preSamples, postSamples, std::forward<TCallback>(callback)), false);
         ensureHistorySize(preSamples);
     }
 
-    template<trigger::Matcher M, DataSetCallback<T> Callback>
-    void registerMultiplexedCallback(M&& matcher, std::size_t maximumWindowSize, Callback&& callback) {
+    template<trigger::Matcher TMatcher, DataSetCallback<T> TCallback>
+    void registerMultiplexedCallback(TMatcher&& matcher, std::size_t maximumWindowSize, TCallback&& callback) {
         std::lock_guard lg(_listener_mutex);
-        addListener(std::make_unique<MultiplexedListener<Callback, M>>(std::forward<M>(matcher), maximumWindowSize, std::forward<Callback>(callback)), false);
+        addListener(std::make_unique<MultiplexedListener<TMatcher, TCallback>>(std::forward<TMatcher>(matcher), maximumWindowSize, std::forward<TCallback>(callback)), false);
     }
 
-    template<trigger::Matcher M, DataSetCallback<T> Callback>
-    void registerSnapshotCallback(M&& matcher, std::chrono::nanoseconds delay, Callback&& callback) {
+    template<trigger::Matcher TMatcher, DataSetCallback<T> TCallback>
+    void registerSnapshotCallback(TMatcher&& matcher, std::chrono::nanoseconds delay, TCallback&& callback) {
         std::lock_guard lg(_listener_mutex);
-        addListener(std::make_unique<SnapshotListener<Callback, M>>(std::forward<M>(matcher), delay, std::forward<Callback>(callback)), false);
+        addListener(std::make_unique<SnapshotListener<TMatcher, TCallback>>(std::forward<TMatcher>(matcher), delay, std::forward<TCallback>(callback)), false);
     }
 
     void stop() noexcept {
@@ -613,13 +614,9 @@ public:
     }
 
     [[nodiscard]] work::Status processBulk(InputSpanLike auto& inData) noexcept {
-        std::optional<property_map> tagData;
+        std::vector<Tag> tags;
         for (const auto& [relIndex, tagMapRef] : inData.tags()) {
-            if (!tagData) {
-                tagData.emplace(tagMapRef.get());
-            } else {
-                tagData->merge(property_map(tagMapRef.get()));
-            }
+            tags.emplace_back(static_cast<std::size_t>(relIndex), tagMapRef.get());
         }
 
         {
@@ -627,7 +624,7 @@ public:
             const auto      historyView = _history ? _history->get_span(0UZ) : std::span<const T>();
             std::erase_if(_listeners, [](const auto& l) { return l->expired; });
             for (auto& listener : _listeners) {
-                listener->process(historyView, inData, tagData);
+                listener->process(historyView, inData, tags);
             }
             if (_history) {
                 _history->push_front(inData);
@@ -671,354 +668,366 @@ private:
 
         virtual void setMetadata(detail::Metadata) = 0;
 
-        virtual void process(std::span<const T> history, std::span<const T> data, std::optional<property_map> tagData0) = 0;
-        virtual void stop()                                                                                             = 0;
+        virtual void process(std::span<const T> history, std::span<const T> data, std::span<const Tag> tags) = 0;
+        virtual void stop()                                                                                  = 0;
     };
 
-    template<typename Callback>
+    template<trigger::Matcher TMatcher, typename TCallback>
     struct DataSetBaseListener : public AbstractListener {
-        bool                            isBlocking = false;
-        std::weak_ptr<DataSetPoller<T>> poller;
-        Callback                        callback;
+        static constexpr bool hasCallback = !std::is_same_v<TCallback, gr::meta::null_type>;
 
-        template<typename CallbackFW>
-        explicit DataSetBaseListener(CallbackFW&& callback_) : callback(std::forward<CallbackFW>(callback_)) {}
+        bool                            _isBlocking = false;
+        TMatcher                        _matcher;
+        gr::property_map                _matcherState;
+        detail::Metadata                _metadata;
+        std::weak_ptr<DataSetPoller<T>> _poller;
+        TCallback                       _callback;
 
-        explicit DataSetBaseListener(std::shared_ptr<DataSetPoller<T>> poller_, bool isBlocking_) : isBlocking(isBlocking_), poller(std::move(poller_)) {}
+        template<trigger::Matcher TMatcherFW>
+        explicit DataSetBaseListener(TMatcherFW&& matcher, std::shared_ptr<DataSetPoller<T>> poller, bool isBlocking)
+        requires(!hasCallback)
+            : _isBlocking(isBlocking), _matcher(std::forward<TMatcherFW>(matcher)), _poller(std::move(poller)) {}
+
+        template<trigger::Matcher TMatcherFW, typename TCallbackFW>
+        explicit DataSetBaseListener(TMatcherFW&& matcher, TCallbackFW&& callback)
+        requires(hasCallback)
+            : _matcher(std::forward<TMatcherFW>(matcher)), _callback(std::forward<TCallbackFW>(callback)) {}
 
         inline void publishDataSet(DataSet<T>&& data) {
-            if constexpr (!std::is_same_v<Callback, gr::meta::null_type>) {
-                callback(std::move(data));
-            } else {
-                auto pollerPtr = poller.lock();
-                if (!pollerPtr) {
-                    this->setExpired();
-                    return;
-                }
-
-                if (isBlocking || pollerPtr->writer.available() > 0) {
-                    auto writeData = pollerPtr->writer.reserve(1UZ);
-                    writeData[0UZ] = std::move(data);
-                    writeData.publish(1UZ);
-                } else {
-                    pollerPtr->dropCount++;
-                }
-            }
-        }
-    };
-
-    template<typename Callback>
-    struct ContinuousListener : public AbstractListener {
-        static constexpr auto hasCallback       = !std::is_same_v<Callback, gr::meta::null_type>;
-        static constexpr auto callbackTakesTags = std::is_invocable_v<Callback, std::span<const T>, std::span<const Tag>> || std::is_invocable_v<Callback, std::span<const T>, std::span<const Tag>, const DataSink<T>&>;
-
-        const DataSink<T>&              parent_sink;
-        bool                            block           = false;
-        std::size_t                     samples_written = 0;
-        std::optional<detail::Metadata> _pendingMetadata;
-
-        // callback-only
-        std::size_t      buffer_fill = 0;
-        std::vector<T>   buffer;
-        std::vector<Tag> tag_buffer;
-
-        // polling-only
-        std::weak_ptr<StreamingPoller<T>> polling_handler = {};
-        Callback                          callback;
-
-        template<typename CallbackFW>
-        explicit ContinuousListener(std::size_t maxChunkSize, CallbackFW&& c, const DataSink<T>& parent) : parent_sink(parent), buffer(maxChunkSize), callback{std::forward<CallbackFW>(c)} {}
-
-        explicit ContinuousListener(std::shared_ptr<StreamingPoller<T>> poller_, bool doBlock, const DataSink<T>& parent) : parent_sink(parent), block(doBlock), polling_handler{std::move(poller_)} {}
-
-        inline void callCallback(std::span<const T> data, std::span<const Tag> tags) {
-            if constexpr (std::is_invocable_v<Callback, std::span<const T>, std::span<const Tag>, const DataSink<T>&>) {
-                callback(std::move(data), tags, parent_sink);
-            } else if constexpr (std::is_invocable_v<Callback, std::span<const T>, std::span<const Tag>>) {
-                callback(std::move(data), tags);
-            } else {
-                callback(std::move(data));
-            }
-        }
-
-        void setMetadata(detail::Metadata metadata) override { _pendingMetadata = std::move(metadata); }
-
-        void process(std::span<const T>, std::span<const T> data, std::optional<property_map> tagData0) override {
             if constexpr (hasCallback) {
-                // if there's pending data, fill buffer and send out
-                if (buffer_fill > 0) {
-                    const auto n = std::min(data.size(), buffer.size() - buffer_fill);
-                    std::ranges::copy(data.first(n), buffer.begin() + static_cast<std::ptrdiff_t>(buffer_fill));
-                    if constexpr (callbackTakesTags) {
-                        if (auto tag = detail::tagAndMetadata(tagData0, _pendingMetadata)) {
-                            tag_buffer.emplace_back(static_cast<std::ptrdiff_t>(buffer_fill), std::move(*tag));
-                        }
-                        _pendingMetadata.reset();
-                        tagData0.reset();
-                    }
-                    buffer_fill += n;
-                    if (buffer_fill == buffer.size()) {
-                        callCallback(std::span(buffer), std::span(tag_buffer));
-                        samples_written += buffer.size();
-                        buffer_fill = 0;
-                        tag_buffer.clear();
-                    }
-
-                    data = data.last(data.size() - n);
-                }
-
-                // send out complete chunks directly
-                while (data.size() >= buffer.size()) {
-                    if constexpr (callbackTakesTags) {
-                        std::vector<Tag> tags;
-                        if (auto tag = detail::tagAndMetadata(tagData0, _pendingMetadata)) {
-                            tags.emplace_back(0, std::move(*tag));
-                        }
-                        tagData0.reset();
-                        _pendingMetadata.reset();
-                        callCallback(data.first(buffer.size()), std::span(tags));
-                    } else {
-                        callback(data.first(buffer.size()));
-                    }
-                    samples_written += buffer.size();
-                    data = data.last(data.size() - buffer.size());
-                }
-
-                // write remaining data to the buffer
-                if (!data.empty()) {
-                    std::ranges::copy(data, buffer.begin());
-                    buffer_fill = data.size();
-                    if constexpr (callbackTakesTags) {
-                        if (auto tag = detail::tagAndMetadata(tagData0, _pendingMetadata)) {
-                            tag_buffer.emplace_back(0, std::move(*tag));
-                        }
-                        _pendingMetadata.reset();
-                    }
-                }
+                _callback(std::move(data));
             } else {
-                auto poller = polling_handler.lock();
+                auto poller = _poller.lock();
                 if (!poller) {
                     this->setExpired();
                     return;
                 }
 
-                const auto toWrite = block ? data.size() : std::min(data.size(), poller->writer.available());
-
-                if (toWrite > 0) {
-                    if (auto tag = detail::tagAndMetadata(tagData0, _pendingMetadata)) {
-                        auto tw = poller->tagWriter.reserve(1UZ);
-                        tw[0UZ] = {samples_written, std::move(*tag)};
-                        tw.publish(1UZ);
-                    }
-                    _pendingMetadata.reset();
-                    auto writeData = poller->writer.reserve(toWrite);
-                    std::ranges::copy(data | std::views::take(toWrite), writeData.begin());
-                    writeData.publish(writeData.size());
+                if (_isBlocking || poller->writer.available() > 0) {
+                    auto writeData = poller->writer.reserve(1UZ);
+                    writeData[0UZ] = std::move(data);
+                    writeData.publish(1UZ);
+                } else {
+                    poller->dropCount++;
                 }
-                poller->dropCount += data.size() - toWrite;
-                samples_written += toWrite;
+            }
+        }
+
+        void setMetadata(detail::Metadata metadata) override { _metadata = std::move(metadata); }
+    };
+
+    template<typename TCallback>
+    struct ContinuousListener : public AbstractListener {
+        static constexpr auto hasCallback       = !std::is_same_v<TCallback, gr::meta::null_type>;
+        static constexpr auto callbackTakesTags = std::is_invocable_v<TCallback, std::span<const T>, std::span<const Tag>> || std::is_invocable_v<TCallback, std::span<const T>, std::span<const Tag>, const DataSink<T>&>;
+
+        const DataSink<T>&              _parentSink;
+        bool                            _isBlocking        = false;
+        std::size_t                     _nPublishedSamples = 0;
+        std::optional<detail::Metadata> _pendingMetadata;
+
+        // callback mode only
+        std::size_t _maxChunkSize; // 0 = no limit; process all available samples at once
+        TCallback   _callback;
+
+        // poller mode only
+        std::weak_ptr<StreamingPoller<T>> _poller = {};
+
+        template<typename TCallbackFW>
+        explicit ContinuousListener(std::size_t maxChunkSize, TCallbackFW&& callback, const DataSink<T>& parent)
+        requires(hasCallback)
+            : _parentSink(parent), _maxChunkSize(maxChunkSize), _callback{std::forward<TCallbackFW>(callback)} {}
+
+        explicit ContinuousListener(std::shared_ptr<StreamingPoller<T>> poller, bool isBlocking, const DataSink<T>& parent)
+        requires(!hasCallback)
+            : _parentSink(parent), _isBlocking(isBlocking), _poller{std::move(poller)} {}
+
+        inline void callCallback(std::span<const T> data, std::span<const Tag> tags) {
+            if constexpr (std::is_invocable_v<TCallback, std::span<const T>, std::span<const Tag>, const DataSink<T>&>) {
+                _callback(data, tags, _parentSink);
+            } else if constexpr (std::is_invocable_v<TCallback, std::span<const T>, std::span<const Tag>>) {
+                _callback(data, tags);
+            } else {
+                _callback(data);
+            }
+        }
+
+        void setMetadata(detail::Metadata metadata) override { _pendingMetadata = std::move(metadata); }
+
+        void process(std::span<const T>, std::span<const T> data, std::span<const Tag> tags) override {
+            if constexpr (hasCallback) {
+                const std::size_t nSamples = data.size();
+                const std::size_t chunk    = _maxChunkSize != 0UZ ? _maxChunkSize : nSamples;
+                std::size_t       offset   = 0UZ;
+
+                while (offset < nSamples) {
+                    const std::size_t len   = std::min(chunk, nSamples - offset);
+                    auto              slice = data.subspan(offset, len);
+                    if constexpr (callbackTakesTags) {
+                        const std::size_t end            = offset + len;
+                        const auto        nTagsInRange   = static_cast<std::size_t>(std::ranges::count_if(tags, [offset, end](const Tag& tag) { return tag.index >= offset && tag.index < end; }));
+                        const std::size_t nTagsToPublish = _pendingMetadata.has_value() ? nTagsInRange + 1UZ : nTagsInRange;
+                        std::vector<Tag>  tmpTags;
+                        if (nTagsToPublish > 0UZ) {
+                            tmpTags.reserve(nTagsToPublish);
+                            if (_pendingMetadata.has_value()) {
+                                tmpTags.emplace_back(0UZ, _pendingMetadata->toTagMap());
+                                _pendingMetadata.reset();
+                            }
+
+                            for (const Tag& tag : tags) {
+                                if (tag.index >= offset && tag.index < end) {
+                                    tmpTags.emplace_back(tag.index - offset, tag.map);
+                                }
+                            }
+                        }
+                        callCallback(slice, std::span(tmpTags));
+                    } else {
+                        _callback(slice);
+                    }
+                    _nPublishedSamples += len;
+                    offset += len;
+                }
+            } else {
+                auto poller = _poller.lock();
+                if (!poller) {
+                    this->setExpired();
+                    return;
+                }
+
+                const std::size_t nSamplesToPublish  = _isBlocking ? data.size() : std::min(data.size(), poller->writer.available());
+                const auto        nTagsInRange       = static_cast<std::size_t>(std::ranges::count_if(tags, [nSamplesToPublish](const Tag& tag) { return tag.index < nSamplesToPublish; }));
+                const std::size_t availableInputTags = _pendingMetadata.has_value() ? nTagsInRange + 1UZ : nTagsInRange;
+                const std::size_t nTagsToPublish     = _isBlocking ? availableInputTags : std::min(availableInputTags, poller->tagWriter.available());
+
+                if (nSamplesToPublish > 0UZ) {
+                    if (nTagsToPublish > 0UZ) {
+                        WriterSpanLike auto outTags = poller->tagWriter.reserve(nTagsToPublish);
+                        std::size_t         counter = 0UZ;
+                        if (_pendingMetadata.has_value()) {
+                            outTags[counter++] = {_nPublishedSamples, _pendingMetadata->toTagMap()};
+                            _pendingMetadata.reset();
+                        }
+                        for (const Tag& tag : tags) {
+                            if (counter >= nTagsToPublish) {
+                                break;
+                            }
+                            if (tag.index < nSamplesToPublish) {
+                                outTags[counter++] = {_nPublishedSamples + tag.index, tag.map};
+                            }
+                        }
+                        outTags.publish(nTagsToPublish);
+                    }
+                    WriterSpanLike auto outSamples = poller->writer.reserve(nSamplesToPublish);
+                    std::ranges::copy(data | std::views::take(nSamplesToPublish), outSamples.begin());
+                    outSamples.publish(nSamplesToPublish);
+                }
+                poller->droppedSampleCount += data.size() - nSamplesToPublish;
+                poller->droppedTagCount += availableInputTags - nTagsToPublish;
+                _nPublishedSamples += nSamplesToPublish;
             }
         }
 
         void stop() override {
-            if constexpr (hasCallback) {
-                if (buffer_fill > 0) {
-                    callCallback(std::span(buffer).first(buffer_fill), std::span(tag_buffer));
-                    tag_buffer.clear();
-                    buffer_fill = 0;
-                }
-            } else {
-                if (auto p = polling_handler.lock()) {
+            if constexpr (!hasCallback) {
+                if (auto p = _poller.lock()) {
                     p->finished = true;
                 }
             }
         }
     };
 
-    struct PendingWindow {
+    struct TriggerCapture {
         DataSet<T>  dataset;
-        std::size_t pending_post_samples = 0;
+        std::size_t nRemainingPostSamples = 0;
     };
 
-    template<typename Callback, trigger::Matcher TMatcher>
-    struct TriggerListener : public DataSetBaseListener<Callback> {
-        std::size_t preSamples  = 0;
-        std::size_t postSamples = 0;
+    template<trigger::Matcher TMatcher, typename TCallback = gr::meta::null_type>
+    struct TriggerListener : public DataSetBaseListener<TMatcher, TCallback> {
+        using Base = DataSetBaseListener<TMatcher, TCallback>;
 
-        detail::Metadata          _metadata;
-        gr::property_map          trigger_matcher_state;
-        TMatcher                  trigger_matcher = {};
-        std::deque<PendingWindow> pending_trigger_windows; // triggers that still didn't receive all their data
+        std::size_t                _preSamples  = 0;
+        std::size_t                _postSamples = 0;
+        std::deque<TriggerCapture> _triggerCaptures; // trigger captures that still didn't receive all their data
 
-        template<trigger::Matcher Matcher>
-        explicit TriggerListener(Matcher&& matcher, std::shared_ptr<DataSetPoller<T>> poller_, std::size_t pre, std::size_t post, bool doBlock) : DataSetBaseListener<Callback>(std::move(poller_), doBlock), preSamples(pre), postSamples(post), trigger_matcher(std::forward<Matcher>(matcher)) {}
+        template<trigger::Matcher TMatcherFW>
+        explicit TriggerListener(TMatcherFW&& matcher, std::shared_ptr<DataSetPoller<T>> poller, std::size_t pre, std::size_t post, bool isBlocking)
+        requires(!Base::hasCallback)
+            : Base(std::forward<TMatcherFW>(matcher), std::move(poller), isBlocking), _preSamples(pre), _postSamples(post) {}
 
-        template<typename CallbackFW, trigger::Matcher Matcher>
-        explicit TriggerListener(Matcher&& matcher, std::size_t pre, std::size_t post, CallbackFW&& cb) : DataSetBaseListener<Callback>(std::forward<CallbackFW>(cb)), preSamples(pre), postSamples(post), trigger_matcher(std::forward<Matcher>(matcher)) {}
+        template<trigger::Matcher TMatcherFW, typename TCallbackFW>
+        explicit TriggerListener(TMatcherFW&& matcher, std::size_t pre, std::size_t post, TCallbackFW&& callback)
+        requires(Base::hasCallback)
+            : Base(std::forward<TMatcherFW>(matcher), std::forward<TCallbackFW>(callback)), _preSamples(pre), _postSamples(post) {}
 
-        void setMetadata(detail::Metadata metadata) override { _metadata = std::move(metadata); }
+        void process(std::span<const T> history, std::span<const T> inData, std::span<const Tag> tags) override {
+            for (const Tag& tag : tags) {
+                detail::checkTag(tag);
 
-        void process(std::span<const T> history, std::span<const T> inData, std::optional<property_map> tagData0) override {
-            if (tagData0 && trigger_matcher("", Tag{0, *tagData0}, trigger_matcher_state) == trigger::MatchResult::Matching) {
-                DataSet<T>        dataset       = detail::createDataset<T>(_metadata);
-                const std::size_t minPreSamples = std::min(preSamples, history.size());
-                dataset.signal_values.reserve(minPreSamples + postSamples);
-                dataset.axis_values.reserve(minPreSamples + postSamples);
-
-                std::ranges::copy(history.subspan(0UZ, minPreSamples) | std::views::reverse, std::back_inserter(dataset.signal_values));
-                std::ranges::copy(std::views::iota(0UZ, minPreSamples), std::back_inserter(dataset.axis_values[0]));
-                dataset.extents[0UZ] = static_cast<std::int32_t>(dataset.signalValues(0UZ).size());
-
-                dataset.timing_events = {{{static_cast<std::ptrdiff_t>(minPreSamples), *tagData0}}};
-                pending_trigger_windows.push_back({.dataset = std::move(dataset), .pending_post_samples = postSamples});
+                if (!tag.map.empty() && this->_matcher("", tag, this->_matcherState) == trigger::MatchResult::Matching) {
+                    const std::size_t minPreSamples = std::min(_preSamples, history.size());
+                    DataSet<T>        dataset       = detail::createDataset<T>(this->_metadata, minPreSamples + _postSamples);
+                    std::ranges::copy(history.subspan(0UZ, minPreSamples) | std::views::reverse, std::back_inserter(dataset.signal_values));
+                    std::ranges::copy(std::views::iota(0UZ, minPreSamples), std::back_inserter(dataset.axis_values[0]));
+                    dataset.extents[0UZ] = static_cast<std::int32_t>(dataset.signalValues(0UZ).size());
+                    dataset.timing_events[0UZ].emplace_back(static_cast<std::ptrdiff_t>(minPreSamples), tag.map);
+                    _triggerCaptures.push_back({.dataset = std::move(dataset), .nRemainingPostSamples = _postSamples});
+                }
             }
 
-            auto window = pending_trigger_windows.begin();
-            while (window != pending_trigger_windows.end()) {
-                const std::size_t nPostSamples = std::min(window->pending_post_samples, inData.size());
-                const std::size_t oldSize      = window->dataset.signal_values.size();
-                std::ranges::copy(inData.first(nPostSamples), std::back_inserter(window->dataset.signal_values));
-                std::ranges::copy(std::views::iota(oldSize, window->dataset.signalValues(0UZ).size()), std::back_inserter(window->dataset.axis_values[0UZ]));
-                window->dataset.extents[0UZ] = static_cast<std::int32_t>(window->dataset.signalValues(0UZ).size());
+            auto capture = _triggerCaptures.begin();
+            while (capture != _triggerCaptures.end()) {
+                const std::size_t nPostSamples = std::min(capture->nRemainingPostSamples, inData.size());
+                const std::size_t oldSize      = capture->dataset.signalValues(0UZ).size();
+                std::ranges::copy(inData.first(nPostSamples), std::back_inserter(capture->dataset.signal_values));
+                const std::size_t newSize = capture->dataset.signalValues(0UZ).size();
+                std::ranges::copy(std::views::iota(oldSize, newSize), std::back_inserter(capture->dataset.axis_values[0UZ]));
+                capture->dataset.extents[0UZ] = static_cast<std::int32_t>(newSize);
 
-                window->pending_post_samples -= nPostSamples;
+                capture->nRemainingPostSamples -= nPostSamples;
 
-                if (window->pending_post_samples == 0) {
-                    this->publishDataSet(std::move(window->dataset));
-                    window = pending_trigger_windows.erase(window);
+                if (capture->nRemainingPostSamples == 0UZ) {
+                    this->publishDataSet(std::move(capture->dataset));
+                    capture = _triggerCaptures.erase(capture);
                 } else {
-                    ++window;
+                    ++capture;
                 }
             }
         }
 
         void stop() override {
-            for (auto& window : pending_trigger_windows) {
+            for (auto& window : _triggerCaptures) {
                 if (!window.dataset.signal_values.empty()) {
                     this->publishDataSet(std::move(window.dataset));
                 }
             }
-            pending_trigger_windows.clear();
-            if (auto p = this->poller.lock()) {
+            _triggerCaptures.clear();
+            if (auto p = this->_poller.lock()) {
                 p->finished = true;
             }
         }
     };
 
-    template<typename Callback, trigger::Matcher M>
-    struct MultiplexedListener : public DataSetBaseListener<Callback> {
-        M                         matcher;
-        gr::property_map          matcher_state;
-        detail::Metadata          _metadata;
-        std::optional<DataSet<T>> pending_dataset;
-        std::size_t               maximumWindowSize;
+    template<trigger::Matcher TMatcher, typename TCallback = gr::meta::null_type>
+    struct MultiplexedListener : public DataSetBaseListener<TMatcher, TCallback> {
+        using Base = DataSetBaseListener<TMatcher, TCallback>;
 
-        template<typename CallbackFW, trigger::Matcher Matcher>
-        explicit MultiplexedListener(Matcher&& matcher_, std::size_t maxWindowSize, CallbackFW&& cb) : DataSetBaseListener<Callback>(std::forward<CallbackFW>(cb)), matcher(std::forward<Matcher>(matcher_)), maximumWindowSize(maxWindowSize) {}
+        std::optional<DataSet<T>> _curDataset;
+        std::size_t               _maxDataSetSize; // 0 == unlimited
 
-        template<trigger::Matcher Matcher>
-        explicit MultiplexedListener(Matcher&& matcher_, std::size_t maxWindowSize, std::shared_ptr<DataSetPoller<T>> poller_, bool doBlock) : DataSetBaseListener<Callback>(std::move(poller_), doBlock), matcher(std::forward<Matcher>(matcher_)), maximumWindowSize(maxWindowSize) {}
+        template<typename TCallbackFW, trigger::Matcher TMatcherFW>
+        explicit MultiplexedListener(TMatcherFW&& matcher, std::size_t maxDataSetSize, TCallbackFW&& callback)
+        requires(Base::hasCallback)
+            : Base(std::forward<TMatcherFW>(matcher), std::forward<TCallbackFW>(callback)), _maxDataSetSize(maxDataSetSize) {}
 
-        void setMetadata(detail::Metadata metadata) override { _metadata = std::move(metadata); }
+        template<trigger::Matcher TMatcherFW>
+        explicit MultiplexedListener(TMatcherFW&& matcher, std::size_t maxDataSetSize, std::shared_ptr<DataSetPoller<T>> poller, bool isBlocking)
+        requires(!Base::hasCallback)
+            : Base(std::forward<TMatcherFW>(matcher), std::move(poller), isBlocking), _maxDataSetSize(maxDataSetSize) {}
 
-        void process(std::span<const T>, std::span<const T> inData, std::optional<property_map> tagData0) override {
-            if (tagData0) {
-                const auto obsr = matcher("", Tag{0, *tagData0}, matcher_state);
-                if (obsr == trigger::MatchResult::NotMatching || obsr == trigger::MatchResult::Matching) {
-                    if (pending_dataset) {
-                        if (obsr == trigger::MatchResult::NotMatching) {
-                            pending_dataset->timing_events[0UZ].emplace_back(pending_dataset->signal_values.size(), *tagData0);
-                        }
-                        this->publishDataSet(std::move(*pending_dataset));
-                        pending_dataset.reset();
+        void process(std::span<const T>, std::span<const T> inData, std::span<const Tag> tags) override {
+            // Overlapping trigger windows are not supported. A new start closes and publishes
+            // the current data set, then starts a new one.
+            for (const Tag& tag : tags) {
+                detail::checkTag(tag);
+                const auto matchResult = this->_matcher("", tag, this->_matcherState);
+                if (matchResult == trigger::MatchResult::NotMatching || matchResult == trigger::MatchResult::Matching) {
+                    if (_curDataset) {
+                        _curDataset->timing_events[0UZ].emplace_back(static_cast<std::ptrdiff_t>(_curDataset->signalValues(0UZ).size()), tag.map);
+                        this->publishDataSet(std::move(*_curDataset));
+                        _curDataset.reset();
                     }
                 }
-                if (obsr == trigger::MatchResult::Matching) {
-                    pending_dataset = detail::createDataset<T>(_metadata);
-                    pending_dataset->signal_values.reserve(maximumWindowSize);
-                    pending_dataset->axis_values.reserve(maximumWindowSize);
-                    pending_dataset->timing_events = {{{0, *tagData0}}};
+                if (matchResult == trigger::MatchResult::Matching) {
+                    _curDataset = detail::createDataset<T>(this->_metadata, _maxDataSetSize);
+                    _curDataset->timing_events[0UZ].emplace_back(0, tag.map);
                 }
             }
-            if (pending_dataset) {
-                const auto        toWrite = std::min(inData.size(), maximumWindowSize - pending_dataset->signal_values.size());
-                const std::size_t oldSize = pending_dataset->signal_values.size();
-                std::ranges::copy(inData.first(toWrite), std::back_inserter(pending_dataset->signal_values));
-                std::ranges::copy(std::views::iota(oldSize, pending_dataset->signal_values.size()), std::back_inserter(pending_dataset->axis_values[0UZ]));
-                pending_dataset->extents[0UZ] = static_cast<std::int32_t>(pending_dataset->signal_values.size());
-
-                if (pending_dataset->signal_values.size() == maximumWindowSize) {
-                    this->publishDataSet(std::move(*pending_dataset));
-                    pending_dataset.reset();
+            if (_curDataset) {
+                const std::size_t maxSize = _maxDataSetSize == 0UZ ? std::numeric_limits<std::size_t>::max() : _maxDataSetSize;
+                const std::size_t oldSize = _curDataset->signalValues(0UZ).size();
+                const std::size_t toWrite = std::min(inData.size(), maxSize - oldSize);
+                const std::size_t newSize = oldSize + toWrite;
+                if (toWrite > 0UZ) {
+                    std::ranges::copy(inData.first(toWrite), std::back_inserter(_curDataset->signal_values));
+                    std::ranges::copy(std::views::iota(oldSize, newSize), std::back_inserter(_curDataset->axis_values[0UZ]));
+                    _curDataset->extents[0UZ] = static_cast<std::int32_t>(newSize);
+                }
+                if (newSize == maxSize) {
+                    this->publishDataSet(std::move(*_curDataset));
+                    _curDataset.reset();
                 }
             }
         }
 
         void stop() override {
-            if (pending_dataset) {
-                this->publishDataSet(std::move(*pending_dataset));
-                pending_dataset.reset();
+            if (_curDataset) {
+                this->publishDataSet(std::move(*_curDataset));
+                _curDataset.reset();
             }
-            if (auto p = this->poller.lock()) {
+            if (auto p = this->_poller.lock()) {
                 p->finished = true;
             }
         }
     };
 
-    struct PendingSnapshot {
-        property_map tag_data;
-        std::size_t  delay           = 0;
-        std::size_t  pending_samples = 0;
+    struct Snapshot {
+        property_map tagMap;
+        std::size_t  triggerIndex      = 0;
+        std::size_t  nRemainingSamples = 0;
     };
 
-    template<typename Callback, trigger::Matcher M>
-    struct SnapshotListener : public DataSetBaseListener<Callback> {
-        std::chrono::nanoseconds    time_delay;
-        std::size_t                 sample_delay = 0;
-        detail::Metadata            _metadata;
-        M                           trigger_matcher = {};
-        gr::property_map            trigger_matcher_state;
-        std::deque<PendingSnapshot> pending;
+    template<trigger::Matcher TMatcher, typename TCallback = gr::meta::null_type>
+    struct SnapshotListener : public DataSetBaseListener<TMatcher, TCallback> {
+        using Base = DataSetBaseListener<TMatcher, TCallback>;
 
-        template<trigger::Matcher Matcher>
-        explicit SnapshotListener(Matcher&& matcher, std::chrono::nanoseconds delay, std::shared_ptr<DataSetPoller<T>> poller_, bool doBlock) : DataSetBaseListener<Callback>(std::move(poller_), doBlock), time_delay(delay), trigger_matcher(std::forward<Matcher>(matcher)) {}
+        std::chrono::nanoseconds _timeDelay;       // set by the user
+        std::size_t              _sampleDelay = 0; // calculated from _timeDelay and sample rate
+        std::deque<Snapshot>     _snapshots;
 
-        template<typename CallbackFW, trigger::Matcher Matcher>
-        explicit SnapshotListener(Matcher&& matcher, std::chrono::nanoseconds delay, CallbackFW&& cb) : DataSetBaseListener<Callback>(std::forward<CallbackFW>(cb)), time_delay(delay), trigger_matcher(std::forward<Matcher>(matcher)) {}
+        template<trigger::Matcher TMatcherFW>
+        explicit SnapshotListener(TMatcherFW&& matcher, std::chrono::nanoseconds delay, std::shared_ptr<DataSetPoller<T>> poller, bool isBlocking)
+        requires(!Base::hasCallback)
+            : Base(std::forward<TMatcherFW>(matcher), std::move(poller), isBlocking), _timeDelay(delay) {}
+
+        template<typename TCallbackFW, trigger::Matcher TMatcherFW>
+        explicit SnapshotListener(TMatcherFW&& matcher, std::chrono::nanoseconds delay, TCallbackFW&& callback)
+        requires(Base::hasCallback)
+            : Base(std::forward<TMatcherFW>(matcher), std::forward<TCallbackFW>(callback)), _timeDelay(delay) {}
 
         void setMetadata(detail::Metadata metadata) override {
-            sample_delay = static_cast<std::size_t>(std::round(std::chrono::duration_cast<std::chrono::duration<float>>(time_delay).count() * metadata.sampleRate));
-            _metadata    = std::move(metadata);
+            _sampleDelay    = static_cast<std::size_t>(std::round(std::chrono::duration_cast<std::chrono::duration<float>>(_timeDelay).count() * metadata.sampleRate));
+            this->_metadata = std::move(metadata);
         }
 
-        void process(std::span<const T>, std::span<const T> inData, std::optional<property_map> tagData0) override {
-            if (tagData0 && trigger_matcher("", {0, *tagData0}, trigger_matcher_state) == trigger::MatchResult::Matching) {
-                auto new_pending = PendingSnapshot{*tagData0, sample_delay, sample_delay};
-                // make sure pending is sorted by number of pending_samples (insertion might be not at end if sample rate decreased)
-                auto rit = std::find_if(pending.rbegin(), pending.rend(), [delay = sample_delay](const auto& other) { return other.pending_samples < delay; });
-                pending.insert(rit.base(), std::move(new_pending));
+        void process(std::span<const T>, std::span<const T> inData, std::span<const Tag> tags) override {
+            for (const Tag& tag : tags) {
+                detail::checkTag(tag);
+                if (!tag.map.empty() && this->_matcher("", tag, this->_matcherState) == trigger::MatchResult::Matching) {
+                    _snapshots.push_back(Snapshot{tag.map, _sampleDelay, _sampleDelay});
+                }
             }
 
-            auto it = pending.begin();
-            while (it != pending.end()) {
-                if (it->pending_samples >= inData.size()) {
-                    it->pending_samples -= inData.size();
-                    break;
+            auto it = _snapshots.begin();
+            while (it != _snapshots.end()) {
+                if (it->nRemainingSamples >= inData.size()) {
+                    it->nRemainingSamples -= inData.size();
+                    ++it;
+                } else {
+                    DataSet<T> dataset = detail::createDataset<T>(this->_metadata, 1UZ);
+                    dataset.timing_events[0UZ].emplace_back(-static_cast<std::ptrdiff_t>(it->triggerIndex), std::move(it->tagMap));
+                    dataset.signal_values.push_back(inData[it->nRemainingSamples]);
+                    dataset.axis_values[0UZ].push_back(0);
+                    dataset.extents[0UZ] = std::int32_t(1);
+                    this->publishDataSet(std::move(dataset));
+                    it = _snapshots.erase(it);
                 }
-
-                DataSet<T> dataset    = detail::createDataset<T>(_metadata);
-                dataset.timing_events = {{{-static_cast<std::ptrdiff_t>(it->delay), std::move(it->tag_data)}}};
-                dataset.signal_values = {inData[it->pending_samples]};
-                std::ranges::copy(std::views::iota(0UZ, dataset.signalValues(0UZ).size()), std::back_inserter(dataset.axis_values[0]));
-                dataset.extents[0UZ] = static_cast<std::int32_t>(dataset.signalValues(0UZ).size());
-                this->publishDataSet(std::move(dataset));
-                it = pending.erase(it);
             }
         }
 
         void stop() override {
-            pending.clear();
-            if (auto p = this->poller.lock()) {
+            _snapshots.clear();
+            if (auto p = this->_poller.lock()) {
                 p->finished = true;
             }
         }

--- a/blocks/basic/include/gnuradio-4.0/basic/StreamToDataSet.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/StreamToDataSet.hpp
@@ -9,6 +9,14 @@
 #include <gnuradio-4.0/algorithm/dataset/DataSetUtils.hpp>
 #include <gnuradio-4.0/meta/utils.hpp>
 
+#include <algorithm>
+#include <cassert>
+#include <deque>
+#include <iterator>
+#include <optional>
+#include <ranges>
+#include <vector>
+
 namespace gr::basic {
 
 GR_REGISTER_BLOCK("gr::basic::StreamToDataSet", gr::basic::StreamFilterImpl, ([T], false), [ uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double, std::complex<float>, std::complex<double> ]);
@@ -16,18 +24,27 @@ GR_REGISTER_BLOCK("gr::basic::StreamFilter", gr::basic::StreamFilterImpl, ([T], 
 
 template<typename T, bool streamOut = false, trigger::Matcher TMatcher = trigger::BasicTriggerNameCtxMatcher::Filter>
 requires(std::is_arithmetic_v<T> || gr::meta::complex_like<T>)
-struct StreamFilterImpl : Block<StreamFilterImpl<T, streamOut, TMatcher>> {
-    using Description = Doc<R"(@brief Converts stream of input data into chunked discrete DataSet<T> based on tag-based pre- / post-conditions
-Notes:
-* n_pre must be less than the size of the output port's CircularBuffer. The block waits until all n_pre samples can be written to the output in a single iteration.
-* In stream-to-stream mode, the 'stop' Tag is not included in the output stream.
-* In stream-to-dataset mode, the 'stop' Tag is included in the DataSet output.
-* Stream-to-stream mode has limited support for overlapping triggers. Configurations such as Start-Stop-Start-Stop work as expected,
-but configurations like Start-Start-Stop-Stop result in undefined behavior.
-If data accumulation is active, the second 'start' is ignored, and the output may vary depending on subsequent tags.
-* Tags for pre-samples are not stored and are not included in the output.
-* It is expected that 'start' and 'stop' Tags will come from different iterations.
-If multiple 'start' or 'stop' Tags arrive in a single merged tag, only one DataSet is created. This may lead to incorrect or unexpected output.)">;
+struct StreamFilterImpl : Block<StreamFilterImpl<T, streamOut, TMatcher>, NoTagPropagation> {
+    using Description = Doc<R"(@brief Selects ranges from an input stream using trigger tags and publishes them as either a stream or DataSet<T>.
+Basic behavior:
+* filter selects the trigger tags that open and close a range.
+* n_pre adds samples before the start trigger. n_post adds samples after the stop trigger. n_max limits the DataSet size.
+* Sample tags are published only when their attached sample is copied to the output. They keep the correct sample position.
+* The block also publishes a merged auto-forward tag. It contains only keys from the block's auto-forward list, which is initialized from kDefaultTags. It is published once at the next output position. If the same key is seen more than once, the newest value is used.
+* Tags at the same input sample are checked one by one. They are not merged before trigger matching. If several tags match, the first matching tag controls the range.
+
+StreamFilter output:
+* Publishes selected samples as a normal stream.
+* Publishes tags in the selected range at the correct output samples.
+* Drops old sample tags once they are outside the n_pre history window. Their auto-forward keys can still be included in the next merged auto-forward tag.
+* Supports simple non-overlapping ranges. Start-Stop-Start-Stop works. Nested Start-Start-Stop-Stop is undefined and later start tags can be ignored.
+
+StreamToDataSet output:
+* Publishes one DataSet<T> for each completed range.
+* Publishes all tags in the selected range to DataSet::timing_events, attached to the matching DataSet samples.
+* Publishes the merged auto-forward tag as a normal output tag on the published DataSet.
+* Supports overlapping DataSets when starts and stops are processed in separate work calls.
+* If the stop matcher excludes the stop sample and n_post == 0, the stop tag closes the range but is not published as a sample tag.)">;
 
     constexpr static std::size_t MIN_BUFFER_SIZE = 1024U;
     template<typename U, gr::meta::fixed_string description = "", typename... Arguments> // optional annotation shortening
@@ -52,11 +69,13 @@ If multiple 'start' or 'stop' Tags arrive in a single merged tag, only one DataS
     A<float, "signal_min", Doc<"signal physical max. (e.g. DAQ) limit">>                                     signal_min = 0.f;
     A<float, "signal_max", Doc<"signal physical max. (e.g. DAQ) limit">>                                     signal_max = 1.f;
 
-    GR_MAKE_REFLECTABLE(StreamFilterImpl, filter, in, out, filter, n_pre, n_post, n_max, sample_rate, signal_name, signal_quantity, signal_unit, signal_min, signal_max);
+    GR_MAKE_REFLECTABLE(StreamFilterImpl, filter, in, out, n_pre, n_post, n_max, sample_rate, signal_name, signal_quantity, signal_unit, signal_min, signal_max);
 
     // internal trigger state
-    HistoryBuffer<T> _history{MIN_BUFFER_SIZE + n_pre};
-    TMatcher         _matcher{};
+    HistoryBuffer<T>    _history{MIN_BUFFER_SIZE + n_pre};
+    std::deque<gr::Tag> _historyTags;
+    property_map        _mergedAutoForwardTag;
+    TMatcher            _matcher{};
 
     struct AccumulationState {
         bool        isActive           = false;
@@ -117,6 +136,8 @@ If multiple 'start' or 'stop' Tags arrive in a single merged tag, only one DataS
             _tempDataSets.clear();
             _accState.clear();
         }
+        _historyTags.clear();
+        _mergedAutoForwardTag.clear();
     }
 
     void settingsChanged(const gr::property_map& /*oldSettings*/, const gr::property_map& newSettings) {
@@ -152,11 +173,16 @@ If multiple 'start' or 'stop' Tags arrive in a single merged tag, only one DataS
     }
 
     gr::work::Status processBulkStream(InputSpanLike auto& inSamples, OutputSpanLike auto& outSamples) {
-        const auto [startTrigger, endTrigger, isSingleTrigger] = detectTrigger(_filterState, inSamples);
+        const auto                       inTags          = inputTags(inSamples);
+        const std::optional<std::size_t> matchedTagIndex = findFirstTriggerTag(inTags);
+        const Tag                        emptyTag{};
+        const Tag&                       matchedTag = matchedTagIndex.has_value() ? inTags[*matchedTagIndex] : emptyTag;
+
+        const auto [startTrigger, endTrigger, isSingleTrigger] = detectTrigger(matchedTag, _filterState);
         _accState.update(startTrigger, endTrigger, isSingleTrigger, n_pre, n_post);
 
         if (!_accState.isActive) { // If accumulation is not active, consume all input samples and publish 0 samples.
-            copyInputSamplesToHistory(inSamples, inSamples.size());
+            updateHistory(inSamples, inSamples.size(), true);
             std::ignore = inSamples.consume(inSamples.size());
             outSamples.publish(0UZ);
         } else { // accumulation is active
@@ -193,18 +219,61 @@ If multiple 'start' or 'stop' Tags arrive in a single merged tag, only one DataS
                 _accState.updatePostSamples(nPostSamplesToCopy);
             }
 
-            copyInputSamplesToHistory(inSamples, nSamplesToPublish - nPreSamplesToCopy);
-            std::ignore = inSamples.consume(nSamplesToPublish - nPreSamplesToCopy);
+            if (nSamplesToPublish == 0UZ && _accState.isActive) {
+                std::ignore = inSamples.consume(0UZ);
+                outSamples.publish(0UZ);
+                return nOutAvailable == 0UZ ? work::Status::INSUFFICIENT_OUTPUT_ITEMS : work::Status::INSUFFICIENT_INPUT_ITEMS;
+            }
+
+            bool inTagsPublished = false;
+            if (nSamplesToPublish > 0UZ) {
+                publishMergedAutoForwardTag(outSamples);
+
+                for (const Tag& tag : _historyTags) {
+                    const std::size_t offset = (n_pre > 0 && tag.index < nPreSamplesToCopy) ? (nPreSamplesToCopy - tag.index) : 0UZ;
+                    outSamples.publishTag(tag.map, offset);
+                }
+                _historyTags.clear();
+
+                const std::size_t nCurrentSamplesCopied = nSamplesToPublish - nPreSamplesToCopy;
+                for (const Tag& tag : inTags) {
+                    if (tag.index >= nCurrentSamplesCopied) {
+                        continue;
+                    }
+                    const std::size_t offset = nPreSamplesToCopy + tag.index;
+                    outSamples.publishTag(tag.map, offset);
+                }
+                inTagsPublished = true;
+            }
+
+            if (_accState.isActive) {
+                updateHistory(inSamples, nSamplesToPublish - nPreSamplesToCopy, !inTagsPublished);
+                std::ignore = inSamples.consume(nSamplesToPublish - nPreSamplesToCopy);
+            } else {
+                updateHistory(inSamples, inSamples.size(), !inTagsPublished);
+                std::ignore = inSamples.consume(inSamples.size());
+            }
             outSamples.publish(nSamplesToPublish);
         }
         return work::Status::OK;
     }
 
     gr::work::Status processBulkDataSet(InputSpanLike auto& inSamples, OutputSpanLike auto& outSamples) {
+        if (!_tempDataSets.empty() && !_accState.front().isActive && outSamples.size() == 0UZ) {
+            std::ignore = inSamples.consume(0UZ);
+            outSamples.publish(0UZ);
+            return work::Status::INSUFFICIENT_OUTPUT_ITEMS;
+        }
+
+        const auto                       inTags          = inputTags(inSamples);
+        const std::optional<std::size_t> matchedTagIndex = findFirstTriggerTag(inTags);
+        const Tag                        emptyTag{};
+        const Tag&                       matchedTag = matchedTagIndex.has_value() ? inTags[*matchedTagIndex] : emptyTag;
+
         //    This is a workaround to support cases of overlapping datasets, for example, Start1-Start2-Stop1-Stop2 case.
         //    always add new DataSet when Start trigger is present
         property_map tmpFilterState;
-        const auto [startTrigger, endTrigger, isSingleTrigger] = detectTrigger(tmpFilterState, inSamples);
+        const auto [startTrigger, endTrigger, isSingleTrigger] = detectTrigger(matchedTag, tmpFilterState);
         if (startTrigger) {
             _tempDataSets.emplace_back();
             initNewDataSet(_tempDataSets.back());
@@ -217,8 +286,11 @@ If multiple 'start' or 'stop' Tags arrive in a single merged tag, only one DataS
 
         // Update state only for the front dataset which is not in the isPostActiveState
         for (std::size_t i = 0; i < _tempDataSets.size(); i++) {
+            if (!_accState[i].isActive) {
+                continue;
+            }
             if (!_accState[i].isPostActive) {
-                const auto [startTrigger2, endTrigger2, isSingleTrigger2] = detectTrigger(_filterState[i], inSamples);
+                const auto [startTrigger2, endTrigger2, isSingleTrigger2] = detectTrigger(matchedTag, _filterState[i]);
                 if (endTrigger2) {
                     _accState[i].update(startTrigger2, endTrigger2, isSingleTrigger2, n_pre, n_post);
                 }
@@ -226,8 +298,8 @@ If multiple 'start' or 'stop' Tags arrive in a single merged tag, only one DataS
             }
         }
 
-        if (_tempDataSets.empty()) { // If accumulation is not active (no active DataSets), consume all input samples and publish 0 samples.
-            copyInputSamplesToHistory(inSamples, inSamples.size());
+        if (_tempDataSets.empty()) { // If accumulation is not active (no active DataSets) -> update history, consume all input samples and publish 0 samples.
+            updateHistory(inSamples, inSamples.size(), true);
             std::ignore = inSamples.consume(inSamples.size());
             outSamples.publish(0UZ);
             return work::Status::OK;
@@ -235,6 +307,9 @@ If multiple 'start' or 'stop' Tags arrive in a single merged tag, only one DataS
             for (std::size_t i = 0; i < _tempDataSets.size(); i++) {
                 auto& ds       = _tempDataSets[i];
                 auto& accState = _accState[i];
+                if (!accState.isActive) {
+                    continue;
+                }
 
                 // pre samples data accumulation
                 if (accState.isPreActive) {
@@ -246,25 +321,24 @@ If multiple 'start' or 'stop' Tags arrive in a single merged tag, only one DataS
                     accState.isPreActive = false;
                     accState.nPreSamples = nPreSamplesToCopy;
                     accState.nSamples += nPreSamplesToCopy;
-                }
 
-                // Note: Tags for pre-samples are not added to DataSet
-                if (n_max.value == 0UZ || ds.signal_values.size() < n_max.value) { // Add tags only if the DataSet is not full
-                    if (!ds.timing_events.empty() && accState.isActive) {
-                        for (const auto& [relIndex, tagMapRef] : inSamples.tags()) {
-                            if (relIndex == 0 && !tagMapRef.get().empty()) {
-                                ds.timing_events[0].emplace_back(static_cast<std::ptrdiff_t>(ds.signal_values.size()), tagMapRef.get());
+                    if (nPreSamplesToCopy > 0UZ) {
+                        for (const Tag& tag : _historyTags) {
+                            if (tag.index <= nPreSamplesToCopy && !tag.map.empty()) {
+                                ds.timing_events[0].emplace_back(static_cast<std::ptrdiff_t>(nPreSamplesToCopy - tag.index), tag.map);
                             }
                         }
                     }
                 }
 
+                std::size_t nNonPreSamplesCopied = 0UZ;
                 if (!accState.isPostActive) { // normal data accumulation
                     const std::size_t nSamplesToCopy = n_max.value == 0UZ ? inSamples.size() : std::min(n_max.value - ds.signal_values.size(), inSamples.size());
                     if (nSamplesToCopy > 0) {
                         ds.signal_values.insert(ds.signal_values.end(), inSamples.begin(), inSamples.begin() + static_cast<std::ptrdiff_t>(nSamplesToCopy));
                         fillAxisValues(ds, static_cast<int>(accState.nSamples - accState.nPreSamples), nSamplesToCopy);
                         accState.nSamples += nSamplesToCopy;
+                        nNonPreSamplesCopied += nSamplesToCopy;
                     }
                 } else {                                                                                                                  // post samples data accumulation
                     const std::size_t nPostSamplesToCopy = n_max.value == 0UZ ? std::min(accState.nPostSamplesRemain, inSamples.size()) : //
@@ -273,35 +347,46 @@ If multiple 'start' or 'stop' Tags arrive in a single merged tag, only one DataS
                         ds.signal_values.insert(ds.signal_values.end(), inSamples.begin(), std::next(inSamples.begin(), static_cast<std::ptrdiff_t>(nPostSamplesToCopy)));
                         fillAxisValues(ds, static_cast<int>(accState.nSamples - accState.nPreSamples), nPostSamplesToCopy);
                         accState.updatePostSamples(nPostSamplesToCopy);
+                        nNonPreSamplesCopied += nPostSamplesToCopy;
                     } else {
                         accState.isActive = false;
                     }
                 }
+
+                // Add tags only if at least one sample from current iteration is copied to DataSet
+                if (nNonPreSamplesCopied > 0UZ && !ds.timing_events.empty() && !inTags.empty()) {
+                    for (const Tag& tag : inTags) {
+                        if (tag.index < nNonPreSamplesCopied && !tag.map.empty()) {
+                            ds.timing_events[0].emplace_back(static_cast<std::ptrdiff_t>(accState.nSamples - nNonPreSamplesCopied + tag.index), tag.map);
+                        }
+                    }
+                }
             }
-            // tags are per-sample from input span — no persistent state to clear
         }
 
-        copyInputSamplesToHistory(inSamples, inSamples.size());
+        updateHistory(inSamples, inSamples.size(), true);
         std::ignore = inSamples.consume(inSamples.size());
 
         // publish all completed DataSet<T>
         std::size_t publishedCounter = 0UZ;
-        while (true) {
-            if (!_tempDataSets.empty() && !_accState.front().isActive) {
-                auto& ds = _tempDataSets.front();
-                assert(!ds.extents.empty());
-                ds.extents[0UZ] = static_cast<std::int32_t>(ds.signal_values.size());
-                if (!ds.signal_values.empty()) { // TODO: do we need to publish empty  DataSet at all, empty DataSet can occur when n_max is set.
-                    gr::dataset::updateMinMax(ds);
-                }
-                outSamples[publishedCounter] = std::move(ds);
-                _tempDataSets.pop_front();
-                _accState.pop_front();
-                _filterState.pop_front();
-                publishedCounter++;
-            } else {
+        while (!_tempDataSets.empty() && !_accState.front().isActive) {
+            if (publishedCounter >= outSamples.size()) {
                 break;
             }
+            auto& ds = _tempDataSets.front();
+            assert(!ds.extents.empty());
+            ds.extents[0UZ] = static_cast<std::int32_t>(ds.signal_values.size());
+            if (!ds.signal_values.empty()) { // TODO: do we need to publish empty  DataSet at all, empty DataSet can occur when n_max is set.
+                gr::dataset::updateMinMax(ds);
+            }
+            outSamples[publishedCounter] = std::move(ds);
+            _tempDataSets.pop_front();
+            _accState.pop_front();
+            _filterState.pop_front();
+            publishedCounter++;
+        }
+        if (publishedCounter > 0UZ) {
+            publishMergedAutoForwardTag(outSamples);
         }
         outSamples.publish(publishedCounter);
 
@@ -310,20 +395,67 @@ If multiple 'start' or 'stop' Tags arrive in a single merged tag, only one DataS
 
 private:
     template<typename TInputSpan>
-    auto detectTrigger(property_map& filterState, TInputSpan& inSpan) {
+    [[nodiscard]] std::vector<Tag> inputTags(TInputSpan& inSpan) const {
+        std::vector<Tag> tags;
+        for (const auto& [relIndex, tagMapRef] : inSpan.tags()) {
+            tags.emplace_back(relIndex < 0 ? 0UZ : static_cast<std::size_t>(relIndex), tagMapRef.get());
+        }
+        return tags;
+    }
+
+    [[nodiscard]] std::optional<std::size_t> findFirstTriggerTag(const std::vector<Tag>& inTags) {
+        // If multiple Start/Stop/SingleTrigger trigger tags arrive at the same sample index ,
+        // we process only the first one (regardless of Start, Stop or singleTrigger) and ignore the rest.
+        // This should not occur in practice because it guarantees at most one trigger per sample index.
+        // Note: StreamToDataSet have only Tags at index 0, since input_chunk_size == 1
+        if (inTags.empty()) {
+            return std::nullopt;
+        }
+
+        for (std::size_t i = 0UZ; i < inTags.size(); ++i) {
+            const Tag& tag = inTags[i];
+            if (tag.index != 0UZ) {
+                continue;
+            }
+
+            if constexpr (streamOut) {
+                property_map tmpFilterState                            = _filterState;
+                const auto [startTrigger, endTrigger, isSingleTrigger] = detectTrigger(tag, tmpFilterState);
+                if (startTrigger || endTrigger || isSingleTrigger) {
+                    return i;
+                }
+            } else {
+                property_map tmpEmptyFilterState;
+                const auto [startTriggerEmpty, endTriggerEmpty, isSingleTriggerEmpty] = detectTrigger(tag, tmpEmptyFilterState);
+                if (startTriggerEmpty || endTriggerEmpty || isSingleTriggerEmpty) {
+                    return i;
+                }
+
+                for (const property_map& filterState : _filterState) {
+                    property_map tmpFilterState                            = filterState;
+                    const auto [startTrigger, endTrigger, isSingleTrigger] = detectTrigger(tag, tmpFilterState);
+                    if (startTrigger || endTrigger || isSingleTrigger) {
+                        return i;
+                    }
+                }
+            }
+        }
+
+        const auto firstCurrentTag = std::ranges::find_if(inTags, [](const Tag& tag) { return tag.index == 0UZ; });
+        if (firstCurrentTag != inTags.end()) {
+            return static_cast<std::size_t>(std::distance(inTags.begin(), firstCurrentTag));
+        }
+        return std::nullopt;
+    }
+
+    [[nodiscard]] auto detectTrigger(const Tag& tag, property_map& filterState) {
         struct {
             bool startTrigger    = false;
             bool endTrigger      = false;
             bool isSingleTrigger = false;
         } result;
 
-        Tag inputTag;
-        for (const auto& [relIndex, tagMapRef] : inSpan.tags()) {
-            if (relIndex == 0) {
-                inputTag.map.merge(property_map(tagMapRef.get()));
-            }
-        }
-        const trigger::MatchResult matchResult = _matcher(filter.value, inputTag, filterState);
+        const trigger::MatchResult matchResult = _matcher(filter.value, tag, filterState);
         if (matchResult != trigger::MatchResult::Ignore) {
             assert(filterState.contains("isSingleTrigger"));
             result.startTrigger    = matchResult == trigger::MatchResult::Matching;
@@ -333,10 +465,78 @@ private:
         return result;
     }
 
-    void copyInputSamplesToHistory(InputSpanLike auto& inSamples, std::size_t maxSamplesToCopy) {
-        if (n_pre > 0) {
-            const auto samplesToCopy = std::min(maxSamplesToCopy, inSamples.size());
-            _history.push_front(inSamples.begin(), std::next(inSamples.begin(), static_cast<std::ptrdiff_t>(samplesToCopy)));
+    void updateHistory(InputSpanLike auto& inSamples, std::size_t maxSamplesToCopy, bool copyInputTags) {
+        const auto samplesToCopy = std::min(maxSamplesToCopy, inSamples.size());
+        if (samplesToCopy > 0UZ) {
+            const auto inTags = inputTags(inSamples);
+            if constexpr (streamOut) {
+                if (copyInputTags) {
+                    if (n_pre > 0) {
+                        _historyTags.insert(_historyTags.end(), inTags.begin(), inTags.end());
+                    } else {
+                        mergeAutoForwardTags(inTags);
+                    }
+                }
+            } else {
+                if (copyInputTags && n_pre > 0) {
+                    _historyTags.insert(_historyTags.end(), inTags.begin(), inTags.end());
+                }
+                mergeAutoForwardTags(inTags);
+            }
+
+            if (n_pre > 0) {
+                const auto samplesEnd = std::next(inSamples.begin(), static_cast<std::ptrdiff_t>(samplesToCopy));
+                _history.push_front(inSamples.begin(), samplesEnd);
+                for (Tag& tag : _historyTags) {
+                    tag.index += samplesToCopy;
+                }
+            }
+
+            if constexpr (streamOut) {
+                if (n_pre > 0) {
+                    std::vector<Tag> expiredTags;
+                    std::erase_if(_historyTags, [N = static_cast<std::size_t>(n_pre.value), &expiredTags](const Tag& tag) {
+                        if (tag.index <= N) {
+                            return false;
+                        }
+                        expiredTags.push_back(tag);
+                        return true;
+                    });
+                    mergeAutoForwardTags(expiredTags);
+                }
+            } else {
+                std::erase_if(_historyTags, [N = static_cast<std::size_t>(n_pre.value)](const Tag& tag) { return tag.index > N; });
+            }
+        }
+    }
+
+    void mergeAutoForwardTags(const std::vector<Tag>& tags) {
+        const auto&                 autoForwardKeys = this->settings().autoForwardParameters();
+        const auto&                 blockSettings   = CtxSettings<StreamFilterImpl<T, streamOut, TMatcher>>::allWritableMembers();
+        std::optional<property_map> cachedSettings;
+
+        for (const Tag& tag : tags) {
+            for (const auto& [key, value] : tag.map) {
+                const auto shortKey = convert_string_domain(key);
+                if (!autoForwardKeys.contains(shortKey)) {
+                    continue;
+                }
+                if (!cachedSettings) {
+                    cachedSettings.emplace(this->settings().get());
+                }
+                if (const auto it = cachedSettings->find(key); blockSettings.contains(shortKey) && it != cachedSettings->end()) {
+                    _mergedAutoForwardTag.insert_or_assign(key, it->second);
+                } else {
+                    _mergedAutoForwardTag.insert_or_assign(key, value);
+                }
+            }
+        }
+    }
+
+    void publishMergedAutoForwardTag(OutputSpanLike auto& outSpan) {
+        if (!_mergedAutoForwardTag.empty()) {
+            outSpan.publishTag(_mergedAutoForwardTag, 0UZ);
+            _mergedAutoForwardTag.clear();
         }
     }
 

--- a/blocks/basic/test/qa_DataSink.cpp
+++ b/blocks/basic/test/qa_DataSink.cpp
@@ -18,19 +18,6 @@
 
 using namespace std::chrono_literals;
 
-template<>
-struct std::formatter<gr::Tag> {
-    template<typename ParseContext>
-    constexpr auto parse(ParseContext& ctx) {
-        return ctx.begin();
-    }
-
-    template<typename FormatContext>
-    constexpr auto format(const gr::Tag& tag, FormatContext& ctx) const {
-        return std::format_to(ctx.out(), "{} -> {}", tag.index, tag.map);
-    }
-};
-
 namespace gr::basic::data_sink_test {
 
 constexpr auto kProcessingDelayMs = 600u;
@@ -106,12 +93,14 @@ struct Matcher {
 
 static Tag makeTag(std::size_t index, int year, int month, int day) { return Tag{index, {{"YEAR", year}, {"MONTH", month}, {"DAY", day}}}; }
 
-static std::vector<Tag> makeTestTags(std::size_t firstIndex, std::size_t interval) {
+static std::vector<Tag> makeTestTags(std::size_t firstIndex, std::size_t interval, std::size_t nTagsPerIndex = 1UZ) {
     std::vector<Tag> tags;
     for (int y = 1; y <= 3; ++y) {
         for (int m = 1; m <= 2; ++m) {
             for (int d = 1; d <= 3; ++d) {
-                tags.push_back(makeTag(firstIndex, y, m, d));
+                for (int iT = 0; iT < static_cast<int>(nTagsPerIndex); ++iT) {
+                    tags.push_back(makeTag(firstIndex, y + iT, m + iT, d + iT));
+                }
                 firstIndex += interval;
             }
         }
@@ -138,13 +127,6 @@ static std::string toAsciiArt(std::span<trigger::MatchResult> states) {
     return r;
 }
 
-std::size_t checkedSum(std::size_t a, std::ptrdiff_t b) {
-    using namespace boost::ut;
-    const auto signedA = static_cast<std::ptrdiff_t>(a);
-    expect(ge(signedA + b, 0));
-    return static_cast<std::size_t>(signedA + b);
-}
-
 template<trigger::Matcher TMatcher>
 std::string runMatcherTest(std::span<const Tag> tags, TMatcher matcher) {
     std::vector<trigger::MatchResult> result;
@@ -153,81 +135,6 @@ std::string runMatcherTest(std::span<const Tag> tags, TMatcher matcher) {
         result.push_back(matcher("", tag, {}));
     }
     return toAsciiArt(result);
-}
-
-std::pair<std::vector<Tag>, std::vector<Tag>> extractMetadataTags(const std::vector<Tag>& tags) {
-    constexpr auto   tagsToExtract = std::array{gr::tag::SAMPLE_RATE.shortKey(), gr::tag::SIGNAL_NAME.shortKey(), gr::tag::SIGNAL_UNIT.shortKey(), gr::tag::SIGNAL_MIN.shortKey(), gr::tag::SIGNAL_MAX.shortKey()};
-    std::vector<Tag> metadataTags;
-    std::vector<Tag> nonMetadataTags;
-    for (const auto& tag : tags) {
-        Tag metadata;
-        Tag nonMetadata;
-        metadata.index    = tag.index;
-        nonMetadata.index = tag.index;
-        for (const auto& [key, value] : tag.map) {
-            if (std::find(tagsToExtract.begin(), tagsToExtract.end(), key) != tagsToExtract.end()) {
-                metadata.map[key] = value;
-            } else {
-                nonMetadata.map[key] = value;
-            }
-        }
-        if (!metadata.map.empty()) {
-            metadataTags.push_back(metadata);
-        }
-        if (!nonMetadata.map.empty()) {
-            nonMetadataTags.push_back(nonMetadata);
-        }
-    }
-    return {metadataTags, nonMetadataTags};
-}
-
-struct Metadata {
-    std::optional<std::string> signal_name;
-    std::optional<std::string> signal_unit;
-    std::optional<float>       signal_min;
-    std::optional<float>       signal_max;
-    std::optional<float>       sample_rate;
-};
-
-Metadata metadataFromTag(const Tag& tag) {
-    Metadata m;
-    for (const auto& [key, value] : tag.map) {
-        if (key == gr::tag::SIGNAL_NAME.shortKey()) {
-            m.signal_name = test::get_value_or_fail<std::string>(value);
-        } else if (key == gr::tag::SIGNAL_UNIT.shortKey()) {
-            m.signal_unit = test::get_value_or_fail<std::string>(value);
-        } else if (key == gr::tag::SIGNAL_MIN.shortKey()) {
-            m.signal_min = test::get_value_or_fail<float>(value);
-        } else if (key == gr::tag::SIGNAL_MAX.shortKey()) {
-            m.signal_max = test::get_value_or_fail<float>(value);
-        } else if (key == gr::tag::SAMPLE_RATE.shortKey()) {
-            m.sample_rate = test::get_value_or_fail<float>(value);
-        }
-    }
-    return m;
-}
-
-Metadata latestMetadata(const std::vector<Tag>& tags) {
-    Metadata metadata;
-    for (const auto& tag : tags | std::views::reverse) {
-        const auto m = metadataFromTag(tag);
-        if (!metadata.signal_name) {
-            metadata.signal_name = m.signal_name;
-        }
-        if (!metadata.signal_unit) {
-            metadata.signal_unit = m.signal_unit;
-        }
-        if (!metadata.signal_min) {
-            metadata.signal_min = m.signal_min;
-        }
-        if (!metadata.signal_max) {
-            metadata.signal_max = m.signal_max;
-        }
-        if (!metadata.sample_rate) {
-            metadata.sample_rate = m.sample_rate;
-        }
-    }
-    return metadata;
 }
 
 bool spinUntil(std::chrono::milliseconds timeout, auto fnc) {
@@ -242,19 +149,60 @@ bool spinUntil(std::chrono::milliseconds timeout, auto fnc) {
     return false;
 }
 
+trigger::MatchResult isTrigger(std::string_view /* filterSpec */, const Tag& tag, const property_map& /* filter state */) {
+    const auto v = tag.get(gr::tag::TRIGGER_NAME.shortKey());
+    return (v && gr::test::get_value_or_fail<std::string>(v->get()) == "TRIGGER") ? trigger::MatchResult::Matching : trigger::MatchResult::Ignore;
+};
+
+struct DataSetTestParams {
+    std::size_t nSignalValues  = 0;
+    std::string signalName     = "TestName";
+    std::string signalUnit     = "TestUnit";
+    std::string signalQuantity = "TestQuantity";
+    float       rangeMin       = -2.f;
+    float       rangeMax       = 2.f;
+
+    std::ptrdiff_t timingEventIndex = 0;
+    std::string    triggerName      = "TRIGGER";
+    std::uint64_t  triggerTimeMax   = 0;
+};
+
+void checkDataSet(const DataSet<float>& dataset, std::vector<float>& receivedData, std::size_t& nReceivedTags, DataSetTestParams expectedParams = {}, std::source_location location = std::source_location::current()) {
+    using namespace boost::ut;
+    using namespace gr::tag;
+
+    const auto                     locationStr = std::format("{}:{} ", location.file_name(), location.line());
+    std::expected<void, gr::Error> dsCheck     = dataset::checkConsistency(dataset, "dataset - blocking polling trigger mode overlapping");
+    expect(dsCheck.has_value()) << [&] { return std::format("unexpected: {}", dsCheck.error()); } << fatal;
+    expect(eq(dataset.size(), 1UZ)) << locationStr;
+
+    expect(eq(dataset.signal_values.size(), expectedParams.nSignalValues)) << locationStr;
+
+    expect(eq(dataset.signalName(0UZ), expectedParams.signalName)) << locationStr;
+    expect(eq(dataset.signalUnit(0UZ), expectedParams.signalUnit)) << locationStr;
+    expect(eq(dataset.signalQuantity(0UZ), expectedParams.signalQuantity)) << locationStr;
+    expect(eq(dataset.signalRange(0UZ), gr::Range<float>{expectedParams.rangeMin, expectedParams.rangeMax})) << locationStr;
+
+    expect(eq(dataset.timingEvents(0UZ).size(), 1UZ)) << locationStr; // only trigger is stored
+    expect(eq(dataset.timingEvents(0UZ)[0UZ].first, static_cast<std::ptrdiff_t>(expectedParams.timingEventIndex))) << locationStr;
+    const auto eventMap = dataset.timingEvents(0UZ)[0UZ].second;
+    expect(eq(eventMap.size(), 2UZ)) << locationStr;
+    const bool containsTriggerName = eventMap.contains(TRIGGER_NAME.shortKey());
+    expect(containsTriggerName) << locationStr;
+    if (containsTriggerName) {
+        expect(eq(gr::test::get_value_or_fail<std::string>(eventMap.at(TRIGGER_NAME.shortKey())), expectedParams.triggerName)) << locationStr;
+    }
+    const bool containsTriggerTime = eventMap.contains(TRIGGER_TIME.shortKey());
+    expect(containsTriggerTime) << locationStr;
+    if (containsTriggerTime) {
+        expect(lt(gr::test::get_value_or_fail<std::uint64_t>(eventMap.at(TRIGGER_TIME.shortKey())), static_cast<std::uint64_t>(expectedParams.triggerTimeMax))) << locationStr;
+    }
+
+    receivedData.insert(receivedData.end(), dataset.signal_values.begin(), dataset.signal_values.end());
+    nReceivedTags += dataset.timingEvents(0UZ).size();
+};
+
 } // namespace gr::basic::data_sink_test
-
-template<typename T>
-std::string formatList(const T& l) {
-    return std::format("[{}]", gr::join(l, ", "));
-}
-
-template<typename T, typename U>
-bool indexesMatch(const T& lhs, const U& rhs) {
-    auto index_match = [](const auto& l, const auto& r) { return l.index == r.index; };
-
-    return std::equal(std::begin(lhs), std::end(lhs), std::begin(rhs), std::end(rhs), index_match);
-}
 
 using Scheduler = gr::scheduler::Simple<gr::scheduler::ExecutionPolicy::multiThreaded>;
 
@@ -266,18 +214,19 @@ const boost::ut::suite DataSinkTests = [] {
     using namespace std::string_literals;
     using namespace gr::test;
 
-    "callback continuous mode"_test = [] {
-        constexpr gr::Size_t  kSamples   = 200005;
-        constexpr std::size_t kChunkSize = 1000;
+    "continuous mode - callback"_test = [] {
+        using namespace gr::tag;
+        constexpr gr::Size_t  kSamples      = 200005;
+        constexpr std::size_t kMaxChunkSize = 1000;
 
-        const auto srcTags = makeTestTags(0, 1000);
+        const std::vector<Tag> srcTags = makeTestTags(0, 1234, 1);
 
-        gr::Graph                testGraph;
-        auto&                    src                   = testGraph.emplaceBlock<gr::testing::TagSource<float>>({{"n_samples_max", kSamples}, {"mark_tag", false}, {"signal_name", "test source"}, {"signal_unit", "test unit"}, {"signal_min", -42.f}, {"signal_max", 42.f}});
-        auto&                    delay                 = testGraph.emplaceBlock<testing::Delay<float>>({{"delay_ms", kProcessingDelayMs}});
-        std::vector<std::string> customAutoForwardKeys = {"DAY", "MONTH", "YEAR"};
-        delay.settings().autoForwardParameters().insert(customAutoForwardKeys.begin(), customAutoForwardKeys.end());
-        auto& sink = testGraph.emplaceBlock<DataSink<float>>({{"name", "test_sink"}, {"signal_name", "test source"}});
+        gr::Graph testGraph;
+        auto&     src   = testGraph.emplaceBlock<gr::testing::TagSource<float>>({{"n_samples_max", kSamples}, {"mark_tag", false}, //
+                  {SIGNAL_NAME.shortKey(), "TestName"}, {SIGNAL_UNIT.shortKey(), "TestUnit"}, {SIGNAL_QUANTITY.shortKey(), "TestQuantity"}, {SIGNAL_MIN.shortKey(), -42.f}, {SIGNAL_MAX.shortKey(), 42.f}});
+        auto&     delay = testGraph.emplaceBlock<testing::Delay<float>>({{"delay_ms", kProcessingDelayMs}});
+        delay.settings().autoForwardParameters().insert({"DAY", "MONTH", "YEAR"}); // custom auto forward keys
+        auto& sink = testGraph.emplaceBlock<DataSink<float>>({{"name", "test_sink"}, {SIGNAL_NAME.shortKey(), "TestName"}});
         src._tags  = srcTags;
 
         expect(testGraph.connect<"out", "in">(src, delay).has_value());
@@ -285,26 +234,20 @@ const boost::ut::suite DataSinkTests = [] {
 
         std::atomic<std::size_t> samplesSeen1 = 0;
         std::atomic<std::size_t> chunksSeen1  = 0;
-        auto                     callback     = [&samplesSeen1, &chunksSeen1, &kChunkSize](std::span<const float> buffer) {
+        auto                     callback     = [&samplesSeen1, &chunksSeen1, &kMaxChunkSize](std::span<const float> buffer) {
             for (std::size_t i = 0; i < buffer.size(); ++i) {
                 expect(eq(buffer[i], static_cast<float>(samplesSeen1 + i)));
             }
-
             samplesSeen1 += buffer.size();
             chunksSeen1++;
-            if (chunksSeen1 < 201) {
-                expect(eq(buffer.size(), kChunkSize));
-            } else {
-                expect(eq(buffer.size(), 5UZ));
-            }
+            expect(le(buffer.size(), kMaxChunkSize));
         };
 
         std::mutex       m2;
         std::size_t      samplesSeen2 = 0;
         std::size_t      chunksSeen2  = 0;
         std::vector<Tag> receivedTags;
-
-        auto callbackWithTags = [&samplesSeen2, &chunksSeen2, &m2, &receivedTags, &kChunkSize](std::span<const float> buffer, std::span<const Tag> tags) {
+        auto             callbackWithTags = [&samplesSeen2, &chunksSeen2, &m2, &receivedTags, &kMaxChunkSize](std::span<const float> buffer, std::span<const Tag> tags) {
             for (std::size_t i = 0; i < buffer.size(); ++i) {
                 expect(eq(buffer[i], static_cast<float>(samplesSeen2 + i)));
             }
@@ -314,17 +257,12 @@ const boost::ut::suite DataSinkTests = [] {
                 expect(lt(tag.index, buffer.size()));
             }
 
-            auto lg = std::lock_guard{m2};
-
+            auto lg       = std::lock_guard{m2};
             auto absolute = tags | std::views::transform([&samplesSeen2](const auto& t) { return gr::Tag{t.index + samplesSeen2, t.map}; });
             receivedTags.insert(receivedTags.end(), absolute.begin(), absolute.end());
             samplesSeen2 += buffer.size();
             chunksSeen2++;
-            if (chunksSeen2 < 201) {
-                expect(eq(buffer.size(), kChunkSize));
-            } else {
-                expect(eq(buffer.size(), 5UZ));
-            }
+            expect(le(buffer.size(), kMaxChunkSize));
         };
 
         auto callbackWithTagsAndSink = [&sink](std::span<const float>, std::span<const Tag>, const DataSink<float>& passedSink) {
@@ -340,13 +278,13 @@ const boost::ut::suite DataSinkTests = [] {
 
             expect(spinUntil(4s, [&] {
                 if (!callbackRegistered) {
-                    callbackRegistered = globalDataSinkRegistry().registerStreamingCallback<float>(DataSinkQuery::sinkName("test_sink"), kChunkSize, callback);
+                    callbackRegistered = globalDataSinkRegistry().registerStreamingCallback<float>(DataSinkQuery::sinkName("test_sink"), kMaxChunkSize, callback);
                 }
                 if (!callbackWithTagsRegistered) {
-                    callbackWithTagsRegistered = globalDataSinkRegistry().registerStreamingCallback<float>(DataSinkQuery::sinkName("test_sink"), kChunkSize, callbackWithTags);
+                    callbackWithTagsRegistered = globalDataSinkRegistry().registerStreamingCallback<float>(DataSinkQuery::sinkName("test_sink"), kMaxChunkSize, callbackWithTags);
                 }
                 if (!callbackWithTagsAndSinkRegistered) {
-                    callbackWithTagsAndSinkRegistered = globalDataSinkRegistry().registerStreamingCallback<float>(DataSinkQuery::sinkName("test_sink"), kChunkSize, callbackWithTagsAndSink);
+                    callbackWithTagsAndSinkRegistered = globalDataSinkRegistry().registerStreamingCallback<float>(DataSinkQuery::sinkName("test_sink"), kMaxChunkSize, callbackWithTagsAndSink);
                 }
                 return callbackRegistered && callbackWithTagsRegistered && callbackWithTagsAndSinkRegistered;
             })) << boost::ut::fatal;
@@ -359,46 +297,58 @@ const boost::ut::suite DataSinkTests = [] {
         expect(sched.runAndWait().has_value());
         registerThread.join();
 
+        expect(eq(src._nSamplesProduced, kSamples));
+
         auto lg = std::lock_guard{m2};
-        expect(eq(chunksSeen1.load(), 201UZ));
-        expect(eq(chunksSeen2, 201UZ));
+        expect(ge(chunksSeen1.load(), 201UZ));
+        expect(ge(chunksSeen2, 201UZ));
         expect(eq(samplesSeen1.load(), static_cast<std::size_t>(kSamples)));
         expect(eq(samplesSeen2, static_cast<std::size_t>(kSamples)));
-        const auto& [metadataTags, nonMetadataTags] = extractMetadataTags(receivedTags);
-        expect(eq(nonMetadataTags.size(), srcTags.size()));
-        expect(indexesMatch(nonMetadataTags, srcTags)) << std::format("{} != {}", formatList(receivedTags), formatList(srcTags));
-        const auto metadata = latestMetadata(metadataTags);
-        expect(eq(metadata.signal_name.value_or("<unset>"s), "test source"s));
-        expect(eq(metadata.signal_unit.value_or("<unset>"s), "test unit"s));
-        expect(eq(metadata.signal_min.value_or(-1234567.f), -42.f));
-        expect(eq(metadata.signal_max.value_or(-1234567.f), 42.f));
+
+        std::vector<Tag> srcAndMetaTags;
+        // Add metadata tag published by DataSink
+        srcAndMetaTags.emplace_back(0UZ, property_map{{SAMPLE_RATE.shortKey(), 1.f}, {SIGNAL_MAX.shortKey(), 42.f}, {SIGNAL_MIN.shortKey(), -42.f}, //
+                                             {SIGNAL_NAME.shortKey(), "TestName"}, {SIGNAL_QUANTITY.shortKey(), "TestQuantity"}, {SIGNAL_UNIT.shortKey(), "TestUnit"}});
+        // Add tag published by TagSource init with parameters
+        srcAndMetaTags.emplace_back(0UZ, property_map{{SIGNAL_MAX.shortKey(), 42.f}, {SIGNAL_MIN.shortKey(), -42.f}, {SIGNAL_NAME.shortKey(), "TestName"}, {SIGNAL_UNIT.shortKey(), "TestUnit"}, //
+                                             {SIGNAL_QUANTITY.shortKey(), "TestQuantity"}});
+
+        // Add sources tags
+        srcAndMetaTags.insert(srcAndMetaTags.end(), srcTags.begin(), srcTags.end());
+        expect(gr::testing::equal_tag_lists(receivedTags, srcAndMetaTags));
     };
 
-    "blocking polling continuous mode"_test = [] {
-        constexpr gr::Size_t kSamples = 200000;
+    "continuous mode - blocking/non-blocking polling"_test = [](bool isBlocking) {
+        using namespace gr::tag;
+        OverflowPolicy       overflowPolicy = isBlocking ? OverflowPolicy::Backpressure : OverflowPolicy::Drop;
+        constexpr gr::Size_t kSamples       = 200005;
 
         gr::Graph  testGraph;
-        const auto tags                                = makeTestTags(0, 1000);
-        auto&      src                                 = testGraph.emplaceBlock<gr::testing::TagSource<float>>({{"n_samples_max", kSamples}, {"mark_tag", false}, {"signal_name", "test signal"}, {"signal_unit", "test unit"}, {"signal_min", -42.f}, {"signal_max", 42.f}});
-        src._tags                                      = tags;
-        auto&                    delay                 = testGraph.emplaceBlock<testing::Delay<float>>({{"delay_ms", kProcessingDelayMs}});
-        std::vector<std::string> customAutoForwardKeys = {"DAY", "MONTH", "YEAR"};
-        delay.settings().autoForwardParameters().insert(customAutoForwardKeys.begin(), customAutoForwardKeys.end());
-        auto& sink = testGraph.emplaceBlock<DataSink<float>>({{"name", "test_sink"}, {"signal_name", "test signal"}});
+        const auto srcTags = makeTestTags(0, 1234, 2);
+        auto&      src     = testGraph.emplaceBlock<gr::testing::TagSource<float>>({{"n_samples_max", kSamples}, {"mark_tag", false}, //
+                     {SIGNAL_NAME.shortKey(), "TestName"}, {SIGNAL_UNIT.shortKey(), "TestUnit"}, {SIGNAL_QUANTITY.shortKey(), "TestQuantity"}, {SIGNAL_MIN.shortKey(), -42.f}, {SIGNAL_MAX.shortKey(), 42.f}});
+        src._tags          = srcTags;
+        auto& delay        = testGraph.emplaceBlock<testing::Delay<float>>({{"delay_ms", kProcessingDelayMs}});
+        delay.settings().autoForwardParameters().insert({"DAY", "MONTH", "YEAR"}); // custom auto forward keys
+        auto& sink = testGraph.emplaceBlock<DataSink<float>>({{"name", "test_sink"}, {SIGNAL_NAME.shortKey(), "TestName"}});
 
         expect(testGraph.connect<"out", "in">(src, delay).has_value());
         expect(testGraph.connect<"out", "in">(delay, sink).has_value());
 
-        auto runner1 = std::async([] {
+        auto invalidTypePoller = globalDataSinkRegistry().getStreamingPoller<double>(DataSinkQuery::sinkName("test_sink"));
+        expect(eq(invalidTypePoller, nullptr));
+
+        auto runner1 = std::async([overflowPolicy] {
             std::shared_ptr<StreamingPoller<float>> poller;
-            expect(spinUntil(4s, [&poller] {
-                poller = globalDataSinkRegistry().getStreamingPoller<float>(DataSinkQuery::sinkName("test_sink"));
+            expect(spinUntil(4s, [&poller, overflowPolicy] {
+                poller = globalDataSinkRegistry().getStreamingPoller<float>(DataSinkQuery::sinkName("test_sink"), {.overflowPolicy = overflowPolicy});
                 return poller != nullptr;
             })) << boost::ut::fatal;
 
             std::vector<float> received;
             bool               seenFinished = false;
             while (!seenFinished) {
+                std::this_thread::sleep_for(50ms); // always wait to force full buffer
                 seenFinished = poller->finished;
                 while (poller->process([&received](const auto& data) { received.insert(received.end(), data.begin(), data.end()); })) {
                 }
@@ -407,16 +357,17 @@ const boost::ut::suite DataSinkTests = [] {
             return std::make_tuple(poller, received);
         });
 
-        auto runner2 = std::async([] {
+        auto runner2 = std::async([overflowPolicy] {
             std::shared_ptr<StreamingPoller<float>> poller;
-            expect(spinUntil(4s, [&poller] {
-                poller = globalDataSinkRegistry().getStreamingPoller<float>(DataSinkQuery::signalName("test signal"));
+            expect(spinUntil(4s, [&poller, overflowPolicy] {
+                poller = globalDataSinkRegistry().getStreamingPoller<float>(DataSinkQuery::signalName("TestName"), {.overflowPolicy = overflowPolicy});
                 return poller != nullptr;
             })) << boost::ut::fatal;
             std::vector<float> received;
             std::vector<Tag>   receivedTags;
             bool               seenFinished = false;
             while (!seenFinished) {
+                std::this_thread::sleep_for(50ms); // always wait to force full buffer
                 seenFinished = poller->finished;
                 while (poller->process([&received, &receivedTags](const auto& data, const auto& tags_) {
                     auto absolute = tags_ | std::views::transform([&received](const auto& t) { return gr::Tag{t.index + received.size(), t.map}; });
@@ -448,74 +399,95 @@ const boost::ut::suite DataSinkTests = [] {
 
         const auto& [pollerDataOnly, received1]               = runner1.get();
         const auto& [pollerWithTags, received2, receivedTags] = runner2.get();
-        const auto& [metadataTags, nonMetadataTags]           = extractMetadataTags(receivedTags);
-        expect(eq(received1.size(), expected.size()));
-        expect(eq(received1, expected));
-        expect(eq(pollerDataOnly->dropCount.load(), 0UZ));
-        expect(eq(received2.size(), expected.size()));
-        expect(eq(received2, expected));
-        expect(eq(nonMetadataTags.size(), tags.size()));
-        expect(eq(indexesMatch(nonMetadataTags, tags), true)) << std::format("{} != {}", formatList(nonMetadataTags), formatList(tags));
-        expect(eq(metadataTags.size(), 1UZ));
-        expect(eq(metadataTags[0UZ].index, 0UZ));
-        const auto metadata = latestMetadata(metadataTags);
-        expect(eq(metadata.signal_name.value_or("<unset>"s), "test signal"s));
-        expect(eq(metadata.signal_unit.value_or("<unset>"s), "test unit"s));
-        expect(eq(metadata.signal_min.value_or(-1234567.f), -42.f));
-        expect(eq(metadata.signal_max.value_or(-1234567.f), 42.f));
-        expect(eq(pollerWithTags->dropCount.load(), 0UZ));
-    };
 
-    "blocking polling trigger mode non-overlapping"_test = [] {
+        if (isBlocking) {
+            std::vector<Tag> srcAndMetaTags;
+            // Add metadata tag published by DataSink
+            srcAndMetaTags.emplace_back(0UZ, property_map{{SAMPLE_RATE.shortKey(), 1.f}, {SIGNAL_MAX.shortKey(), 42.f}, {SIGNAL_MIN.shortKey(), -42.f}, //
+                                                 {SIGNAL_NAME.shortKey(), "TestName"}, {SIGNAL_QUANTITY.shortKey(), "TestQuantity"}, {SIGNAL_UNIT.shortKey(), "TestUnit"}});
+            // Add tag published by TagSource init with parameters
+            srcAndMetaTags.emplace_back(0UZ, property_map{{SIGNAL_MAX.shortKey(), 42.f}, {SIGNAL_MIN.shortKey(), -42.f}, {SIGNAL_NAME.shortKey(), "TestName"}, {SIGNAL_UNIT.shortKey(), "TestUnit"}, //
+                                                 {SIGNAL_QUANTITY.shortKey(), "TestQuantity"}});
+            // Add sources tags
+            srcAndMetaTags.insert(srcAndMetaTags.end(), srcTags.begin(), srcTags.end());
+            expect(gr::testing::equal_tag_lists(receivedTags, srcAndMetaTags));
+
+            expect(eq(received1.size(), expected.size()));
+            expect(eq(received1, expected));
+            expect(eq(received2.size(), expected.size()));
+            expect(eq(received2, expected));
+
+            expect(eq(pollerWithTags->droppedSampleCount.load(), 0UZ));
+            expect(eq(pollerWithTags->droppedTagCount.load(), 0UZ));
+            expect(eq(pollerDataOnly->droppedSampleCount.load(), 0UZ));
+            expect(eq(pollerDataOnly->droppedTagCount.load(), 0UZ));
+        } else {
+            expect(eq(received1.size() + pollerDataOnly->droppedSampleCount.load(), expected.size()));
+            expect(eq(received2.size() + pollerWithTags->droppedSampleCount.load(), expected.size()));
+            expect(gt(pollerWithTags->droppedSampleCount.load(), 0UZ));
+            expect(gt(pollerDataOnly->droppedSampleCount.load(), 0UZ));
+        }
+    } | std::vector<bool>{true, false};
+
+    "trigger mode - polling/callback overlapping/non-overlapping"_test = [] {
         using namespace gr::tag;
-        constexpr gr::Size_t kSamples = 200000;
+        const std::uint32_t nSamples    = 150000;
+        const std::size_t   preSamples  = 5;
+        const std::size_t   postSamples = 7;
+
+        const std::vector<std::size_t> triggerIndices = {1001, 1001, 1002, 1003, 1003, 1005, 1007, 10000, 10000, 20000};
+        std::vector<Tag>               srcTags;
+        std::uint64_t                  timeCounter = 0;
+        for (std::size_t i : triggerIndices) {
+            // tags should not be identical, duplicates are ignored by Block::inputTags()
+            srcTags.push_back(Tag{i, {{TRIGGER_NAME.shortKey(), "TRIGGER"}, {TRIGGER_TIME.shortKey(), timeCounter++}}});
+        }
+        srcTags.push_back(Tag{21000, {{TRIGGER_NAME.shortKey(), "NO_TRIGGER1"}, {TRIGGER_TIME.shortKey(), timeCounter + 1}}});
+        srcTags.push_back(Tag{21000, {{TRIGGER_NAME.shortKey(), "NO_TRIGGER2"}, {TRIGGER_TIME.shortKey(), timeCounter + 2}}});
+        srcTags.push_back(Tag{22000, {{TRIGGER_NAME.shortKey(), "NO_TRIGGER3"}, {TRIGGER_TIME.shortKey(), timeCounter + 3}}});
 
         gr::Graph testGraph;
-        auto&     src = testGraph.emplaceBlock<gr::testing::TagSource<int32_t>>({{"n_samples_max", kSamples}, {"mark_tag", false}});
+        auto&     src = testGraph.emplaceBlock<gr::testing::TagSource<float>>({{"n_samples_max", nSamples}, {"mark_tag", false}, {"verbose_console", true}, //
+                {SIGNAL_NAME.shortKey(), "TestName"}, {SIGNAL_UNIT.shortKey(), "TestUnit"}, {SIGNAL_QUANTITY.shortKey(), "TestQuantity"}, {SIGNAL_MIN.shortKey(), -2.f}, {SIGNAL_MAX.shortKey(), 2.f}});
 
-        const auto tags = std::vector<Tag>{{3000, {{TRIGGER_NAME.shortKey(), "TRIGGER"}}}, {8000, {{TRIGGER_NAME.shortKey(), "NO_TRIGGER"}}}, {180000, {{TRIGGER_NAME.shortKey(), "TRIGGER"}}}};
-        src._tags       = tags;
-        auto& delay     = testGraph.emplaceBlock<testing::Delay<int32_t>>({{"delay_ms", kProcessingDelayMs}});
-        auto& sink      = testGraph.emplaceBlock<DataSink<int32_t>>({{"name", "test_sink"}, {"signal_name", "test signal"}, {"signal_unit", "none"}, {"signal_min", -2.0f}, {"signal_max", 2.0f}});
+        src._tags   = srcTags;
+        auto& delay = testGraph.emplaceBlock<testing::Delay<float>>({{"delay_ms", kProcessingDelayMs}});
+        auto& sink  = testGraph.emplaceBlock<DataSink<float>>({{"name", "test_sink"}, {"signal_name", "TestName"}});
 
         expect(testGraph.connect<"out", "in">(src, delay).has_value());
         expect(testGraph.connect<"out", "in">(delay, sink).has_value());
 
-        auto polling = std::async([] {
-            auto isTrigger = [](std::string_view /* filterSpec */, const Tag& tag, const property_map& /* filter state */) {
-                const auto v = tag.get(TRIGGER_NAME.shortKey());
-                return v && test::get_value_or_fail<std::string>(v->get()) == "TRIGGER" ? trigger::MatchResult::Matching : trigger::MatchResult::Ignore;
-            };
+        std::mutex         mutexCallback;
+        std::vector<float> receivedDataCallback;
+        std::size_t        nReceivedTagsCallback = 0;
+        auto               callback              = [&receivedDataCallback, &nReceivedTagsCallback, &mutexCallback, timeCounter](auto&& dataset) {
+            std::lock_guard lg{mutexCallback};
+            checkDataSet(dataset, receivedDataCallback, nReceivedTagsCallback, {.nSignalValues = preSamples + postSamples, .timingEventIndex = preSamples, .triggerTimeMax = timeCounter});
+        };
+        auto callbackThread = std::thread([&] { //
+            gr::thread_pool::thread::setThreadName("qa_DS:registerThread");
+            expect(spinUntil(4s, [&] { return globalDataSinkRegistry().registerTriggerCallback<float>(DataSinkQuery::sinkName("test_sink"), isTrigger, preSamples, postSamples, callback); })) << boost::ut::fatal;
+        });
 
-            std::shared_ptr<DataSetPoller<int32_t>> poller;
+        auto polling = std::async([timeCounter, preSamples, postSamples] {
+            std::shared_ptr<DataSetPoller<float>> poller;
             expect(spinUntil(4s, [&] {
-                // lookup by signal name
-                poller = globalDataSinkRegistry().getTriggerPoller<int32_t>(DataSinkQuery::signalName("test signal"), isTrigger, {.preSamples = 3, .postSamples = 2});
+                poller = globalDataSinkRegistry().getTriggerPoller<float>(DataSinkQuery::sinkName("test_sink"), isTrigger, {.preSamples = preSamples, .postSamples = postSamples});
                 return poller != nullptr;
             })) << boost::ut::fatal;
-            std::vector<int32_t>                                 receivedData;
-            std::vector<std::pair<std::ptrdiff_t, property_map>> receivedTags;
-            bool                                                 seenFinished = false;
+            std::vector<float> receivedData;
+            std::size_t        nReceivedTags = 0;
+            bool               seenFinished  = false;
             while (!seenFinished) {
-                seenFinished            = poller->finished;
-                [[maybe_unused]] auto r = poller->process([&receivedData, &receivedTags](const auto& datasets) {
+                seenFinished = poller->finished.load();
+                while (poller->process([&receivedData, &nReceivedTags, timeCounter, preSamples, postSamples](const auto& datasets) {
                     for (const auto& dataset : datasets) {
-                        receivedData.insert(receivedData.end(), dataset.signal_values.begin(), dataset.signal_values.end());
-                        std::expected<void, gr::Error> dsCheck = dataset::checkConsistency(dataset, "dataset - blocking polling trigger mode non-overlapping");
-                        expect(dsCheck.has_value()) << [&] { return std::format("unexpected: {}", dsCheck.error()); } << fatal;
-                        expect(eq(dataset.size(), 1UZ)) << "DataSink supports only 1 signal per DataSet<T> (for the time being)";
-
-                        // signal info from sink settings
-                        expect(eq(dataset.signalName(0UZ), "test signal"s));
-                        expect(eq(dataset.signalUnit(0UZ), "none"s));
-                        expect(eq(dataset.signalRange(0UZ), gr::Range<std::int32_t>{-2, +2}));
-                        expect(eq(dataset.timingEvents(0UZ).size(), 1UZ));
-                        expect(eq(dataset.timingEvents(0UZ)[0UZ].first, 3));
-                        receivedTags.insert(receivedTags.end(), dataset.timingEvents(0UZ).begin(), dataset.timingEvents(0UZ).end());
+                        checkDataSet(dataset, receivedData, nReceivedTags, {.nSignalValues = preSamples + postSamples, .timingEventIndex = preSamples, .triggerTimeMax = timeCounter});
                     }
-                });
+                })) {
+                }
             }
-            return std::make_tuple(poller, receivedData, receivedTags);
+            return std::make_tuple(poller, receivedData, nReceivedTags);
         });
 
         Scheduler sched;
@@ -523,140 +495,94 @@ const boost::ut::suite DataSinkTests = [] {
             throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
         }
         expect(sched.runAndWait().has_value());
+        callbackThread.join();
 
-        const auto& [poller, receivedData, receivedTags] = polling.get();
-        const auto expected_tags                         = {tags[0UZ], tags[2UZ]}; // triggers-only
+        expect(eq(src._nSamplesProduced, nSamples));
 
-        expect(eq(receivedData.size(), 10UZ));
-        expect(eq(receivedData, std::vector<int32_t>{2997, 2998, 2999, 3000, 3001, 179997, 179998, 179999, 180000, 180001}));
-        expect(eq(receivedTags.size(), expected_tags.size()));
+        const auto& [poller, receivedData, nReceivedTags] = polling.get();
+        expect(eq(poller->dropCount.load(), 0u));
 
-        expect(eq(poller->dropCount.load(), 0UZ));
-    };
-
-    "propagation of signal metadata per data set"_test = [] {
-        using namespace gr::tag;
-        constexpr gr::Size_t kSamples = 40000000;
-
-        gr::Graph  testGraph;
-        auto&      src  = testGraph.emplaceBlock<gr::testing::TagSource<int32_t>>({{"n_samples_max", kSamples}, {"mark_tag", false}, {"signal_name", "test signal"}, {"signal_unit", "no unit"}, {"signal_min", -2.f}, {"signal_max", 2.f}});
-        const auto tags = std::vector<Tag>{{39000000, {{TRIGGER_NAME.shortKey(), "TRIGGER"}}}};
-        src._tags       = tags;
-        auto& delay     = testGraph.emplaceBlock<testing::Delay<int32_t>>({{"delay_ms", kProcessingDelayMs}});
-        auto& sink      = testGraph.emplaceBlock<DataSink<int32_t>>({{"signal_name", "test signal"}});
-
-        expect(testGraph.connect<"out", "in">(src, delay).has_value());
-        expect(testGraph.connect<"out", "in">(delay, sink).has_value());
-
-        auto polling = std::async([] {
-            std::vector<int32_t>                                 receivedData;
-            std::vector<std::pair<std::ptrdiff_t, property_map>> receivedTags;
-            bool                                                 seenFinished = false;
-
-            auto isTrigger = [](std::string_view /* filterSpec */, const Tag& tag, const property_map& /* filter state */) {
-                const auto type = tag.get(TRIGGER_NAME.shortKey());
-                return (type && test::get_value_or_fail<std::string>(type->get()) == "TRIGGER") ? trigger::MatchResult::Matching : trigger::MatchResult::Ignore;
-            };
-            std::shared_ptr<DataSetPoller<int32_t>> poller;
-            expect(spinUntil(4s, [&] {
-                poller = globalDataSinkRegistry().getTriggerPoller<int32_t>(DataSinkQuery::signalName("test signal"), isTrigger, {.preSamples = 0UZ, .postSamples = 2UZ});
-                return poller != nullptr;
-            })) << boost::ut::fatal;
-
-            if (!poller) {
-                return std::make_tuple(poller, receivedData, receivedTags);
+        std::vector<float> expectedData;
+        expectedData.reserve(triggerIndices.size() * (preSamples + postSamples));
+        for (std::size_t i : triggerIndices) {
+            for (std::size_t k = i - preSamples; k < i + postSamples; k++) {
+                expectedData.push_back(static_cast<float>(k));
             }
-
-            while (!seenFinished) {
-                seenFinished            = poller->finished;
-                [[maybe_unused]] auto r = poller->process([&receivedData, &receivedTags](const auto& datasets) {
-                    for (const auto& dataset : datasets) {
-                        receivedData.insert(receivedData.end(), dataset.signal_values.begin(), dataset.signal_values.end());
-                        std::expected<void, gr::Error> dsCheck = dataset::checkConsistency(dataset, "DataSet");
-                        expect(dsCheck.has_value()) << [&] { return std::format("unexpected: {}", dsCheck.error()); } << fatal;
-                        expect(eq(dataset.size(), 1UZ)) << "DataSink supports only 1 signal per DataSet<T> (for the time being)";
-
-                        // signal info from sink settings
-                        expect(eq(dataset.signalName(0UZ), "test signal"s));
-                        expect(eq(dataset.signalUnit(0UZ), "no unit"s));
-                        expect(eq(dataset.signalRange(0UZ), gr::Range<std::int32_t>{-2, +2}));
-                        expect(eq(dataset.timingEvents(0UZ).size(), 1UZ));
-                        expect(eq(dataset.timingEvents(0UZ)[0UZ].first, 0));
-                        receivedTags.insert(receivedTags.end(), dataset.timingEvents(0UZ).begin(), dataset.timingEvents(0UZ).end());
-                    }
-                });
-            }
-            return std::make_tuple(poller, receivedData, receivedTags);
-        });
-
-        Scheduler sched;
-        if (auto ret = sched.exchange(std::move(testGraph)); !ret) {
-            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
         }
-        expect(sched.runAndWait().has_value());
 
-        const auto& [_, receivedData, receivedTags] = polling.get();
-        expect(eq(receivedData, std::vector<int32_t>{39000000, 39000001}));
+        // polling
+        expect(eq(receivedData.size(), triggerIndices.size() * (preSamples + postSamples)));
+        expect(eq(receivedData, expectedData));
+        expect(eq(nReceivedTags, triggerIndices.size()));
+
+        // callback
+        expect(eq(receivedDataCallback.size(), triggerIndices.size() * (preSamples + postSamples)));
+        expect(eq(receivedDataCallback, expectedData));
+        expect(eq(nReceivedTagsCallback, triggerIndices.size()));
     };
 
-    "blocking snapshot mode"_test = [] {
+    "snapshot mode - polling/callback"_test = [] {
         using namespace gr::tag;
-        constexpr gr::Size_t kSamples = 200000;
+        constexpr gr::Size_t kSamples      = 200000;
+        constexpr float      kSampleRate   = 10000.f;
+        constexpr auto       kDelay        = std::chrono::milliseconds{500}; // sample rate 10000 -> 5000 samples
+        const double         seconds       = std::chrono::duration<double>(kDelay).count();
+        const std::size_t    nSamplesDelay = static_cast<std::size_t>(seconds * static_cast<double>(kSampleRate));
+
+        const std::vector<std::size_t> triggerIndices = {1001, 1001, 1002, 1003, 1003, 1005, 1007, 10000, 10000, 20000};
+        std::vector<Tag>               srcTags;
+        std::uint64_t                  timeCounter = 0;
+        for (std::size_t i : triggerIndices) {
+            srcTags.push_back(Tag{i, {{TRIGGER_NAME.shortKey(), "TRIGGER"}, {TRIGGER_TIME.shortKey(), timeCounter++}}});
+        }
+        srcTags.push_back(Tag{21000, {{TRIGGER_NAME.shortKey(), "NO_TRIGGER1"}, {TRIGGER_TIME.shortKey(), timeCounter + 1}}});
+        srcTags.push_back(Tag{21000, {{TRIGGER_NAME.shortKey(), "NO_TRIGGER2"}, {TRIGGER_TIME.shortKey(), timeCounter + 2}}});
+        srcTags.push_back(Tag{22000, {{TRIGGER_NAME.shortKey(), "NO_TRIGGER3"}, {TRIGGER_TIME.shortKey(), timeCounter + 3}}});
 
         gr::Graph testGraph;
-        auto&     src = testGraph.emplaceBlock<gr::testing::TagSource<int32_t>>({{"n_samples_max", kSamples}, {"mark_tag", false}, {gr::tag::SAMPLE_RATE.shortKey(), 10000.f}, {"signal_name", "test signal"}, {"signal_unit", "none"}, {"signal_min", 0.f}, {"signal_max", static_cast<float>(kSamples - 1)}});
-        src._tags     = {{3000, {{TRIGGER_NAME.shortKey(), "TRIGGER"}}}, {8000, {{TRIGGER_NAME.shortKey(), "NO_TRIGGER"}}}, {180000, {{TRIGGER_NAME.shortKey(), "TRIGGER"}}}};
-        auto& delay   = testGraph.emplaceBlock<testing::Delay<int32_t>>({{"delay_ms", kProcessingDelayMs}});
-        auto& sink    = testGraph.emplaceBlock<DataSink<int32_t>>({{"name", "test_sink"}, {"signal_name", "test signal"}});
+        auto&     src = testGraph.emplaceBlock<gr::testing::TagSource<float>>({{"n_samples_max", kSamples}, {"mark_tag", false},                                                 //
+                {SAMPLE_RATE.shortKey(), kSampleRate}, {SIGNAL_NAME.shortKey(), "TestName"}, {SIGNAL_UNIT.shortKey(), "TestUnit"}, {SIGNAL_QUANTITY.shortKey(), "TestQuantity"}, //
+                {SIGNAL_MIN.shortKey(), 0.f}, {SIGNAL_MAX.shortKey(), static_cast<float>(kSamples - 1)}});
+        src._tags     = srcTags;
+        auto& delay   = testGraph.emplaceBlock<testing::Delay<float>>({{"delay_ms", kProcessingDelayMs}});
+        auto& sink    = testGraph.emplaceBlock<DataSink<float>>({{"name", "test_sink"}, {SIGNAL_NAME.shortKey(), "TestName"}});
 
         expect(testGraph.connect<"out", "in">(src, delay).has_value());
         expect(testGraph.connect<"out", "in">(delay, sink).has_value());
 
-        constexpr auto kDelay = std::chrono::milliseconds{500}; // sample rate 10000 -> 5000 samples
+        DataSetTestParams dataSetTestParams = {.nSignalValues = 1, .rangeMin = 0.f, .rangeMax = static_cast<float>(kSamples - 1.), .timingEventIndex = -static_cast<std::ptrdiff_t>(nSamplesDelay), .triggerTimeMax = timeCounter};
 
-        std::vector<int32_t> receivedDataCb;
-
-        auto callback = [&receivedDataCb](const auto& dataset) { receivedDataCb.insert(receivedDataCb.end(), dataset.signal_values.begin(), dataset.signal_values.end()); };
-
-        auto isTrigger = [](std::string_view /* filterSpec */, const Tag& tag, const property_map& /* filter state */) {
-            const auto v = tag.get(TRIGGER_NAME.shortKey());
-            return (v && test::get_value_or_fail<std::string>(v->get()) == "TRIGGER") ? trigger::MatchResult::Matching : trigger::MatchResult::Ignore;
+        std::vector<float> receivedDataCallback;
+        std::size_t        nReceivedTagsCallback = 0;
+        auto               callback              = [&receivedDataCallback, &nReceivedTagsCallback, &dataSetTestParams](const auto& dataset) { //
+            checkDataSet(dataset, receivedDataCallback, nReceivedTagsCallback, dataSetTestParams);
         };
 
-        auto registerThread = std::thread([&] {
+        auto callbackThread = std::thread([&] {
             gr::thread_pool::thread::setThreadName("qa_DS:registerThread");
-            expect(spinUntil(4s, [&] { return globalDataSinkRegistry().registerSnapshotCallback<int32_t>(DataSinkQuery::sinkName("test_sink"), isTrigger, kDelay, callback); })) << boost::ut::fatal;
+            expect(spinUntil(4s, [&] { return globalDataSinkRegistry().registerSnapshotCallback<float>(DataSinkQuery::sinkName("test_sink"), isTrigger, kDelay, callback); })) << boost::ut::fatal;
         });
 
-        auto poller_result = std::async([isTrigger, kDelay] {
-            std::shared_ptr<DataSetPoller<int32_t>> poller;
+        auto polling = std::async([kDelay, &dataSetTestParams] {
+            std::shared_ptr<DataSetPoller<float>> poller;
             expect(spinUntil(4s, [&] {
-                poller = globalDataSinkRegistry().getSnapshotPoller<int32_t>(DataSinkQuery::sinkName("test_sink"), isTrigger, {.delay = kDelay});
+                poller = globalDataSinkRegistry().getSnapshotPoller<float>(DataSinkQuery::sinkName("test_sink"), isTrigger, {.delay = kDelay});
                 return poller != nullptr;
             })) << boost::ut::fatal;
 
-            std::vector<int32_t> receivedData;
+            std::vector<float> receivedData;
+            std::size_t        nReceivedTags = 0;
 
             bool seenFinished = false;
             while (!seenFinished) {
                 seenFinished            = poller->finished;
-                [[maybe_unused]] auto r = poller->process([&receivedData](const auto& datasets) {
+                [[maybe_unused]] auto r = poller->process([&receivedData, &nReceivedTags, &dataSetTestParams](const auto& datasets) {
                     for (const auto& dataset : datasets) {
-                        std::expected<void, gr::Error> dsCheck = dataset::checkConsistency(dataset, "dataset blocking snapshot mode");
-                        expect(dsCheck.has_value()) << [&] { return std::format("unexpected: {}", dsCheck.error()); } << fatal;
-                        expect(eq(dataset.size(), 1UZ)) << "DataSink supports only 1 signal per DataSet<T> (for the time being)";
-
-                        // signal info propagated from source to sink
-                        expect(eq(dataset.signalName(0UZ), "test signal"s));
-                        expect(eq(dataset.signalUnit(0UZ), "none"s));
-                        expect(eq(dataset.signalRange(0UZ), gr::Range<int32_t>{0, kSamples - 1}));
-                        expect(eq(dataset.timingEvents(0UZ)[0UZ].first, -5000));
-                        receivedData.insert(receivedData.end(), dataset.signal_values.begin(), dataset.signal_values.end());
+                        checkDataSet(dataset, receivedData, nReceivedTags, dataSetTestParams);
                     }
                 });
             }
-
-            return std::make_tuple(poller, receivedData);
+            return std::make_tuple(poller, receivedData, nReceivedTags);
         });
 
         Scheduler sched;
@@ -664,26 +590,37 @@ const boost::ut::suite DataSinkTests = [] {
             throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
         }
         expect(sched.runAndWait().has_value());
+        callbackThread.join();
 
-        registerThread.join();
+        expect(eq(src._nSamplesProduced, kSamples));
 
-        const auto& [poller, receivedData] = poller_result.get();
-        expect(eq(receivedDataCb, receivedData));
-        expect(eq(receivedData, std::vector<int32_t>{8000, 185000}));
-        expect(eq(poller->dropCount.load(), 0UZ));
+        const auto& [poller, receivedData, nReceivedTags] = polling.get();
+        expect(eq(poller->dropCount.load(), 0u));
+
+        std::vector<float> expectedData;
+        std::ranges::transform(triggerIndices, std::back_inserter(expectedData), [nSamplesDelay](std::size_t i) { return static_cast<float>(i + nSamplesDelay); });
+
+        // polling
+        expect(eq(receivedData.size(), triggerIndices.size()));
+        expect(eq(receivedData, expectedData));
+        expect(eq(nReceivedTags, triggerIndices.size()));
+
+        // callback
+        expect(eq(receivedDataCallback.size(), triggerIndices.size()));
+        expect(eq(receivedDataCallback, expectedData));
+        expect(eq(nReceivedTagsCallback, triggerIndices.size()));
     };
 
-    "blocking multiplexed mode"_test = [] {
+    "multiplexed mode - blocking polling"_test = [] {
         // Use large delay and timeout to ensure this also works in debug/coverage builds
         const auto tags = makeTestTags(0, 10000);
 
         const gr::Size_t n_samples = static_cast<gr::Size_t>(tags.size() * 10000 + 100000);
         gr::Graph        testGraph;
-        auto&            src                           = testGraph.emplaceBlock<gr::testing::TagSource<int32_t>>({{"n_samples_max", n_samples}, {"mark_tag", false}});
-        src._tags                                      = tags;
-        auto&                    delay                 = testGraph.emplaceBlock<testing::Delay<int32_t>>({{"delay_ms", 2500u}});
-        std::vector<std::string> customAutoForwardKeys = {"DAY", "MONTH", "YEAR"};
-        delay.settings().autoForwardParameters().insert(customAutoForwardKeys.begin(), customAutoForwardKeys.end());
+        auto&            src = testGraph.emplaceBlock<gr::testing::TagSource<int32_t>>({{"n_samples_max", n_samples}, {"mark_tag", false}});
+        src._tags            = tags;
+        auto& delay          = testGraph.emplaceBlock<testing::Delay<int32_t>>({{"delay_ms", 2500u}});
+        delay.settings().autoForwardParameters().insert({"DAY", "MONTH", "YEAR"}); // custom auto forward keys
         auto& sink = testGraph.emplaceBlock<DataSink<int32_t>>({{"name", "test_sink"}, {"signal_name", "test signal"}});
 
         expect(testGraph.connect<"out", "in">(src, delay).has_value());
@@ -772,165 +709,7 @@ const boost::ut::suite DataSinkTests = [] {
         }
     };
 
-    "blocking polling trigger mode overlapping"_test = [] {
-        using namespace gr::tag;
-        constexpr std::uint32_t kSamples  = 150000;
-        constexpr std::size_t   kTriggers = 300;
-
-        gr::Graph testGraph;
-        auto&     src = testGraph.emplaceBlock<gr::testing::TagSource<float>>({{"n_samples_max", kSamples}, {"mark_tag", false}});
-
-        for (std::size_t i = 0; i < kTriggers; ++i) {
-            src._tags.push_back(Tag{60000UZ + i, {{TRIGGER_NAME.shortKey(), "TRIGGER"}}});
-        }
-
-        auto& delay = testGraph.emplaceBlock<testing::Delay<float>>({{"delay_ms", kProcessingDelayMs}});
-        auto& sink  = testGraph.emplaceBlock<DataSink<float>>({{"name", "test_sink"}, {"signal_name", "test signal"}});
-
-        expect(testGraph.connect<"out", "in">(src, delay).has_value());
-        expect(testGraph.connect<"out", "in">(delay, sink).has_value());
-
-        auto polling = std::async([] {
-            auto isTrigger = [](std::string_view /* filterSpec */, const Tag&, const property_map& /* filter state */) { return trigger::MatchResult::Matching; };
-
-            std::shared_ptr<DataSetPoller<float>> poller;
-            expect(spinUntil(4s, [&] {
-                poller = globalDataSinkRegistry().getTriggerPoller<float>(DataSinkQuery::sinkName("test_sink"), isTrigger, {.preSamples = 3000, .postSamples = 2000});
-                return poller != nullptr;
-            })) << boost::ut::fatal;
-            std::vector<float> receivedData;
-            std::vector<Tag>   receivedTags;
-            bool               seenFinished = false;
-            while (!seenFinished) {
-                seenFinished = poller->finished.load();
-                while (poller->process([&receivedData, &receivedTags](const auto& datasets) {
-                    for (const auto& dataset : datasets) {
-                        std::expected<void, gr::Error> dsCheck = dataset::checkConsistency(dataset, "dataset - blocking polling trigger mode overlapping");
-                        expect(dsCheck.has_value()) << [&] { return std::format("unexpected: {}", dsCheck.error()); } << fatal;
-                        expect(eq(dataset.size(), 1UZ)) << "DataSink supports only 1 signal per DataSet<T> (for the time being)";
-
-                        expect(eq(dataset.signal_values.size(), 5000u) >> fatal);
-                        receivedData.push_back(dataset.signal_values.front());
-                        receivedData.push_back(dataset.signal_values.back());
-                        expect(eq(dataset.timingEvents(0UZ).size(), 1UZ));
-                        expect(eq(dataset.timingEvents(0UZ)[0UZ].first, 3000));
-                        auto absolute = dataset.timingEvents(0UZ) | std::views::transform([&receivedData](const auto& t) { return gr::Tag{checkedSum(receivedData.size(), t.first), t.second}; });
-                        receivedTags.insert(receivedTags.end(), absolute.begin(), absolute.end());
-                    }
-                })) {
-                }
-            }
-            return std::make_tuple(poller, receivedData, receivedTags);
-        });
-
-        Scheduler sched;
-        if (auto ret = sched.exchange(std::move(testGraph)); !ret) {
-            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
-        }
-        expect(sched.runAndWait().has_value());
-
-        const auto& [poller, receivedData, receivedTags] = polling.get();
-        auto expectedStart                               = std::vector<float>{57000, 61999, 57001, 62000, 57002};
-        expect(eq(poller->dropCount.load(), 0u));
-        expect(eq(receivedData.size(), 2 * kTriggers) >> fatal);
-        expect(eq(std::vector(receivedData.begin(), receivedData.begin() + 5), expectedStart));
-        expect(eq(receivedTags.size(), kTriggers));
-    };
-
-    "callback trigger mode overlapping"_test = [] {
-        using namespace gr::tag;
-        constexpr std::uint32_t kSamples  = 150000;
-        constexpr std::size_t   kTriggers = 300;
-
-        gr::Graph testGraph;
-        auto&     src = testGraph.emplaceBlock<gr::testing::TagSource<float>>({{"n_samples_max", kSamples}, {"mark_tag", false}});
-
-        for (std::size_t i = 0; i < kTriggers; ++i) {
-            src._tags.push_back(Tag{60000UZ + i, {{TRIGGER_NAME.shortKey(), "TRIGGER"}}});
-        }
-
-        auto& delay = testGraph.emplaceBlock<testing::Delay<float>>({{"delay_ms", kProcessingDelayMs}});
-        auto& sink  = testGraph.emplaceBlock<DataSink<float>>({{"name", "test_sink"}, {"signal_name", "test signal"}});
-
-        expect(testGraph.connect<"out", "in">(src, delay).has_value());
-        expect(testGraph.connect<"out", "in">(delay, sink).has_value());
-
-        auto isTrigger = [](std::string_view /* filterSpec */, const Tag&, const property_map& /* filter state */) { return trigger::MatchResult::Matching; };
-
-        std::mutex         m;
-        std::vector<float> receivedData;
-
-        auto callback = [&receivedData, &m](auto&& dataset) {
-            std::lock_guard lg{m};
-            expect(eq(dataset.signal_values.size(), 5000u));
-            receivedData.push_back(dataset.signal_values.front());
-            receivedData.push_back(dataset.signal_values.back());
-        };
-
-        auto registerThread = std::thread([&] { //
-            gr::thread_pool::thread::setThreadName("qa_DS:registerThread");
-            expect(spinUntil(4s, [&] { return globalDataSinkRegistry().registerTriggerCallback<float>(DataSinkQuery::sinkName("test_sink"), isTrigger, 3000, 2000, callback); })) << boost::ut::fatal;
-        });
-
-        Scheduler sched;
-        if (auto ret = sched.exchange(std::move(testGraph)); !ret) {
-            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
-        }
-        expect(sched.runAndWait().has_value());
-        registerThread.join();
-
-        std::lock_guard lg{m};
-        auto            expectedStart = std::vector<float>{57000, 61999, 57001, 62000, 57002};
-        expect(eq(receivedData.size(), 2 * kTriggers));
-        expect(eq(std::vector(receivedData.begin(), receivedData.begin() + 5), expectedStart));
-    };
-
-    "non-blocking polling continuous mode"_test = [] {
-        constexpr std::uint32_t kSamples = 200000;
-
-        gr::Graph testGraph;
-        auto&     src   = testGraph.emplaceBlock<gr::testing::TagSource<float>>({{"n_samples_max", kSamples}, {"mark_tag", false}});
-        auto&     delay = testGraph.emplaceBlock<testing::Delay<float>>({{"delay_ms", kProcessingDelayMs}});
-        auto&     sink  = testGraph.emplaceBlock<DataSink<float>>({{"name", "test_sink"}, {"signal_name", "test signal"}});
-
-        expect(testGraph.connect<"out", "in">(src, delay).has_value());
-        expect(testGraph.connect<"out", "in">(delay, sink).has_value());
-
-        auto invalid_type_poller = globalDataSinkRegistry().getStreamingPoller<double>(DataSinkQuery::sinkName("test_sink"));
-        expect(eq(invalid_type_poller, nullptr));
-
-        auto polling = std::async([] {
-            std::shared_ptr<StreamingPoller<float>> poller;
-            expect(spinUntil(4s, [&poller] {
-                poller = globalDataSinkRegistry().getStreamingPoller<float>(DataSinkQuery::sinkName("test_sink"));
-                return poller != nullptr;
-            })) << boost::ut::fatal;
-
-            std::size_t samplesSeen  = 0;
-            bool        seenFinished = false;
-            while (!seenFinished) {
-                using namespace std::chrono_literals;
-                std::this_thread::sleep_for(20ms);
-
-                seenFinished = poller->finished.load();
-                while (poller->process([&samplesSeen](const auto& data) { samplesSeen += data.size(); })) {
-                }
-            }
-
-            return std::make_tuple(poller, samplesSeen);
-        });
-
-        Scheduler sched;
-        if (auto ret = sched.exchange(std::move(testGraph)); !ret) {
-            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
-        }
-        expect(sched.runAndWait().has_value());
-
-        const auto& [poller, samplesSeen] = polling.get();
-        expect(eq(samplesSeen + poller->dropCount, static_cast<std::size_t>(kSamples)));
-    };
-
-    "data set poller"_test = [] {
+    "DataSet - polling"_test = [] {
         gr::Graph testGraph;
         auto&     source          = testGraph.emplaceBlock<testing::TagSource<float, testing::ProcessFunction::USE_PROCESS_BULK>>({{"n_samples_max", static_cast<gr::Size_t>(1024)}, {"signal_name", "test signal"}, {"signal_unit", "test unit"}, {"mark_tag", false}});
         auto&     delay           = testGraph.emplaceBlock<testing::Delay<float>>({{"delay_ms", kProcessingDelayMs}});
@@ -989,7 +768,7 @@ const boost::ut::suite DataSinkTests = [] {
         expect(eq(receivedDataSets[1UZ].timingEvents(0UZ)[0UZ].first, 100));
     };
 
-    "data set callback"_test = [] {
+    "DataSet - callback"_test = [] {
         gr::Graph testGraph;
         auto&     source          = testGraph.emplaceBlock<testing::TagSource<float, testing::ProcessFunction::USE_PROCESS_BULK>>({{"n_samples_max", static_cast<gr::Size_t>(1024)}, {"signal_name", "test signal"}, {"signal_unit", "test unit"}, {"mark_tag", false}});
         auto&     delay           = testGraph.emplaceBlock<testing::Delay<float>>({{"delay_ms", kProcessingDelayMs}});

--- a/blocks/basic/test/qa_StreamToDataSet.cpp
+++ b/blocks/basic/test/qa_StreamToDataSet.cpp
@@ -12,6 +12,11 @@
 
 #include <boost/ut.hpp>
 
+#include <initializer_list>
+#include <limits>
+#include <source_location>
+#include <string_view>
+
 const boost::ut::suite<"StreamToDataSet Block"> selectorTest = [] {
     using namespace boost::ut;
 
@@ -125,10 +130,88 @@ const boost::ut::suite<"StreamToDataSet Block"> selectorTest = [] {
     tag("visual") / "single trigger"_test              = [&runUIExample] { runUIExample(10, "CMD_DIAG_TRIGGER1", 30, 30); };
 };
 
-gr::Tag genTrigger(std::size_t index, std::string triggerName, std::string triggerCtx = {}) {
-    return {index, {{gr::tag::TRIGGER_NAME.shortKey(), triggerName}, {gr::tag::TRIGGER_TIME.shortKey(), std::uint64_t(0)}, {gr::tag::TRIGGER_OFFSET.shortKey(), 0.f}, //
-                       {gr::tag::CONTEXT.shortKey(), triggerCtx},                                                                                                     //
+inline std::uint64_t gTriggerTimeCounter = 0UZ;
+inline std::uint64_t nextTriggerTime() { return gTriggerTimeCounter++; }
+inline void          resetTriggerTime(std::uint64_t v = 0UZ) { gTriggerTimeCounter = v; }
+
+gr::Tag genTrigger(std::size_t index, std::string triggerName, std::string triggerCtx, std::uint64_t triggerTime) {
+    return {index, {{gr::tag::TRIGGER_NAME.shortKey(), triggerName}, {gr::tag::TRIGGER_TIME.shortKey(), triggerTime}, {gr::tag::TRIGGER_OFFSET.shortKey(), 0.f}, //
+                       {gr::tag::CONTEXT.shortKey(), triggerCtx},                                                                                                //
                        {gr::tag::TRIGGER_META_INFO.shortKey(), gr::property_map{}}}};
+};
+
+gr::Tag genTrigger(std::size_t index, std::string triggerName, std::string triggerCtx = {}) { return genTrigger(index, std::move(triggerName), std::move(triggerCtx), nextTriggerTime()); }
+
+gr::Tag genStart(std::size_t index, std::uint64_t triggerTime = std::numeric_limits<std::uint64_t>::max()) { return genTrigger(index, "CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=1", triggerTime == std::numeric_limits<std::uint64_t>::max() ? nextTriggerTime() : triggerTime); }
+
+gr::Tag genStop(std::size_t index, std::uint64_t triggerTime = std::numeric_limits<std::uint64_t>::max()) { return genTrigger(index, "CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=2", triggerTime == std::numeric_limits<std::uint64_t>::max() ? nextTriggerTime() : triggerTime); }
+
+gr::Tag genSingle(std::size_t index, std::uint64_t triggerTime = std::numeric_limits<std::uint64_t>::max()) { return genTrigger(index, "CMD_DIAG_TRIGGER1", "", triggerTime == std::numeric_limits<std::uint64_t>::max() ? nextTriggerTime() : triggerTime); }
+
+gr::Tag genNoTrigger(std::size_t index, std::uint64_t triggerTime = std::numeric_limits<std::uint64_t>::max()) { return genTrigger(index, "NO_TRIGGER", "", triggerTime == std::numeric_limits<std::uint64_t>::max() ? nextTriggerTime() : triggerTime); }
+
+gr::Tag sampleRateTag(std::size_t index) { return {index, {{"sample_rate", 1000.f}}}; }
+
+gr::Tag mergedAutoForwardTag(std::size_t index, std::initializer_list<gr::Tag> tags) {
+    gr::property_map merged;
+    for (const gr::Tag& tag : tags) {
+        for (const auto& [key, value] : tag.map) {
+            merged.insert_or_assign(key, value);
+        }
+    }
+    return {index, std::move(merged)};
+}
+
+void printTagList(std::string_view label, const std::vector<gr::Tag>& tags) {
+    std::println("{} tags ({}):", label, tags.size());
+    for (const gr::Tag& tag : tags) {
+        gr::testing::print_tag(tag, "  ");
+    }
+}
+
+void runTestStream(gr::Size_t nSamples, std::string filter, gr::Size_t preSamples, gr::Size_t postSamples, const std::vector<float>& expectedValues, const std::vector<gr::Tag>& expectedTags, std::source_location srcLocation = std::source_location::current()) {
+    using namespace boost::ut;
+    using namespace gr;
+    using namespace gr::basic;
+    using namespace gr::testing;
+
+    const auto locationStr = std::format("{}:{} ", srcLocation.file_name(), srcLocation.line());
+
+    constexpr float sampleRate = 1'000.f;
+    Graph           graph;
+
+    auto& tagSrc = graph.emplaceBlock<TagSource<float, ProcessFunction::USE_PROCESS_BULK>>({{"sample_rate", sampleRate}, //
+        {"n_samples_max", nSamples}, {"name", "TagSource"}, {"verbose_console", false}, {"repeat_tags", false}, {"mark_tag", false}});
+
+    resetTriggerTime();
+    tagSrc._tags = {genNoTrigger(2), genSingle(4), genStart(5), genSingle(8), genStop(10), genSingle(12), genStart(15), genStop(20), genSingle(22)};
+
+    const property_map blockSettings        = {{"filter", filter}, {"n_pre", preSamples}, {"n_post", postSamples}};
+    auto&              filterStreamToStream = graph.emplaceBlock<StreamFilter<float>>(blockSettings);
+    auto&              streamSink           = graph.emplaceBlock<TagSink<float, ProcessFunction::USE_PROCESS_BULK>>({{"name", "streamSink"}, {"log_tags", true}, {"log_samples", true}, {"verbose_console", false}});
+    expect(graph.connect<"out", "in">(tagSrc, filterStreamToStream).has_value()) << locationStr;
+    expect(graph.connect<"out", "in">(filterStreamToStream, streamSink).has_value()) << locationStr;
+
+    gr::scheduler::Simple sched;
+    if (auto ret = sched.exchange(std::move(graph)); !ret) {
+        throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+    }
+    std::println("start -> Stream-to-Stream with filter: {} n_pre:{} n_post:{}", filter, preSamples, postSamples);
+    expect(sched.runAndWait().has_value()) << std::format("runAndWait - filter {}", filter) << locationStr;
+    std::println("done -> Stream-to-Stream with filter: {} n_pre:{} n_post:{}", filter, preSamples, postSamples);
+
+    expect(eq(tagSrc.sample_rate, sampleRate)) << locationStr;
+    expect(eq(filterStreamToStream.sample_rate, sampleRate)) << locationStr;
+    expect(eq(streamSink.sample_rate, sampleRate)) << locationStr;
+
+    expect(eq(streamSink._samples.size(), expectedValues.size())) << locationStr;
+    expect(std::ranges::equal(streamSink._samples, expectedValues)) << locationStr;
+    const bool tagsMatch = equal_tag_lists(streamSink._tags, expectedTags);
+    if (!tagsMatch) {
+        printTagList("actual", streamSink._tags);
+        printTagList("expected", expectedTags);
+    }
+    expect(tagsMatch) << locationStr;
 };
 
 const boost::ut::suite<"StreamToStream test"> streamToStreamTest = [] {
@@ -137,66 +220,156 @@ const boost::ut::suite<"StreamToStream test"> streamToStreamTest = [] {
     using namespace gr::basic;
     using namespace gr::testing;
 
-    auto runTestStream = [](gr::Size_t nSamples, std::string filter, gr::Size_t preSamples, gr::Size_t postSamples, const std::vector<float>& expectedValues, std::size_t nTags) {
-        constexpr float sample_rate = 1'000.f;
-        Graph           graph;
-
-        auto& tagSrc = graph.emplaceBlock<TagSource<float, ProcessFunction::USE_PROCESS_BULK>>({{"sample_rate", sample_rate}, //
-            {"n_samples_max", nSamples}, {"name", "TagSource"}, {"verbose_console", false}, {"repeat_tags", false}, {"mark_tag", false}});
-        tagSrc._tags = {
-            genTrigger(5, "CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=1"),  // start
-            genTrigger(8, "CMD_DIAG_TRIGGER1", ""),                      // it is also used to split samples processing into 2 iterations
-            genTrigger(10, "CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=2"), // stop
-            genTrigger(12, "CMD_DIAG_TRIGGER1", ""),                     // it is also used as end trigger for "including" mode
-            genTrigger(15, "CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=1"), // start
-            genTrigger(20, "CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=2"), // stop
-            genTrigger(22, "CMD_DIAG_TRIGGER1", "")                      // it is also used as end trigger for "including" mode
-        };
-
-        const property_map blockSettings        = {{"filter", filter}, {"n_pre", preSamples}, {"n_post", postSamples}};
-        auto&              filterStreamToStream = graph.emplaceBlock<StreamFilter<float>>(blockSettings);
-        auto&              streamSink           = graph.emplaceBlock<TagSink<float, ProcessFunction::USE_PROCESS_ONE>>({{"name", "streamSink"}, {"log_tags", true}, {"log_samples", true}, {"verbose_console", false}});
-        expect(graph.connect<"out", "in">(tagSrc, filterStreamToStream).has_value());
-        expect(graph.connect<"out", "in">(filterStreamToStream, streamSink).has_value());
-
-        gr::scheduler::Simple sched;
-        if (auto ret = sched.exchange(std::move(graph)); !ret) {
-            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
-        }
-        std::println("start -> Stream-to-Stream with filter: {} n_pre:{} n_post:{}", filter, preSamples, postSamples);
-        expect(sched.runAndWait().has_value()) << std::format("runAndWait - filter {}", filter);
-        std::println("done -> Stream-to-Stream with filter: {} n_pre:{} n_post:{}", filter, preSamples, postSamples);
-
-        expect(eq(tagSrc.sample_rate, sample_rate));
-        expect(eq(filterStreamToStream.sample_rate, sample_rate));
-        expect(eq(streamSink.sample_rate, sample_rate));
-
-        expect(eq(streamSink._samples.size(), expectedValues.size()));
-        expect(std::ranges::equal(streamSink._samples, expectedValues));
-
-        expect(eq(streamSink._tags.size(), nTags)) << [&]() {
-            std::string ret = std::format("Stream nTags: {}\n", streamSink._tags.size());
-            for (const auto& tag : streamSink._tags) {
-                ret += std::format("tag.index: {} .map: {}\n", tag.index, tag.map);
-            }
-            return ret;
-        }();
-    };
     // We always test scenarios where no overlaps occur. If accumulation is currently active in the block, no new "Start" should happen.
     // Any new Start events are ignored, and this behavior is considered undefined for stream-to-stream mode
-    std::vector<float> expectedValues                = {5, 6, 7, 8, 9, 15, 16, 17, 18, 19};
-    "start->stop matcher (excluding)"_test           = [&runTestStream, &expectedValues] { runTestStream(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2]", 0, 0, expectedValues, 3UZ /* 2 BPs (2 starts) + custom diag trigger */); };
-    expectedValues                                   = {3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 14, 15, 16, 17, 18, 19, 20, 21};
-    "start->stop matcher (excluding +pre/post)"_test = [&runTestStream, &expectedValues] { runTestStream(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2]", 2, 2, expectedValues, 5UZ /* 4 BPs (2 starts + 2 stops) + custom diag trigger */); };
 
-    expectedValues                                     = {5, 6, 7, 8, 9, 10, 11, 15, 16, 17, 18, 19, 20, 21};
-    "start->^stop matcher (including)"_test            = [&runTestStream, &expectedValues] { runTestStream(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/^FAIR.SELECTOR.C=1:S=1:P=2]", 0, 0, expectedValues, 5UZ /* 4 BPs (2 starts + 2 stops) + custom diag trigger */); };
-    expectedValues                                     = {3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23};
-    "start->^stop matcher (including. +pre/post)"_test = [&runTestStream, &expectedValues] { runTestStream(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/^FAIR.SELECTOR.C=1:S=1:P=2]", 2, 2, expectedValues, 7UZ /* 4 BPs (2 starts + 2 stops) + 3 custom diag event */); };
+    "start->stop matcher (excluding)"_test = [] {
+        const std::vector<float> expectedValues = {5, 6, 7, 8, 9, 15, 16, 17, 18, 19};
+        resetTriggerTime();
+        const std::vector<Tag> expectedTags = {
+            mergedAutoForwardTag(0, {sampleRateTag(0), genNoTrigger(0), genSingle(0)}),
+            genStart(0),
+            genSingle(3),
+            mergedAutoForwardTag(5, {genStop(5), genSingle(5)}),
+            genStart(5),
+        };
+        runTestStream(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2]", 0, 0, expectedValues, expectedTags);
+    };
 
-    expectedValues                    = {6, 7, 8, 9, 10, 11, 12, 13, 20, 21, 22, 23};
-    "single trigger (+pre/post)"_test = [&runTestStream, &expectedValues] { runTestStream(50U, "CMD_DIAG_TRIGGER1", 2, 2, expectedValues, 3UZ); };
+    "start->stop matcher (excluding +pre/post)"_test = [] {
+        const std::vector<float> expectedValues = {3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 14, 15, 16, 17, 18, 19, 20, 21};
+        resetTriggerTime();
+        const std::vector<Tag> expectedTags = {
+            mergedAutoForwardTag(0, {sampleRateTag(0), genNoTrigger(0)}),
+            genSingle(1),
+            genStart(2),
+            genSingle(5),
+            genStop(7),
+            genSingle(9),
+            genStart(11),
+            genStop(16),
+        };
+        runTestStream(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2]", 2, 2, expectedValues, expectedTags);
+    };
+
+    "start->^stop matcher (including)"_test = [] {
+        const std::vector<float> expectedValues = {5, 6, 7, 8, 9, 10, 11, 15, 16, 17, 18, 19, 20, 21};
+        resetTriggerTime();
+        const std::vector<Tag> expectedTags = {
+            mergedAutoForwardTag(0, {sampleRateTag(0), genNoTrigger(0), genSingle(0)}),
+            genStart(0),
+            genSingle(3),
+            genStop(5),
+            genSingle(7),
+            genStart(7),
+            genStop(12),
+        };
+        runTestStream(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/^FAIR.SELECTOR.C=1:S=1:P=2]", 0, 0, expectedValues, expectedTags);
+    };
+
+    "start->^stop matcher (including. +pre/post)"_test = [] {
+        const std::vector<float> expectedValues = {3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23};
+        resetTriggerTime();
+        const std::vector<Tag> expectedTags = {
+            mergedAutoForwardTag(0, {sampleRateTag(0), genNoTrigger(0)}),
+            genSingle(1),
+            genStart(2),
+            genSingle(5),
+            genStop(7),
+            genSingle(9),
+            genStart(13),
+            genStop(18),
+            genSingle(20),
+        };
+        runTestStream(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/^FAIR.SELECTOR.C=1:S=1:P=2]", 2, 2, expectedValues, expectedTags);
+    };
+
+    "single trigger (+pre/post)"_test = [] {
+        const std::vector<float> expectedValues = {2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 20, 21, 22, 23};
+        resetTriggerTime();
+        const std::vector<Tag> expectedTags = {
+            mergedAutoForwardTag(0, {sampleRateTag(0)}),
+            genNoTrigger(0),
+            genSingle(2),
+            genStart(3),
+            genSingle(6),
+            genStop(8),
+            genSingle(10),
+            mergedAutoForwardTag(12, {genStart(12)}),
+            genStop(12),
+            genSingle(14),
+        };
+        runTestStream(50U, "CMD_DIAG_TRIGGER1", 2, 2, expectedValues, expectedTags);
+    };
 };
+
+void runTestDataSet(gr::Size_t nSamples, std::string filter, gr::Size_t preSamples, gr::Size_t postSamples, const std::vector<std::vector<float>>& expectedValues, const std::vector<std::vector<gr::Tag>>& expectedTags, gr::Size_t maxSamples = 100000U, std::source_location srcLocation = std::source_location::current()) {
+    using namespace boost::ut;
+    using namespace gr;
+    using namespace gr::basic;
+    using namespace gr::testing;
+
+    const auto locationStr = std::format("{}:{} ", srcLocation.file_name(), srcLocation.line());
+
+    constexpr float sampleRate = 1'000.f;
+    Graph           graph;
+
+    auto& tagSrc = graph.emplaceBlock<TagSource<float, ProcessFunction::USE_PROCESS_BULK>>({{"sample_rate", sampleRate}, //
+        {"n_samples_max", nSamples}, {"name", "TagSource"}, {"verbose_console", false}, {"repeat_tags", false}, {"mark_tag", false}});
+
+    resetTriggerTime();
+    tagSrc._tags = {genNoTrigger(2), genSingle(4), genNoTrigger(5), genStart(5), genSingle(8), genStop(10), genSingle(12), genStart(15), genStart(20), genStop(25), genSingle(27), genStop(30), genSingle(32)};
+
+    const property_map blockSettings         = {{"filter", filter}, {"n_pre", preSamples}, {"n_post", postSamples}, {"n_max", maxSamples}};
+    auto&              filterStreamToDataSet = graph.emplaceBlock<StreamToDataSet<float>>(blockSettings);
+    auto&              dataSetSink           = graph.emplaceBlock<TagSink<DataSet<float>, ProcessFunction::USE_PROCESS_BULK>>({{"name", "dataSetSink"}, {"log_tags", true}, {"log_samples", true}, {"verbose_console", false}});
+    expect(graph.connect<"out", "in">(tagSrc, filterStreamToDataSet).has_value()) << locationStr;
+    expect(graph.connect<"out", "in">(filterStreamToDataSet, dataSetSink).has_value()) << locationStr;
+
+    gr::scheduler::Simple sched;
+    if (auto ret = sched.exchange(std::move(graph)); !ret) {
+        throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+    }
+    std::println("start -> Stream-to-DataSet with filter: {} n_pre:{} n_post:{}", filter, preSamples, postSamples);
+    expect(sched.runAndWait().has_value()) << std::format("runAndWait - filter {}", filter) << locationStr;
+    std::println("done -> Stream-to-DataSet with filter: {} n_pre:{} n_post:{}", filter, preSamples, postSamples);
+
+    expect(eq(tagSrc.sample_rate, sampleRate)) << locationStr;
+    expect(eq(filterStreamToDataSet.sample_rate, sampleRate)) << locationStr;
+    expect(eq(dataSetSink.sample_rate, sampleRate)) << locationStr;
+
+    expect(eq(dataSetSink._samples.size(), expectedValues.size())) << locationStr;
+    for (std::size_t i = 0UZ; i < dataSetSink._samples.size(); i++) {
+        const DataSet<float>&          ds      = dataSetSink._samples.at(i);
+        std::expected<void, gr::Error> dsCheck = dataset::checkConsistency(ds, "TestDataSet");
+        expect(dsCheck.has_value()) << [&] { return std::format("unexpected: {}", dsCheck.error()); } << fatal << locationStr;
+        expect(std::ranges::equal(ds.signal_values, expectedValues[i])) << locationStr;
+
+        expect(fatal(eq(ds.timing_events.size(), 1UZ))) << locationStr;
+        const auto& timingEvt0 = ds.timing_events[0];
+        expect(eq(timingEvt0.size(), expectedTags[i].size())) << locationStr;
+        auto             view = timingEvt0 | std::views::transform([](const auto& p) { return Tag(static_cast<std::size_t>(p.first), p.second); });
+        std::vector<Tag> tags(std::ranges::begin(view), std::ranges::end(view));
+        expect(equal_tag_lists(tags, expectedTags[i], std::vector<std::string>{gr::tag::TRIGGER_TIME.shortKey()})) << locationStr;
+    }
+
+    expect(le(dataSetSink._tags.size(), dataSetSink._samples.size())) << locationStr;
+    expect(!dataSetSink._tags.empty()) << locationStr;
+    const auto& autoForwardKeys = filterStreamToDataSet.settings().autoForwardParameters();
+    for (const Tag& tag : dataSetSink._tags) {
+        expect(le(tag.index, dataSetSink._samples.size() - 1UZ)) << locationStr;
+        for (const auto& entry : tag.map) {
+            expect(autoForwardKeys.contains(convert_string_domain(entry.first))) << locationStr;
+        }
+    }
+    if (!dataSetSink._tags.empty()) {
+        const bool hasSampleRate = dataSetSink._tags.front().map.contains("sample_rate");
+        expect(hasSampleRate) << locationStr;
+        if (hasSampleRate) {
+            expect(eq(dataSetSink._tags.front().map.at("sample_rate").value_or(0.f), sampleRate)) << locationStr;
+        }
+    }
+}
 
 const boost::ut::suite<"StreamToDataSet test"> streamToDataSetTest = [] {
     using namespace boost::ut;
@@ -204,113 +377,138 @@ const boost::ut::suite<"StreamToDataSet test"> streamToDataSetTest = [] {
     using namespace gr::basic;
     using namespace gr::testing;
 
-    auto runTestDataSet = [](gr::Size_t nSamples, std::string filter, gr::Size_t preSamples, gr::Size_t postSamples, const std::vector<std::vector<float>>& expectedValues, const std::vector<std::size_t>& nTags, gr::Size_t maxSamples = 100000U) {
-        using namespace gr;
-        using namespace gr::basic;
-        using namespace gr::testing;
+    const std::vector<std::vector<float>> expectedValues1 = { //
+        {5, 6, 7, 8, 9},                                      //
+        {15, 16, 17, 18, 19, 20, 21, 22, 23, 24},             //
+        {20, 21, 22, 23, 24, 25, 26, 27, 28, 29}};
+    const std::vector<std::vector<Tag>>   expectedTags1   = { //
+        {genNoTrigger(0), genStart(0), genSingle(3)},     //
+        {genStart(0), genStart(5)},                       //
+        {genStart(0), genStop(5), genSingle(7)}};
 
-        constexpr float sample_rate = 1'000.f;
-        Graph           graph;
+    "start->stop (excluding)"_test         = [&expectedValues1, &expectedTags1] { runTestDataSet(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2]", 0, 0, expectedValues1, expectedTags1); };
+    "start->stop (excluding) n_max=0"_test = [&expectedValues1, &expectedTags1] { runTestDataSet(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2]", 0, 0, expectedValues1, expectedTags1, 0UZ); };
 
-        auto& tagSrc = graph.emplaceBlock<TagSource<float, ProcessFunction::USE_PROCESS_BULK>>({{"sample_rate", sample_rate}, //
-            {"n_samples_max", nSamples}, {"name", "TagSource"}, {"verbose_console", false}, {"repeat_tags", false}, {"mark_tag", false}});
-        tagSrc._tags = {
-            genTrigger(5, "CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=1"),  // start
-            genTrigger(8, "CMD_DIAG_TRIGGER1", ""),                      // it is also used to split samples processing into 2 iterations
-            genTrigger(10, "CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=2"), // stop
-            genTrigger(12, "CMD_DIAG_TRIGGER1", ""),                     // it is also used as end trigger for "including" mode
-            genTrigger(15, "CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=1"), // start
-            genTrigger(20, "CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=1"), // start
-            genTrigger(25, "CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=2"), // stop
-            genTrigger(27, "CMD_DIAG_TRIGGER1", ""),                     // it is also used as end trigger for "including" mode
-            genTrigger(30, "CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=2"), // stop
-            genTrigger(32, "CMD_DIAG_TRIGGER1", "")                      // it is also used as end trigger for "including" mode
-        };
-
-        const property_map blockSettings         = {{"filter", filter}, {"n_pre", preSamples}, {"n_post", postSamples}, {"n_max", maxSamples}};
-        auto&              filterStreamToDataSet = graph.emplaceBlock<StreamToDataSet<float>>(blockSettings);
-        auto&              dataSetSink           = graph.emplaceBlock<TagSink<DataSet<float>, ProcessFunction::USE_PROCESS_BULK>>({{"name", "dataSetSink"}, {"log_tags", true}, {"log_samples", true}, {"verbose_console", false}});
-        expect(graph.connect<"out", "in">(tagSrc, filterStreamToDataSet).has_value());
-        expect(graph.connect<"out", "in">(filterStreamToDataSet, dataSetSink).has_value());
-
-        gr::scheduler::Simple sched;
-        if (auto ret = sched.exchange(std::move(graph)); !ret) {
-            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
-        }
-        std::println("start -> Stream-to-DataSet with filter: {} n_pre:{} n_post:{}", filter, preSamples, postSamples);
-        expect(sched.runAndWait().has_value()) << std::format("runAndWait - filter {}", filter);
-        std::println("done -> Stream-to-DataSet with filter: {} n_pre:{} n_post:{}", filter, preSamples, postSamples);
-
-        expect(eq(tagSrc.sample_rate, sample_rate));
-        expect(eq(filterStreamToDataSet.sample_rate, sample_rate));
-        expect(eq(dataSetSink.sample_rate, sample_rate));
-
-        expect(eq(dataSetSink._samples.size(), expectedValues.size()));
-        for (std::size_t i = 0; i < dataSetSink._samples.size(); i++) {
-            const DataSet<float>&          ds      = dataSetSink._samples.at(i);
-            std::expected<void, gr::Error> dsCheck = dataset::checkConsistency(ds, "TestDataSet");
-            expect(dsCheck.has_value()) << [&] { return std::format("unexpected: {}", dsCheck.error()); } << fatal;
-            expect(std::ranges::equal(ds.signal_values, expectedValues[i]));
-
-            expect(fatal(eq(ds.timing_events.size(), 1UZ)));
-            const auto& timingEvt0 = ds.timing_events[0];
-            expect(eq(timingEvt0.size(), nTags[i])) << [&]() {
-                std::string ret = std::format("DataSet nTags: {}\n", timingEvt0.size());
-                for (const auto& tag : timingEvt0) {
-                    ret += std::format("tag.index: {} .map: {}\n", tag.first, tag.second);
-                }
-                return ret;
-            }();
-        }
+    "start->stop (excluding +pre/post)"_test = [] {
+        const std::vector<std::vector<float>> expectedValues = {                                            //
+            {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},                                     //
+            {8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31}, //
+            {13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36}};
+        const std::vector<std::vector<Tag>>   expectedTags   = {                                                                                                          //
+            {Tag{0, {{"sample_rate", 1000.f}}}, genNoTrigger(2), genSingle(4), genNoTrigger(5), genStart(5), genSingle(8), genStop(10), genSingle(12), genStart(15)}, //
+            {genSingle(0), genStop(2), genSingle(4), genStart(7), genStart(12), genStop(17), genSingle(19), genStop(22)},                                             //
+            {genStart(2), genStart(7), genStop(12), genSingle(14), genStop(17), genSingle(19)}};
+        runTestDataSet(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2]", 7, 7, expectedValues, expectedTags);
     };
 
-    std::vector<std::vector<float>> expectedValues = {{5, 6, 7, 8, 9}, {15, 16, 17, 18, 19, 20, 21, 22, 23, 24}, {20, 21, 22, 23, 24, 25, 26, 27, 28, 29}};
-    "start->stop (excluding)"_test                 = [&runTestDataSet, &expectedValues] { runTestDataSet(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2]", 0, 0, expectedValues, {3UZ, 3UZ, 4UZ}); };
-    "start->stop (excluding) n_max=0"_test         = [&runTestDataSet, &expectedValues] { runTestDataSet(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2]", 0, 0, expectedValues, {3UZ, 3UZ, 4UZ}, 0UZ); };
+    const std::vector<std::vector<float>> expectedValues2 = { //
+        {5, 6, 7, 8, 9, 10, 11},                              //
+        {15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26},     //
+        {20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31}};
+    const std::vector<std::vector<Tag>>   expectedTags2   = {         //
+        {genNoTrigger(0), genStart(0), genSingle(3), genStop(5)}, //
+        {genStart(0), genStart(5), genStop(10)},                  //
+        {genStart(0), genStop(5), genSingle(7), genStop(10)}};
 
-    expectedValues                           = {{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},                       //
-                                  {8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31}, //
-                                  {13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36}};
-    "start->stop (excluding +pre/post)"_test = [&runTestDataSet, &expectedValues] { runTestDataSet(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2]", 7, 7, expectedValues, {5UZ, 5UZ, 5UZ}); };
+    "start->^stop (including)"_test         = [&expectedValues2, &expectedTags2] { runTestDataSet(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/^FAIR.SELECTOR.C=1:S=1:P=2]", 0, 0, expectedValues2, expectedTags2); };
+    "start->^stop (including) n_max=0"_test = [&expectedValues2, &expectedTags2] { runTestDataSet(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/^FAIR.SELECTOR.C=1:S=1:P=2]", 0, 0, expectedValues2, expectedTags2, 0UZ); };
 
-    expectedValues                          = {{5, 6, 7, 8, 9, 10, 11}, {15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26}, {20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31}};
-    "start->^stop (including)"_test         = [&runTestDataSet, &expectedValues] { runTestDataSet(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/^FAIR.SELECTOR.C=1:S=1:P=2]", 0, 0, expectedValues, {4UZ, 4UZ, 5UZ}); };
-    "start->^stop (including) n_max=0"_test = [&runTestDataSet, &expectedValues] { runTestDataSet(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/^FAIR.SELECTOR.C=1:S=1:P=2]", 0, 0, expectedValues, {4UZ, 4UZ, 5UZ}, 0UZ); };
+    "start->^stop (including. +pre/post)"_test = [] {
+        const std::vector<std::vector<float>> expectedValues = {                                                    //
+            {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18},                                     //
+            {8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33}, //
+            {13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38}};
+        const std::vector<std::vector<Tag>>   expectedTags   = {                                                                                                          //
+            {Tag{0, {{"sample_rate", 1000.f}}}, genNoTrigger(2), genSingle(4), genNoTrigger(5), genStart(5), genSingle(8), genStop(10), genSingle(12), genStart(15)}, //
+            {genSingle(0), genStop(2), genSingle(4), genStart(7), genStart(12), genStop(17), genSingle(19), genStop(22), genSingle(24)},                              //
+            {genStart(2), genStart(7), genStop(12), genSingle(14), genStop(17), genSingle(19)}};
+        runTestDataSet(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/^FAIR.SELECTOR.C=1:S=1:P=2]", 7, 7, expectedValues, expectedTags);
+    };
 
-    expectedValues                             = {{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18},                       //
-                                    {8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33}, //
-                                    {13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38}};
-    "start->^stop (including. +pre/post)"_test = [&runTestDataSet, &expectedValues] { runTestDataSet(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/^FAIR.SELECTOR.C=1:S=1:P=2]", 7, 7, expectedValues, {5UZ, 6UZ, 5UZ}); };
+    "single trigger (+pre/post)"_test = [] {
+        const std::vector<std::vector<float>> expectedValues = {      //
+            {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},                       //
+            {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14},          //
+            {5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18},      //
+            {20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33}, //
+            {25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38}};
+        const std::vector<std::vector<Tag>>   expectedTags   = {                                                                             //
+            {Tag{0, {{"sample_rate", 1000.f}}}, genNoTrigger(2), genSingle(4), genNoTrigger(5), genStart(5), genSingle(8), genStop(10)}, //
+            {genNoTrigger(1), genSingle(3), genNoTrigger(4), genStart(4), genSingle(7), genStop(9), genSingle(11)},                      //
+            {genNoTrigger(0), genStart(0), genSingle(3), genStop(5), genSingle(7), genStart(10)},                                        //
+            {genStart(0), genStop(5), genSingle(7), genStop(10), genSingle(12)},                                                         //
+            {genStop(0), genSingle(2), genStop(5), genSingle(7)}};
+        runTestDataSet(50U, "CMD_DIAG_TRIGGER1", 7, 7, expectedValues, expectedTags);
+    };
 
-    expectedValues                    = {{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14}, //
-                           {5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18},           //
-                           {20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33},      //
-                           {25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38}};
-    "single trigger (+pre/post)"_test = [&runTestDataSet, &expectedValues] { runTestDataSet(50U, "CMD_DIAG_TRIGGER1", 7, 7, expectedValues, {3UZ, 2UZ, 3UZ, 1UZ}); };
+    "start->stop (excluding, n_max)"_test = [] {
+        const gr::Size_t                      nMaxSamples    = 6;
+        const std::vector<std::vector<float>> expectedValues = { //
+            {5, 6, 7, 8, 9},                                     //
+            {15, 16, 17, 18, 19, 20},                            //
+            {20, 21, 22, 23, 24, 25}};
+        const std::vector<std::vector<Tag>>   expectedTags   = { //
+            {genNoTrigger(0), genStart(0), genSingle(3)},    //
+            {genStart(0), genStart(5)},                      //
+            {genStart(0), genStop(5)}};
+        runTestDataSet(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2]", 0, 0, expectedValues, expectedTags, nMaxSamples);
+    };
 
-    // n_max test
-    gr::Size_t nMaxSamples                = 6;
-    expectedValues                        = {{5, 6, 7, 8, 9}, {15, 16, 17, 18, 19, 20}, {20, 21, 22, 23, 24, 25}};
-    "start->stop (excluding, n_max)"_test = [&runTestDataSet, &expectedValues, &nMaxSamples] { runTestDataSet(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2]", 0, 0, expectedValues, {3UZ, 2UZ, 2UZ}, nMaxSamples); };
+    "start->stop (excluding +pre/post, n_max)"_test = [] {
+        const gr::Size_t                      nMaxSamples    = 14;
+        const std::vector<std::vector<float>> expectedValues = {    //
+            {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13},         //
+            {8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21}, //
+            {13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26}};
+        const std::vector<std::vector<Tag>>   expectedTags   = {                                                                                            //
+            {Tag{0, {{"sample_rate", 1000.f}}}, genNoTrigger(2), genSingle(4), genNoTrigger(5), genStart(5), genSingle(8), genStop(10), genSingle(12)}, //
+            {genSingle(0), genStop(2), genSingle(4), genStart(7), genStart(12)},                                                                        //
+            {genStart(2), genStart(7), genStop(12)}};
+        runTestDataSet(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2]", 7, 7, expectedValues, expectedTags, nMaxSamples);
+    };
 
-    nMaxSamples                                     = 14;
-    expectedValues                                  = {{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13}, {8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21}, {13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26}};
-    "start->stop (excluding +pre/post, n_max)"_test = [&runTestDataSet, &expectedValues, &nMaxSamples] { runTestDataSet(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2]", 7, 7, expectedValues, {4UZ, 2UZ, 2UZ}, nMaxSamples); };
+    "start->^stop (including, n_max)"_test = [] {
+        const gr::Size_t                      nMaxSamples    = 6;
+        const std::vector<std::vector<float>> expectedValues = { //
+            {5, 6, 7, 8, 9, 10},                                 //
+            {15, 16, 17, 18, 19, 20},                            //
+            {20, 21, 22, 23, 24, 25}};
+        const std::vector<std::vector<Tag>>   expectedTags   = {          //
+            {genNoTrigger(0), genStart(0), genSingle(3), genStop(5)}, //
+            {genStart(0), genStart(5)},                               //
+            {genStart(0), genStop(5)}};
+        runTestDataSet(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/^FAIR.SELECTOR.C=1:S=1:P=2]", 0, 0, expectedValues, expectedTags, nMaxSamples);
+    };
 
-    nMaxSamples                            = 6;
-    expectedValues                         = {{5, 6, 7, 8, 9, 10}, {15, 16, 17, 18, 19, 20}, {20, 21, 22, 23, 24, 25}};
-    "start->^stop (including, n_max)"_test = [&runTestDataSet, &expectedValues, &nMaxSamples] { runTestDataSet(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/^FAIR.SELECTOR.C=1:S=1:P=2]", 0, 0, expectedValues, {3UZ, 2UZ, 2UZ}, nMaxSamples); };
+    "start->^stop (including. +pre/post, n_max)"_test = [] {
+        const gr::Size_t                      nMaxSamples    = 14;
+        const std::vector<std::vector<float>> expectedValues = {    //
+            {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13},         //
+            {8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21}, //
+            {13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26}};
+        const std::vector<std::vector<Tag>>   expectedTags   = {                                                                                            //
+            {Tag{0, {{"sample_rate", 1000.f}}}, genNoTrigger(2), genSingle(4), genNoTrigger(5), genStart(5), genSingle(8), genStop(10), genSingle(12)}, //
+            {genSingle(0), genStop(2), genSingle(4), genStart(7), genStart(12)},                                                                        //
+            {genStart(2), genStart(7), genStop(12)}};
+        runTestDataSet(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/^FAIR.SELECTOR.C=1:S=1:P=2]", 7, 7, expectedValues, expectedTags, nMaxSamples);
+    };
 
-    nMaxSamples                                       = 14;
-    expectedValues                                    = {{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13}, {8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21}, {13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26}};
-    "start->^stop (including. +pre/post, n_max)"_test = [&runTestDataSet, &expectedValues, &nMaxSamples] { runTestDataSet(50U, "[CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1, CMD_BP_START/^FAIR.SELECTOR.C=1:S=1:P=2]", 7, 7, expectedValues, {4UZ, 2UZ, 2UZ}, nMaxSamples); };
-
-    nMaxSamples                              = 14;
-    expectedValues                           = {{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14}, //
-                                  {5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18},           //
-                                  {20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33},      //
-                                  {25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38}};
-    "single trigger (+pre/post, n_max)"_test = [&runTestDataSet, &expectedValues, &nMaxSamples] { runTestDataSet(50U, "CMD_DIAG_TRIGGER1", 7, 7, expectedValues, {3UZ, 2UZ, 3UZ, 1UZ}, nMaxSamples); };
+    "single trigger (+pre/post, n_max)"_test = [] {
+        const gr::Size_t                      nMaxSamples    = 14;
+        const std::vector<std::vector<float>> expectedValues = {      //
+            {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},                       //
+            {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14},          //
+            {5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18},      //
+            {20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33}, //
+            {25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38}};
+        const std::vector<std::vector<Tag>>   expectedTags   = {                                                                             //
+            {Tag{0, {{"sample_rate", 1000.f}}}, genNoTrigger(2), genSingle(4), genNoTrigger(5), genStart(5), genSingle(8), genStop(10)}, //
+            {genNoTrigger(1), genSingle(3), genNoTrigger(4), genStart(4), genSingle(7), genStop(9), genSingle(11)},                      //
+            {genNoTrigger(0), genStart(0), genSingle(3), genStop(5), genSingle(7), genStart(10)},                                        //
+            {genStart(0), genStop(5), genSingle(7), genStop(10), genSingle(12)},                                                         //
+            {genStop(0), genSingle(2), genStop(5), genSingle(7)}};
+        runTestDataSet(50U, "CMD_DIAG_TRIGGER1", 7, 7, expectedValues, expectedTags, nMaxSamples);
+    };
 };
 
 int main() { /* not needed for UT */ }


### PR DESCRIPTION
 Update `DataSink` to support multiple tags
    - Preserve multiple input tags through streaming pollers and callbacks
    - Extend DataSink tests for overlapping triggers, snapshots, and tag propagation
    - Fix listener handling for continuous, trigger, multiplexed, and snapshot modes

Update `StreamToDataSet` to support multiple tags, preserve and publish pre-samples tags.
    - Publish pre-sample tags
    - Extend tests to check exact output tags