### PR TITLE
797: Fix Python redefinitions by moving include orders

### DIFF
--- a/blocks/basic/include/gnuradio-4.0/basic/PythonInterpreter.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/PythonInterpreter.hpp
@@ -24,15 +24,6 @@
 
 #include <gnuradio-4.0/Message.hpp>
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-#ifndef __clang__
-#pragma GCC diagnostic ignored "-Wuseless-cast"
-#endif
-#endif
-#include <Python.h>
-
 #include <numpy/numpyconfig.h>
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/arrayobject.h>

--- a/blocks/basic/include/gnuradio-4.0/basic/PythonInterpreter.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/PythonInterpreter.hpp
@@ -1,6 +1,16 @@
 #ifndef GNURADIO_PYTHONINTERPRETER_HPP
 #define GNURADIO_PYTHONINTERPRETER_HPP
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#ifndef __clang__
+#pragma GCC diagnostic ignored "-Wuseless-cast"
+#endif
+#endif
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
 #include <atomic>
 #include <cassert>
 #include <cctype>

--- a/blocks/basic/test/qa_PythonBlock.cpp
+++ b/blocks/basic/test/qa_PythonBlock.cpp
@@ -1,7 +1,9 @@
+
+#include <gnuradio-4.0/basic/PythonBlock.hpp>
+
 #include <boost/ut.hpp>
 
 #include <gnuradio-4.0/Graph.hpp>
-#include <gnuradio-4.0/basic/PythonBlock.hpp>
 
 #include <gnuradio-4.0/Scheduler.hpp>
 #include <gnuradio-4.0/meta/UnitTestHelper.hpp>


### PR DESCRIPTION
This fixes #797 by moving the include orders, its not a very pretty solution I am open to alternatives.

This is needed because of this Python issue: https://github.com/python/cpython/issues/61322