### PR TITLE
Serialize scheduler block parameters when inspecting graph

### DIFF
--- a/core/include/gnuradio-4.0/Scheduler.hpp
+++ b/core/include/gnuradio-4.0/Scheduler.hpp
@@ -1415,6 +1415,8 @@ detecting cycles and blocks which can be reached from several source blocks.)"">
 
     static_assert(execution == ExecutionPolicy::singleThreaded || execution == ExecutionPolicy::multiThreaded, "Unsupported execution policy");
 
+    using SchedulerBase<BreadthFirst<execution, TProfiler>, execution, TProfiler>::SchedulerBase;
+
     void customInit() {
         /* implements Breadth-first search scheduling algorithm (https://en.wikipedia.org/wiki/Breadth-first_search)
          * 1. compute 'adjacencyList'
@@ -1485,6 +1487,8 @@ template<ExecutionPolicy execution = ExecutionPolicy::singleThreaded, profiling:
 struct DepthFirst : SchedulerBase<DepthFirst<execution, TProfiler>, execution, TProfiler> {
     using Description = Doc<R""(Depth First Scheduler which traverses the graph starting from the source blocks in a depth-first manner.)"">;
     static_assert(execution == ExecutionPolicy::singleThreaded || execution == ExecutionPolicy::multiThreaded, "Unsupported execution policy");
+
+    using SchedulerBase<DepthFirst<execution, TProfiler>, execution, TProfiler>::SchedulerBase;
 
     void customInit() {
         /**

--- a/core/src/BlockModel.cpp
+++ b/core/src/BlockModel.cpp
@@ -4,6 +4,64 @@
 #include <gnuradio-4.0/Graph_yaml_importer.hpp>
 #include <gnuradio-4.0/PluginLoader.hpp>
 
+namespace {
+void serializeBlockSettings(gr::property_map& output, gr::BlockModel& block) {
+    using namespace gr;
+    // Helper function to write parameters
+    auto writeParameters = [&](const property_map& settingsMap) {
+        pmt::Value::Map parameters;
+        auto            writeMap = [&](const auto& localMap) {
+            for (const auto& [settingsKey, settingsValue] : localMap) {
+                parameters[settingsKey] = settingsValue;
+            }
+        };
+        writeMap(settingsMap);
+        return parameters;
+    };
+
+    // We don't have a use for info which parameters weren't applied here
+    const auto& applyResult = block.settings().applyStagedParameters();
+    const auto& stored      = block.settings().getStoredAll();
+
+    output.emplace(serialization_fields::BLOCK_PARAMETERS, writeParameters(block.settings().get()));
+
+    using namespace std::string_literals;
+    Tensor<pmt::Value> ctxParamsSeq;
+    ctxParamsSeq.reserve(stored.size());
+    for (const auto& [ctx, ctxParameters] : stored) {
+        if (ctx.holds<std::string>()) {
+            if (auto str = ctx.value_or(std::string_view{}); str.empty()) {
+                continue;
+            }
+        }
+
+        for (const auto& [ctxTime, settingsMap] : ctxParameters) {
+            pmt::Value::Map ctxParam;
+
+            // Convert ctxTime.context to a string, regardless of its actual type
+            std::string contextStr;
+            pmt::ValueVisitor([&contextStr]<typename T>(const T& arg) {
+                if constexpr (std::is_same_v<T, std::string>) {
+                    contextStr = arg;
+                } else if constexpr (std::is_same_v<std::string_view, T> || std::is_same_v<std::pmr::string, T>) {
+                    contextStr = std::string(arg);
+                } else if constexpr (std::is_arithmetic_v<T>) {
+                    contextStr = std::to_string(arg);
+                } else {
+                    contextStr.clear();
+                }
+            }).visit(ctxTime.context);
+
+            ctxParam.emplace(gr::tag::CONTEXT.shortKey(), contextStr);
+            ctxParam.emplace(gr::tag::CONTEXT_TIME.shortKey(), ctxTime.time);
+            ctxParam.emplace(serialization_fields::BLOCK_PARAMETERS, writeParameters(settingsMap));
+            ctxParamsSeq.emplace_back(std::move(ctxParam));
+        }
+    }
+    output.emplace(serialization_fields::BLOCK_CTX_PARAMETERS, std::move(ctxParamsSeq));
+}
+} // namespace
+
 namespace gr {
 property_map serializeBlockImpl(gr::PluginLoader& pluginLoader, const std::shared_ptr<BlockModel>& block, int flags) {
     using namespace std::string_literals;
@@ -11,6 +69,7 @@ property_map serializeBlockImpl(gr::PluginLoader& pluginLoader, const std::share
     property_map result;
     result.emplace(serialization_fields::BLOCK_ID, pluginLoader.registry().typeName(block));
     result.emplace(serialization_fields::BLOCK_UNIQUE_NAME, std::string(block->uniqueName()));
+    result.emplace(serialization_fields::BLOCK_NAME, std::string(block->name()));
     result.emplace(serialization_fields::BLOCK_CATEGORY, std::string(gr::meta::enumName(block->blockCategory()).value_or("")));
 
     if (!block->metaInformation().empty()) {
@@ -18,58 +77,7 @@ property_map serializeBlockImpl(gr::PluginLoader& pluginLoader, const std::share
     }
 
     if (flags & BlockSerializationFlags::Settings) {
-        // Helper function to write parameters
-        auto writeParameters = [&](const property_map& settingsMap) {
-            pmt::Value::Map parameters;
-            auto            writeMap = [&](const auto& localMap) {
-                for (const auto& [settingsKey, settingsValue] : localMap) {
-                    parameters[settingsKey] = settingsValue;
-                }
-            };
-            writeMap(settingsMap);
-            return parameters;
-        };
-
-        // We don't have a use for info which parameters weren't applied here
-        const auto& applyResult = block->settings().applyStagedParameters();
-        const auto& stored      = block->settings().getStoredAll();
-
-        result.emplace(serialization_fields::BLOCK_PARAMETERS, writeParameters(block->settings().get()));
-
-        using namespace std::string_literals;
-        Tensor<pmt::Value> ctxParamsSeq;
-        ctxParamsSeq.reserve(stored.size());
-        for (const auto& [ctx, ctxParameters] : stored) {
-            if (ctx.holds<std::string>()) {
-                if (auto str = ctx.value_or(std::string_view{}); str.empty()) {
-                    continue;
-                }
-            }
-
-            for (const auto& [ctxTime, settingsMap] : ctxParameters) {
-                pmt::Value::Map ctxParam;
-
-                // Convert ctxTime.context to a string, regardless of its actual type
-                std::string contextStr;
-                pmt::ValueVisitor([&contextStr]<typename T>(const T& arg) {
-                    if constexpr (std::is_same_v<T, std::string>) {
-                        contextStr = arg;
-                    } else if constexpr (std::is_same_v<std::string_view, T> || std::is_same_v<std::pmr::string, T>) {
-                        contextStr = std::string(arg);
-                    } else if constexpr (std::is_arithmetic_v<T>) {
-                        contextStr = std::to_string(arg);
-                    } else {
-                        contextStr.clear();
-                    }
-                }).visit(ctxTime.context);
-
-                ctxParam.emplace(gr::tag::CONTEXT.shortKey(), contextStr);
-                ctxParam.emplace(gr::tag::CONTEXT_TIME.shortKey(), ctxTime.time);
-                ctxParam.emplace(serialization_fields::BLOCK_PARAMETERS, writeParameters(settingsMap));
-                ctxParamsSeq.emplace_back(std::move(ctxParam));
-            }
-        }
-        result.emplace(serialization_fields::BLOCK_CTX_PARAMETERS, std::move(ctxParamsSeq));
+        serializeBlockSettings(result, *block);
     }
 
     if (flags & BlockSerializationFlags::Ports) {
@@ -138,8 +146,11 @@ property_map serializeBlock(PluginLoader& pluginLoader, const std::shared_ptr<Bl
 
         if (const auto* schedulerModel = dynamic_cast<const SchedulerModel*>(block.get()); schedulerModel != nullptr) {
             property_map schedulerMap;
-            schedulerMap["id"] = pluginLoader.schedulerRegistry().typeName(block);
-            map["scheduler"]   = std::move(schedulerMap);
+            schedulerMap[std::pmr::string{serialization_fields::BLOCK_ID}] = pluginLoader.schedulerRegistry().typeName(block);
+            if (flags & BlockSerializationFlags::Settings) {
+                serializeBlockSettings(schedulerMap, *block);
+            }
+            map["scheduler"] = std::move(schedulerMap);
         }
 
     } else {

--- a/core/test/qa_UnmanagedSubGraph.cpp
+++ b/core/test/qa_UnmanagedSubGraph.cpp
@@ -433,5 +433,33 @@ const boost::ut::suite SchedulerInspectTests_ = [] {
     };
 };
 
+const boost::ut::suite SerializationTests_ = [] {
+    "managed graph produces the \"graph\" as well as \"scheduler\" with scheduler block settings"_test = [] {
+        auto schedulerModel = std::make_shared<gr::SchedulerWrapper<gr::scheduler::Simple<>>>();
+
+        expect(schedulerModel->graph());
+
+        auto serialized = gr::serializeBlock(gr::globalPluginLoader(), schedulerModel, BlockSerializationFlags::All);
+        expect(serialized.contains("graph"));
+        auto schedulerMap = gr::test::get_value_or_fail<gr::property_map>(serialized.at("scheduler"));
+        auto id           = gr::test::get_value_or_fail<std::pmr::string>(schedulerMap.at(std::pmr::string(gr::serialization_fields::BLOCK_ID)));
+        auto settings     = gr::test::get_value_or_fail<gr::property_map>(schedulerMap.at(std::pmr::string(gr::serialization_fields::BLOCK_PARAMETERS)));
+        expect(schedulerModel->typeName() == id);
+        gr::test::get_value_or_fail<std::pmr::string>(settings.at("compute_domain")); // settings are present, this is for example used by opendigitizer
+    };
+
+    "unmanaged graph produces the \"scheduler\" with graph block settings"_test = [] {
+        gr::Graph rootGraph;
+        rootGraph.emplaceBlock<SlowSource<float>>();
+        rootGraph.emplaceBlock<CountingSink<float>>();
+        auto unmanagedGraph = rootGraph.addBlock(createDemoSubGraph<float>().graph);
+        expect(unmanagedGraph->graph());
+
+        auto serialized = gr::serializeBlock(gr::globalPluginLoader(), unmanagedGraph, BlockSerializationFlags::All);
+        expect(serialized.contains("graph"));
+        expect(!serialized.contains("scheduler"));
+    };
+};
+
 } // namespace gr::subgraph_test
 int main() { return boost::ut::cfg<boost::ut::override>.run(); }


### PR DESCRIPTION
Adds block settings into the \"scheduler\" field. Opendigitizer can use this to display the `compute_domain` of a scheduler.

Also has a commit fixing missing constructors of `DepthFirst` and `BreadthFirst` which prevents them from being able to be registered.

Also adds `BLOCK_NAME` for regular blocks, for some reason previously that was only being serialized for subgraphs.