### PR TITLE
Add ci-latest-wasm

### DIFF
--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Cache fetchContent
         uses: actions/cache@v5
         with:
-          path: ${{ github.workspace }}/build/_deps
+          path: ${{ github.workspace }}/build-ci-latest-gcc/_deps
           key: fetchContent-cpack-gcc14-relwithdebinfo-${{ hashFiles('CMakeLists.txt') }}
           restore-keys: |
             fetchContent-cpack-gcc14-relwithdebinfo
@@ -55,37 +55,22 @@ jobs:
 
       - name: Configure
         shell: bash
-        env:
-          CC: gcc-14
-          CXX: g++-14
-          CMAKE_EXPORT_COMPILE_COMMANDS: "ON"
-        run: |
-          cmake -S . -B build \
-            -DCMAKE_COLOR_DIAGNOSTICS=ON \
-            -DDISABLE_EXTERNAL_DEPS_WARNINGS=ON \
-            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-            -DCPACK_PACKAGING_INSTALL_PREFIX=/opt/gnuradio4-gcc \
-            -DCPACK_PACKAGE_NAME=gnuradio4-gcc \
-            -DUSE_CCACHE=ON \
-            -DENABLE_EXAMPLES=OFF \
-            -DENABLE_TESTING=OFF \
-            -DENABLE_COVERAGE=OFF \
-            -DADDRESS_SANITIZER=OFF
+        run: cmake --preset ci-latest-gcc
 
       - name: Build CPack packages
         shell: bash
-        run: cmake --build build --target package
+        run: cmake --build --preset ci-latest-gcc
 
       - name: Verify package installation
-        run: sudo apt install ./build/*.deb ./build/*.ddeb -y
+        run: sudo apt install ./build-ci-latest-gcc/*.deb ./build-ci-latest-gcc/*.ddeb -y
 
       - name: Upload packages
         uses: actions/upload-artifact@v7
         with:
           name: ubuntu-gcc14-relwithdebinfo-deb-${{ github.run_number }}
           path: |
-            build/*.deb
-            build/*.ddeb
+            build-ci-latest-gcc/*.deb
+            build-ci-latest-gcc/*.ddeb
           if-no-files-found: error
 
       - name: Publish to latest pre-release
@@ -96,8 +81,8 @@ jobs:
           prerelease: true
           make_latest: false
           files: |
-            build/*.deb
-            build/*.ddeb
+            build-ci-latest-gcc/*.deb
+            build-ci-latest-gcc/*.ddeb
 
       - name: Show final ccache and build directory stats
         if: always()
@@ -105,9 +90,9 @@ jobs:
         run: |
           ccache --show-stats
           echo "--- Build directory ---"
-          du -sh build
+          du -sh build-ci-latest-gcc
           echo "--- Debian packages (.deb/.ddeb) ---"
-          find build \( -name "*.deb" -o -name "*.ddeb" \) -exec du -ch {} + | tail -1
+          find build-ci-latest-gcc \( -name "*.deb" -o -name "*.ddeb" \) -exec du -ch {} + | tail -1
 
   package-clang:
     name: "Ubuntu | clang++-20 | RelWithDebInfo | CPack"
@@ -133,7 +118,7 @@ jobs:
       - name: Cache fetchContent
         uses: actions/cache@v5
         with:
-          path: ${{ github.workspace }}/build/_deps
+          path: ${{ github.workspace }}/build-ci-latest-clang/_deps
           key: fetchContent-cpack-clang20-relwithdebinfo-${{ hashFiles('CMakeLists.txt') }}
           restore-keys: |
             fetchContent-cpack-clang20-relwithdebinfo
@@ -151,38 +136,22 @@ jobs:
 
       - name: Configure
         shell: bash
-        env:
-          CC: clang-20
-          CXX: clang++-20
-          CMAKE_EXPORT_COMPILE_COMMANDS: "ON"
-        run: |
-          cmake -S . -B build \
-            -DCMAKE_COLOR_DIAGNOSTICS=ON \
-            -DDISABLE_EXTERNAL_DEPS_WARNINGS=ON \
-            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-            -DCPACK_PACKAGING_INSTALL_PREFIX=/opt/gnuradio4-clang \
-            -DCPACK_PACKAGE_NAME=gnuradio4-clang \
-            -DGR4_USE_LIBCXX=ON \
-            -DUSE_CCACHE=ON \
-            -DENABLE_EXAMPLES=OFF \
-            -DENABLE_TESTING=OFF \
-            -DENABLE_COVERAGE=OFF \
-            -DADDRESS_SANITIZER=OFF
+        run: cmake --preset ci-latest-clang
 
       - name: Build CPack packages
         shell: bash
-        run: cmake --build build --target package
+        run: cmake --build --preset ci-latest-clang
 
       - name: Verify package installation
-        run: sudo apt install ./build/*.deb ./build/*.ddeb -y
+        run: sudo apt install ./build-ci-latest-clang/*.deb ./build-ci-latest-clang/*.ddeb -y
 
       - name: Upload packages
         uses: actions/upload-artifact@v7
         with:
           name: ubuntu-clang20-relwithdebinfo-deb-${{ github.run_number }}
           path: |
-            build/*.deb
-            build/*.ddeb
+            build-ci-latest-clang/*.deb
+            build-ci-latest-clang/*.ddeb
           if-no-files-found: error
 
       - name: Publish to latest pre-release
@@ -193,8 +162,8 @@ jobs:
           prerelease: true
           make_latest: false
           files: |
-            build/*.deb
-            build/*.ddeb
+            build-ci-latest-clang/*.deb
+            build-ci-latest-clang/*.ddeb
 
       - name: Show final ccache and build directory stats
         if: always()
@@ -202,9 +171,9 @@ jobs:
         run: |
           ccache --show-stats
           echo "--- Build directory ---"
-          du -h -s build
+          du -h -s build-ci-latest-clang
           echo "--- Debian packages (.deb/.ddeb) ---"
-          find build \( -name "*.deb" -o -name "*.ddeb" \) -exec du -ch {} + | tail -1
+          find build-ci-latest-clang \( -name "*.deb" -o -name "*.ddeb" \) -exec du -ch {} + | tail -1
 
   package-emscripten:
     name: "Emscripten | Release | CPack"

--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -207,7 +207,7 @@ jobs:
           find build \( -name "*.deb" -o -name "*.ddeb" \) -exec du -ch {} + | tail -1
 
   package-emscripten:
-    name: "Emscripten | RelWithDebInfo | CPack"
+    name: "Emscripten | Release | CPack"
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/fair-acc/gr4-build-container:latest
@@ -223,17 +223,17 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/.ccache
-          key: ccache-cpack-emscripten-relwithdebinfo-${{ github.sha }}
+          key: ccache-cpack-emscripten-release-${{ github.sha }}
           restore-keys: |
-            ccache-cpack-emscripten-relwithdebinfo
+            ccache-cpack-emscripten-release
 
       - name: Cache fetchContent
         uses: actions/cache@v5
         with:
-          path: ${{ github.workspace }}/build/_deps
-          key: fetchContent-cpack-emscripten-relwithdebinfo-${{ hashFiles('CMakeLists.txt') }}
+          path: ${{ github.workspace }}/build-ci-latest-wasm/_deps
+          key: fetchContent-cpack-emscripten-release-${{ hashFiles('CMakeLists.txt') }}
           restore-keys: |
-            fetchContent-cpack-emscripten-relwithdebinfo
+            fetchContent-cpack-emscripten-release
 
       - name: Configure ccache
         run: |
@@ -252,34 +252,19 @@ jobs:
           export SYSTEM_NODE=$(which node)
           $EMSDK_HOME/emsdk activate $EMSDK_VERSION
           source $EMSDK_HOME/emsdk_env.sh
-          emcmake cmake -S . -B build \
-            -DCMAKE_COLOR_DIAGNOSTICS=ON \
-            -DDISABLE_EXTERNAL_DEPS_WARNINGS=ON \
-            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-            -DCPACK_PACKAGING_INSTALL_PREFIX=/opt/gnuradio4-emscripten \
-            -DCPACK_PACKAGE_NAME=gnuradio4-emscripten \
-            -DCPACK_GENERATOR=DEB \
-            -DCPACK_DEBIAN_PACKAGE_ARCHITECTURE=all \
-            -DCPACK_DEBIAN_PACKAGE_SHLIBDEPS=OFF \
-            -DCPACK_DEBIAN_DEBUGINFO_PACKAGE=OFF \
-            -DUSE_CCACHE=ON \
-            -DENABLE_EXAMPLES=OFF \
-            -DENABLE_TESTING=OFF \
-            -DENABLE_COVERAGE=OFF \
-            -DCMAKE_CROSSCOMPILING_EMULATOR=${SYSTEM_NODE} \
-            -DGNURADIO_PARSE_REGISTRATIONS_TOOL_CXX_COMPLILER=g++-14
+          cmake --preset ci-latest-wasm
 
       - name: Build CPack packages
         shell: bash
         run: |
           source $EMSDK_HOME/emsdk_env.sh
-          cmake --build build --target package
+          cmake --build --preset ci-latest-wasm
 
       - name: Upload packages
         uses: actions/upload-artifact@v7
         with:
-          name: emscripten-relwithdebinfo-deb-${{ github.run_number }}
-          path: build/*.deb
+          name: emscripten-release-deb-${{ github.run_number }}
+          path: build-ci-latest-wasm/*.deb
           if-no-files-found: error
 
       - name: Publish to latest pre-release
@@ -289,7 +274,7 @@ jobs:
           name: "Latest build"
           prerelease: true
           make_latest: false
-          files: build/*.deb
+          files: build-ci-latest-wasm/*.deb
 
       - name: Show final ccache and build directory stats
         if: always()
@@ -297,6 +282,6 @@ jobs:
         run: |
           ccache --show-stats
           echo "--- Build directory ---"
-          du -h -s build
+          du -h -s build-ci-latest-wasm
           echo "--- Debian packages (.deb/.ddeb) ---"
-          find build \( -name "*.deb" -o -name "*.ddeb" \) -exec du -ch {} + | tail -1
+          find build-ci-latest-wasm \( -name "*.deb" -o -name "*.ddeb" \) -exec du -ch {} + | tail -1

--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -14,10 +14,26 @@ concurrency:
 
 jobs:
   package:
-    name: "Ubuntu | g++-14 | RelWithDebInfo | CPack"
+    name: "${{ matrix.job_name }} | CPack"
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/fair-acc/gr4-build-container:latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - job_name: Ubuntu | g++-14 | RelWithDebInfo
+            preset: ci-latest-gcc
+            has_ddeb: true
+            needs_emscripten: false
+          - job_name: Ubuntu | clang++-20 | RelWithDebInfo
+            preset: ci-latest-clang
+            has_ddeb: true
+            needs_emscripten: false
+          - job_name: Emscripten | Release
+            preset: ci-latest-wasm
+            has_ddeb: false
+            needs_emscripten: true
     env:
       CCACHE_DIR: ${{ github.workspace }}/.ccache
       CCACHE_BASEDIR: ${{ github.workspace }}
@@ -30,17 +46,17 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/.ccache
-          key: ccache-cpack-gcc14-relwithdebinfo-${{ github.sha }}
+          key: ccache-${{ matrix.preset }}-${{ github.sha }}
           restore-keys: |
-            ccache-cpack-gcc14-relwithdebinfo
+            ccache-${{ matrix.preset }}
 
       - name: Cache fetchContent
         uses: actions/cache@v5
         with:
-          path: ${{ github.workspace }}/build-ci-latest-gcc/_deps
-          key: fetchContent-cpack-gcc14-relwithdebinfo-${{ hashFiles('CMakeLists.txt') }}
+          path: ${{ github.workspace }}/build-${{ matrix.preset }}/_deps
+          key: fetchContent-${{ matrix.preset }}-${{ hashFiles('CMakeLists.txt') }}
           restore-keys: |
-            fetchContent-cpack-gcc14-relwithdebinfo
+            fetchContent-${{ matrix.preset }}
 
       - name: Configure ccache
         run: |
@@ -55,25 +71,46 @@ jobs:
 
       - name: Configure
         shell: bash
-        run: cmake --preset ci-latest-gcc
+        run: |
+          if [[ "${{ matrix.needs_emscripten }}" == "true" ]]; then
+            export SYSTEM_NODE=$(which node)
+            $EMSDK_HOME/emsdk activate $EMSDK_VERSION
+            source $EMSDK_HOME/emsdk_env.sh
+          fi
+          cmake --preset ${{ matrix.preset }}
 
       - name: Build CPack packages
         shell: bash
-        run: cmake --build --preset ci-latest-gcc
+        run: |
+          if [[ "${{ matrix.needs_emscripten }}" == "true" ]]; then
+            source $EMSDK_HOME/emsdk_env.sh
+          fi
+          cmake --build --preset ${{ matrix.preset }}
 
       - name: Verify package installation
-        run: sudo apt install ./build-ci-latest-gcc/*.deb ./build-ci-latest-gcc/*.ddeb -y
+        if: matrix.has_ddeb
+        run: sudo apt install ./build-${{ matrix.preset }}/*.deb ./build-${{ matrix.preset }}/*.ddeb -y
 
-      - name: Upload packages
+      - name: Upload packages (deb + ddeb)
+        if: matrix.has_ddeb
         uses: actions/upload-artifact@v7
         with:
-          name: ubuntu-gcc14-relwithdebinfo-deb-${{ github.run_number }}
+          name: ${{ matrix.preset }}-deb-${{ github.run_number }}
           path: |
-            build-ci-latest-gcc/*.deb
-            build-ci-latest-gcc/*.ddeb
+            build-${{ matrix.preset }}/*.deb
+            build-${{ matrix.preset }}/*.ddeb
           if-no-files-found: error
 
-      - name: Publish to latest pre-release
+      - name: Upload packages (deb)
+        if: ${{ !matrix.has_ddeb }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.preset }}-deb-${{ github.run_number }}
+          path: build-${{ matrix.preset }}/*.deb
+          if-no-files-found: error
+
+      - name: Publish to latest pre-release (deb + ddeb)
+        if: matrix.has_ddeb
         uses: softprops/action-gh-release@v3
         with:
           tag_name: latest
@@ -81,89 +118,18 @@ jobs:
           prerelease: true
           make_latest: false
           files: |
-            build-ci-latest-gcc/*.deb
-            build-ci-latest-gcc/*.ddeb
+            build-${{ matrix.preset }}/*.deb
+            build-${{ matrix.preset }}/*.ddeb
 
-      - name: Show final ccache and build directory stats
-        if: always()
-        continue-on-error: true
-        run: |
-          ccache --show-stats
-          echo "--- Build directory ---"
-          du -sh build-ci-latest-gcc
-          echo "--- Debian packages (.deb/.ddeb) ---"
-          find build-ci-latest-gcc \( -name "*.deb" -o -name "*.ddeb" \) -exec du -ch {} + | tail -1
-
-  package-clang:
-    name: "Ubuntu | clang++-20 | RelWithDebInfo | CPack"
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/fair-acc/gr4-build-container:latest
-    env:
-      CCACHE_DIR: ${{ github.workspace }}/.ccache
-      CCACHE_BASEDIR: ${{ github.workspace }}
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
-      - name: Cache ccache
-        uses: actions/cache@v5
-        with:
-          path: ${{ github.workspace }}/.ccache
-          key: ccache-cpack-clang20-relwithdebinfo-${{ github.sha }}
-          restore-keys: |
-            ccache-cpack-clang20-relwithdebinfo
-
-      - name: Cache fetchContent
-        uses: actions/cache@v5
-        with:
-          path: ${{ github.workspace }}/build-ci-latest-clang/_deps
-          key: fetchContent-cpack-clang20-relwithdebinfo-${{ hashFiles('CMakeLists.txt') }}
-          restore-keys: |
-            fetchContent-cpack-clang20-relwithdebinfo
-
-      - name: Configure ccache
-        run: |
-          ccache --max-size=3G
-          ccache --set-config=compression=true
-          ccache --set-config=compression_level=6
-          ccache --set-config=depend_mode=true
-          ccache --set-config=hash_dir=false
-          ccache --set-config=sloppiness=file_macro,time_macros,include_file_mtime,include_file_ctime
-          ccache -z
-          ccache --show-stats
-
-      - name: Configure
-        shell: bash
-        run: cmake --preset ci-latest-clang
-
-      - name: Build CPack packages
-        shell: bash
-        run: cmake --build --preset ci-latest-clang
-
-      - name: Verify package installation
-        run: sudo apt install ./build-ci-latest-clang/*.deb ./build-ci-latest-clang/*.ddeb -y
-
-      - name: Upload packages
-        uses: actions/upload-artifact@v7
-        with:
-          name: ubuntu-clang20-relwithdebinfo-deb-${{ github.run_number }}
-          path: |
-            build-ci-latest-clang/*.deb
-            build-ci-latest-clang/*.ddeb
-          if-no-files-found: error
-
-      - name: Publish to latest pre-release
+      - name: Publish to latest pre-release (deb)
+        if: ${{ !matrix.has_ddeb }}
         uses: softprops/action-gh-release@v3
         with:
           tag_name: latest
           name: "Latest build"
           prerelease: true
           make_latest: false
-          files: |
-            build-ci-latest-clang/*.deb
-            build-ci-latest-clang/*.ddeb
+          files: build-${{ matrix.preset }}/*.deb
 
       - name: Show final ccache and build directory stats
         if: always()
@@ -171,86 +137,6 @@ jobs:
         run: |
           ccache --show-stats
           echo "--- Build directory ---"
-          du -h -s build-ci-latest-clang
+          du -h -s build-${{ matrix.preset }}
           echo "--- Debian packages (.deb/.ddeb) ---"
-          find build-ci-latest-clang \( -name "*.deb" -o -name "*.ddeb" \) -exec du -ch {} + | tail -1
-
-  package-emscripten:
-    name: "Emscripten | Release | CPack"
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/fair-acc/gr4-build-container:latest
-    env:
-      CCACHE_DIR: ${{ github.workspace }}/.ccache
-      CCACHE_BASEDIR: ${{ github.workspace }}
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
-      - name: Cache ccache
-        uses: actions/cache@v5
-        with:
-          path: ${{ github.workspace }}/.ccache
-          key: ccache-cpack-emscripten-release-${{ github.sha }}
-          restore-keys: |
-            ccache-cpack-emscripten-release
-
-      - name: Cache fetchContent
-        uses: actions/cache@v5
-        with:
-          path: ${{ github.workspace }}/build-ci-latest-wasm/_deps
-          key: fetchContent-cpack-emscripten-release-${{ hashFiles('CMakeLists.txt') }}
-          restore-keys: |
-            fetchContent-cpack-emscripten-release
-
-      - name: Configure ccache
-        run: |
-          ccache --max-size=3G
-          ccache --set-config=compression=true
-          ccache --set-config=compression_level=6
-          ccache --set-config=depend_mode=true
-          ccache --set-config=hash_dir=false
-          ccache --set-config=sloppiness=file_macro,time_macros,include_file_mtime,include_file_ctime
-          ccache -z
-          ccache --show-stats
-
-      - name: Configure
-        shell: bash
-        run: |
-          export SYSTEM_NODE=$(which node)
-          $EMSDK_HOME/emsdk activate $EMSDK_VERSION
-          source $EMSDK_HOME/emsdk_env.sh
-          cmake --preset ci-latest-wasm
-
-      - name: Build CPack packages
-        shell: bash
-        run: |
-          source $EMSDK_HOME/emsdk_env.sh
-          cmake --build --preset ci-latest-wasm
-
-      - name: Upload packages
-        uses: actions/upload-artifact@v7
-        with:
-          name: emscripten-release-deb-${{ github.run_number }}
-          path: build-ci-latest-wasm/*.deb
-          if-no-files-found: error
-
-      - name: Publish to latest pre-release
-        uses: softprops/action-gh-release@v3
-        with:
-          tag_name: latest
-          name: "Latest build"
-          prerelease: true
-          make_latest: false
-          files: build-ci-latest-wasm/*.deb
-
-      - name: Show final ccache and build directory stats
-        if: always()
-        continue-on-error: true
-        run: |
-          ccache --show-stats
-          echo "--- Build directory ---"
-          du -h -s build-ci-latest-wasm
-          echo "--- Debian packages (.deb/.ddeb) ---"
-          find build-ci-latest-wasm \( -name "*.deb" -o -name "*.ddeb" \) -exec du -ch {} + | tail -1
+          find build-${{ matrix.preset }} \( -name "*.deb" -o -name "*.ddeb" \) -exec du -ch {} + | tail -1

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -7,6 +7,53 @@
   },
   "configurePresets": [
     {
+      "name": "ci-latest-gcc",
+      "displayName": "CI latest GCC (RelWithDebInfo)",
+      "description": "Configure preset for latest.yml GCC packaging job",
+      "binaryDir": "${sourceDir}/build-${presetName}",
+      "cacheVariables": {
+        "CMAKE_COLOR_DIAGNOSTICS": "ON",
+        "DISABLE_EXTERNAL_DEPS_WARNINGS": "ON",
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "CPACK_PACKAGING_INSTALL_PREFIX": "/opt/gnuradio4-gcc",
+        "CPACK_PACKAGE_NAME": "gnuradio4-gcc",
+        "USE_CCACHE": "ON",
+        "ENABLE_EXAMPLES": "OFF",
+        "ENABLE_TESTING": "OFF",
+        "ENABLE_COVERAGE": "OFF",
+        "ADDRESS_SANITIZER": "OFF",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+      },
+      "environment": {
+        "CC": "gcc-14",
+        "CXX": "g++-14"
+      }
+    },
+    {
+      "name": "ci-latest-clang",
+      "displayName": "CI latest Clang (RelWithDebInfo)",
+      "description": "Configure preset for latest.yml Clang packaging job",
+      "binaryDir": "${sourceDir}/build-${presetName}",
+      "cacheVariables": {
+        "CMAKE_COLOR_DIAGNOSTICS": "ON",
+        "DISABLE_EXTERNAL_DEPS_WARNINGS": "ON",
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "CPACK_PACKAGING_INSTALL_PREFIX": "/opt/gnuradio4-clang",
+        "CPACK_PACKAGE_NAME": "gnuradio4-clang",
+        "GR4_USE_LIBCXX": "ON",
+        "USE_CCACHE": "ON",
+        "ENABLE_EXAMPLES": "OFF",
+        "ENABLE_TESTING": "OFF",
+        "ENABLE_COVERAGE": "OFF",
+        "ADDRESS_SANITIZER": "OFF",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+      },
+      "environment": {
+        "CC": "clang-20",
+        "CXX": "clang++-20"
+      }
+    },
+    {
       "name": "ci-latest-wasm",
       "displayName": "CI latest WASM (Release)",
       "description": "Configure preset for latest.yml Emscripten packaging job",
@@ -32,6 +79,24 @@
     }
   ],
   "buildPresets": [
+    {
+      "name": "ci-latest-gcc",
+      "displayName": "CI latest GCC build",
+      "description": "Build preset for latest.yml GCC packaging job",
+      "configurePreset": "ci-latest-gcc",
+      "targets": [
+        "package"
+      ]
+    },
+    {
+      "name": "ci-latest-clang",
+      "displayName": "CI latest Clang build",
+      "description": "Build preset for latest.yml Clang packaging job",
+      "configurePreset": "ci-latest-clang",
+      "targets": [
+        "package"
+      ]
+    },
     {
       "name": "ci-latest-wasm",
       "displayName": "CI latest WASM build",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,45 @@
+{
+  "version": 6,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 27,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "ci-latest-wasm",
+      "displayName": "CI latest WASM (Release)",
+      "description": "Configure preset for latest.yml Emscripten packaging job",
+      "binaryDir": "${sourceDir}/build-${presetName}",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "$env{EMSDK}/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake",
+        "CMAKE_COLOR_DIAGNOSTICS": "ON",
+        "DISABLE_EXTERNAL_DEPS_WARNINGS": "ON",
+        "CMAKE_BUILD_TYPE": "Release",
+        "CPACK_PACKAGING_INSTALL_PREFIX": "/opt/gnuradio4-emscripten",
+        "CPACK_PACKAGE_NAME": "gnuradio4-emscripten",
+        "CPACK_GENERATOR": "DEB",
+        "CPACK_DEBIAN_PACKAGE_ARCHITECTURE": "all",
+        "CPACK_DEBIAN_PACKAGE_SHLIBDEPS": "OFF",
+        "CPACK_DEBIAN_DEBUGINFO_PACKAGE": "OFF",
+        "USE_CCACHE": "ON",
+        "ENABLE_EXAMPLES": "OFF",
+        "ENABLE_TESTING": "OFF",
+        "ENABLE_COVERAGE": "OFF",
+        "CMAKE_CROSSCOMPILING_EMULATOR": "$env{SYSTEM_NODE}",
+        "GNURADIO_PARSE_REGISTRATIONS_TOOL_CXX_COMPLILER": "g++-14"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "ci-latest-wasm",
+      "displayName": "CI latest WASM build",
+      "description": "Build preset for latest.yml Emscripten packaging job",
+      "configurePreset": "ci-latest-wasm",
+      "targets": [
+        "package"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
 - Allows for easier CI - DEV builds with the same cmake flags
 - Builds in Release mode as debug info inflates the files and browsers have limits.