### PR TITLE
Fix deadlock when scheduler is handling `kGraphGRC` message

### DIFF
--- a/core/include/gnuradio-4.0/Scheduler.hpp
+++ b/core/include/gnuradio-4.0/Scheduler.hpp
@@ -134,6 +134,7 @@ protected:
     bool                          _valid{true};
     std::size_t                   _nWatchdogsRunning{0};
     meta::indirect<gr::Graph>     _graph{};
+    std::size_t                   _graphGeneration{0}; // incremented on exchange()
     TProfiler                     _profiler{};
     ProfileHandle                 _profilerHandler{_profiler.forThisThread()};
     std::shared_ptr<TaskExecutor> _pool{gr::thread_pool::Manager::instance().defaultCpuPool()};
@@ -291,6 +292,8 @@ public:
         if (this->state() == ERROR || this->state() == STOPPED) {
             reset(); // reset internal states
         }
+
+        gr::atomic_ref(_graphGeneration).fetch_add(1);
 
         auto oldGraph = std::exchange(_graph, std::move(newGraph));
 
@@ -498,9 +501,9 @@ public:
         return {};
     }
 
-    void waitDone() {
+    void waitDone(bool isCalledFromWorker = false) {
         [[maybe_unused]] const auto pe = _profilerHandler->startCompleteEvent("scheduler_base.waitDone");
-        while (_nRunningJobs->value() > 0UZ) {
+        while (_nRunningJobs->value() > (isCalledFromWorker ? 1UZ : 0UZ)) {
             std::this_thread::sleep_for(std::chrono::milliseconds(timeout_ms));
         }
         // _nRunningJobs == 0 is the only quiescence point shared by the runAndWait /
@@ -644,7 +647,10 @@ protected:
 
         ioThreadPool->execute([this] { this->runWatchDog(watchdog_timeout.value, timeout_inactivity_count.value); });
 
-        assert(_nRunningJobs->value() == 0UZ);
+        // it is possible that a stray thread is still running due to it
+        // dispatching an exchange(), stopping only threads other than itself
+        waitDone();
+
         assert(!_executionOrder->empty());
         if constexpr (executionPolicy() == ExecutionPolicy::singleThreaded || executionPolicy() == ExecutionPolicy::singleThreadedBlocking) {
             static_cast<Derived*>(this)->poolWorker(0UZ, _executionOrder);
@@ -670,6 +676,12 @@ protected:
 
         nRunningJobs->incrementAndGet();
         nRunningJobs->notify_all();
+
+        on_scope_exit decrement = [nRunningJobs] {
+            std::ignore = nRunningJobs->subAndGet(1UZ);
+            nRunningJobs->notify_all();
+        };
+
         gr::thread_pool::thread::setThreadName(std::format("pW{}-{}", runnerID, gr::meta::shorten_type_name(this->unique_name)));
 
         [[maybe_unused]] auto profiler_handler = _profiler.forThisThread();
@@ -683,6 +695,7 @@ protected:
             std::ranges::copy(blocks, std::back_inserter(localBlockList));
         }
 
+        const auto            initialGeneration  = gr::atomic_ref(_graphGeneration).load_acquire();
         [[maybe_unused]] auto currentProgress    = this->_graph->progress().value();
         std::size_t           inactiveCycleCount = 0UZ;
         std::size_t           msgToCount         = 0UZ;
@@ -703,6 +716,9 @@ protected:
             if (hasMessagesToProcess) {
                 if (runnerID == 0UZ || nRunningJobs->value() == 0UZ) {
                     this->processScheduledMessages(); // execute the scheduler- and Graph-specific message handler only once globally
+                    if (initialGeneration != gr::atomic_ref(_graphGeneration).load_acquire()) {
+                        return; // we called exchange()
+                    }
                 }
 
                 // Zombies are cleaned per-thread, as we remove from the localBlockList as well.
@@ -774,8 +790,6 @@ protected:
                 }
             }
         } while (lifecycle::isActive(activeState));
-        std::ignore = nRunningJobs->subAndGet(1UZ);
-        nRunningJobs->notify_all();
     }
 
     void runWatchDog(std::size_t timeOut_ms, std::size_t timeOut_count) {
@@ -1313,9 +1327,34 @@ protected:
 
                     const auto originalState = this->state();
 
+                    // need to stop running scheduler before performing
+                    // exchange, otherwise exchange will do state change
+                    // operations expecting to be called from an external
+                    // thread, but this may be from worker thread (hence
+                    // waitDone(true) call)
+                    if (lifecycle::isActive(originalState)) {
+                        if (auto result = this->changeStateTo(REQUESTED_STOP); !result) {
+                            auto msg = std::format("Failed to request stop: {}", result.error());
+                            this->emitErrorMessage("propertyCallbackGraphGRC", msg);
+                            message.data = std::unexpected(Error{msg});
+                            return message;
+                        }
+                        waitDone(true); // wait for all *other* jobs to complete
+
+                        if (auto result = this->changeStateTo(STOPPED); !result) {
+                            auto msg = std::format("Failed to finish stopping scheduler: {}", result.error());
+                            this->emitErrorMessage("propertyCallbackGraphGRC", msg);
+                            message.data = std::unexpected(Error{msg});
+                            return message;
+                        }
+                    }
+                    assert(this->state() == STOPPED);
+
                     if (auto result = this->exchange(std::move(newGraph)); !result) {
-                        this->emitErrorMessage("propertyCallbackGraphGRC", "Failed to exchange graph");
-                        return {};
+                        auto msg = std::format("Failed to exchange graph: {}", result.error());
+                        this->emitErrorMessage("propertyCallbackGraphGRC", msg);
+                        message.data = std::unexpected(Error{msg});
+                        return message;
                     }
 
                     message.data = property_map{{ "originalSchedulerState", static_cast<int>(originalState) }};

--- a/core/include/gnuradio-4.0/Scheduler.hpp
+++ b/core/include/gnuradio-4.0/Scheduler.hpp
@@ -1462,6 +1462,9 @@ struct Simple : SchedulerBase<Simple<execution, TProfiler>, execution, TProfiler
             }
         }
     }
+
+    // repopulate _executionOrder when restarting the graph because our graph contents may have changed while stopped
+    void customReset() { customInit(); }
 };
 
 namespace detail {
@@ -1561,6 +1564,9 @@ detecting cycles and blocks which can be reached from several source blocks.)"">
         this->_adoptionBlocks.resize(n_batches);
         *this->_executionOrder = detail::batchBlocks(blockList, n_batches);
     }
+
+    // repopulate _executionOrder when restarting the graph because our graph contents may have changed while stopped
+    void customReset() { customInit(); }
 };
 
 template<ExecutionPolicy execution = ExecutionPolicy::singleThreaded, profiling::ProfilerLike TProfiler = profiling::null::Profiler>
@@ -1626,6 +1632,9 @@ struct DepthFirst : SchedulerBase<DepthFirst<execution, TProfiler>, execution, T
         this->_adoptionBlocks.resize(n_batches);
         *this->_executionOrder = detail::batchBlocks(blockList, n_batches);
     }
+
+    // repopulate _executionOrder when restarting the graph because our graph contents may have changed while stopped
+    void customReset() { customInit(); }
 };
 
 } // namespace gr::scheduler

--- a/core/include/gnuradio-4.0/Scheduler.hpp
+++ b/core/include/gnuradio-4.0/Scheduler.hpp
@@ -131,8 +131,61 @@ private:
 protected:
     using ProfileHandle = decltype(std::declval<TProfiler&>().forThisThread());
 
-    bool                          _valid{true};
-    std::size_t                   _nWatchdogsRunning{0};
+    // similar to std::stop_token but guarantees that the cooperating thread
+    // will not do any work after stop is requested. Performance makes sense for
+    // threads which mostly sleep / do little actual work. Requires that the
+    // thread cooperate by sleeping on the sleepVariable.
+    class WatchdogStopContext {
+    private:
+        std::condition_variable _sleepVariable;
+        std::mutex              _requestedMutex;
+        bool                    _stopRequested = false;
+
+    public:
+        [[nodiscard]] std::unique_lock<std::mutex> lock() { return std::unique_lock{_requestedMutex}; }
+        [[nodiscard]] std::condition_variable&     sleepVariable() { return _sleepVariable; }
+        void                                       requestStop() {
+            if (gr::atomic_ref(_stopRequested).load_acquire()) {
+                return; // hint, no need to take mutex
+            }
+
+            bool wasRequested = false;
+            {
+                auto lock    = std::unique_lock{_requestedMutex};
+                wasRequested = !_stopRequested;
+                gr::atomic_ref(_stopRequested).store_release(true);
+            }
+            if (wasRequested) {
+                _sleepVariable.notify_all();
+            }
+        }
+
+        /// only to be called while lock() is held
+        [[nodiscard]] bool stopRequested() const { return _stopRequested; }
+    };
+
+    struct WatchdogThreadHandle {
+        std::mutex                           mutex;
+        std::shared_ptr<WatchdogStopContext> context;
+
+        void stop() {
+            auto lock = std::unique_lock{mutex};
+            if (context) {
+                context->requestStop();
+            }
+        }
+
+        /// Stops the watchdog and creates a context for a new thread
+        std::shared_ptr<WatchdogStopContext> stopOldThreadAndGetNewContext() {
+            auto currentThreadContextLock = std::unique_lock{mutex};
+            if (context) {
+                context->requestStop();
+            }
+            context = std::make_shared<WatchdogStopContext>();
+            return context;
+        }
+    };
+
     meta::indirect<gr::Graph>     _graph{};
     std::size_t                   _graphGeneration{0}; // incremented on exchange()
     TProfiler                     _profiler{};
@@ -141,6 +194,8 @@ protected:
     std::shared_ptr<gr::Sequence> _nRunningJobs = std::allocate_shared<gr::Sequence>(std::pmr::polymorphic_allocator<gr::Sequence>(this->_resources.mechanicsResource()));
     std::recursive_mutex          _executionOrderMutex; // only used when modifying and copying the graph->local job list
     std::shared_ptr<JobLists>     _executionOrder = std::allocate_shared<JobLists>(std::pmr::polymorphic_allocator<JobLists>(this->_resources.mechanicsResource()));
+
+    WatchdogThreadHandle _lastWatchDogThread;
 
     std::mutex                               _zombieBlocksMutex;
     std::vector<std::shared_ptr<BlockModel>> _zombieBlocks;
@@ -265,12 +320,7 @@ public:
         }
         waitDone();
 
-        gr::atomic_ref(_valid).store_release(false); // Mark as invalid
-
-        // the watchdog dereferences SchedulerBase, wait until it finishes
-        while (gr::atomic_ref(_nWatchdogsRunning).load_acquire() != 0) {
-            std::this_thread::sleep_for(std::chrono::milliseconds(10));
-        }
+        _lastWatchDogThread.stop();
 
         _executionOrder.reset(); // force earlier crashes if this is accessed after destruction (e.g. from thread that was kept running)
     }
@@ -292,6 +342,9 @@ public:
         if (this->state() == ERROR || this->state() == STOPPED) {
             reset(); // reset internal states
         }
+
+        // Watchdogs may read from _graph, potentially during the exchange() below
+        _lastWatchDogThread.stop();
 
         gr::atomic_ref(_graphGeneration).fetch_add(1);
 
@@ -642,10 +695,7 @@ protected:
         // start watchdog
         auto ioThreadPool = gr::thread_pool::Manager::defaultIoPool();
 
-        // keep outside of the lambda, as ~SchedulerBase() might finish before watchdog even starts
-        gr::atomic_ref(_nWatchdogsRunning).fetch_add(1UZ);
-
-        ioThreadPool->execute([this] { this->runWatchDog(watchdog_timeout.value, timeout_inactivity_count.value); });
+        ioThreadPool->execute([this, context = _lastWatchDogThread.stopOldThreadAndGetNewContext()] { this->runWatchDog(context, watchdog_timeout.value, timeout_inactivity_count.value); });
 
         // it is possible that a stray thread is still running due to it
         // dispatching an exchange(), stopping only threads other than itself
@@ -792,28 +842,24 @@ protected:
         } while (lifecycle::isActive(activeState));
     }
 
-    void runWatchDog(std::size_t timeOut_ms, std::size_t timeOut_count) {
-        on_scope_exit _ = [this] { gr::atomic_ref(_nWatchdogsRunning).fetch_sub(1UZ); };
+    void runWatchDog(std::shared_ptr<WatchdogStopContext> context, std::size_t timeOut_ms, std::size_t timeOut_count) {
+        auto lock = context->lock();
+        if (context->stopRequested()) {
+            return;
+        }
 
         auto thisName = gr::meta::shorten_type_name(this->unique_name);
         gr::thread_pool::thread::setThreadName(std::format("WatchDog-{}", thisName));
 
-        const auto deadline      = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
-        const auto checkInterval = std::chrono::milliseconds(std::max(timeout_ms / 10UZ, 1UZ));
-        while (gr::atomic_ref(_valid).load_acquire() && _nRunningJobs->value() == 0UZ && std::chrono::steady_clock::now() < deadline && lifecycle::isActive(this->state())) {
-            std::this_thread::sleep_for(checkInterval);
-        }
-
-        if (!gr::atomic_ref(_valid).load_acquire() || _nRunningJobs->value() == 0UZ || !lifecycle::isActive(this->state())) {
-            return; // abort watchdog: scheduler inactive or jobs already finished.
-        }
-
         std::size_t lastProgress = _graph->_progress->value();
         std::size_t nWarnings    = 0;
         do {
-            std::this_thread::sleep_for(std::chrono::milliseconds(timeOut_ms));
-            // check and increase progress if there hasn't been none.
+            context->sleepVariable().wait_for(lock, std::chrono::milliseconds(timeOut_ms));
+            if (context->stopRequested()) { // scheduler exited or a new watchdog was started
+                return;
+            }
 
+            // check and increase progress if there hasn't been none.
             std::size_t currentProgress = _graph->_progress->value();
             if ((_nRunningJobs->value() > 0UZ) && (currentProgress == lastProgress)) {
                 nWarnings++;

--- a/core/test/qa_SchedulerMessages.cpp
+++ b/core/test/qa_SchedulerMessages.cpp
@@ -15,8 +15,6 @@
 using namespace std::chrono_literals;
 using namespace std::string_literals;
 
-namespace ut = boost::ut;
-
 // We don't like new, but this will ensure the object is alive
 // when ut starts running the tests. It runs the tests when
 // its static objects get destroyed, which means other static
@@ -25,8 +23,9 @@ TestContext* context = new TestContext(paths{}, // plugin paths
     gr::blocklib::initGrBasicBlocks,            //
     gr::blocklib::initGrTestingBlocks);
 
+template<gr::scheduler::ExecutionPolicy policy = gr::scheduler::ExecutionPolicy::singleThreaded>
 class TestScheduler {
-    using TScheduler = gr::scheduler::Simple<gr::scheduler::ExecutionPolicy::singleThreaded>;
+    using TScheduler = gr::scheduler::Simple<policy>;
     std::future<std::expected<void, gr::Error>> schedulerRet_;
 
     auto&& withTestingSourceAndSink(gr::Graph&& graph) const noexcept {
@@ -59,9 +58,16 @@ public:
     TestScheduler& operator=(TestScheduler&&)      = delete;
 
     void run() {
+        using namespace boost::ut;
+        if (schedulerRet_.valid()) {
+            // wait for previous thread to close because we gave it a pointer to scheduler_
+            auto result = schedulerRet_.get();
+            if (!result.has_value()) {
+                expect(false) << std::format("Scheduler being restarted waited for the previous thread, which returned failure: \n{}\n", result.error());
+            }
+        }
         schedulerRet_ = gr::test::thread_pool::executeScheduler("qa_SchMess::scheduler", scheduler_);
 
-        using namespace boost::ut;
         // Wait for the scheduler to start running
         expect(gr::testing::awaitCondition(scheduler_, [this] { return scheduler_.state() == gr::lifecycle::State::RUNNING; })) << "scheduler thread up and running w/ timeout";
         expect(scheduler_.state() == gr::lifecycle::State::RUNNING) << "scheduler thread up and running";
@@ -371,7 +377,7 @@ const boost::ut::suite TopologyGraphTests = [] {
 
                     // verify well formed by loading from yaml
                     auto graphFromYaml = gr::loadGrc(context->loader, yaml);
-                    expect(eq(graphFromYaml->blocks().size(), 4UZ)) << std::format("Expected 4 blocks in loaded graph, got {} blocks", graphFromYaml->blocks().size());
+                    expect(eq(graphFromYaml->blocks().size(), 4UZ)) << std::format("Expected 4 blocks in loaded graph, got {} blocks\n", graphFromYaml->blocks().size());
 
                     return true;
                 }
@@ -379,6 +385,73 @@ const boost::ut::suite TopologyGraphTests = [] {
                 return false;
             });
     };
+
+    static const auto setGrcYamlTestGeneric = []<gr::scheduler::ExecutionPolicy policy>() {
+        gr::Graph testGraph(context->loader);
+        auto&     source = testGraph.emplaceBlock<gr::testing::SlowSource<float>>();
+        auto&     copy1  = testGraph.emplaceBlock<gr::testing::Copy<float>>();
+        auto&     copy2  = testGraph.emplaceBlock<gr::testing::Copy<float>>();
+        auto&     sink   = testGraph.emplaceBlock<gr::testing::CountingSink<float>>();
+        expect(testGraph.connect<"out", "in">(source, copy1).has_value());
+        expect(testGraph.connect<"out", "in">(copy1, copy2).has_value());
+        expect(testGraph.connect<"out", "in">(copy2, sink).has_value());
+
+        TestScheduler<policy> scheduler(std::move(testGraph), /*addTestSourceAndSink=*/false);
+        expect(scheduler.state() == lifecycle::State::RUNNING) << fatal;
+
+        const auto getYamlString = [](TestScheduler<policy>& yamlSource) {
+            std::string yaml;
+            testing::sendAndWaitForReply<gr::message::Command::Get>(yamlSource.toScheduler, yamlSource.fromScheduler, yamlSource.unique_name(), scheduler::property::kGraphGRC, {}, [&yaml](const Message& reply) {
+                if (reply.endpoint == scheduler::property::kGraphGRC && reply.data.has_value()) {
+                    yaml = reply.data->value_or<std::string>("value", "NO VALUE KEY"sv);
+                    return true;
+                }
+                return false;
+            });
+            return yaml;
+        };
+
+        std::string yaml = getYamlString(scheduler);
+        {
+            expect(!yaml.empty());
+            auto testGraphFromYaml = gr::loadGrc(context->loader, yaml);
+            expect(eq(testGraphFromYaml->blocks().size(), 4UZ)) << std::format("Expected 4 blocks in loaded graph, got {} blocks\n", testGraphFromYaml->blocks().size());
+        }
+
+        // construct secondary graph to exchange with, which should produce a different result
+        gr::Graph alternativeGraph(context->loader);
+        auto&     altSource = alternativeGraph.emplaceBlock<gr::testing::CountingSource<float>>();
+        auto&     altCopy   = alternativeGraph.emplaceBlock<gr::testing::Copy<float>>();
+        auto&     altSink   = alternativeGraph.emplaceBlock<gr::testing::CountingSink<float>>();
+        expect(alternativeGraph.connect<"out", "in">(altSource, altCopy).has_value());
+        expect(alternativeGraph.connect<"out", "in">(altCopy, altSink).has_value());
+
+        const auto altYaml = gr::saveGrc(context->loader, alternativeGraph);
+
+        testing::sendAndWaitForReply<gr::message::Command::Set>(scheduler.toScheduler, scheduler.fromScheduler, scheduler.unique_name(), scheduler::property::kGraphGRC, gr::property_map{{"value", altYaml}}, [](const Message& reply) {
+            if (reply.endpoint == scheduler::property::kGraphGRC && reply.data.has_value()) {
+                const auto oldState = static_cast<gr::lifecycle::State>(reply.data->value_or<int>("originalSchedulerState", gr::lifecycle::State::IDLE));
+                expect(oldState == gr::lifecycle::State::RUNNING) << "did not transition state from running by doing exchange()\n";
+                return true;
+            }
+            return false;
+        });
+
+        // we must now return the scheduler to a running state, part of the contract of kGraphGRC Set message
+        scheduler.run();
+
+        // scheduler now holds the new graph's yaml
+        std::string savedAltYaml = getYamlString(scheduler);
+        {
+            expect(!savedAltYaml.empty());
+            auto alternativeGraphFromYaml = gr::loadGrc(context->loader, savedAltYaml);
+            expect(eq(alternativeGraphFromYaml->blocks().size(), 3UZ)) << std::format("Expected 3 blocks in loaded graph, got {} blocks", alternativeGraphFromYaml->blocks().size());
+        }
+    };
+
+    "singlethreaded Set GRC yaml"_test          = [] { setGrcYamlTestGeneric.operator()<gr::scheduler::ExecutionPolicy::singleThreaded>(); };
+    "multithreaded Set GRC yaml"_test           = [] { setGrcYamlTestGeneric.operator()<gr::scheduler::ExecutionPolicy::multiThreaded>(); };
+    "singlethreaded blocking Set GRC yaml"_test = [] { setGrcYamlTestGeneric.operator()<gr::scheduler::ExecutionPolicy::singleThreadedBlocking>(); };
 
     "UI constraints setting test"_test = [] {
         // Build a fully connected source→copy1→copy2→sink chain. Orphan blocks


### PR DESCRIPTION
This PR adds reproducing tests and a fix for a deadlock in the scheduler, caused by setting a graphs GRC via messages. A worker thread picks it up and then tries to do `exchange()`, which calls `waitDone()`, which waits on itself.

My solution was just to have a worker thread do `waitDone()` for only the other threads, ie. waiting for `_nRunningJobs` to decrease to 1, and then stop the graph and exchange things. This works because only one thread processes scheduler messages.

The thread processing scheduler messages does not quit after the scheduler has been stopped and the graph replaced, it may continue to process messages. AFAICT this is harmless.

I noticed an issue where there was a potential data race on the `_graph` pointer from the watchdog thread. Then I also noticed that it was possible for watchdogs to miss that the graph had been stopped and restarted due to the AB problem with `_nRunningJobs`. (A similar issue still exists with `waitDone()`, where it is theoretically possible for `waitDone()` to be called while threads are still starting up and therefore `_nRunningJobs` goes to zero but other threads start afterwards).
I wanted to have some stronger guarantees about the watchdog threads, partially to fix these two issues and partially because I think it makes things easier to think about when I'm trying to think through all the ways that ordering can happen.  So I added this `WatchdogThreadContext` which enables the calling thread to do `_lastWatchdogThread.stop()` and be certain that the watchdog will not do any work after, but it does not block on a sleeping watchdog. LMK if there are some standard library mechanisms or something that can do this more concisely... it seems like something that should have an existing primitive, but I did not find one.

A problem here is that `propertyCallbackGraphGRC` might fail to do the `exchange()`, in which case it cannot recover from / undo the `makeAllZombies()` call. I think that is fine... I guess if that happens the user has bigger problems.