### PR TITLE
meta: align .zenodo.json license with the Zenodo deposit schema; add concept DOI

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,9 +1,7 @@
 {
   "title": "GNU Radio 4.0",
   "description": "GNU Radio 4.0 — a free, open-source signal-processing toolkit.",
-  "license": {
-    "id": "MIT"
-  },
+  "license": "mit",
   "upload_type": "software",
   "creators": [
     {

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,6 +4,10 @@ message: "If you use this software, please cite it using the metadata from this 
 type: software
 license: MIT
 repository-code: "https://github.com/fair-acc/gnuradio4"
+identifiers:
+  - type: doi
+    value: "10.5281/zenodo.19010697"
+    description: "Concept DOI resolving to the latest published version on Zenodo."
 keywords:
   - signal processing
   - software-defined radio


### PR DESCRIPTION
## What

Two small citation-metadata hygiene fixes, mirroring the cleanup applied to `fair-acc/opendigitizer`:

- **`.zenodo.json`** — the `license` field used the InvenioRDM record object form (`{"id": "MIT"}`). The GitHub→Zenodo deposit expects the [documented](https://help.zenodo.org/docs/github/describe-software/zenodo-json/) lowercase SPDX **string** (`"mit"`); the object form is ignored, leaving Zenodo to auto-detect the licence from `LICENSE`. This makes the deposit explicit and schema-correct.
- **`CITATION.cff`** — added the Zenodo **concept DOI** [`10.5281/zenodo.19010697`](https://doi.org/10.5281/zenodo.19010697) as an identifier, so "cite this repository" resolves to the all-versions record.

**Licence intentionally left as MIT.** The LGPL relicense is tracked separately; this PR must not change the declared licence until that lands and the released versions genuinely carry it.

Author roster, keywords and everything else are unchanged.
