### PR TITLE
[docs] Generate Ninja on tutorial how to build GR4 for development

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -27,7 +27,7 @@ me@host$ docker run \
     ghcr.io/fair-acc/gr4-build-container bash
 
 me@aba123ef$ # export CXX=c++ # uncomment to use clang
-me@aba123ef$ cmake -S . -B build
+me@aba123ef$ cmake -S . -B build -G Ninja
 me@aba123ef$ cmake --build build
 me@aba123ef$ ctest --test-dir build
 ```
@@ -54,7 +54,7 @@ Once these are installed, you should be able to just compile and run GNURadio4:
 
 ```bash
 me@host$ cd gnuradio4
-me@host$ cmake -S . -B build
+me@host$ cmake -S . -B build -G Ninja
 me@host$ cmake --build build
 me@host$ ctest --test-dir build
 ```
@@ -127,7 +127,7 @@ $ cmake -DCMAKE_BUILD_TYPE=Debug \
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
             -DWARNINGS_AS_ERRORS=OFF \
             -DCMAKE_INSTALL_PREFIX=/home/$USER/gr4 \
-            -S . -B build
+            -S . -B build -G Ninja
 ```
 
 Then follow the rest of the build steps outlined above.


### PR DESCRIPTION
In DEVELOPMENT.md:
```
Native
To be able to natively compile some prerequisites have to be installed:

gcc >= 13 and/or clang >= 17
cmake >= 3.25.0
ninja (or GNU make)
optional for python block support: python3
optional for soapy (limesdr,rtlsdr) blocks: soapysdr
optional for compiling to webassembly: emscripten >= 5.0.0
```

But I did not see any command that generate ninja (`-G Ninja`)

To verify this, I am following DEVELOPMENT.md tutorial on how to natively build gr4, after `sudo ninja` in the build folder, I got `ninja: error: loading 'build.ninja': No such file or directory`.

Adding `-G Ninja` solves this problem

