### PR TITLE
Fixes for building with gcc14 or UBsan

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -861,14 +861,6 @@ install(
   NAMESPACE gnuradio4::
   DESTINATION "${GR_CMAKECONFIG_INSTALL_DIR}")
 
-if(TARGET gnuradio-plugin)
-  install(
-    EXPORT gnuradio4PluginTargets
-    FILE gnuradio4PluginTargets.cmake
-    NAMESPACE gnuradio4::
-    DESTINATION "${GR_CMAKECONFIG_INSTALL_DIR}")
-endif()
-
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/gnuradio4Config.cmake"
               "${CMAKE_CURRENT_BINARY_DIR}/gnuradio4ConfigVersion.cmake" DESTINATION "${GR_CMAKECONFIG_INSTALL_DIR}")
 

--- a/cmake/gnuradio4Config.cmake.in
+++ b/cmake/gnuradio4Config.cmake.in
@@ -36,8 +36,9 @@ endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/gnuradio4Targets.cmake")
 
-if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/gnuradio4PluginTargets.cmake")
-  include("${CMAKE_CURRENT_LIST_DIR}/gnuradio4PluginTargets.cmake")
+# gnuradio4-plugin is legacy, it has since been merged with gnuradio4-core
+if(TARGET gnuradio4::gnuradio-core AND NOT TARGET gnuradio4::gnuradio-plugin)
+  add_library(gnuradio4::gnuradio-plugin ALIAS gnuradio4::gnuradio-core)
 endif()
 
 check_required_components(gnuradio4)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,13 +1,12 @@
-add_library(
-  gnuradio-core STATIC
-  src/Value.cpp
-  src/ValueHelper.cpp
-  src/Block.cpp
-  src/BlockModel.cpp
-  src/Settings.cpp
-  src/Graph.cpp
-  src/PluginLoader.cpp
-  src/PmtTypeHelpers.cpp)
+set(gnuradio_core_sources
+    src/Value.cpp
+    src/ValueHelper.cpp
+    src/Block.cpp
+    src/BlockModel.cpp
+    src/Settings.cpp
+    src/Graph.cpp
+    src/PluginLoader.cpp
+    src/PmtTypeHelpers.cpp)
 
 set(public_headers
     include/gnuradio-4.0/annotated.hpp
@@ -48,6 +47,14 @@ set(public_headers
     include/gnuradio-4.0/WaitStrategy.hpp
     include/gnuradio-4.0/YamlPmt.hpp)
 
+if(INTERNAL_ENABLE_BLOCK_PLUGINS)
+  # provide definitions for Plugin.hpp which is only used by PluginLoader.hpp if INTERNAL_ENABLE_BLOCK_PLUGINS is on
+  list(APPEND gnuradio_core_sources src/plugin.cpp)
+  list(APPEND public_headers include/gnuradio-4.0/Plugin.hpp)
+endif()
+
+add_library(gnuradio-core STATIC ${gnuradio_core_sources})
+
 set_target_properties(gnuradio-core PROPERTIES PUBLIC_HEADER "${public_headers}")
 add_library(gnuradio4::gnuradio-core ALIAS gnuradio-core)
 target_include_directories(
@@ -65,8 +72,12 @@ target_link_libraries(
          magic_enum
          vir)
 
+# gnuradio-plugin is legacy and has since been merged into core
+add_library(gnuradio-plugin ALIAS gnuradio-core)
+add_library(gnuradio4::gnuradio-plugin ALIAS gnuradio-core)
+
 add_library(gnuradio-blocklib-core SHARED src/BlockRegistry.cpp)
-set(blocklib_public_headers include/gnuradio-4.0/BlockRegistry.hpp include/gnuradio-4.0/Plugin.hpp)
+set(blocklib_public_headers include/gnuradio-4.0/BlockRegistry.hpp)
 set_target_properties(gnuradio-blocklib-core PROPERTIES PUBLIC_HEADER "${blocklib_public_headers}")
 add_library(gnuradio4::gnuradio-blocklib-core ALIAS gnuradio-blocklib-core)
 message(INFO "PATH include " $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/>)

--- a/core/include/gnuradio-4.0/Graph.hpp
+++ b/core/include/gnuradio-4.0/Graph.hpp
@@ -84,9 +84,8 @@ constexpr PortNameIndexPair parsePort(std::string_view portString) {
 
 template<fixed_string Name>
 struct for_name {
-    static constexpr std::string_view name   = Name;
-    static constexpr std::size_t      endPos = name.find('#');
-    static constexpr std::size_t      size   = endPos == std::string_view::npos ? name.size() : endPos;
+    static constexpr std::size_t endPos = Name.find_char('#');
+    static constexpr std::size_t size   = endPos < Name.size ? endPos : Name.size;
 
     template<typename TPort>
     static consteval bool matcherImpl() {

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -1,18 +1,3 @@
-if(NOT EMSCRIPTEN)
-  add_library(gnuradio-plugin SHARED plugin.cpp)
-  add_library(gnuradio4::gnuradio-plugin ALIAS gnuradio-plugin)
-  set_target_properties(gnuradio-plugin PROPERTIES BUILD_WITH_INSTALL_RPATH ON)
-  target_include_directories(
-    gnuradio-plugin PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-                           $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}> $<INSTALL_INTERFACE:include/>)
-  target_link_libraries(gnuradio-plugin PUBLIC gnuradio-core gnuradio-blocklib-core gnuradio-options)
-
-  install(
-    TARGETS gnuradio-plugin
-    EXPORT gnuradio4PluginTargets
-    PUBLIC_HEADER DESTINATION include/gnuradio-4.0)
-endif()
-
 if(ENABLE_EXAMPLES)
   add_executable(main main.cpp)
   target_link_libraries(main PUBLIC gnuradio-options gnuradio-core magic_enum)


### PR DESCRIPTION
The version of gcc14 I have (`gcc-14 (Ubuntu 14.3.0-8ubuntu1) 14.3.0`)  is slightly less good than 15 at understanding that things should be constexpr, which caused find_or_default to not work.
I am uncertain what is different between my setup and CI here, but I wasn't able to resolve the discrepancy so this helps me for now. Also, I think making sure gcc-14 on ubuntu 24.04 works out of the box is a good idea. Otherwise I would/will use gcc-15 locally.

Also, I was using ubsan which will instantiate references to typeinfo. That causes linker errors because some targets were consuming PluginLoader.hpp/Plugin.hpp without linking gnuradio-plugin which has the typeinfo for gr_plugin_base.
My solution to this was to merge `core` and `plugin` as I don't think it is needed for them to be separate afaict. Merging them only has the effect of making Plugin.hpp available to consumers of `core` who may not need it.

See commit messages for more details