### PR TITLE
Update DEVELOPMENT.md to reflect minimum compiler version for Development

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -41,7 +41,7 @@ By default this will use the gcc-14 compiler included in the image, by setting `
 
 To be able to natively compile some prerequisites have to be installed:
 
-- gcc >= 13 and/or clang >= 17
+- gcc >= 14.2 and/or clang >= 17
 - cmake >= 3.25.0
 - ninja (or GNU make)
 - optional for python block support: python3


### PR DESCRIPTION
Updated documentation for the DEVELOPMENT.md to reflect the correct gcc version necessary for compiling GR4. This PR was created for issue [786](https://github.com/fair-acc/gnuradio4/issues/786). 