### PR TITLE
Add static display_name to blocks, and displayName() to registry

### DIFF
--- a/core/include/gnuradio-4.0/BlockRegistry.hpp
+++ b/core/include/gnuradio-4.0/BlockRegistry.hpp
@@ -52,6 +52,7 @@ class GeneralRegistry {
 
     struct TTypeHandler {
         std::string                     alias;
+        std::string                     displayName;
         decltype(this_t::factoryProto)* createFunction = nullptr;
     };
 
@@ -88,7 +89,19 @@ public:
             return meta::detail::makePortableTypeName(std::string{alias} + "<" + std::string{aliasParameters} + ">");
         }();
 
-        auto handler = TTypeHandler{.alias = fullAlias, .createFunction = defaultFactory<TBlock>};
+        constexpr static std::string_view blockDisplayName = [] {
+            if constexpr (requires { typename TBlock::DisplayName; }) {
+                return static_cast<std::string_view>(TBlock::DisplayName::value);
+            } else {
+                return std::string_view{};
+            }
+        }();
+
+        auto handler = TTypeHandler{
+            .alias          = fullAlias,
+            .displayName    = std::string{blockDisplayName},
+            .createFunction = defaultFactory<TBlock>,
+        };
 
         auto resName = _blockTypeHandlers.insert_or_assign(name, handler);
 
@@ -126,6 +139,14 @@ public:
     }
 
     [[nodiscard]] bool contains(std::string_view blockName) const { return _blockTypeHandlers.contains(blockName); }
+
+    std::optional<std::string> displayName(std::string_view typeName) {
+        auto it = _blockTypeHandlers.find(typeName);
+        if (it != _blockTypeHandlers.end() && !it->second.displayName.empty()) {
+            return it->second.displayName;
+        }
+        return {};
+    }
 
     std::string typeName(const std::shared_ptr<BlockModel>& block) {
         auto name = block->typeName();

--- a/core/include/gnuradio-4.0/Scheduler.hpp
+++ b/core/include/gnuradio-4.0/Scheduler.hpp
@@ -1346,9 +1346,31 @@ protected:
     }
 };
 
+namespace detail {
+template<ExecutionPolicy policy>
+consteval auto executionPolicyName() {
+    if constexpr (policy == ExecutionPolicy::singleThreaded) {
+        return gr::meta::fixed_string("singleThreaded");
+    } else if constexpr (policy == ExecutionPolicy::multiThreaded) {
+        return gr::meta::fixed_string("multiThreaded");
+    } else if constexpr (policy == ExecutionPolicy::singleThreadedBlocking) {
+        return gr::meta::fixed_string("singleThreadedBlocking");
+    } else {
+        static_assert(false, "Unsupported ExecutionPolicy for scheduler display name");
+    }
+}
+
+template<gr::meta::fixed_string SchedulerName, ExecutionPolicy policy>
+consteval auto schedulerDisplayName() {
+    return SchedulerName + "<" + executionPolicyName<policy>() + ">";
+}
+} // namespace detail
+
 template<ExecutionPolicy execution = ExecutionPolicy::singleThreaded, profiling::ProfilerLike TProfiler = profiling::null::Profiler>
 struct Simple : SchedulerBase<Simple<execution, TProfiler>, execution, TProfiler> {
     using Description = Doc<R""(Simple loop based Scheduler, which iterates over all blocks in the order they have beein defined and emplaced definition in the graph.)"">;
+
+    using DisplayName = Doc<detail::schedulerDisplayName<"Simple", execution>()>();
 
     using SchedulerBase<Simple<execution, TProfiler>, execution, TProfiler>::SchedulerBase;
 
@@ -1412,6 +1434,8 @@ template<ExecutionPolicy execution = ExecutionPolicy::singleThreaded, profiling:
 struct BreadthFirst : SchedulerBase<BreadthFirst<execution, TProfiler>, execution, TProfiler> {
     using Description = Doc<R""(Breadth First Scheduler which traverses the graph starting from the source blocks in a breath first fashion
 detecting cycles and blocks which can be reached from several source blocks.)"">;
+
+    using DisplayName = Doc<detail::schedulerDisplayName<"BreadthFirst", execution>()>();
 
     static_assert(execution == ExecutionPolicy::singleThreaded || execution == ExecutionPolicy::multiThreaded, "Unsupported execution policy");
 
@@ -1484,6 +1508,9 @@ detecting cycles and blocks which can be reached from several source blocks.)"">
 template<ExecutionPolicy execution = ExecutionPolicy::singleThreaded, profiling::ProfilerLike TProfiler = profiling::null::Profiler>
 struct DepthFirst : SchedulerBase<DepthFirst<execution, TProfiler>, execution, TProfiler> {
     using Description = Doc<R""(Depth First Scheduler which traverses the graph starting from the source blocks in a depth-first manner.)"">;
+
+    using DisplayName = Doc<detail::schedulerDisplayName<"DepthFirst", execution>()>();
+
     static_assert(execution == ExecutionPolicy::singleThreaded || execution == ExecutionPolicy::multiThreaded, "Unsupported execution policy");
 
     void customInit() {

--- a/core/include/gnuradio-4.0/Scheduler.hpp
+++ b/core/include/gnuradio-4.0/Scheduler.hpp
@@ -1439,6 +1439,8 @@ detecting cycles and blocks which can be reached from several source blocks.)"">
 
     static_assert(execution == ExecutionPolicy::singleThreaded || execution == ExecutionPolicy::multiThreaded, "Unsupported execution policy");
 
+    using SchedulerBase<BreadthFirst<execution, TProfiler>, execution, TProfiler>::SchedulerBase;
+
     void customInit() {
         /* implements Breadth-first search scheduling algorithm (https://en.wikipedia.org/wiki/Breadth-first_search)
          * 1. compute 'adjacencyList'
@@ -1512,6 +1514,8 @@ struct DepthFirst : SchedulerBase<DepthFirst<execution, TProfiler>, execution, T
     using DisplayName = Doc<detail::schedulerDisplayName<"DepthFirst", execution>()>();
 
     static_assert(execution == ExecutionPolicy::singleThreaded || execution == ExecutionPolicy::multiThreaded, "Unsupported execution policy");
+
+    using SchedulerBase<DepthFirst<execution, TProfiler>, execution, TProfiler>::SchedulerBase;
 
     void customInit() {
         /**


### PR DESCRIPTION
Enables blocks to define `using DisplayName = Doc<...>` which can then be read by UIs for a not-necessarily-unique and human readable name.

Will be used to address [opendigitizer/449](https://github.com/fair-acc/opendigitizer/issues/449)

Also includes a small fix for schedulers to use SchedulerBase constructors which is required so they can be registered, that helps [opendigitizer/448](https://github.com/fair-acc/opendigitizer/issues/448)

Potentially breaking change in that it adds a new requirement to the block concept.