### PR TITLE
Enable yaml importer and yaml messages on `-fno-exceptions`/embedded targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,10 +122,7 @@ jobs:
           cache-name: cache-fetchContent-cache
         with:
           path: ${{runner.workspace}}/build/_deps
-          key: fetchContent-${{ runner.os }}-${{ matrix.compiler.label || matrix.compiler.cc }}-${{ matrix.cmake-build-type }}-${{ hashFiles('CMakeLists.txt') }}
-          restore-keys: |
-            fetchContent-${{ runner.os }}-${{ matrix.compiler.label || matrix.compiler.cc }}-${{ matrix.cmake-build-type }}
-            fetchContent-${{ runner.os }}-${{ matrix.compiler.label || matrix.compiler.cc }}
+          key: fetchContent-${{ runner.os }}-${{ matrix.compiler.label || matrix.compiler.cc }}-${{ matrix.cmake-build-type }}-${{ hashFiles('CMakeLists.txt', 'patches/**') }}
 
       - name: Configure
         if: matrix.compiler.cmake_wrapper == null && matrix.compiler.cxx != 'acpp'

--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -54,9 +54,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/build-${{ matrix.preset }}/_deps
-          key: fetchContent-${{ matrix.preset }}-${{ hashFiles('CMakeLists.txt') }}
-          restore-keys: |
-            fetchContent-${{ matrix.preset }}
+          key: fetchContent-${{ matrix.preset }}-${{ hashFiles('CMakeLists.txt', 'patches/**') }}
 
       - name: Configure ccache
         run: |

--- a/.github/workflows/tag_builds.yml
+++ b/.github/workflows/tag_builds.yml
@@ -35,9 +35,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/build/_deps
-          key: fetchContent-tag-gcc14-relwithdebinfo-${{ hashFiles('CMakeLists.txt') }}
-          restore-keys: |
-            fetchContent-tag-gcc14-relwithdebinfo
+          key: fetchContent-tag-gcc14-relwithdebinfo-${{ hashFiles('CMakeLists.txt', 'patches/**') }}
 
       - name: Configure ccache
         run: |
@@ -128,9 +126,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/build/_deps
-          key: fetchContent-tag-clang20-relwithdebinfo-${{ hashFiles('CMakeLists.txt') }}
-          restore-keys: |
-            fetchContent-tag-clang20-relwithdebinfo
+          key: fetchContent-tag-clang20-relwithdebinfo-${{ hashFiles('CMakeLists.txt', 'patches/**') }}
 
       - name: Configure ccache
         run: |
@@ -222,9 +218,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/build/_deps
-          key: fetchContent-tag-emscripten-relwithdebinfo-${{ hashFiles('CMakeLists.txt') }}
-          restore-keys: |
-            fetchContent-tag-emscripten-relwithdebinfo
+          key: fetchContent-tag-emscripten-relwithdebinfo-${{ hashFiles('CMakeLists.txt', 'patches/**') }}
 
       - name: Configure ccache
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -636,6 +636,7 @@ if(NOT EMSCRIPTEN)
     --ignore-space-change
     --ignore-whitespace
     "${CMAKE_CURRENT_SOURCE_DIR}/patches/cpr-disable-std-fs-test.diff"
+    "${CMAKE_CURRENT_SOURCE_DIR}/patches/cpr-throw-ifdef-cppexceptions.diff"
     ||
     true
     FETCH_VARIABLES

--- a/algorithm/include/gnuradio-4.0/algorithm/fileio/FileIo.hpp
+++ b/algorithm/include/gnuradio-4.0/algorithm/fileio/FileIo.hpp
@@ -404,7 +404,7 @@ inline void pushFinal(ReaderState* state, bool publishPending = true) {
 
     bool expected = false;
     if (!state->finalPublished.compare_exchange_strong(expected, true, std::memory_order_acq_rel)) {
-        throw gr::exception("pushFinal called more than once on the same ReadState");
+        gr::log::fatal("pushFinal called more than once on the same ReadState");
     }
 
     gr::Message finalMsg;

--- a/core/include/gnuradio-4.0/Graph.hpp
+++ b/core/include/gnuradio-4.0/Graph.hpp
@@ -441,7 +441,7 @@ public:
         return *rawBlockRef;
     }
 
-    [[maybe_unused]] std::shared_ptr<BlockModel> const& emplaceBlock(std::string_view type, property_map initialSettings);
+    std::expected<std::shared_ptr<BlockModel>, Error> emplaceBlock(std::string_view type, property_map initialSettings);
 
     bool containsEdge(const Edge& edge) const {
         return std::ranges::any_of(_edges, [&](const Edge& e) { return e == edge; });
@@ -479,7 +479,7 @@ public:
         return removedBlock;
     }
 
-    std::pair<std::shared_ptr<BlockModel>, std::shared_ptr<BlockModel>> replaceBlock(std::string_view uniqueName, std::string_view type, const property_map& properties);
+    [[nodiscard]] std::expected<std::pair<std::shared_ptr<BlockModel>, std::shared_ptr<BlockModel>>, Error> replaceBlock(std::string_view uniqueName, std::string_view type, const property_map& properties);
 
     [[nodiscard]] std::expected<std::shared_ptr<BlockModel>, Error> groupBlocks(std::span<const std::shared_ptr<BlockModel>> targetBlocks, std::string_view schedulerTypename, std::source_location location = std::source_location::current());
 

--- a/core/include/gnuradio-4.0/Graph_yaml_importer.hpp
+++ b/core/include/gnuradio-4.0/Graph_yaml_importer.hpp
@@ -80,16 +80,7 @@ inline std::expected<T, gr::Error> getProperty(const gr::pmt::Value& val, std::s
     return getProperty<T>(*mapOpt, propertyName, propertySubNames...);
 }
 
-template<typename T>
-T getOrThrow(std::expected<T, gr::Error>&& expectedValue, std::source_location location = std::source_location::current()) {
-    if (!expectedValue) {
-        throw gr::exception(std::format("Got an error {}, caller {}:{}", expectedValue.error().message, location.file_name(), location.line()));
-    } else {
-        return *expectedValue;
-    }
-}
-
-inline void loadGraphFromMap(PluginLoader& loader, gr::Graph& resultGraph, gr::property_map yaml, std::source_location location = std::source_location::current()) {
+inline std::expected<void, gr::Error> loadGraphFromMap(PluginLoader& loader, gr::Graph& resultGraph, gr::property_map yaml, std::source_location location = std::source_location::current()) {
     std::map<std::string, std::shared_ptr<BlockModel>> createdBlocks;
 
     Tensor<Value> blks;
@@ -107,24 +98,32 @@ inline void loadGraphFromMap(PluginLoader& loader, gr::Graph& resultGraph, gr::p
         }
         const auto& grcBlock = *_grcBlock;
 
-        const auto blockName = getOrThrow(getProperty<std::string>(grcBlock, "parameters"sv, "name"sv));
-        const auto blockType = getOrThrow(getProperty<std::string>(grcBlock, "id"sv));
+        auto blockName = getProperty<std::string>(grcBlock, "parameters"sv, "name"sv);
+        if (!blockName) {
+            return std::unexpected(std::move(blockName).error());
+        }
 
-        if (blockType == "SUBGRAPH") {
-            auto loadGraph = [&grcBlock, &loader, &location](auto graphWrapper) {
-                // bind to lvalues — get_if<>() pointers alias the Value's storage; temps would dangle
+        auto blockType = getProperty<std::string>(grcBlock, "id"sv);
+        if (!blockType) {
+            return std::unexpected(std::move(blockType).error());
+        }
+
+        if (*blockType == "SUBGRAPH") {
+            auto loadGraph = [&grcBlock, &loader, &location](auto graphWrapper) -> std::expected<void, gr::Error> {
                 const auto graphIt = grcBlock.find("graph");
                 if (graphIt == grcBlock.end()) {
-                    return;
+                    return {};
                 }
                 const Value graphEntry = (*graphIt).second;
                 const auto  _graphData = graphEntry.get_if<property_map>();
                 if (!_graphData) {
-                    return;
+                    return {};
                 }
                 const auto& graphData = *_graphData;
                 gr::Graph&  graph     = *graphWrapper->graph();
-                loadGraphFromMap(loader, graph, graphData);
+                if (auto result = loadGraphFromMap(loader, graph, graphData); !result) {
+                    return result;
+                }
 
                 const auto exportedPortsIt = graphData.find("exported_ports");
                 // Tensor<Value> decode requires Value::_resource for sub-Value allocations.
@@ -133,7 +132,7 @@ inline void loadGraphFromMap(PluginLoader& loader, gr::Graph& resultGraph, gr::p
                 for (const auto& exportedPort_ : exportedPorts) {
                     auto exportedPort = exportedPort_.get_if<TensorView<Value>>();
                     if (!exportedPort || exportedPort->size() != 4) {
-                        throw gr::exception(std::format("Unable to parse exported port ({} instead of 4 elements)", exportedPort ? exportedPort->size() : -1UZ));
+                        return std::unexpected(gr::Error(std::format("Unable to parse exported port ({} instead of 4 elements)", exportedPort ? exportedPort->size() : -1UZ)));
                     }
 
                     // snapshot keeps Values alive so string_views from value_or<> don't dangle
@@ -143,7 +142,7 @@ inline void loadGraphFromMap(PluginLoader& loader, gr::Graph& resultGraph, gr::p
                     const auto internalPortName    = fields.data()[2].value_or(std::string_view{});
                     const auto exportedPortName    = fields.data()[3].value_or(std::string_view{});
                     if (requiredBlockName.data() == nullptr || portDirectionString.data() == nullptr || internalPortName.data() == nullptr || exportedPortName.data() == nullptr) {
-                        throw gr::exception(std::format("Required fields for exported ports missing"));
+                        return std::unexpected(gr::Error("Required fields for exported ports missing"));
                     }
 
                     std::string blockUniqueName;
@@ -153,7 +152,7 @@ inline void loadGraphFromMap(PluginLoader& loader, gr::Graph& resultGraph, gr::p
                         }
                     }
                     if (blockUniqueName.empty()) {
-                        throw gr::exception(std::format("Required Block {} not found in:\n{}", requiredBlockName, gr::graph::format(graph)), location);
+                        return std::unexpected(gr::Error(std::format("Required Block {} not found in:\n{}", requiredBlockName, gr::graph::format(graph)), location));
                     }
 
                     if (auto result = graphWrapper->exportPort(true,                                       //
@@ -162,9 +161,10 @@ inline void loadGraphFromMap(PluginLoader& loader, gr::Graph& resultGraph, gr::p
                             internalPortName,                                                              //
                             exportedPortName);
                         !result.has_value()) {
-                        throw result.error();
+                        return std::unexpected(std::move(result).error());
                     }
                 }
+                return {};
             };
 
             auto       schedulerIt = grcBlock.find("scheduler");
@@ -174,9 +174,13 @@ inline void loadGraphFromMap(PluginLoader& loader, gr::Graph& resultGraph, gr::p
                 const Value schedulerValue = (*schedulerIt).second; // bind to lvalue so the Map* below aliases live storage
                 auto        schedulerPmt   = schedulerValue.get_if<property_map>();
                 if (!schedulerPmt) {
-                    throw gr::exception(std::format("scheduler is not a property_map"));
+                    return std::unexpected(gr::Error("scheduler is not a property_map"));
                 }
-                auto schedulerId = getOrThrow(getProperty<std::string>(*schedulerPmt, "id"sv));
+                auto schedulerIdResult = getProperty<std::string>(*schedulerPmt, "id"sv);
+                if (!schedulerIdResult) {
+                    return std::unexpected(std::move(schedulerIdResult).error());
+                }
+                auto schedulerId = std::move(*schedulerIdResult);
 
                 property_map schedulerParams;
                 if (auto paramsIt = schedulerPmt->find("parameters"); paramsIt != schedulerPmt->end()) {
@@ -188,31 +192,34 @@ inline void loadGraphFromMap(PluginLoader& loader, gr::Graph& resultGraph, gr::p
 
                 auto scheduler = loader.instantiateScheduler(schedulerId, schedulerParams);
                 if (!scheduler) {
-                    throw gr::exception(std::format("Unable to create scheduler of type '{}'", schedulerId));
+                    return std::unexpected(gr::Error(std::format("Unable to create scheduler of type '{}'", schedulerId)));
                 }
 
                 auto schedulerBlock = SchedulerModel::asBlockModelPtr(scheduler);
                 resultGraph.addBlock(schedulerBlock);
-                createdBlocks[blockName] = schedulerBlock;
-                schedulerBlock->setName(blockName);
+                createdBlocks[*blockName] = schedulerBlock;
+                schedulerBlock->setName(*blockName);
 
-                loadGraph(schedulerBlock);
+                if (auto result = loadGraph(schedulerBlock); !result) {
+                    return result;
+                }
 
             } else {
                 const std::shared_ptr<BlockModel>& subGraph = resultGraph.addBlock(std::make_shared<GraphWrapper<gr::Graph>>());
-                createdBlocks[blockName]                    = subGraph;
-                subGraph->setName(blockName);
+                createdBlocks[*blockName]                   = subGraph;
+                subGraph->setName(*blockName);
 
-                loadGraph(static_cast<GraphWrapper<gr::Graph>*>(subGraph.get()));
+                if (auto result = loadGraph(static_cast<GraphWrapper<gr::Graph>*>(subGraph.get())); !result) {
+                    return result;
+                }
             }
         } else {
-            auto currentBlock = loader.instantiate(blockType);
+            auto currentBlock = loader.instantiate(*blockType);
             if (!currentBlock) {
-                throw gr::exception(std::format("Unable to create block of type '{}'", blockType));
+                return std::unexpected(gr::Error(std::format("Unable to create block of type '{}'", *blockType)));
             }
 
-            // This sets the previously read "name" field for the block
-            currentBlock->setName(blockName);
+            currentBlock->setName(*blockName);
 
             if (auto paramsIt = grcBlock.find("parameters"); paramsIt != grcBlock.end()) {
                 const Value parametersPmt = (*paramsIt).second; // bind to lvalue so get_if<property_map>() aliases live storage
@@ -229,16 +236,15 @@ inline void loadGraphFromMap(PluginLoader& loader, gr::Graph& resultGraph, gr::p
                 const Value ctxParamsValue = (*it).second; // bind to lvalue so the TensorView aliases live storage
                 auto        parametersCtx  = ctxParamsValue.get_if<TensorView<Value>>();
                 if (!parametersCtx) {
-                    throw gr::exception(std::format("ctx_parameters is not a vector<Value>"));
+                    return std::unexpected(gr::Error("ctx_parameters is not a vector<Value>"));
                 }
 
                 for (const auto& ctxPmt : *parametersCtx) {
                     const auto ctxPar = ctxPmt.get_if<property_map>();
                     if (!ctxPar) {
-                        throw gr::exception(std::format("ctxPar is not a property_map"));
+                        return std::unexpected(gr::Error("ctxPar is not a property_map"));
                     }
 
-                    // bind to lvalues — string_view / get_if<>() pointers alias the Value's storage
                     const auto findOr = [&ctxPar](std::string_view key) -> Value {
                         auto entryIt = ctxPar->find(key);
                         return entryIt != ctxPar->end() ? (*entryIt).second : Value{};
@@ -250,7 +256,7 @@ inline void loadGraphFromMap(PluginLoader& loader, gr::Graph& resultGraph, gr::p
                     const auto  ctxTime          = ctxTimeVal.get_if<std::uint64_t>();
                     const auto  ctxParameters    = ctxParametersVal.get_if<property_map>();
                     if (ctxName.empty() || !ctxTime || !ctxParameters) {
-                        throw gr::exception(std::format("Missing context values for loadParametersFromPropertyMap"));
+                        return std::unexpected(gr::Error("Missing context values for loadParametersFromPropertyMap"));
                     }
 
                     currentBlock->settings().loadParametersFromPropertyMap(*ctxParameters, SettingsCtx{*ctxTime, ctxName});
@@ -258,10 +264,10 @@ inline void loadGraphFromMap(PluginLoader& loader, gr::Graph& resultGraph, gr::p
             }
 
             if (const auto failed = currentBlock->settings().activateContext(); failed == std::nullopt) {
-                throw gr::exception("Settings for context could not be activated");
+                return std::unexpected(gr::Error("Settings for context could not be activated"));
             }
 
-            createdBlocks[blockName] = resultGraph.addBlock(std::move(currentBlock));
+            createdBlocks[*blockName] = resultGraph.addBlock(std::move(currentBlock));
         }
     } // for blocks
 
@@ -276,56 +282,62 @@ inline void loadGraphFromMap(PluginLoader& loader, gr::Graph& resultGraph, gr::p
     for (const auto& conn : connections) {
         auto _connection = conn.get_if<TensorView<Value>>();
         if (!_connection || _connection->size() < 4) {
-            throw gr::exception(std::format("Unable to parse connection ({} instead of >=4 elements)", _connection ? _connection->size() : -1UZ));
+            return std::unexpected(gr::Error(std::format("Unable to parse connection ({} instead of >=4 elements)", _connection ? _connection->size() : -1UZ)));
         }
         const auto& connection = *_connection;
 
-        auto parseBlockPort = [&](const Value& blockField, const Value& portField) {
+        struct ParsedBlockPort {
+            decltype(createdBlocks)::iterator block_it;
+            PortDefinition                    port_definition;
+        };
+
+        auto parseBlockPort = [&](const Value& blockField, const Value& portField) -> std::expected<ParsedBlockPort, gr::Error> {
             const auto blockName = blockField.value_or(std::string_view{});
             if (blockName.empty()) {
-                throw gr::exception(std::format("Invalid blockField"));
+                return std::unexpected(gr::Error("Invalid blockField"));
             }
             auto block = createdBlocks.find(std::string(blockName));
             if (block == createdBlocks.end()) {
-                throw gr::exception(std::format("Unknown block '{}'", blockName));
+                return std::unexpected(gr::Error(std::format("Unknown block '{}'", blockName)));
             }
-
-            struct result {
-                decltype(block) block_it;
-                PortDefinition  port_definition;
-            };
 
             if (auto portFields = portField.template get_if<TensorView<Value>>()) {
                 if (portFields->size() != 2) {
-                    throw gr::exception(std::format("Port definition has invalid length ({} instead of 2)", portFields->size()));
+                    return std::unexpected(gr::Error(std::format("Port definition has invalid length ({} instead of 2)", portFields->size())));
                 }
                 const auto fields   = portFields->owned();
                 const auto index    = checked_access_ptr{fields.data()[0].template get_if<std::int64_t>()};
                 const auto subIndex = checked_access_ptr{fields.data()[1].template get_if<std::int64_t>()};
                 if (index == nullptr || subIndex == nullptr) {
-                    throw gr::exception(std::format("Port definition missing values"));
+                    return std::unexpected(gr::Error("Port definition missing values"));
                 }
 
-                return result{block, {static_cast<std::size_t>(*index), static_cast<std::size_t>(*subIndex)}};
+                return ParsedBlockPort{block, {static_cast<std::size_t>(*index), static_cast<std::size_t>(*subIndex)}};
 
             } else if (const auto portFieldString = portField.value_or(std::string_view{}); portFieldString.data()) {
-                return result{block, {std::string(portFieldString)}};
+                return ParsedBlockPort{block, {std::string(portFieldString)}};
 
             } else {
                 const auto index = checked_access_ptr{portField.template get_if<std::int64_t>()};
                 if (index == nullptr) {
-                    throw gr::exception(std::format("Port definition missing values"));
+                    return std::unexpected(gr::Error("Port definition missing values"));
                 }
-                return result{block, {static_cast<std::size_t>(*index)}};
+                return ParsedBlockPort{block, {static_cast<std::size_t>(*index)}};
             }
         };
 
         auto src = parseBlockPort(connection[0], connection[1]);
+        if (!src) {
+            return std::unexpected(std::move(src).error());
+        }
         auto dst = parseBlockPort(connection[2], connection[3]);
+        if (!dst) {
+            return std::unexpected(std::move(dst).error());
+        }
 
         if (connection.size() == 4) {
-            if (auto r = resultGraph.connect(src.block_it->second, src.port_definition, dst.block_it->second, dst.port_definition, EdgeParameters{.minBufferSize = undefined_size, .weight = graph::defaultWeight, .name = graph::defaultEdgeName}, location); !r) {
-                throw gr::exception(std::format("connection failed: {}", r.error().message));
+            if (auto r = resultGraph.connect(src->block_it->second, src->port_definition, dst->block_it->second, dst->port_definition, EdgeParameters{.minBufferSize = undefined_size, .weight = graph::defaultWeight, .name = graph::defaultEdgeName}, location); !r) {
+                return std::unexpected(gr::Error(std::format("connection failed: {}", r.error().message)));
             }
         } else {
             std::size_t minBufferSize{};
@@ -339,11 +351,13 @@ inline void loadGraphFromMap(PluginLoader& loader, gr::Graph& resultGraph, gr::p
                 }
             }).visit(connection[4]);
 
-            if (auto r = resultGraph.connect(src.block_it->second, src.port_definition, dst.block_it->second, dst.port_definition, EdgeParameters{.minBufferSize = minBufferSize, .weight = graph::defaultWeight, .name = graph::defaultEdgeName}, location); !r) {
-                throw gr::exception(std::format("connection failed: {}", r.error().message));
+            if (auto r = resultGraph.connect(src->block_it->second, src->port_definition, dst->block_it->second, dst->port_definition, EdgeParameters{.minBufferSize = minBufferSize, .weight = graph::defaultWeight, .name = graph::defaultEdgeName}, location); !r) {
+                return std::unexpected(gr::Error(std::format("connection failed: {}", r.error().message)));
             }
         }
     } // for connections
+
+    return {};
 }
 
 inline gr::property_map saveGraphToMap(PluginLoader& loader, const gr::Graph& rootGraph) {
@@ -402,49 +416,44 @@ inline gr::property_map saveGraphToMap(PluginLoader& loader, const gr::Graph& ro
 
 } // namespace detail
 
-inline gr::meta::indirect<gr::Graph> loadGrc(PluginLoader& loader, std::string_view yamlSrc, std::source_location location = std::source_location::current()) {
+inline std::expected<gr::meta::indirect<gr::Graph>, gr::Error> loadGrc(PluginLoader& loader, std::string_view yamlSrc, std::source_location location = std::source_location::current()) {
     gr::meta::indirect<gr::Graph> resultGraph;
     const auto                    yaml = pmt::yaml::deserialize(yamlSrc);
     if (!yaml) {
-        throw gr::exception(std::format("Could not parse yaml: {}:{}\n{}", yaml.error().message, yaml.error().line, yamlSrc));
+        return std::unexpected(gr::Error(std::format("Could not parse yaml: {}:{}\n{}", yaml.error().message, yaml.error().line, yamlSrc)));
     }
 
-    detail::loadGraphFromMap(loader, *resultGraph, *yaml, location);
+    if (auto result = detail::loadGraphFromMap(loader, *resultGraph, *yaml, location); !result) {
+        return std::unexpected(std::move(result).error());
+    }
     return resultGraph;
 }
 
 inline std::string saveGrc(PluginLoader& loader, const gr::Graph& rootGraph) { return pmt::yaml::serialize(detail::saveGraphToMap(loader, rootGraph)); }
 
 inline std::expected<std::shared_ptr<gr::BlockModel>, gr::Error> detail::instantiateBlockFromYamlDefinition(PluginLoader& loader, const detail::YamlDefinitionsLoader::Definition& def) noexcept {
-    try {
-        auto consistencyResult = detail::checkEmbeddedVersionConsistency(loader.definitionForBlockName(), def);
-
-        gr::Graph tempGraph(loader);
-        detail::loadGraphFromMap(loader, tempGraph, def.definition);
-        auto blocks = tempGraph.blocks();
-        if (blocks.empty()) {
-            return std::unexpected(gr::Error{"YAML definition produced no blocks"});
-        }
-
-        auto result = blocks.front();
-
-        result->uiConstraints().insert_or_assign(std::string_view{"yaml_definition_information"}, gr::property_map{
-                                                                                                      //
-                                                                                                      {"BLOCK_TYPE", def.metadata.block_type},                                                                             //
-                                                                                                      {"PLUGIN_NAME", def.metadata.plugin_name},                                                                           //
-                                                                                                      {"PLUGIN_VERSION", def.metadata.plugin_version},                                                                     //
-                                                                                                      {"BLOCK_DEFINITION", def.definition},                                                                                //
-                                                                                                      {"BLOCK_DEFINITION_UPDATED_INFO", consistencyResult.has_value() ? std::string() : consistencyResult.error().message} //
-                                                                                                  });
-
-        return result;
-    } catch (const gr::exception& e) {
-        return std::unexpected(gr::Error{e});
-    } catch (const std::exception& e) {
-        return std::unexpected(gr::Error{e});
-    } catch (const gr::Error& e) {
-        return std::unexpected(e);
+    auto      consistencyResult = detail::checkEmbeddedVersionConsistency(loader.definitionForBlockName(), def);
+    gr::Graph tempGraph;
+    if (auto result = detail::loadGraphFromMap(loader, tempGraph, def.definition); !result) {
+        return std::unexpected(std::move(result).error());
     }
+    auto blocks = tempGraph.blocks();
+    if (blocks.empty()) {
+        return std::unexpected(gr::Error{"YAML definition produced no blocks"});
+    }
+
+    auto& result = blocks.front();
+
+    result->uiConstraints().insert_or_assign(std::string_view{"yaml_definition_information"}, gr::property_map{
+                                                                                                  //
+                                                                                                  {"BLOCK_TYPE", def.metadata.block_type},                                                                             //
+                                                                                                  {"PLUGIN_NAME", def.metadata.plugin_name},                                                                           //
+                                                                                                  {"PLUGIN_VERSION", def.metadata.plugin_version},                                                                     //
+                                                                                                  {"BLOCK_DEFINITION", def.definition},                                                                                //
+                                                                                                  {"BLOCK_DEFINITION_UPDATED_INFO", consistencyResult.has_value() ? std::string() : consistencyResult.error().message} //
+                                                                                              });
+
+    return result;
 }
 
 } // namespace gr

--- a/core/include/gnuradio-4.0/Scheduler.hpp
+++ b/core/include/gnuradio-4.0/Scheduler.hpp
@@ -12,14 +12,12 @@
 #include <utility>
 
 #include <gnuradio-4.0/Graph.hpp>
-#include <gnuradio-4.0/SchedulerModel.hpp> // nested-scheduler dispatch (detail::asSchedulerModel)
-#if __cpp_exceptions                       // yaml/plugin graph-mutation is hosted-only; the yaml chain needs exceptions and is absent in the freestanding subset
 #include <gnuradio-4.0/Graph_yaml_importer.hpp>
-#endif
 #include <gnuradio-4.0/LifeCycle.hpp>
 #include <gnuradio-4.0/Message.hpp>
 #include <gnuradio-4.0/Port.hpp>
 #include <gnuradio-4.0/Profiler.hpp>
+#include <gnuradio-4.0/SchedulerModel.hpp> // nested-scheduler dispatch (detail::asSchedulerModel)
 #include <gnuradio-4.0/meta/indirect.hpp>
 #include <gnuradio-4.0/meta/reflection.hpp>
 #include <gnuradio-4.0/thread/thread_pool.hpp>
@@ -237,20 +235,18 @@ protected:
 
     void registerPropertyCallbacks() noexcept {
         _forbid_reserved_overrides();
-        using PropertyCallback                         = BlockBase::PropertyCallback;
-        auto& callbacks                                = this->propertyCallbacks;
-        callbacks[scheduler::property::kRemoveBlock]   = static_cast<PropertyCallback>(&SchedulerBase::propertyCallbackRemoveBlock);
-        callbacks[scheduler::property::kGroupBlocks]   = static_cast<PropertyCallback>(&SchedulerBase::propertyCallbackGroupBlocks);
-        callbacks[scheduler::property::kUngroupBlocks] = static_cast<PropertyCallback>(&SchedulerBase::propertyCallbackUngroupBlocks);
-        callbacks[scheduler::property::kRemoveEdge]    = static_cast<PropertyCallback>(&SchedulerBase::propertyCallbackRemoveEdge);
-        callbacks[scheduler::property::kEmplaceEdge]   = static_cast<PropertyCallback>(&SchedulerBase::propertyCallbackEmplaceEdge);
-        callbacks[graph::property::kInspectBlock]      = static_cast<PropertyCallback>(&SchedulerBase::propertyCallbackInspectBlock);
-#if __cpp_exceptions // yaml/plugin graph-mutation handlers are hosted-only (freestanding/MCU graphs are static)
+        using PropertyCallback                            = BlockBase::PropertyCallback;
+        auto& callbacks                                   = this->propertyCallbacks;
+        callbacks[scheduler::property::kRemoveBlock]      = static_cast<PropertyCallback>(&SchedulerBase::propertyCallbackRemoveBlock);
+        callbacks[scheduler::property::kGroupBlocks]      = static_cast<PropertyCallback>(&SchedulerBase::propertyCallbackGroupBlocks);
+        callbacks[scheduler::property::kUngroupBlocks]    = static_cast<PropertyCallback>(&SchedulerBase::propertyCallbackUngroupBlocks);
+        callbacks[scheduler::property::kRemoveEdge]       = static_cast<PropertyCallback>(&SchedulerBase::propertyCallbackRemoveEdge);
+        callbacks[scheduler::property::kEmplaceEdge]      = static_cast<PropertyCallback>(&SchedulerBase::propertyCallbackEmplaceEdge);
+        callbacks[graph::property::kInspectBlock]         = static_cast<PropertyCallback>(&SchedulerBase::propertyCallbackInspectBlock);
         callbacks[scheduler::property::kEmplaceBlock]     = static_cast<PropertyCallback>(&SchedulerBase::propertyCallbackEmplaceBlock);
         callbacks[scheduler::property::kReplaceBlock]     = static_cast<PropertyCallback>(&SchedulerBase::propertyCallbackReplaceBlock);
         callbacks[scheduler::property::kGraphGRC]         = static_cast<PropertyCallback>(&SchedulerBase::propertyCallbackGraphGRC);
         callbacks[scheduler::property::kSchedulerInspect] = static_cast<PropertyCallback>(&SchedulerBase::propertyCallbackSchedulerInspect);
-#endif
         this->settings().updateActiveParameters();
     }
 
@@ -1167,14 +1163,11 @@ protected:
         }
     }
 
-#if __cpp_exceptions
     std::optional<Message> propertyCallbackEmplaceBlock([[maybe_unused]] std::string_view propertyName, Message message) {
         using enum lifecycle::State;
         assert(propertyName == scheduler::property::kEmplaceBlock);
         using namespace std::string_literals;
         const auto& messageData = message.data.value();
-
-        message.endpoint = scheduler::property::kBlockEmplaced;
 
         auto* targetGraph = findTargetSubGraph(messageData);
         if (targetGraph == nullptr) {
@@ -1214,10 +1207,8 @@ protected:
                 graphMap.insert_or_assign(std::string_view{"blocks"}, std::move(blocksSeq));
 
                 const std::size_t blocksBefore = targetGraph->blocks().size();
-                try {
-                    gr::detail::loadGraphFromMap(targetGraph->pluginLoader(), *targetGraph, std::move(graphMap));
-                } catch (const std::exception& e) {
-                    message.data = std::unexpected(Error{std::format("Failed to create subgraph from yaml: {}", e.what())});
+                if (auto loadResult = gr::detail::loadGraphFromMap(targetGraph->pluginLoader(), *targetGraph, std::move(graphMap)); !loadResult) {
+                    message.data = std::unexpected(Error{std::format("Failed to create subgraph from yaml: {}", loadResult.error().message)});
                     return message;
                 }
 
@@ -1265,7 +1256,12 @@ protected:
         const bool   isYamlPath   = messageData.contains("yaml");
         property_map yamlSettings = isYamlPath ? std::exchange(blockProperties, {}) : property_map{};
 
-        auto& newBlock = targetGraph->emplaceBlock(blockType, blockProperties);
+        auto emplaceResult = targetGraph->emplaceBlock(blockType, blockProperties);
+        if (!emplaceResult) {
+            message.data = std::unexpected(emplaceResult.error());
+            return message;
+        }
+        auto newBlock = std::move(*emplaceResult);
 
         if (isYamlPath && !yamlSettings.empty()) {
             newBlock->settings().loadParametersFromPropertyMap(yamlSettings);
@@ -1280,7 +1276,6 @@ protected:
         // Message is sent as a reaction to emplaceBlock, no need for a separate one
         return {};
     }
-#endif
 
     std::optional<Message> propertyCallbackRemoveBlock([[maybe_unused]] std::string_view propertyName, Message message) {
         assert(propertyName == scheduler::property::kRemoveBlock);
@@ -1750,22 +1745,24 @@ protected:
         this->_graph->clear();
     }
 
-#if __cpp_exceptions
     std::optional<Message> propertyCallbackGraphGRC([[maybe_unused]] std::string_view propertyName, Message message) {
         using enum lifecycle::State;
         assert(propertyName == scheduler::property::kGraphGRC);
 
         auto& pluginLoader = gr::globalPluginLoader();
         if (message.cmd == message::Command::Get) {
-            message.data = property_map{{ "value", gr::saveGrc(pluginLoader, *_graph) }};
+            message.data = property_map{{"value", gr::saveGrc(pluginLoader, *_graph)}};
         } else if (message.cmd == message::Command::Set) {
             const auto& messageData = message.data.value();
             const auto  yamlContent = std::string(messageData.value_or<std::string_view>("value", std::string_view{}));
             if (yamlContent.empty()) {
                 message.data = std::unexpected(Error{std::format("Yaml content not found")});
             } else {
-                try {
-                    auto newGraph = gr::loadGrc(pluginLoader, yamlContent);
+                auto newGraphResult = gr::loadGrc(pluginLoader, yamlContent);
+                if (!newGraphResult) {
+                    message.data = std::unexpected(Error{std::format("Error parsing YAML: {}", newGraphResult.error().message)});
+                } else {
+                    auto newGraph = std::move(*newGraphResult);
 
                     makeAllZombies();
 
@@ -1801,14 +1798,12 @@ protected:
                         return message;
                     }
 
-                    message.data = property_map{{ "originalSchedulerState", static_cast<int>(originalState) }};
-                } catch (const std::exception& e) {
-                    message.data = std::unexpected(Error{std::format("Error parsing YAML: {}", e.what())});
+                    message.data = property_map{{"originalSchedulerState", static_cast<int>(originalState)}};
                 }
             }
 
         } else {
-            throw gr::exception(std::format("Unexpected command type {}", message.cmd));
+            message.data = std::unexpected(Error{std::format("Unexpected command type {}", message.cmd)});
         }
 
         return message;
@@ -1846,13 +1841,12 @@ protected:
                 return result;
             }();
         } else {
-            message.data = {{ "yamlData", saveGrc(gr::globalPluginLoader(), *_graph) }};
+            message.data = {{"yamlData", saveGrc(gr::globalPluginLoader(), *_graph)}};
         }
 
         message.endpoint = scheduler::property::kSchedulerInspected;
         return message;
     }
-#endif
 
     std::optional<Message> propertyCallbackInspectBlock([[maybe_unused]] std::string_view propertyName, Message message) {
         auto result = _graph->propertyCallbackInspectBlock(propertyName, message);
@@ -1862,7 +1856,6 @@ protected:
         return result;
     }
 
-#if __cpp_exceptions
     std::optional<Message> propertyCallbackReplaceBlock([[maybe_unused]] std::string_view propertyName, Message message) {
         assert(propertyName == scheduler::property::kReplaceBlock);
         using namespace std::string_literals;
@@ -1893,7 +1886,12 @@ protected:
             return message;
         }
 
-        auto [oldBlock, newBlockRaw] = targetGraph->replaceBlock(uniqueName, type, properties);
+        auto replaceResult = targetGraph->replaceBlock(uniqueName, type, properties);
+        if (!replaceResult) {
+            message.data = std::unexpected(replaceResult.error());
+            return message;
+        }
+        auto& [oldBlock, newBlockRaw] = *replaceResult;
         makeZombie(std::move(oldBlock));
 
         std::optional<Message> result = gr::Message{};
@@ -1905,7 +1903,6 @@ protected:
 
         return result;
     }
-#endif
 };
 
 template<ExecutionPolicy execution = ExecutionPolicy::singleThreaded, profiling::ProfilerLike TProfiler = profiling::null::Profiler>

--- a/core/include/gnuradio-4.0/YamlPmt.hpp
+++ b/core/include/gnuradio-4.0/YamlPmt.hpp
@@ -547,20 +547,12 @@ std::expected<T, ValueParseError> parseAs(std::string_view sv) {
         } else if (sv == ".nan" || sv == ".NaN" || sv == ".NAN") {
             return std::numeric_limits<T>::quiet_NaN();
         }
-        std::string tempParse(sv.data(), sv.size());
-        try {
-            if constexpr (std::is_same_v<T, float>) {
-                return std::stof(tempParse);
-            } else {
-                return std::stod(tempParse);
-            }
-        } catch (std::invalid_argument& e) { // specifically: std::invalid_argument or std::out_of_range
-            return std::unexpected(ValueParseError{0UZ, std::format("std::invalid_argument exception for expected floating-point value of '{}' - error: {}", tempParse, e.what())});
-        } catch (std::out_of_range& e) { // specifically: std::invalid_argument or std::out_of_range
-            return std::unexpected(ValueParseError{0UZ, std::format("std::out_of_range exception for expected floating-point value of '{}' - error: {}", tempParse, e.what())});
-        } catch (std::exception& e) { // specifically: std::invalid_argument or std::out_of_range
-            return std::unexpected(ValueParseError{0UZ, std::format("std::exception for expected floating-point value of '{}' - error: {}", tempParse, e.what())});
+        T value;
+        const auto [ptr, ec] = std::from_chars(sv.data(), sv.data() + sv.size(), value);
+        if (ec != std::errc{} || ptr != sv.data() + sv.size()) {
+            return std::unexpected(ValueParseError{0UZ, std::format("invalid floating-point value '{}' (error: {})", sv, std::make_error_code(ec).message())});
         }
+        return value;
     } else if constexpr (std::is_integral_v<T>) {
         sv                 = trim(sv); // trim leading and trailing whitespace
         auto parseWithBase = [](std::string_view s, int base) -> std::expected<T, ValueParseError> {

--- a/core/src/Graph.cpp
+++ b/core/src/Graph.cpp
@@ -17,29 +17,27 @@ Graph::Graph(property_map settings) : Graph(gr::globalPluginLoader(), std::move(
 
 gr::PluginLoader& Graph::pluginLoader() noexcept { return _pluginLoader != nullptr ? *_pluginLoader : gr::globalPluginLoader(); }
 
-[[maybe_unused]] std::shared_ptr<BlockModel> const& Graph::emplaceBlock(std::string_view type, property_map initialSettings) {
+std::expected<std::shared_ptr<BlockModel>, Error> Graph::emplaceBlock(std::string_view type, property_map initialSettings) {
     if (type.starts_with("gr::Graph")) {
         auto subGraphModel = std::unique_ptr<BlockModel>(std::make_unique<GraphWrapper<Graph>>().release());
         return addBlock(std::move(subGraphModel));
     } else if (std::shared_ptr<BlockModel> block_load = _pluginLoader->instantiate(type, std::move(initialSettings)); block_load) {
-        const std::shared_ptr<BlockModel>& newBlock = addBlock(block_load);
-        return newBlock;
+        return addBlock(block_load);
     } else if (std::shared_ptr<SchedulerModel> scheduler_load = _pluginLoader->instantiateScheduler(type, std::move(initialSettings)); scheduler_load) {
-        const std::shared_ptr<BlockModel>& newBlock = addBlock(SchedulerModel::asBlockModelPtr(scheduler_load));
-        return newBlock;
+        return addBlock(SchedulerModel::asBlockModelPtr(scheduler_load));
     }
-    throw gr::exception(std::format("Cannot create block '{}'", type));
+    return std::unexpected(Error(std::format("Cannot create block '{}'", type)));
 }
 
-std::pair<std::shared_ptr<BlockModel>, std::shared_ptr<BlockModel>> Graph::replaceBlock(std::string_view uniqueName, std::string_view type, const property_map& properties) {
+std::expected<std::pair<std::shared_ptr<BlockModel>, std::shared_ptr<BlockModel>>, Error> Graph::replaceBlock(std::string_view uniqueName, std::string_view type, const property_map& properties) {
     auto it = std::ranges::find_if(_blocks, [&uniqueName](const auto& block) { return block->uniqueName() == uniqueName; });
     if (it == _blocks.end()) {
-        throw gr::exception(std::format("Block {} was not found in {}", uniqueName, this->unique_name));
+        return std::unexpected(Error(std::format("Block {} was not found in {}", uniqueName, this->unique_name)));
     }
 
-    auto newBlock = gr::globalPluginLoader().instantiate(type, properties);
+    auto newBlock = _pluginLoader->instantiate(type, properties);
     if (!newBlock) {
-        throw gr::exception(std::format("Can not create block {}", type));
+        return std::unexpected(Error(std::format("Cannot create block '{}'", type)));
     }
 
     addBlock(newBlock);
@@ -57,7 +55,7 @@ std::pair<std::shared_ptr<BlockModel>, std::shared_ptr<BlockModel>> Graph::repla
     std::shared_ptr<BlockModel> oldBlock = std::move(*it);
     _blocks.erase(it);
 
-    return {std::move(oldBlock), newBlock};
+    return std::pair{std::move(oldBlock), newBlock};
 }
 
 namespace {

--- a/core/test/qa_Embedded.cpp
+++ b/core/test/qa_Embedded.cpp
@@ -12,10 +12,14 @@
 #include <boost/ut.hpp>
 
 #include <gnuradio-4.0/BlockMerging.hpp>
+#include <gnuradio-4.0/BlockRegistry.hpp>
 #include <gnuradio-4.0/BlockTraits.hpp>
 #include <gnuradio-4.0/Graph.hpp>
+#include <gnuradio-4.0/Graph_yaml_importer.hpp>
 #include <gnuradio-4.0/Logger.hpp>
 #include <gnuradio-4.0/MemoryAllocators.hpp>
+#include <gnuradio-4.0/Message.hpp>
+#include <gnuradio-4.0/PluginLoader.hpp>
 #include <gnuradio-4.0/Port.hpp>
 #include <gnuradio-4.0/Scheduler.hpp>
 
@@ -460,5 +464,84 @@ const boost::ut::suite<"MCU superloop on real gr::Graph + Simple<externalStep>">
         std::ignore = sched.changeStateTo(STOPPED);
     };
 };
+
+// block registry is needed to resolve typenames
+#ifdef GR_ENABLE_BLOCK_REGISTRY
+namespace {
+gr::PluginLoader makeEmbeddedLoader(gr::BlockRegistry& registry, gr::SchedulerRegistry& schedulerRegistry) {
+    expect(registry.insert<CountSource<int>>("=count_source")) << "failed to register count_source";
+    expect(registry.insert<ExpectSink<int>>("=expect_sink")) << "failed to register expect_sink";
+    static const std::vector<std::string> noPlugins;
+    return gr::PluginLoader(registry, schedulerRegistry, noPlugins);
+}
+} // namespace
+
+const boost::ut::suite<"yaml import + scheduler graph-mutation (no exceptions)"> _yamlImport = [] {
+    using namespace gr;
+    using enum gr::lifecycle::State;
+
+    "loadGrc parses a two-block graph from a raw string"_test = [] {
+        BlockRegistry     registry;
+        SchedulerRegistry schedulerRegistry;
+        PluginLoader      loader = makeEmbeddedLoader(registry, schedulerRegistry);
+
+        constexpr std::string_view yaml = R"(
+blocks:
+  - id: count_source
+    parameters:
+      name: source
+  - id: expect_sink
+    parameters:
+      name: sink
+connections:
+  - [source, [0, 0], sink, [0, 0]]
+)";
+
+        auto graphResult = gr::loadGrc(loader, yaml);
+        expect(graphResult.has_value()) << [&] { return graphResult ? std::string{} : graphResult.error().message; };
+        if (!graphResult) {
+            return;
+        }
+
+        auto& graph = *graphResult; // gr::meta::indirect<gr::Graph>
+        expect(eq(graph->blocks().size(), 2UZ)) << "source + sink emplaced from yaml";
+        expect(eq(graph->edges().size(), 1UZ)) << "single source->sink edge parsed from yaml";
+    };
+
+    "emplaceBlock message adds a block to a running externalStep scheduler"_test = [] {
+        BlockRegistry     registry;
+        SchedulerRegistry schedulerRegistry;
+        PluginLoader      loader = makeEmbeddedLoader(registry, schedulerRegistry);
+
+        gr::scheduler::Simple<gr::scheduler::ExecutionPolicy::externalStep> sched;
+        expect(sched.exchange(gr::Graph(loader)).has_value());
+        expect(sched.changeStateTo(INITIALISED).has_value());
+        expect(sched.changeStateTo(RUNNING).has_value()) << "externalStep start() primes to RUNNING without a worker";
+        expect(eq(sched.graph().blocks().size(), 0UZ)) << "graph starts empty";
+
+        gr::MsgPortOut toScheduler;
+        gr::MsgPortIn  fromScheduler;
+        expect(toScheduler.connect(sched.msgIn).has_value()) << "connect client -> scheduler.msgIn";
+        expect(sched.msgOut.connect(fromScheduler).has_value()) << "connect scheduler.msgOut -> client";
+
+        gr::sendMessage<message::Command::Set>(toScheduler, sched.unique_name, scheduler::property::kEmplaceBlock, //
+            property_map{{"type", "count_source"}, {"properties", property_map{}}});
+
+        sched.processScheduledMessages();
+
+        expect(eq(sched.graph().blocks().size(), 1UZ)) << "emplaceBlock message added one block";
+
+        const auto available = fromScheduler.streamReader().available();
+        expect(gt(available, 0UZ)) << "scheduler must reply to the emplace request";
+        ReaderSpanLike auto replies  = fromScheduler.streamReader().get(available);
+        const bool          emplaced = std::ranges::any_of(replies, [](const Message& reply) { return reply.endpoint == scheduler::property::kBlockEmplaced; });
+        expect(replies.consume(replies.size()));
+        expect(emplaced) << "reply endpoint is BlockEmplaced";
+
+        std::ignore = sched.changeStateTo(REQUESTED_STOP);
+        std::ignore = sched.changeStateTo(STOPPED);
+    };
+};
+#endif
 
 int main() { /* tests are statically executed */ }

--- a/core/test/qa_SchedulerMessages.cpp
+++ b/core/test/qa_SchedulerMessages.cpp
@@ -192,8 +192,8 @@ const boost::ut::suite TopologyGraphTests = [] {
 
     "Block removal tests"_test = [] {
         gr::Graph graph(context->loader);
-        graph.emplaceBlock("gr::testing::Copy<float32>", {});
-        auto& temporaryBlock = graph.emplaceBlock("gr::testing::Copy<float32>", {});
+        std::ignore         = graph.emplaceBlock("gr::testing::Copy<float32>", {}).value();
+        auto temporaryBlock = graph.emplaceBlock("gr::testing::Copy<float32>", {}).value();
 
         TestScheduler scheduler(std::move(graph));
         const auto&   testGraph = scheduler.graph();
@@ -743,9 +743,9 @@ const boost::ut::suite TopologyGraphTests = [] {
     "Block replacement tests"_test = [] {
         gr::Graph graph(context->loader);
 
-        auto& block = graph.emplaceBlock("gr::testing::Copy<float32>", {});
+        auto block = graph.emplaceBlock("gr::testing::Copy<float32>", {}).value();
         expect(eq(graph.blocks().size(), 1UZ));
-        auto& temporaryBlock = graph.emplaceBlock("gr::testing::Copy<float32>", {});
+        auto temporaryBlock = graph.emplaceBlock("gr::testing::Copy<float32>", {}).value();
 
         TestScheduler scheduler(std::move(graph));
         "Replace a known block"_test = [&] {
@@ -775,9 +775,9 @@ const boost::ut::suite TopologyGraphTests = [] {
     "Edge addition tests"_test = [&] {
         gr::Graph testGraph(context->loader);
 
-        auto& blockOut       = testGraph.emplaceBlock("gr::testing::Copy<float32>", {});
-        auto& blockIn        = testGraph.emplaceBlock("gr::testing::Copy<float32>", {});
-        auto& blockWrongType = testGraph.emplaceBlock("gr::testing::Copy<float64>", {});
+        auto blockOut       = testGraph.emplaceBlock("gr::testing::Copy<float32>", {}).value();
+        auto blockIn        = testGraph.emplaceBlock("gr::testing::Copy<float32>", {}).value();
+        auto blockWrongType = testGraph.emplaceBlock("gr::testing::Copy<float64>", {}).value();
 
         TestScheduler scheduler(std::move(testGraph));
 
@@ -827,8 +827,8 @@ const boost::ut::suite TopologyGraphTests = [] {
 
         // disconnect_on_done=false: dangling blocks would otherwise self-stop and tear down
         // the freshly emplaced connection via disconnectFromUpStreamParents()
-        auto& blockOut = testGraph.emplaceBlock("gr::testing::Copy<float32>", {{"disconnect_on_done", false}});
-        auto& blockIn  = testGraph.emplaceBlock("gr::testing::Copy<float32>", {{"disconnect_on_done", false}});
+        auto blockOut = testGraph.emplaceBlock("gr::testing::Copy<float32>", {{"disconnect_on_done", false}}).value();
+        auto blockIn  = testGraph.emplaceBlock("gr::testing::Copy<float32>", {{"disconnect_on_done", false}}).value();
 
         TestScheduler scheduler(std::move(testGraph));
 
@@ -864,8 +864,8 @@ const boost::ut::suite TopologyGraphTests = [] {
 
     "Settings change via messages"_test = [] {
         gr::Graph testGraph(context->loader);
-        testGraph.emplaceBlock("gr::testing::Copy<float32>", {});
-        testGraph.emplaceBlock("gr::testing::Copy<float32>", {});
+        std::ignore = testGraph.emplaceBlock("gr::testing::Copy<float32>", {}).value();
+        std::ignore = testGraph.emplaceBlock("gr::testing::Copy<float32>", {}).value();
 
         TestScheduler scheduler(std::move(testGraph));
 
@@ -944,8 +944,8 @@ const boost::ut::suite TopologyGraphTests = [] {
 
     "Get GRC Yaml tests"_test = [] {
         gr::Graph testGraph(context->loader);
-        testGraph.emplaceBlock("gr::testing::Copy<float32>", {});
-        testGraph.emplaceBlock("gr::testing::Copy<float32>", {});
+        std::ignore = testGraph.emplaceBlock("gr::testing::Copy<float32>", {}).value();
+        std::ignore = testGraph.emplaceBlock("gr::testing::Copy<float32>", {}).value();
 
         TestScheduler scheduler(std::move(testGraph));
 
@@ -959,7 +959,7 @@ const boost::ut::suite TopologyGraphTests = [] {
                     std::println("YAML content:\n{}", yaml);
 
                     // verify well formed by loading from yaml
-                    auto graphFromYaml = gr::loadGrc(context->loader, yaml);
+                    auto graphFromYaml = gr::loadGrc(context->loader, yaml).value();
                     expect(eq(graphFromYaml->blocks().size(), 4UZ)) << std::format("Expected 4 blocks in loaded graph, got {} blocks\n", graphFromYaml->blocks().size());
 
                     return true;
@@ -997,7 +997,7 @@ const boost::ut::suite TopologyGraphTests = [] {
         std::string yaml = getYamlString(scheduler);
         {
             expect(!yaml.empty());
-            auto testGraphFromYaml = gr::loadGrc(context->loader, yaml);
+            auto testGraphFromYaml = gr::loadGrc(context->loader, yaml).value();
             expect(eq(testGraphFromYaml->blocks().size(), 4UZ)) << std::format("Expected 4 blocks in loaded graph, got {} blocks\n", testGraphFromYaml->blocks().size());
         }
 
@@ -1027,7 +1027,7 @@ const boost::ut::suite TopologyGraphTests = [] {
         std::string savedAltYaml = getYamlString(scheduler);
         {
             expect(!savedAltYaml.empty());
-            auto alternativeGraphFromYaml = gr::loadGrc(context->loader, savedAltYaml);
+            auto alternativeGraphFromYaml = gr::loadGrc(context->loader, savedAltYaml).value();
             expect(eq(alternativeGraphFromYaml->blocks().size(), 3UZ)) << std::format("Expected 3 blocks in loaded graph, got {} blocks", alternativeGraphFromYaml->blocks().size());
         }
     };
@@ -1096,13 +1096,13 @@ const boost::ut::suite TopologyGraphTests = [] {
                 const auto& map = reply->data.value();
                 expect(!map.empty()) << "Resulting map should not be empty";
 
-                const auto& children = gr::detail::getOrThrow(gr::detail::getProperty<gr::property_map>(map, "children"s));
+                const auto children = gr::detail::getProperty<gr::property_map>(map, "children"s).value();
 
                 std::set<float> seenUiConstraintsX;
                 std::set<float> seenUiConstraintsY;
 
                 for (const auto& child : children) {
-                    const auto& uiConstraints = gr::detail::getOrThrow(gr::detail::getProperty<gr::property_map>(gr::test::get_value_or_fail<gr::property_map>(child.second), "parameters"s, "ui_constraints"s));
+                    const auto uiConstraints = gr::detail::getProperty<gr::property_map>(gr::test::get_value_or_fail<gr::property_map>(child.second), "parameters"s, "ui_constraints"s).value();
                     seenUiConstraintsX.insert(gr::test::get_value_or_fail<float>(uiConstraints.find_value("x").value()));
                     seenUiConstraintsY.insert(gr::test::get_value_or_fail<float>(uiConstraints.find_value("y").value()));
                 }

--- a/core/test/qa_Settings.cpp
+++ b/core/test/qa_Settings.cpp
@@ -991,7 +991,7 @@ connections:
         PluginLoader loader(registry, schedulerRegistry, {});
         try {
             gr::scheduler::Simple<> sched;
-            if (auto ret = sched.exchange(loadGrc(loader, std::string(grc))); !ret) {
+            if (auto ret = sched.exchange(loadGrc(loader, std::string(grc)).value()); !ret) {
                 throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
             }
             expect(sched.runAndWait().has_value());

--- a/core/test/qa_YamlPmt.cpp
+++ b/core/test/qa_YamlPmt.cpp
@@ -573,7 +573,7 @@ doubles:
 
         testYAML(src, expected);
 
-        expect(fuzzy_eq(formatResult(yaml::deserialize("value: !!float64 string")), "Error in 1:18: std::invalid_argument exception for expected floating-point value of 'string' - error: stod"sv));
+        expect(fuzzy_eq(formatResult(yaml::deserialize("value: !!float64 string")), "Error in 1:18: invalid floating-point value 'string' (error: Invalid argument)"sv));
         expect(fuzzy_eq(formatResult(yaml::deserialize("value: !!int64 0xGG")), "Error in 1:16: Invalid integral-type value 'GG' (error: Invalid argument)"sv));
         expect(fuzzy_eq(formatResult(yaml::deserialize("value: !!int64 0o99")), "Error in 1:16: Invalid integral-type value '99' (error: Invalid argument)"sv));
         expect(fuzzy_eq(formatResult(yaml::deserialize("value: !!int64 0b1234")), "Error in 1:16: Invalid integral-type value"sv));
@@ -880,8 +880,8 @@ complex5: !!complex32 (  1.0  ,   -1.0)
         expect(fuzzy_eq(formatResult(yaml::deserialize("complex: !!complex64 (1.01.0)")), "Error in 1:22: Invalid value for complex<>-type"sv));
         expect(fuzzy_eq(formatResult(yaml::deserialize("complex: !!complex64 Hello")), "Error in 1:22: Invalid value for complex<>-type"sv));
         expect(fuzzy_eq(formatResult(yaml::deserialize("complex: !!complex64 (1.0, -1.0, 2.0)")), "Error in 1:22: Invalid value for complex<>-type"sv));
-        expect(fuzzy_eq(formatResult(yaml::deserialize("complex: !!complex64 (foo, bar)")), "Error in 1:22: std::invalid_argument exception for expected floating-point value of 'foo' - error: stod"sv));
-        expect(fuzzy_eq(formatResult(yaml::deserialize("complex: !!complex64 (1.0, bar)")), "Error in 1:22: std::invalid_argument exception for expected floating-point value of 'bar' - error: stod"sv));
+        expect(fuzzy_eq(formatResult(yaml::deserialize("complex: !!complex64 (foo, bar)")), "Error in 1:22: invalid floating-point value 'foo' (error: Invalid argument)"sv));
+        expect(fuzzy_eq(formatResult(yaml::deserialize("complex: !!complex64 (1.0, bar)")), "Error in 1:22: invalid floating-point value 'bar' (error: Invalid argument)"sv));
     };
 
     "empty lines"_test = [] {

--- a/core/test/qa_grc.cpp
+++ b/core/test/qa_grc.cpp
@@ -155,7 +155,7 @@ connections:
             }
 
             const auto graphSrc = ymlDecodeEncode(testGrc);
-            auto       graph    = gr::loadGrc(context->loader, graphSrc);
+            auto       graph    = gr::loadGrc(context->loader, graphSrc).value();
 
             for (const auto& block : graph->blocks()) {
                 if (block->name() == "ArraySource<float64>") {
@@ -178,9 +178,9 @@ connections:
         using namespace gr;
 
         try {
-            auto graph1        = gr::loadGrc(context->loader, testGrc);
+            auto graph1        = gr::loadGrc(context->loader, testGrc).value();
             auto graphSavedSrc = gr::saveGrc(context->loader, *graph1);
-            auto graph2        = gr::loadGrc(context->loader, graphSavedSrc);
+            auto graph2        = gr::loadGrc(context->loader, graphSavedSrc).value();
             expect(eq(collectBlocks(*graph1), collectBlocks(*graph2)));
             expect(eq(collectEdges(*graph1), collectEdges(*graph2)));
         } catch (const std::string& e) {
@@ -227,8 +227,8 @@ connections:
             const auto graphSrc2 = ymlDecodeEncode<pmt::yaml::TypeTagMode::None>(pluginsTestGrc);
             std::println("yml-before:\n {}\nwith type-tags:\n{}\nwithout type tags:\n{}", pluginsTestGrc, graphSrc1, graphSrc2);
 
-            auto graph  = gr::loadGrc(context->loader, graphSrc1);
-            auto graph2 = gr::loadGrc(context->loader, pluginsTestGrc);
+            auto graph  = gr::loadGrc(context->loader, graphSrc1).value();
+            auto graph2 = gr::loadGrc(context->loader, pluginsTestGrc).value();
 
             expect(eq(graph->blocks().size(), 4UZ));
 
@@ -294,7 +294,7 @@ connections:
 )";
 
             const auto graphSrc = ymlDecodeEncode(pluginsTestGrc);
-            auto       graph    = gr::loadGrc(context->loader, graphSrc);
+            auto       graph    = gr::loadGrc(context->loader, graphSrc).value();
 
             expect(eq(graph->blocks().size(), 5UZ));
 
@@ -354,7 +354,7 @@ connections:
 )";
 
             const auto graphSrc = ymlDecodeEncode(pluginsTestGrc);
-            auto       graph    = gr::loadGrc(context->loader, graphSrc);
+            auto       graph    = gr::loadGrc(context->loader, graphSrc).value();
 
             expect(eq(graph->blocks().size(), 5UZ));
 
@@ -418,7 +418,7 @@ connections:
     )";
 
             const auto graphSrc = ymlDecodeEncode(pluginsTestGrc);
-            auto       graph    = gr::loadGrc(context->loader, graphSrc);
+            auto       graph    = gr::loadGrc(context->loader, graphSrc).value();
 
             expect(eq(graph->blocks().size(), 5UZ));
 
@@ -471,7 +471,7 @@ connections:
             using namespace gr;
             const auto graphSrc = ymlDecodeEncode(testGrc);
 
-            auto graph = gr::loadGrc(context->loader, graphSrc);
+            auto graph = gr::loadGrc(context->loader, graphSrc).value();
 
             {
                 std::unordered_set expectedSizes{1024UZ, 2048UZ, 8192UZ};
@@ -496,7 +496,7 @@ connections:
             auto graphSavedSrc = gr::saveGrc(context->loader, *graph);
 
             {
-                auto               graphDuplicate = gr::loadGrc(context->loader, graphSrc);
+                auto               graphDuplicate = gr::loadGrc(context->loader, graphSrc).value();
                 std::unordered_set expectedSizes{1024UZ, 2048UZ, 8192UZ};
                 gr::graph::forEachEdge<gr::block::Category::NormalBlock>(*graph, [&expectedSizes](const auto& edge) {
                     auto it = expectedSizes.find(edge.minBufferSize());
@@ -535,7 +535,7 @@ connections:
         }
 
         const auto graph1Saved = gr::saveGrc(context->loader, graph1);
-        const auto graph2      = gr::loadGrc(context->loader, graph1Saved);
+        const auto graph2      = gr::loadGrc(context->loader, graph1Saved).value();
 
         expect(eq(collectBlocks(graph1), collectBlocks(*graph2)));
         expect(eq(collectEdges(graph1), collectEdges(*graph2)));
@@ -562,7 +562,7 @@ connections:
         }
 
         const auto graph1Saved = gr::saveGrc(context->loader, graph1);
-        const auto graph2      = gr::loadGrc(context->loader, graph1Saved);
+        const auto graph2      = gr::loadGrc(context->loader, graph1Saved).value();
 
         expect(eq(collectBlocks(graph1), collectBlocks(*graph2)));
         expect(eq(collectEdges(graph1), collectEdges(*graph2)));
@@ -594,7 +594,7 @@ const boost::ut::suite SettingsTests = [] {
                 {"bool_vector", expectedBoolVector}, {"string_vector", expectedStringVector}, {"double_vector", expectedDoubleVector}, {"int16_vector", expectedInt16Vector}, {"complex_vector", expectedComplexVector}});
 
             const auto graph1Saved = gr::saveGrc(context->loader, graph1);
-            const auto graph2      = gr::loadGrc(context->loader, graph1Saved);
+            const auto graph2      = gr::loadGrc(context->loader, graph1Saved).value();
             gr::graph::forEachBlock<gr::block::Category::NormalBlock>(*graph2, [&](const auto node) {
                 const auto settings = node->settings().get();
                 expect(eq(test::get_value_or_fail<bool>(settings.find_value("bool_setting").value()), expectedBool));
@@ -634,7 +634,7 @@ const boost::ut::suite SettingsTests = [] {
 
             const auto graph1Saved = gr::saveGrc(context->loader, graph1);
 
-            const auto graph2 = gr::loadGrc(context->loader, graph1Saved);
+            const auto graph2 = gr::loadGrc(context->loader, graph1Saved).value();
 
             gr::graph::forEachBlock<gr::block::Category::NormalBlock>(*graph2, [&](const auto node) {
                 const auto& stored = node->settings().getStoredAll();

--- a/core/test/qa_plugin_schedulers_test.cpp
+++ b/core/test/qa_plugin_schedulers_test.cpp
@@ -33,8 +33,8 @@ const boost::ut::suite PluginSchedulerTests = [] {
     "SchedulerInstantiation"_test = [&] {
         gr::Graph testGraph(context->loader);
 
-        auto& source = testGraph.emplaceBlock("good::fixed_source<float64>", {});
-        auto& sink   = testGraph.emplaceBlock("good::cout_sink<float64>", {});
+        auto source = testGraph.emplaceBlock("good::fixed_source<float64>", {}).value();
+        auto sink   = testGraph.emplaceBlock("good::cout_sink<float64>", {}).value();
 
         auto connection = testGraph.connect(source, 0, sink, 0);
         expect(connection.has_value());

--- a/core/test/qa_plugins_test.cpp
+++ b/core/test/qa_plugins_test.cpp
@@ -133,7 +133,7 @@ const boost::ut::suite BasicPluginBlocksConnectionTests = [] {
         gr::Graph testGraph(context->loader);
 
         // Instantiate the node that is defined in a plugin
-        auto& block_source = testGraph.emplaceBlock("good::fixed_source<float64>", {});
+        auto block_source = testGraph.emplaceBlock("good::fixed_source<float64>", {}).value();
 
         // Instantiate a built-in node in a static way
         gr::property_map block_multiply_1_params;
@@ -142,10 +142,10 @@ const boost::ut::suite BasicPluginBlocksConnectionTests = [] {
         auto  block_multiply_double        = gr::graph::findBlock(testGraph, block_multiply_double_direct);
 
         // Instantiate a built-in node via the plugin loader
-        auto& block_multiply_float = testGraph.emplaceBlock("builtin_multiply<float32>", {});
+        auto block_multiply_float = testGraph.emplaceBlock("builtin_multiply<float32>", {}).value();
 
-        auto& block_convert_to_float  = testGraph.emplaceBlock("good::convert<float64, float32>", {});
-        auto& block_convert_to_double = testGraph.emplaceBlock("good::convert<float32, float64>", {});
+        auto block_convert_to_float  = testGraph.emplaceBlock("good::convert<float64, float32>", {}).value();
+        auto block_convert_to_double = testGraph.emplaceBlock("good::convert<float32, float64>", {}).value();
 
         //
         std::size_t      repeats = 10;

--- a/patches/cpr-throw-ifdef-cppexceptions.diff
+++ b/patches/cpr-throw-ifdef-cppexceptions.diff
@@ -1,0 +1,100 @@
+diff --git a/include/cpr/async_wrapper.h b/include/cpr/async_wrapper.h
+index c90ea06..6ff964d 100644
+--- a/include/cpr/async_wrapper.h
++++ b/include/cpr/async_wrapper.h
+@@ -4,6 +4,7 @@
+ #include <atomic>
+ #include <future>
+ #include <memory>
++#include <cstdlib>
+
+ namespace cpr {
+ enum class [[nodiscard]] CancellationResult : uint8_t { failure, success, invalid_operation };
+@@ -25,7 +26,12 @@ class AsyncWrapper<T, false> {
+
+     void throw_if_invalid(const char* error) const {
+         if (!future.valid()) {
++#if __cpp_exceptions
+             throw std::logic_error{error};
++#else
++            (void)error;
++            std::abort();
++#endif
+         }
+     }
+
+@@ -85,7 +91,12 @@ class AsyncWrapper<T, true> : public AsyncWrapper<T, false> {
+
+     void throw_if_cancelled(const char* error) const {
+         if (is_cancelled->load()) {
++#if __cpp_exceptions
+             throw std::logic_error{error};
++#else
++            (void)error;
++            std::abort();
++#endif
+         }
+     }
+
+diff --git a/include/cpr/body.h b/include/cpr/body.h
+index cea7cdf..cd1a94d 100644
+--- a/include/cpr/body.h
++++ b/include/cpr/body.h
+@@ -5,6 +5,7 @@
+ #include <fstream>
+ #include <initializer_list>
+ #include <string>
++#include <cstdlib>
+
+ #include "cpr/buffer.h"
+ #include "cpr/cprtypes.h"
+@@ -29,7 +30,11 @@ class Body : public StringHolder<Body> {
+     Body(const File& file) {
+         std::ifstream is(file.filepath, std::ifstream::binary);
+         if (!is) {
++#if __cpp_exceptions
+             throw std::invalid_argument("Can't open the file for HTTP request body!");
++#else
++            std::abort();
++#endif
+         }
+
+         is.seekg(0, std::ios::end);
+diff --git a/include/cpr/multiperform.h b/include/cpr/multiperform.h
+index a481237..9effdb9 100644
+--- a/include/cpr/multiperform.h
++++ b/include/cpr/multiperform.h
+@@ -9,6 +9,7 @@
+ #include <queue>
+ #include <stdexcept>
+ #include <vector>
++#include <cstdlib>
+
+ namespace cpr {
+
+@@ -122,7 +123,11 @@ void MultiPerform::PrepareDownload(DownloadArgTypes... args) {
+ template <typename... DownloadArgTypes>
+ std::vector<Response> MultiPerform::Download(DownloadArgTypes... args) {
+     if (sizeof...(args) != sessions_.size()) {
++#if __cpp_exceptions
+         throw std::invalid_argument("Number of download arguments has to match the number of sessions added to the multiperform!");
++#else
++        std::abort();
++#endif
+     }
+     PrepareDownload(args...);
+     return MakeDownloadRequest();
+@@ -131,7 +136,11 @@ std::vector<Response> MultiPerform::Download(DownloadArgTypes... args) {
+ template <typename... DownloadArgTypes>
+ std::vector<Response> MultiPerform::PerformDownload(DownloadArgTypes... args) {
+     if (sizeof...(args) != sessions_.size()) {
++#if __cpp_exceptions
+         throw std::invalid_argument("Number of download arguments has to match the number of sessions added to the multiperform!");
++#else
++        std::abort();
++#endif
+     }
+     PrepareDownloadSessions<DownloadArgTypes...>(0, args...);
+     return MakeDownloadRequest();
+--
+2.54.0


### PR DESCRIPTION
Loading graphs from yaml when using `-fno-exceptions` is the main change here.

This PR has been altered, initially it was intended to remove all (avoidable) internal uses of exceptions, now it is only removing exceptions from the YAML importer.

There is an additional commit which changes how the CI caches fetchcontent dependencies. Previously, `restore-keys` was used, but from a bit of research it seems that does not make sense, because FetchContent is not a progressive cache. ie. `restore-keys` would be used for something like ccache where an old or partial cache can still be used and then updated to be more recent. But FetchContent will not update anything if the deps are already cloned, so you just get an out of date cache entry.

~~Otherwise I just tried to remove all instances of `throw` and `#if __cpp_exceptions` as much as possible. The ones that remain should only be ones dedicated to maintaining strong exception safety in the case of exceptions thrown by the user.~~

~~One sort-of exception (ha) to that is in `SchedulerBase::processScheduledMessages()`:~~
```cpp
        if (this->msgOut.buffer().streamBuffer.n_readers() == 0) {
            // nobody is listening on messages -> escalate otherwise-ignored child errors
            for (const auto& msg : messagesFromChildren) {
                if (!msg.data.has_value()) {
#if __cpp_exceptions
                    throw gr::exception(std::format("scheduler {}: throwing ignored exception {:t}", this->name, msg.data.error()));
#else
                    std::ignore = gr::log::error(std::format("scheduler {}: ignored child error {:t}", this->name, msg.data.error()));
#endif
                }
            }
            return;
        }
```

~~Which I am treating as some sort of weak exception propagation (ie not aborting when exceptions are disabled). The only thing here is that the user might set a `message->data = Error {...}` and then the message gets ignored and turned into a thrown exception here, in which case GR is throwing exceptions when the user is not. I am considering just having this always use `gr::log::error`. Especially if in the future the user can register log handlers/hooks. Feedback appreciated.~~