### PR TITLE
Fix `kRemoveEdge` creating ghost edges

### DIFF
--- a/blocks/basic/test/qa_TriggerBlocks.cpp
+++ b/blocks/basic/test/qa_TriggerBlocks.cpp
@@ -109,10 +109,10 @@ const suite<"SchmittTrigger Block"> triggerTests = [] {
             std::vector<std::size_t> falling_edge_indices;
 
             for (const auto& tag : tagSink._tags) {
-                if (!tag.map.contains(std::string(gr::tag::TRIGGER_NAME))) {
+                if (!tag.map.contains(gr::tag::TRIGGER_NAME)) {
                     continue;
                 }
-                std::string trigger_name = tag.map.find_value(std::pmr::string(gr::tag::TRIGGER_NAME)).value().value_or(std::string());
+                std::string trigger_name = tag.map.find_value(gr::tag::TRIGGER_NAME).value().value_or(std::string());
                 if (trigger_name == "MY_RISING_EDGE") {
                     rising_edge_indices.push_back(tag.index);
                 } else if (trigger_name == "MY_FALLING_EDGE") {

--- a/blocks/sdr/test/qa_RTL2832Source.cpp
+++ b/blocks/sdr/test/qa_RTL2832Source.cpp
@@ -445,7 +445,7 @@ const boost::ut::suite<"RTL2832Source"> rtl2832Tests = [] {
         expect(metaInfo.has_value());
         if (metaInfo) {
             for (const auto* key : {"trigger_source", "clock_source", "device_name", "sample_rate", "frequency", "gain", "auto_gain"}) {
-                expect(metaInfo->contains(std::pmr::string(key)));
+                expect(metaInfo->contains(key));
             }
         }
 
@@ -455,8 +455,8 @@ const boost::ut::suite<"RTL2832Source"> rtl2832Tests = [] {
             const auto  secondMeta = secondTag.map.get_if<property_map>(tag::TRIGGER_META_INFO);
             expect(secondMeta.has_value());
             if (secondMeta) {
-                expect(!secondMeta->contains(std::pmr::string("device_name")));
-                expect(!secondMeta->contains(std::pmr::string("sample_rate")));
+                expect(!secondMeta->contains("device_name"));
+                expect(!secondMeta->contains("sample_rate"));
             }
         }
 
@@ -612,7 +612,7 @@ const boost::ut::suite<"RTL2832Source"> rtl2832Tests = [] {
                 foundPpsTriggerName = true;
             }
             if (auto metaMap = capturedTag.map.get_if<property_map>(tag::TRIGGER_META_INFO)) {
-                const auto clockSource = metaMap->value_or<std::string_view>(std::pmr::string("clock_source"), "");
+                const auto clockSource = metaMap->value_or<std::string_view>("clock_source", "");
                 if (clockSource.find("PPS") != std::string_view::npos) {
                     foundClockSource = true;
                 }
@@ -688,11 +688,11 @@ const boost::ut::suite<"RTL2832Source"> rtl2832Tests = [] {
                 foundGpsTriggerName = true;
             }
             if (auto metaMap = capturedTag.map.get_if<property_map>(tag::TRIGGER_META_INFO)) {
-                const auto clockSource = metaMap->value_or<std::string_view>(std::pmr::string("clock_source"), "");
+                const auto clockSource = metaMap->value_or<std::string_view>("clock_source", "");
                 if (clockSource.find("GPS") != std::string_view::npos) {
                     foundGpsClockSource = true;
                 }
-                if (metaMap->contains(std::pmr::string("clock_offset_ns"))) {
+                if (metaMap->contains("clock_offset_ns")) {
                     foundClockOffset = true;
                 }
             }

--- a/blocks/sdr/test/qa_SoapyIntegration.cpp
+++ b/blocks/sdr/test/qa_SoapyIntegration.cpp
@@ -116,7 +116,7 @@ const boost::ut::suite<"SoapySource + Loopback"> integrationTests = [] {
             {"chunk_size", gr::Size_t{100}},
         });
         clock.tags  = {
-            {0, {{std::pmr::string(gr::tag::TRIGGER_NAME), std::pmr::string("GPS_PPS")}, {std::pmr::string(gr::tag::TRIGGER_TIME), std::uint64_t{1'000'000'000ULL}}}},
+            {0, {{gr::tag::TRIGGER_NAME, "GPS_PPS"}, {gr::tag::TRIGGER_TIME, std::uint64_t{1'000'000'000ULL}}}},
         };
 
         auto& source = flow.emplaceBlock<SoapySource<CF32, 1UZ>>({
@@ -148,7 +148,7 @@ const boost::ut::suite<"SoapySource + Loopback"> integrationTests = [] {
         // verify at least one tag carries the forwarded clock name
         bool foundClockTag = false;
         for (const auto& tag : sink._tags) {
-            auto nameIt = tag.map.find(std::pmr::string(gr::tag::TRIGGER_NAME));
+            auto nameIt = tag.map.find(gr::tag::TRIGGER_NAME);
             if (nameIt != tag.map.end()) {
                 const gr::Value entry = (*nameIt).second;
                 if (auto name = entry.get_if<std::string_view>()) {

--- a/blocks/timing/test/qa_GpsSource.cpp
+++ b/blocks/timing/test/qa_GpsSource.cpp
@@ -120,22 +120,22 @@ const boost::ut::suite<"GpsSource"> gpsSourceTests = [] {
 
         bool foundTriggerTag = false;
         for (const auto& tag : sink._tags) {
-            if (auto it = tag.map.find(std::pmr::string(gr::tag::TRIGGER_NAME)); it != tag.map.end()) {
+            if (auto it = tag.map.find(gr::tag::TRIGGER_NAME); it != tag.map.end()) {
                 foundTriggerTag = true;
             }
-            if (auto it = tag.map.find(std::pmr::string(gr::tag::TRIGGER_TIME)); it != tag.map.end()) {
+            if (auto it = tag.map.find(gr::tag::TRIGGER_TIME); it != tag.map.end()) {
                 auto time = (*it).second.value_or(std::uint64_t{0});
                 expect(gt(time, 0ULL)) << "trigger_time > 0";
             }
-            if (auto it = tag.map.find(std::pmr::string(gr::tag::TRIGGER_META_INFO)); it != tag.map.end()) {
+            if (auto it = tag.map.find(gr::tag::TRIGGER_META_INFO); it != tag.map.end()) {
                 const gr::Value metaEntry = (*it).second;
                 auto            meta      = metaEntry.get_if<property_map>();
                 expect(meta.has_value()) << "trigger_meta_info is a map";
                 if (meta) {
-                    expect(meta->contains(std::pmr::string("geolocation"))) << "geolocation present";
-                    expect(meta->contains(std::pmr::string("local_time"))) << "local_time present";
-                    expect(meta->contains(std::pmr::string("fix_type"))) << "fix_type present";
-                    expect(meta->contains(std::pmr::string("device_info"))) << "device_info present";
+                    expect(meta->contains("geolocation")) << "geolocation present";
+                    expect(meta->contains("local_time")) << "local_time present";
+                    expect(meta->contains("fix_type")) << "fix_type present";
+                    expect(meta->contains("device_info")) << "device_info present";
                 }
             }
         }
@@ -169,7 +169,7 @@ const boost::ut::suite<"GpsSource"> gpsSourceTests = [] {
 
         for (const auto& tag : sink._tags) {
             expect(!tag.map.contains(gr::tag::TRIGGER_META_INFO)) << "no meta_info when emit_meta_info=false";
-            if (auto it = tag.map.find(std::pmr::string(gr::tag::TRIGGER_NAME)); it != tag.map.end()) {
+            if (auto it = tag.map.find(gr::tag::TRIGGER_NAME); it != tag.map.end()) {
                 expect(true) << "trigger_name still present";
             }
         }
@@ -240,7 +240,7 @@ const boost::ut::suite<"GpsSource"> gpsSourceTests = [] {
 
         bool foundUnlocked = false;
         for (const auto& tag : sink._tags) {
-            if (auto it = tag.map.find(std::pmr::string(gr::tag::TRIGGER_NAME)); it != tag.map.end()) {
+            if (auto it = tag.map.find(gr::tag::TRIGGER_NAME); it != tag.map.end()) {
                 auto name = std::string((*it).second.value_or(std::string_view{}));
                 if (name.find("unlocked") != std::string::npos) {
                     foundUnlocked = true;

--- a/blocks/timing/test/qa_PpsSource.cpp
+++ b/blocks/timing/test/qa_PpsSource.cpp
@@ -31,28 +31,28 @@ const boost::ut::suite<"PpsSource"> ppsSourceTests = [] {
 
         bool foundTriggerTag = false;
         for (const auto& tag : sink._tags) {
-            if (auto it = tag.map.find(std::pmr::string(gr::tag::TRIGGER_NAME)); it != tag.map.end()) {
+            if (auto it = tag.map.find(gr::tag::TRIGGER_NAME); it != tag.map.end()) {
                 foundTriggerTag = true;
                 auto name       = std::string((*it).second.value_or(std::string_view{}));
                 expect(name.find("PPS") != std::string::npos) << "trigger_name contains PPS";
                 expect(name.find("NTP") != std::string::npos) << "trigger_name contains NTP";
             }
-            if (auto it = tag.map.find(std::pmr::string(gr::tag::TRIGGER_TIME)); it != tag.map.end()) {
+            if (auto it = tag.map.find(gr::tag::TRIGGER_TIME); it != tag.map.end()) {
                 auto time = (*it).second.value_or(std::uint64_t{0});
                 expect(gt(time, 0ULL)) << "trigger_time > 0";
             }
-            if (auto it = tag.map.find(std::pmr::string(gr::tag::TRIGGER_META_INFO)); it != tag.map.end()) {
+            if (auto it = tag.map.find(gr::tag::TRIGGER_META_INFO); it != tag.map.end()) {
                 const gr::Value metaEntry = (*it).second;
                 auto            meta      = metaEntry.get_if<property_map>();
                 expect(meta.has_value()) << "trigger_meta_info is a map";
                 if (meta) {
-                    expect(meta->contains(std::pmr::string("clock_mode"))) << "clock_mode present";
-                    expect(meta->contains(std::pmr::string("wakeup_offset_ns"))) << "wakeup_offset_ns present";
-                    expect(meta->contains(std::pmr::string("synchronised"))) << "synchronised present";
-                    expect(meta->contains(std::pmr::string("kernel_offset_ns"))) << "kernel_offset_ns present";
-                    expect(meta->contains(std::pmr::string("est_error_ns"))) << "est_error_ns present";
-                    expect(meta->contains(std::pmr::string("sequence"))) << "sequence present";
-                    expect(meta->contains(std::pmr::string("leap_status"))) << "leap_status present";
+                    expect(meta->contains("clock_mode")) << "clock_mode present";
+                    expect(meta->contains("wakeup_offset_ns")) << "wakeup_offset_ns present";
+                    expect(meta->contains("synchronised")) << "synchronised present";
+                    expect(meta->contains("kernel_offset_ns")) << "kernel_offset_ns present";
+                    expect(meta->contains("est_error_ns")) << "est_error_ns present";
+                    expect(meta->contains("sequence")) << "sequence present";
+                    expect(meta->contains("leap_status")) << "leap_status present";
                 }
             }
         }

--- a/core/include/gnuradio-4.0/Graph.hpp
+++ b/core/include/gnuradio-4.0/Graph.hpp
@@ -521,6 +521,18 @@ public:
             return std::unexpected(Error(std::format("Block {} sourcePortRef could not be disconnected {}: {}", sourceBlock, this->unique_name, result.error().message)));
         }
 
+        std::erase_if(_edges, [&](const Edge& edge) {
+            if (edge.sourceBlock() != *sourceBlockIt) {
+                return false;
+            }
+            if (edge._sourcePort == std::addressof(sourcePortRef)) {
+                return true;
+            }
+            const PortDefinition sourceDefinition      = edge.sourcePortDefinition();
+            const auto*          stringBasedDefinition = std::get_if<PortDefinition::StringBased>(&sourceDefinition.definition);
+            return stringBasedDefinition && stringBasedDefinition->name == sourcePort;
+        });
+
         return {};
     }
 

--- a/core/test/message_utils.hpp
+++ b/core/test/message_utils.hpp
@@ -147,14 +147,14 @@ inline std::string sendAndWaitMessageEmplaceBlock(gr::MsgPortOut& toGraph, gr::M
 
 inline void sendAndWaitMessageEmplaceEdge(gr::MsgPortOut& toGraph, gr::MsgPortIn& fromGraph, std::string sourceBlock, std::string sourcePort, std::string destinationBlock, std::string destinationPort, std::string serviceName = "", std::source_location sourceLocation = std::source_location::current()) {
     expect(eq(getNReplyMessages(fromGraph), 0UZ)) << std::format("Input port has unconsumed messages. Requested at: {}:{}\n", sourceLocation.file_name(), sourceLocation.line());
-    gr::property_map data = {                                                                   //
-        {std::pmr::string(gr::serialization_fields::EDGE_SOURCE_BLOCK), sourceBlock},           //
-        {std::pmr::string(gr::serialization_fields::EDGE_SOURCE_PORT), sourcePort},             //
-        {std::pmr::string(gr::serialization_fields::EDGE_DESTINATION_BLOCK), destinationBlock}, //
-        {std::pmr::string(gr::serialization_fields::EDGE_DESTINATION_PORT), destinationPort},   //
-        {std::pmr::string(gr::serialization_fields::EDGE_MIN_BUFFER_SIZE), gr::undefined_Size}, //
-        {std::pmr::string(gr::serialization_fields::EDGE_WEIGHT), 0},                           //
-        {std::pmr::string(gr::serialization_fields::EDGE_NAME), "unnamed edge"}};
+    gr::property_map data = {                                                 //
+        {gr::serialization_fields::EDGE_SOURCE_BLOCK, sourceBlock},           //
+        {gr::serialization_fields::EDGE_SOURCE_PORT, sourcePort},             //
+        {gr::serialization_fields::EDGE_DESTINATION_BLOCK, destinationBlock}, //
+        {gr::serialization_fields::EDGE_DESTINATION_PORT, destinationPort},   //
+        {gr::serialization_fields::EDGE_MIN_BUFFER_SIZE, gr::undefined_Size}, //
+        {gr::serialization_fields::EDGE_WEIGHT, 0},                           //
+        {gr::serialization_fields::EDGE_NAME, "unnamed edge"}};
     testing::sendAndWaitForReply<gr::message::Command::Set>(toGraph, fromGraph, serviceName, gr::scheduler::property::kEmplaceEdge, data, //
         ReplyChecker{.expectedEndpoint = gr::scheduler::property::kEdgeEmplaced});
 };

--- a/core/test/qa_Block.cpp
+++ b/core/test/qa_Block.cpp
@@ -938,8 +938,8 @@ const boost::ut::suite<"Annotations"> _drawableAnnotations = [] {
         };
         auto testBlock = gr::BlockWrapper<LocalTestBlock>();
         expect(testBlock.uiConstraints().empty());
-        testBlock.uiConstraints().insert_or_assign(std::string_view{"x-position"}, 3.f);
-        testBlock.uiConstraints().insert_or_assign(std::string_view{"y-position"}, 4.f);
+        testBlock.uiConstraints().insert_or_assign("x-position", 3.f);
+        testBlock.uiConstraints().insert_or_assign("y-position", 4.f);
         expect(!testBlock.uiConstraints().empty());
         expect(eq(testBlock.uiConstraints().size(), 2UZ));
         expect(testBlock.uiConstraints().contains("x-position"));

--- a/core/test/qa_Graph.cpp
+++ b/core/test/qa_Graph.cpp
@@ -294,6 +294,20 @@ const boost::ut::suite<"GraphExtensionsTests"> _2 = [] {
         expect(!graph.containsEdge(edge));
     };
 
+    "emplaceEdge then removeEdgeBySourcePort erases the edge"_test = [] {
+        Graph              graph;
+        NullSource<float>& src = graph.emplaceBlock<NullSource<float>>();
+        NullSink<float>&   snk = graph.emplaceBlock<NullSink<float>>();
+
+        const auto emplaced = graph.emplaceEdge(src.unique_name.value(), "out", snk.unique_name.value(), "in", undefined_size, 0, "unnamed edge");
+        expect(emplaced.has_value()) << [&] { return emplaced ? std::string{} : emplaced.error().message; } << fatal;
+        expect(eq(graph.edges().size(), 1UZ));
+
+        const auto removed = graph.removeEdgeBySourcePort(src.unique_name.value(), "out");
+        expect(removed.has_value()) << [&] { return removed ? std::string{} : removed.error().message; } << fatal;
+        expect(eq(graph.edges().size(), 0UZ)) << "removed edge must not remain in the graph's edge list";
+    };
+
     "forEachBlock visits all blocks"_test = [] {
         Graph                    graph;
         std::vector<std::string> visited;

--- a/core/test/qa_ManagedSubGraph.cpp
+++ b/core/test/qa_ManagedSubGraph.cpp
@@ -45,7 +45,7 @@ struct DemoSubSchedulerResult {
     static constexpr std::string_view kSubSchedulerPoolId = "sub_scheduler_cpu";
 
     void setGraph(gr::Graph&& graph) {
-        scheduler           = std::static_pointer_cast<BlockModel>(std::make_shared<Wrapper>(gr::property_map{{"poolName", std::string(kSubSchedulerPoolId)}}));
+        scheduler           = std::static_pointer_cast<BlockModel>(std::make_shared<Wrapper>(gr::property_map{{"poolName", kSubSchedulerPoolId}}));
         schedulerUniqueName = scheduler->uniqueName();
         wrapper             = static_cast<Wrapper*>(scheduler.get());
         wrapper->setGraph(std::move(graph));
@@ -167,10 +167,10 @@ const boost::ut::suite ManagedSubGraph = [] {
         expect(subSchedulerBlock->state() == lifecycle::State::RUNNING) << "sub-scheduler is not running";
 
         testing::sendAndWaitForReply<Set>(toScheduler, fromScheduler, demo.wrapper->uniqueName(), graph::property::kSubgraphExportPort, //
-            property_map{{"uniqueBlockName", std::string(demo.pass2->unique_name)}, {"portDirection", "output"}, {"portName", "out"}, {"exportedName", "outExp"}, {"exportFlag", true}}, [](const Message& reply) { return reply.endpoint == graph::property::kSubgraphExportedPort; });
+            property_map{{"uniqueBlockName", std::string_view(demo.pass2->unique_name)}, {"portDirection", "output"}, {"portName", "out"}, {"exportedName", "outExp"}, {"exportFlag", true}}, [](const Message& reply) { return reply.endpoint == graph::property::kSubgraphExportedPort; });
 
         testing::sendAndWaitForReply<Set>(toScheduler, fromScheduler, demo.wrapper->uniqueName(), graph::property::kSubgraphExportPort, //
-            property_map{{"uniqueBlockName", std::string(demo.pass1->unique_name)}, {"portDirection", "input"}, {"portName", "in"}, {"exportedName", "inExp"}, {"exportFlag", true}}, [](const Message& reply) { return reply.endpoint == graph::property::kSubgraphExportedPort; });
+            property_map{{"uniqueBlockName", std::string_view(demo.pass1->unique_name)}, {"portDirection", "input"}, {"portName", "in"}, {"exportedName", "inExp"}, {"exportFlag", true}}, [](const Message& reply) { return reply.endpoint == graph::property::kSubgraphExportedPort; });
 
         expect(eq(demo.wrapper->dynamicInputPortsSize(), 1UZ));
         expect(eq(demo.wrapper->dynamicOutputPortsSize(), 1UZ));
@@ -209,7 +209,7 @@ const boost::ut::suite ManagedSubGraph = [] {
             expect(eq(subGraphOutConnections, 1UZ));
 
             // Check subgraph topology
-            const auto& subGraphData   = gr::test::get_value_or_fail<property_map>(children.find_value(std::pmr::string(demo.wrapper->uniqueName())).value());
+            const auto& subGraphData   = gr::test::get_value_or_fail<property_map>(children.find_value(demo.wrapper->uniqueName()).value());
             const auto& subGraphGraph  = gr::test::get_value_or_fail<property_map>(subGraphData.find_value("graph").value());
             const auto& subGraphBlocks = gr::test::get_value_or_fail<Tensor<Value>>(subGraphGraph.find_value("blocks").value());
             const auto& subGraphConns  = gr::test::get_value_or_fail<Tensor<Value>>(subGraphGraph.find_value("connections").value());
@@ -337,7 +337,7 @@ const boost::ut::suite ExportPortsTests_ = [] {
                     expect(eq(subGraphOutConnections, 1UZ));
 
                     // Check subgraph topology
-                    const auto& subGraphData   = gr::test::get_value_or_fail<property_map>(children.find_value(std::pmr::string(demo.schedulerUniqueName)).value());
+                    const auto& subGraphData   = gr::test::get_value_or_fail<property_map>(children.find_value(demo.schedulerUniqueName).value());
                     const auto& subGraphGraph  = gr::test::get_value_or_fail<property_map>(subGraphData.find_value("graph").value());
                     const auto& subGraphBlocks = gr::test::get_value_or_fail<Tensor<Value>>(subGraphGraph.find_value("blocks").value());
                     const auto& subGraphConns  = gr::test::get_value_or_fail<Tensor<Value>>(subGraphGraph.find_value("connections").value());
@@ -452,7 +452,7 @@ const boost::ut::suite SchedulerInspectTests_ = [] {
                 const auto& children = gr::test::get_value_or_fail<property_map>(data.find_value("children").value());
                 expect(eq(children.size(), 1UZ)) << "scheduler children should contain the graph";
 
-                const auto& graphData     = gr::test::get_value_or_fail<property_map>(children.find_value(std::pmr::string(graph.unique_name)).value());
+                const auto& graphData     = gr::test::get_value_or_fail<property_map>(children.find_value(graph.unique_name).value());
                 const auto& graphChildren = gr::test::get_value_or_fail<property_map>(graphData.find_value("children").value());
                 expect(eq(graphChildren.size(), 3UZ)) << "graph has source, sink, sub-scheduler";
 

--- a/core/test/qa_Port.cpp
+++ b/core/test/qa_Port.cpp
@@ -481,9 +481,9 @@ const boost::ut::suite<"PortMetaInfo"> _pmi = [] { // NOSONAR (N.B. lambda size)
         props["data_type"]                     = "f32_42";          // this field won't be updated, not in gr::tag::kDefaultTags
         props["name"]                          = "TestPortName_42"; // this field won't be updated, not in gr::tag::kDefaultTags
         props[tag::SAMPLE_RATE.shortKey()]     = 48000.f;
-        props[tag::SIGNAL_NAME.shortKey()]     = std::string("IF");
-        props[tag::SIGNAL_QUANTITY.shortKey()] = std::string("voltage");
-        props[tag::SIGNAL_UNIT.shortKey()]     = std::string("[V]");
+        props[tag::SIGNAL_NAME.shortKey()]     = "IF";
+        props[tag::SIGNAL_QUANTITY.shortKey()] = "voltage";
+        props[tag::SIGNAL_UNIT.shortKey()]     = "[V]";
         props[tag::SIGNAL_MIN.shortKey()]      = -1.f;
         props[tag::SIGNAL_MAX.shortKey()]      = 1.f;
         expect(metaInfo.update(props).has_value());
@@ -897,10 +897,10 @@ const boost::ut::suite<"Port PMR resource access"> portResourceTests = [] {
         tag::put(tagMap, "trigger_name", std::string("GPS_PPS"));
         tag::put(tagMap, "trigger_time", std::uint64_t{42});
 
-        expect(tagMap.contains(std::pmr::string("trigger_name")));
-        expect(tagMap.contains(std::pmr::string("trigger_time")));
+        expect(tagMap.contains("trigger_name"));
+        expect(tagMap.contains("trigger_time"));
 
-        auto nameIt = tagMap.find(std::pmr::string("trigger_name"));
+        auto nameIt = tagMap.find("trigger_name");
         expect(nameIt != tagMap.end());
         expect(eq((*nameIt).second.value_or(std::string_view{}), std::string_view("GPS_PPS")));
     };
@@ -913,11 +913,11 @@ const boost::ut::suite<"Port PMR resource access"> portResourceTests = [] {
         tag::put(tagMap, tag::TRIGGER_TIME, std::uint64_t{123456789});
         tag::put(tagMap, tag::TRIGGER_OFFSET, 0.5f);
 
-        expect(tagMap.contains(std::pmr::string("gr:trigger_name"))) << "wire key used";
-        expect(tagMap.contains(std::pmr::string("gr:trigger_time")));
-        expect(tagMap.contains(std::pmr::string("gr:trigger_offset")));
+        expect(tagMap.contains("gr:trigger_name")) << "wire key used";
+        expect(tagMap.contains("gr:trigger_time"));
+        expect(tagMap.contains("gr:trigger_offset"));
 
-        expect(eq(tagMap[std::pmr::string("gr:trigger_time")].value_or(std::uint64_t{0}), std::uint64_t{123456789}));
+        expect(eq(tagMap["gr:trigger_time"].value_or(std::uint64_t{0}), std::uint64_t{123456789}));
     };
 };
 

--- a/core/test/qa_Scheduler.cpp
+++ b/core/test/qa_Scheduler.cpp
@@ -257,7 +257,7 @@ gr::Graph getBasicFeedBackLoop(std::shared_ptr<Tracer> tracer, std::source_locat
     using namespace boost::ut;
 
     gr::Size_t       nMaxSamples{2};
-    gr::property_map layout_auto{{"layout_pref", std::string("auto")}};
+    gr::property_map layout_auto{{"layout_pref", "auto"}};
 
     gr::Graph flow;
     auto&     source1 = flow.emplaceBlock<CountSource<float>>({{"name", "s1"}, {"n_samples_max", nMaxSamples}});
@@ -287,7 +287,7 @@ gr::Graph getResamplingFeedbackLoop(std::shared_ptr<Tracer> tracer, std::source_
 
     gr::Size_t       nMaxSamples{10};
     gr::Size_t       ratio{5};
-    gr::property_map layout_auto{{"layout_pref", std::string("auto")}};
+    gr::property_map layout_auto{{"layout_pref", "auto"}};
 
     gr::Graph flow;
     auto&     source = flow.emplaceBlock<CountSource<float>>({{"name", "src"}, {"n_samples_max", nMaxSamples}});
@@ -320,7 +320,7 @@ gr::Graph getMultipleNestedFeedbackLoops(std::shared_ptr<Tracer> tracer, std::so
     using namespace boost::ut;
 
     gr::Size_t       nMaxSamples{2};
-    gr::property_map layout_auto{{"layout_pref", std::string("auto")}};
+    gr::property_map layout_auto{{"layout_pref", "auto"}};
 
     gr::Graph flow;
     auto&     source = flow.emplaceBlock<CountSource<float>>({{"name", "src"}, {"n_samples_max", nMaxSamples}});
@@ -609,7 +609,7 @@ const boost::ut::suite<"SchedulerTests"> SchedulerSettingsTests = [] {
         gr::MsgPortIn           fromScheduler;
         expect(sched.msgOut.connect(fromScheduler).has_value());
 
-        std::ignore = sched.settings().set({{"poolName", std::string(kAltPoolName)}});
+        std::ignore = sched.settings().set({{"poolName", kAltPoolName}});
         std::ignore = sched.settings().activateContext();
         std::ignore = sched.settings().applyStagedParameters();
 
@@ -628,7 +628,7 @@ const boost::ut::suite<"SchedulerTests"> SchedulerSettingsTests = [] {
         std::ignore = gr::testing::consumeAllReplyMessages(fromScheduler); // discard any setup-time messages
 
         static constexpr std::string_view kBogusPoolName = "qa_definitely_not_a_pool_xyz";
-        std::ignore                                      = sched.settings().set({{"poolName", std::string(kBogusPoolName)}});
+        std::ignore                                      = sched.settings().set({{"poolName", kBogusPoolName}});
         std::ignore                                      = sched.settings().activateContext();
         std::ignore                                      = sched.settings().applyStagedParameters();
 

--- a/core/test/qa_SchedulerMessages.cpp
+++ b/core/test/qa_SchedulerMessages.cpp
@@ -279,6 +279,46 @@ const boost::ut::suite TopologyGraphTests = [] {
         };
     };
 
+    "Edge removal tests"_test = [&] {
+        gr::Graph testGraph(context->loader);
+
+        // disconnect_on_done=false: dangling blocks would otherwise self-stop and tear down
+        // the freshly emplaced connection via disconnectFromUpStreamParents()
+        auto& blockOut = testGraph.emplaceBlock("gr::testing::Copy<float32>", {{"disconnect_on_done", false}});
+        auto& blockIn  = testGraph.emplaceBlock("gr::testing::Copy<float32>", {{"disconnect_on_done", false}});
+
+        TestScheduler scheduler(std::move(testGraph));
+
+        const property_map edgeData = {{std::pmr::string(gr::serialization_fields::EDGE_SOURCE_BLOCK), std::string(blockOut->uniqueName())}, //
+            {std::pmr::string(gr::serialization_fields::EDGE_SOURCE_PORT), "out"},                                                           //
+            {std::pmr::string(gr::serialization_fields::EDGE_DESTINATION_BLOCK), std::string(blockIn->uniqueName())},                        //
+            {std::pmr::string(gr::serialization_fields::EDGE_DESTINATION_PORT), "in"},                                                       //
+            {std::pmr::string(gr::serialization_fields::EDGE_MIN_BUFFER_SIZE), gr::Size_t()},                                                //
+            {std::pmr::string(gr::serialization_fields::EDGE_WEIGHT), 0},                                                                    //
+            {std::pmr::string(gr::serialization_fields::EDGE_NAME), "unnamed edge"}};
+
+        testing::sendAndWaitForReply<Set>(scheduler.toScheduler, scheduler.fromScheduler, scheduler.unique_name(), //
+            scheduler::property::kEmplaceEdge, edgeData, ReplyChecker{.expectedEndpoint = scheduler::property::kEdgeEmplaced});
+
+        // now the removed edge should be gone
+        testing::sendAndWaitForReply<Set>(scheduler.toScheduler, scheduler.fromScheduler, scheduler.unique_name(), scheduler::property::kRemoveEdge, //
+            {{std::pmr::string(gr::serialization_fields::EDGE_SOURCE_BLOCK), std::string(blockOut->uniqueName())},                                   //
+                {std::pmr::string(gr::serialization_fields::EDGE_SOURCE_PORT), "out"}},
+            ReplyChecker{.expectedEndpoint = scheduler::property::kEdgeRemoved});
+
+        testing::sendAndWaitForReply<Set>(scheduler.toScheduler, scheduler.fromScheduler, "", graph::property::kGraphInspect, property_map{}, //
+            [](const Message& reply) {
+                if (reply.endpoint != graph::property::kGraphInspected) {
+                    return false;
+                }
+
+                const auto& data  = reply.data.value();
+                const auto& edges = gr::test::get_value_or_fail<property_map>(data.find_value(std::pmr::string(serialization_fields::BLOCK_EDGES)).value());
+                expect(eq(edges.size(), 0UZ)) << "removed edge must not appear in the inspected graph";
+                return true;
+            });
+    };
+
     "Settings change via messages"_test = [] {
         gr::Graph testGraph(context->loader);
         testGraph.emplaceBlock("gr::testing::Copy<float32>", {});

--- a/core/test/qa_SchedulerMessages.cpp
+++ b/core/test/qa_SchedulerMessages.cpp
@@ -148,7 +148,7 @@ const boost::ut::suite TopologyGraphTests = [] {
         }
 
         testing::sendAndWaitForReply<message::Command::Set>(scheduler.toScheduler, scheduler.fromScheduler, scheduler.unique_name(), scheduler::property::kEmplaceBlock, //
-            property_map{{"type", std::string("builtin_counter<float32>")}, {"properties", property_map{{"disconnect_on_done", false}}}},                                //
+            property_map{{"type", "builtin_counter<float32>"}, {"properties", property_map{{"disconnect_on_done", false}}}},                                             //
             ReplyChecker{.expectedEndpoint = scheduler::property::kBlockEmplaced});
 
         expect(awaitCondition(scheduler, [&scheduler, initialBlockCount] { return scheduler.graph().blocks().size() > initialBlockCount; })) << "waiting for block to be added to graph";
@@ -184,7 +184,7 @@ const boost::ut::suite TopologyGraphTests = [] {
             consumeAllReplyMessages(scheduler.fromScheduler);
 
             testing::sendAndWaitForReply<Set>(scheduler.toScheduler, scheduler.fromScheduler, scheduler.unique_name(), scheduler::property::kRemoveBlock, //
-                {{"uniqueName", std::string(temporaryBlock->uniqueName())}}, ReplyChecker{.expectedEndpoint = scheduler::property::kBlockRemoved});
+                {{"uniqueName", temporaryBlock->uniqueName()}}, ReplyChecker{.expectedEndpoint = scheduler::property::kBlockRemoved});
 
             expect(eq(testGraph.blocks().size(), 3UZ));
         };
@@ -209,7 +209,7 @@ const boost::ut::suite TopologyGraphTests = [] {
             expect(eq(scheduler.graph().blocks().size(), 4UZ));
 
             testing::sendAndWaitForReply<Set>(scheduler.toScheduler, scheduler.fromScheduler, scheduler.unique_name(), scheduler::property::kReplaceBlock, //
-                {{"uniqueName", std::string(temporaryBlock->uniqueName())},                                                                                //
+                {{"uniqueName", temporaryBlock->uniqueName()},                                                                                             //
                     {"type", "gr::testing::Copy<float32>"}, {"properties", property_map{}}},                                                               //
                 ReplyChecker{.expectedEndpoint = scheduler::property::kBlockReplaced});
         };
@@ -223,7 +223,7 @@ const boost::ut::suite TopologyGraphTests = [] {
 
         "Replace with an unknown block"_test = [&] {
             testing::sendAndWaitForReply<Set>(scheduler.toScheduler, scheduler.fromScheduler, scheduler.unique_name(), scheduler::property::kReplaceBlock, //
-                {{"uniqueName", std::string(block->uniqueName())},                                                                                         //
+                {{"uniqueName", block->uniqueName()},                                                                                                      //
                     {"type", "doesnt_exist::multiply<float32>"}, {"properties", property_map{}}},
                 ReplyChecker{.expectedEndpoint = scheduler::property::kReplaceBlock, .expectedHasData = false});
         };
@@ -239,13 +239,13 @@ const boost::ut::suite TopologyGraphTests = [] {
         TestScheduler scheduler(std::move(testGraph));
 
         "Add an edge"_test = [&] {
-            property_map data = {{std::pmr::string(gr::serialization_fields::EDGE_SOURCE_BLOCK), std::string(blockOut->uniqueName())}, //
-                {std::pmr::string(gr::serialization_fields::EDGE_SOURCE_PORT), "out"},                                                 //
-                {std::pmr::string(gr::serialization_fields::EDGE_DESTINATION_BLOCK), std::string(blockIn->uniqueName())},              //
-                {std::pmr::string(gr::serialization_fields::EDGE_DESTINATION_PORT), "in"},                                             //
-                {std::pmr::string(gr::serialization_fields::EDGE_MIN_BUFFER_SIZE), gr::Size_t()},                                      //
-                {std::pmr::string(gr::serialization_fields::EDGE_WEIGHT), 0},                                                          //
-                {std::pmr::string(gr::serialization_fields::EDGE_NAME), "unnamed edge"}};
+            property_map data = {{gr::serialization_fields::EDGE_SOURCE_BLOCK, blockOut->uniqueName()}, //
+                {gr::serialization_fields::EDGE_SOURCE_PORT, "out"},                                    //
+                {gr::serialization_fields::EDGE_DESTINATION_BLOCK, blockIn->uniqueName()},              //
+                {gr::serialization_fields::EDGE_DESTINATION_PORT, "in"},                                //
+                {gr::serialization_fields::EDGE_MIN_BUFFER_SIZE, gr::Size_t()},                         //
+                {gr::serialization_fields::EDGE_WEIGHT, 0},                                             //
+                {gr::serialization_fields::EDGE_NAME, "unnamed edge"}};
 
             testing::sendAndWaitForReply<Set>(scheduler.toScheduler, scheduler.fromScheduler, scheduler.unique_name(), scheduler::property::kEmplaceEdge, data, //
                 ReplyChecker{.expectedEndpoint = scheduler::property::kEdgeEmplaced});
@@ -253,28 +253,28 @@ const boost::ut::suite TopologyGraphTests = [] {
 
         "Fail to add an edge because source port is invalid"_test = [&] {
             testing::sendAndWaitForReply<Set>(scheduler.toScheduler, scheduler.fromScheduler, scheduler.unique_name(), scheduler::property::kEmplaceEdge, //
-                {{std::pmr::string(gr::serialization_fields::EDGE_SOURCE_BLOCK), std::string(blockOut->uniqueName())},                                    //
-                    {std::pmr::string(gr::serialization_fields::EDGE_SOURCE_PORT), "OUTPUT"},                                                             //
-                    {std::pmr::string(gr::serialization_fields::EDGE_DESTINATION_BLOCK), std::string(blockIn->uniqueName())},                             //
-                    {std::pmr::string(gr::serialization_fields::EDGE_DESTINATION_PORT), "in"}},
+                {{gr::serialization_fields::EDGE_SOURCE_BLOCK, blockOut->uniqueName()},                                                                   //
+                    {gr::serialization_fields::EDGE_SOURCE_PORT, "OUTPUT"},                                                                               //
+                    {gr::serialization_fields::EDGE_DESTINATION_BLOCK, blockIn->uniqueName()},                                                            //
+                    {gr::serialization_fields::EDGE_DESTINATION_PORT, "in"}},
                 ReplyChecker{.expectedEndpoint = scheduler::property::kEmplaceEdge, .expectedHasData = false});
         };
 
         "Fail to add an edge because destination port is invalid"_test = [&] {
             testing::sendAndWaitForReply<Set>(scheduler.toScheduler, scheduler.fromScheduler, scheduler.unique_name(), scheduler::property::kEmplaceEdge, //
-                {{std::pmr::string(gr::serialization_fields::EDGE_SOURCE_BLOCK), std::string(blockOut->uniqueName())},                                    //
-                    {std::pmr::string(gr::serialization_fields::EDGE_SOURCE_PORT), "in"},                                                                 //
-                    {std::pmr::string(gr::serialization_fields::EDGE_DESTINATION_BLOCK), std::string(blockIn->uniqueName())},                             //
-                    {std::pmr::string(gr::serialization_fields::EDGE_DESTINATION_PORT), "INPUT"}},
+                {{gr::serialization_fields::EDGE_SOURCE_BLOCK, blockOut->uniqueName()},                                                                   //
+                    {gr::serialization_fields::EDGE_SOURCE_PORT, "in"},                                                                                   //
+                    {gr::serialization_fields::EDGE_DESTINATION_BLOCK, blockIn->uniqueName()},                                                            //
+                    {gr::serialization_fields::EDGE_DESTINATION_PORT, "INPUT"}},
                 ReplyChecker{.expectedEndpoint = scheduler::property::kEmplaceEdge, .expectedHasData = false});
         };
 
         "Fail to add an edge because ports are not compatible"_test = [&] {
             testing::sendAndWaitForReply<Set>(scheduler.toScheduler, scheduler.fromScheduler, scheduler.unique_name(), scheduler::property::kEmplaceEdge, //
-                {{std::pmr::string(gr::serialization_fields::EDGE_SOURCE_BLOCK), std::string(blockOut->uniqueName())},                                    //
-                    {std::pmr::string(gr::serialization_fields::EDGE_SOURCE_PORT), "out"},                                                                //
-                    {std::pmr::string(gr::serialization_fields::EDGE_DESTINATION_BLOCK), std::string(blockWrongType->uniqueName())},                      //
-                    {std::pmr::string(gr::serialization_fields::EDGE_DESTINATION_PORT), "in"}},
+                {{gr::serialization_fields::EDGE_SOURCE_BLOCK, blockOut->uniqueName()},                                                                   //
+                    {gr::serialization_fields::EDGE_SOURCE_PORT, "out"},                                                                                  //
+                    {gr::serialization_fields::EDGE_DESTINATION_BLOCK, blockWrongType->uniqueName()},                                                     //
+                    {gr::serialization_fields::EDGE_DESTINATION_PORT, "in"}},
                 ReplyChecker{.expectedEndpoint = scheduler::property::kEmplaceEdge, .expectedHasData = false});
         };
     };
@@ -289,21 +289,21 @@ const boost::ut::suite TopologyGraphTests = [] {
 
         TestScheduler scheduler(std::move(testGraph));
 
-        const property_map edgeData = {{std::pmr::string(gr::serialization_fields::EDGE_SOURCE_BLOCK), std::string(blockOut->uniqueName())}, //
-            {std::pmr::string(gr::serialization_fields::EDGE_SOURCE_PORT), "out"},                                                           //
-            {std::pmr::string(gr::serialization_fields::EDGE_DESTINATION_BLOCK), std::string(blockIn->uniqueName())},                        //
-            {std::pmr::string(gr::serialization_fields::EDGE_DESTINATION_PORT), "in"},                                                       //
-            {std::pmr::string(gr::serialization_fields::EDGE_MIN_BUFFER_SIZE), gr::Size_t()},                                                //
-            {std::pmr::string(gr::serialization_fields::EDGE_WEIGHT), 0},                                                                    //
-            {std::pmr::string(gr::serialization_fields::EDGE_NAME), "unnamed edge"}};
+        const property_map edgeData = {{gr::serialization_fields::EDGE_SOURCE_BLOCK, blockOut->uniqueName()}, //
+            {gr::serialization_fields::EDGE_SOURCE_PORT, "out"},                                              //
+            {gr::serialization_fields::EDGE_DESTINATION_BLOCK, blockIn->uniqueName()},                        //
+            {gr::serialization_fields::EDGE_DESTINATION_PORT, "in"},                                          //
+            {gr::serialization_fields::EDGE_MIN_BUFFER_SIZE, gr::Size_t()},                                   //
+            {gr::serialization_fields::EDGE_WEIGHT, 0},                                                       //
+            {gr::serialization_fields::EDGE_NAME, "unnamed edge"}};
 
         testing::sendAndWaitForReply<Set>(scheduler.toScheduler, scheduler.fromScheduler, scheduler.unique_name(), //
             scheduler::property::kEmplaceEdge, edgeData, ReplyChecker{.expectedEndpoint = scheduler::property::kEdgeEmplaced});
 
         // now the removed edge should be gone
         testing::sendAndWaitForReply<Set>(scheduler.toScheduler, scheduler.fromScheduler, scheduler.unique_name(), scheduler::property::kRemoveEdge, //
-            {{std::pmr::string(gr::serialization_fields::EDGE_SOURCE_BLOCK), std::string(blockOut->uniqueName())},                                   //
-                {std::pmr::string(gr::serialization_fields::EDGE_SOURCE_PORT), "out"}},
+            {{gr::serialization_fields::EDGE_SOURCE_BLOCK, blockOut->uniqueName()},                                                                  //
+                {gr::serialization_fields::EDGE_SOURCE_PORT, "out"}},
             ReplyChecker{.expectedEndpoint = scheduler::property::kEdgeRemoved});
 
         testing::sendAndWaitForReply<Set>(scheduler.toScheduler, scheduler.fromScheduler, "", graph::property::kGraphInspect, property_map{}, //
@@ -313,7 +313,7 @@ const boost::ut::suite TopologyGraphTests = [] {
                 }
 
                 const auto& data  = reply.data.value();
-                const auto& edges = gr::test::get_value_or_fail<property_map>(data.find_value(std::pmr::string(serialization_fields::BLOCK_EDGES)).value());
+                const auto& edges = gr::test::get_value_or_fail<property_map>(data.find_value(serialization_fields::BLOCK_EDGES).value());
                 expect(eq(edges.size(), 0UZ)) << "removed edge must not appear in the inspected graph";
                 return true;
             });
@@ -392,7 +392,7 @@ const boost::ut::suite TopologyGraphTests = [] {
 
         std::vector<Value> vec;
         for (int i = 0; i < 2000; ++i) {
-            vec.push_back(property_map{{"key", std::string("value")}});
+            vec.push_back(property_map{{"key", "value"}});
         }
         std::println("std::vector<Value> segfault test before");
         [[maybe_unused]] auto p0 = vec[0]; // Segfault happens here
@@ -624,7 +624,7 @@ const boost::ut::suite MoreTopologyGraphTests = [] {
 
             const auto& data = reply.data.value();
 
-            graphUniqueName = gr::test::get_value_or_fail<std::string>(data.find_value(std::pmr::string(serialization_fields::BLOCK_UNIQUE_NAME)).value());
+            graphUniqueName = gr::test::get_value_or_fail<std::string>(data.find_value(serialization_fields::BLOCK_UNIQUE_NAME).value());
 
             const auto& children = gr::test::get_value_or_fail<property_map>(data.find_value("children").value());
             expect(eq(children.size(), 4UZ));
@@ -694,7 +694,7 @@ const boost::ut::suite InspectBlockTests = [] {
 
         TestScheduler scheduler(std::move(graph));
 
-        auto reply = testing::sendAndWaitForReply<Set>(scheduler.toScheduler, scheduler.fromScheduler, scheduler.graph().unique_name, graph::property::kInspectBlock, property_map{{"uniqueName", std::string(source.unique_name)}}, [](const Message& msg) { return msg.endpoint == graph::property::kBlockInspected; });
+        auto reply = testing::sendAndWaitForReply<Set>(scheduler.toScheduler, scheduler.fromScheduler, scheduler.graph().unique_name, graph::property::kInspectBlock, property_map{{"uniqueName", std::string_view{source.unique_name}}}, [](const Message& msg) { return msg.endpoint == graph::property::kBlockInspected; });
 
         expect(reply.has_value());
         if (reply) {
@@ -711,7 +711,7 @@ const boost::ut::suite InspectBlockTests = [] {
 
         TestScheduler scheduler(std::move(graph));
 
-        auto reply = testing::sendAndWaitForReply<Set>(scheduler.toScheduler, scheduler.fromScheduler, scheduler.graph().unique_name, graph::property::kInspectBlock, property_map{{"uniqueName", std::string(source.unique_name)}, {"serialization_format", "yaml"s}}, [](const Message& msg) { return msg.endpoint == graph::property::kBlockInspected; });
+        auto reply = testing::sendAndWaitForReply<Set>(scheduler.toScheduler, scheduler.fromScheduler, scheduler.graph().unique_name, graph::property::kInspectBlock, property_map{{"uniqueName", std::string_view{source.unique_name}}, {"serialization_format", "yaml"s}}, [](const Message& msg) { return msg.endpoint == graph::property::kBlockInspected; });
 
         expect(reply.has_value());
         if (reply) {
@@ -740,7 +740,7 @@ const boost::ut::suite EmplaceBlockFromYamlTests = [] {
         TestScheduler scheduler(std::move(graph));
 
         // First, inspect the block to get its YAML definition
-        auto inspectReply = testing::sendAndWaitForReply<Set>(scheduler.toScheduler, scheduler.fromScheduler, scheduler.graph().unique_name, graph::property::kInspectBlock, property_map{{"uniqueName", std::string(existingBlock.unique_name)}, {"serialization_format", "yaml"s}}, [](const Message& msg) { return msg.endpoint == graph::property::kBlockInspected; });
+        auto inspectReply = testing::sendAndWaitForReply<Set>(scheduler.toScheduler, scheduler.fromScheduler, scheduler.graph().unique_name, graph::property::kInspectBlock, property_map{{"uniqueName", std::string_view{existingBlock.unique_name}}, {"serialization_format", "yaml"s}}, [](const Message& msg) { return msg.endpoint == graph::property::kBlockInspected; });
 
         expect(fatal(inspectReply.has_value())) << "kInspectBlock must succeed";
         const auto yamlDef = gr::test::get_value_or_fail<std::string>(inspectReply->data.value().find_value("yamlData").value());

--- a/core/test/qa_Settings.cpp
+++ b/core/test/qa_Settings.cpp
@@ -427,7 +427,7 @@ const boost::ut::suite SettingsTests = [] {
         expect(not wrapped1.uniqueName().empty()) << "unique name";
         expect(wrapped1.settings().set({{gr::tag::CONTEXT.shortKey(), "a string"}}).empty()) << "successful set returns empty map";
         expect(eq(wrapped1.settings().getNStoredParameters(), 1UZ)); // new parameters added, but old parameters removed
-        wrapped1.metaInformation().insert_or_assign(std::string_view{"key"}, std::string{"value"});
+        wrapped1.metaInformation().insert_or_assign("key", "value");
         expect(eq(wrapped1.metaInformation().find_value("key").value().value_or(std::string_view()), "value"sv)) << "BlockModel meta-information";
 
         // via constructor
@@ -440,7 +440,7 @@ const boost::ut::suite SettingsTests = [] {
         expect(not wrapped2.uniqueName().empty()) << "unique name";
         expect(wrapped2.settings().set({{gr::tag::CONTEXT.shortKey(), "a string"}}).empty()) << "successful set returns empty map";
         expect(eq(wrapped2.settings().getNStoredParameters(), 1UZ)); // new parameters added, but old parameters removed
-        wrapped2.metaInformation().insert_or_assign(std::string_view{"key"}, std::string{"value"});
+        wrapped2.metaInformation().insert_or_assign("key", "value");
         expect(eq(wrapped2.metaInformation().find_value("key").value().value_or(std::string_view()), "value"sv)) << "BlockModel meta-information";
     };
 

--- a/core/test/qa_Tags.cpp
+++ b/core/test/qa_Tags.cpp
@@ -188,7 +188,7 @@ const boost::ut::suite<"TagTests"> _TagTests = [] {
         const property_map singleEntry = tag::SAMPLE_RATE(42.0f);
         expect(eq(singleEntry.size(), 1UZ));
         expect(singleEntry.find_value(tag::SAMPLE_RATE).value() == 42.0f);
-        std::vector<std::pair<std::size_t, property_map>> tagList = {{0UZ, {{tag::CONTEXT, std::string{"1"}}}}, {100UZ, tag::CONTEXT(std::string{"2"})}};
+        std::vector<std::pair<std::size_t, property_map>> tagList = {{0UZ, {{tag::CONTEXT, "1"}}}, {100UZ, tag::CONTEXT(std::string{"2"})}};
         expect(eq(tagList.size(), 2UZ));
         expect(tagList[0].second.contains(tag::CONTEXT));
         expect(tagList[1].second.contains(tag::CONTEXT));
@@ -376,7 +376,7 @@ const boost::ut::suite<"TagPropagation"> _TagPropagation = [] {
 
         property_map srcParametersForwardedAsTags; // canonical settings are emitted downstream as gr:-prefixed tags
         for (const auto& [key, value] : srcParametersOnlyAutoForward) {
-            srcParametersForwardedAsTags.insert_or_assign(std::string(gr::GR_TAG_PREFIX.view()) + std::string(std::string_view{key}), value);
+            srcParametersForwardedAsTags.insert_or_assign(std::string(gr::GR_TAG_PREFIX.view()) + std::string(key), value);
         }
 
         property_map srcParameter = srcParametersOnlyAutoForward;
@@ -751,7 +751,7 @@ struct ProcessOnePublisher : gr::Block<ProcessOnePublisher<T>> {
         if (std::ranges::find(publishAtSamples, _nSamples) != publishAtSamples.end()) {
             const auto       key = std::format("published_at_{}", _nSamples);
             gr::property_map tag;
-            tag.insert_or_assign(std::pmr::string(key.data(), key.size()), static_cast<std::uint64_t>(_nSamples));
+            tag.insert_or_assign(key, static_cast<std::uint64_t>(_nSamples));
             this->publishTag(tag);
         }
         _nSamples++;

--- a/core/test/qa_UnmanagedSubGraph.cpp
+++ b/core/test/qa_UnmanagedSubGraph.cpp
@@ -374,7 +374,7 @@ const boost::ut::suite SchedulerInspectTests_ = [] {
                 const auto& children = gr::test::get_value_or_fail<property_map>(data.find_value("children").value());
                 expect(eq(children.size(), 1UZ)) << "scheduler children should contain the graph";
 
-                const auto& graphData     = gr::test::get_value_or_fail<property_map>(children.find_value(std::pmr::string(graph.unique_name)).value());
+                const auto& graphData     = gr::test::get_value_or_fail<property_map>(children.find_value(graph.unique_name).value());
                 const auto& graphChildren = gr::test::get_value_or_fail<property_map>(graphData.find_value("children").value());
                 expect(eq(graphChildren.size(), 3UZ)) << "graph has source, sink, subgraph";
 

--- a/core/test/qa_Value.cpp
+++ b/core/test/qa_Value.cpp
@@ -2018,7 +2018,7 @@ const boost::ut::suite<"Value - std::map / std::unordered_map interop"> _generic
 
             Value v{m};
 
-            expect(v.get_if<ValueMap>()->find_value(std::pmr::string{longKey}).value() == Value{42});
+            expect(v.get_if<ValueMap>()->find_value(longKey).value() == Value{42});
         };
     };
 };

--- a/core/test/qa_ValueHelper.cpp
+++ b/core/test/qa_ValueHelper.cpp
@@ -839,7 +839,7 @@ const boost::ut::suite<"Value generic map ctor round-trip"> _generic_map_roundtr
         expect(innerMap.has_value());
         if (innerMap) {
             expect(eq(innerMap->size(), 1UZ));
-            const Value nestedEntry = innerMap->find_value(std::pmr::string{"nested_key"}).value();
+            const Value nestedEntry = innerMap->find_value("nested_key").value();
             expect(eq(*nestedEntry.get_if<std::int32_t>(), 42));
         }
     };

--- a/core/test/qa_ValueMap.cpp
+++ b/core/test/qa_ValueMap.cpp
@@ -563,7 +563,7 @@ const boost::ut::suite<"ValueMap - operator[] / typed at&lt;name&gt; / equal_ran
         const auto  mOpt = v.template get_if<ValueMap>();
         const auto& m    = *mOpt;
         expect(eq(m.size(), 1UZ));
-        expect(eq(m.value_or<std::uint32_t>(std::pmr::string{"inner_count"}, 0U), std::uint32_t{42}));
+        expect(eq(m.value_or<std::uint32_t>("inner_count", 0U), std::uint32_t{42}));
     };
 
     "merge(self) is a no-op (guarded by this == &other)"_test = [] {
@@ -590,7 +590,7 @@ const boost::ut::suite<"ValueMap - operator[] / typed at&lt;name&gt; / equal_ran
         const auto  mOpt = v.template get_if<ValueMap>();
         const auto& m    = *mOpt;
         expect(eq(m.size(), 1UZ));
-        expect(eq(m.value_or<std::uint32_t>(std::pmr::string{"inner_k"}, 0U), std::uint32_t{7}));
+        expect(eq(m.value_or<std::uint32_t>("inner_k", 0U), std::uint32_t{7}));
     };
 
     "SubscriptProxy: write-via-operator[]= updates the entry"_test = [] {
@@ -747,7 +747,7 @@ const boost::ut::suite<"ValueMap - edge cases"> _edge_case_suite = [] {
     "long string value spanning multiple payload-pool growths preserves data"_test = [] {
         ValueMap          map(/*resource=*/nullptr, /*initial_capacity_entries=*/2U);
         const std::string longStr(4096UZ, 'x'); // forces payload-pool growth on insert
-        map.emplace("big", std::string_view{longStr});
+        map.emplace("big", longStr);
         expect(eq(map.value_or<std::string_view>("big", std::string_view{}).size(), 4096UZ));
     };
 
@@ -849,8 +849,8 @@ const boost::ut::suite<"ValueMap - extended value types (complex / nested ValueM
         const auto  mapOpt = v.get_if<ValueMap>();
         const auto& map    = *mapOpt;
         expect(eq(map.size(), 2UZ));
-        expect(eq(map.value_or<std::uint32_t>(std::pmr::string{"inner_count"}, 0U), std::uint32_t{42}));
-        expect(eq(map.value_or<std::string_view>(std::pmr::string{"inner_label"}, std::string_view{}), "abc"sv));
+        expect(eq(map.value_or<std::uint32_t>("inner_count", 0U), std::uint32_t{42}));
+        expect(eq(map.value_or<std::string_view>("inner_label", std::string_view{}), "abc"sv));
         // Sibling entry untouched.
         expect(eq(outer.value_or<float>("sample_rate", 0.f), 48000.0f));
     };
@@ -871,14 +871,14 @@ const boost::ut::suite<"ValueMap - extended value types (complex / nested ValueM
         const auto  mmidOpt = vmid.get_if<ValueMap>();
         const auto& mmid    = *mmidOpt;
         expect(eq(mmid.size(), 2UZ));
-        expect(eq(mmid.value_or<float>(std::pmr::string{"mid_value"}, 0.f), 0.5f));
+        expect(eq(mmid.value_or<float>("mid_value", 0.f), 0.5f));
 
-        const auto vleafEntry = *mmid.find_value(std::pmr::string{"nested_leaf"});
+        const auto vleafEntry = *mmid.find_value("nested_leaf");
         expect(vleafEntry.holds<ValueMap>());
         const auto  mleafOpt = vleafEntry.get_if<ValueMap>();
         const auto& mleaf    = *mleafOpt;
         expect(eq(mleaf.size(), 1UZ));
-        expect(eq(mleaf.value_or<std::int64_t>(std::pmr::string{"leaf_value"}, 0), std::int64_t{-7}));
+        expect(eq(mleaf.value_or<std::int64_t>("leaf_value", 0), std::int64_t{-7}));
     };
 };
 
@@ -1140,7 +1140,7 @@ const boost::ut::suite<"ValueMap - Tensor support"> _tensor_suite = [] {
         // Build the nested-map element via ValueMap construction — Value(Tensor<Value>) cannot
         // store a ValueMap directly, but Value{ValueMap{...}} round-trips through the encoder.
         ValueMap innerMap;
-        innerMap.emplace(std::pmr::string{"k"}, Value{std::int64_t{99}});
+        innerMap.emplace("k", Value{std::int64_t{99}});
         src._data.data()[1] = Value{std::move(innerMap)};
 
         map.emplace("composed", src);
@@ -1158,7 +1158,7 @@ const boost::ut::suite<"ValueMap - Tensor support"> _tensor_suite = [] {
         const auto  nestedOpt = nestedVal.get_if<ValueMap>();
         const auto& nested    = *nestedOpt;
         expect(eq(nested.size(), 1UZ));
-        expect(eq(nested.value_or<std::int64_t>(std::pmr::string{"k"}, 0), std::int64_t{99}));
+        expect(eq(nested.value_or<std::int64_t>("k", 0), std::int64_t{99}));
     };
 
     "ValueMap containing a Tensor<float> coexists with sibling scalar entries"_test = [] {
@@ -1387,12 +1387,12 @@ const boost::ut::suite<"ValueMap - Tensor<Value> view contract"> _tensor_value_v
 
     "Tensor<Value> of ValueMap-with-strings — iter+get_if path mirroring loadGraphFromMap"_test = [] {
         ValueMap blockA;
-        blockA.emplace("name", std::string{"multiplier1"});
-        blockA.emplace("type", std::string{"good::multiply<float64>"});
+        blockA.emplace("name", "multiplier1");
+        blockA.emplace("type", "good::multiply<float64>");
 
         ValueMap blockB;
-        blockB.emplace("name", std::string{"sink"});
-        blockB.emplace("type", std::string{"good::cout_sink<float64>"});
+        blockB.emplace("name", "sink");
+        blockB.emplace("type", "good::cout_sink<float64>");
 
         gr::Tensor<Value> outer(gr::extents_from, std::array<std::size_t, 1>{2UZ});
         outer._data.data()[0] = Value{std::move(blockA)};
@@ -2124,7 +2124,7 @@ const boost::ut::suite<"ValueMap - wire format"> _wire_format_suite = [] {
         gr::Tensor<gr::pmt::Value> tensor(gr::extents_from, std::array<std::size_t, 1>{2UZ});
         tensor._data.data()[0] = Value{"head"sv};
         ValueMap innerMap;
-        innerMap.emplace(std::pmr::string{"k"}, Value{std::int64_t{77}});
+        innerMap.emplace("k", Value{std::int64_t{77}});
         tensor._data.data()[1] = Value{std::move(innerMap)};
         outer.emplace("composed", tensor);
 
@@ -3402,7 +3402,7 @@ const boost::ut::suite<"ValueMapView - bounded mutators (try_emplace / insert_or
         ValueMap host;
         host.reserve(8U, 256U);
         for (int i = 0; i < 5; ++i) {
-            std::ignore = host.try_emplace(std::string_view{i == 0 ? "a" : i == 1 ? "b" : i == 2 ? "c" : i == 3 ? "d" : "e"}, std::int32_t{i});
+            std::ignore = host.try_emplace(i == 0 ? "a" : i == 1 ? "b" : i == 2 ? "c" : i == 3 ? "d" : "e", std::int32_t{i});
         }
         ValueMapView& view  = host;
         const auto    loIt  = view.find("b");

--- a/core/test/qa_YamlPmt.cpp
+++ b/core/test/qa_YamlPmt.cpp
@@ -190,37 +190,37 @@ const boost::ut::suite<"GrepTests"> _GrepTests = [] {
     "Basic serialization grep tests for int"_test = [] {
         {
             gr::property_map map;
-            map.insert_or_assign(std::string_view{"answer"}, 42);
+            map.insert_or_assign("answer", 42);
             grepTest(map, {"42", "answer"});
         }
         {
             gr::property_map map;
-            map.insert_or_assign(std::string_view{"answer"}, Tensor<int>(data_from, {42, 43, 44}));
+            map.insert_or_assign("answer", Tensor<int>(data_from, {42, 43, 44}));
             grepTest(map, {"42", "43", "44", "answer"});
         }
     };
     "Basic serialization grep tests for string"_test = [] {
         {
             gr::property_map map;
-            map.insert_or_assign(std::string_view{"answer"}, "Hello"s);
+            map.insert_or_assign("answer", "Hello"s);
             grepTest(map, {"Hello", "answer"});
         }
         {
             gr::property_map map;
-            map.insert_or_assign(std::string_view{"answer"}, Tensor<pmt::Value>(data_from, {"42"s, "43"s, "44"s}));
+            map.insert_or_assign("answer", Tensor<pmt::Value>(data_from, {"42"s, "43"s, "44"s}));
             grepTest(map, {"42", "43", "44", "answer"});
         }
     };
     "Basic serialization grep tests for a mix"_test = [] {
         {
             gr::property_map map;
-            map.insert_or_assign(std::string_view{"answer"}, 42);
-            map.insert_or_assign(std::string_view{"question"}, "universe"s);
+            map.insert_or_assign("answer", 42);
+            map.insert_or_assign("question", "universe"s);
             grepTest(map, {"42", "universe", "answer", "question"});
         }
         {
             gr::property_map map;
-            map.insert_or_assign(std::string_view{"answer"}, Tensor<pmt::Value>(data_from, {pmt::Value(42), pmt::Value("question"s), pmt::Value("universe"s)}));
+            map.insert_or_assign("answer", Tensor<pmt::Value>(data_from, {pmt::Value(42), pmt::Value("question"s), pmt::Value("universe"s)}));
             grepTest(map, {"42", "universe", "answer", "question"});
         }
     };
@@ -231,7 +231,7 @@ const boost::ut::suite<"GrepTests"> _GrepTests = [] {
             nested["question"] = "universe"s;
 
             property_map map;
-            map.insert_or_assign(std::string_view{"nested"}, std::move(nested));
+            map.insert_or_assign("nested", std::move(nested));
             grepTest(map, {"42", "universe", "answer", "question", "nested"});
         }
         {
@@ -243,7 +243,7 @@ const boost::ut::suite<"GrepTests"> _GrepTests = [] {
             middle["nested"] = std::move(nested);
 
             property_map map;
-            map.insert_or_assign(std::string_view{"middle"}, std::move(middle));
+            map.insert_or_assign("middle", std::move(middle));
             grepTest(map, {"42", "universe", "answer", "question", "nested", "middle"});
         }
     };
@@ -251,8 +251,8 @@ const boost::ut::suite<"GrepTests"> _GrepTests = [] {
     "Basic serialization grep tests for tensors"_test = [] {
         {
             property_map map;
-            map.insert_or_assign(std::string_view{"answers"}, Tensor<int>(data_from, {42, 43, 44}));
-            map.insert_or_assign(std::string_view{"names"}, Tensor<pmt::Value>(data_from, {pmt::Value("John"s), pmt::Value("Smith"s)}));
+            map.insert_or_assign("answers", Tensor<int>(data_from, {42, 43, 44}));
+            map.insert_or_assign("names", Tensor<pmt::Value>(data_from, {pmt::Value("John"s), pmt::Value("Smith"s)}));
             grepTest(map, {"42", "43", "44", "John", "Smith"});
         }
         {
@@ -261,7 +261,7 @@ const boost::ut::suite<"GrepTests"> _GrepTests = [] {
             nested["question"] = "universe"s;
 
             property_map map;
-            map.insert_or_assign(std::string_view{"nested"}, std::move(nested));
+            map.insert_or_assign("nested", std::move(nested));
             grepTest(map, {"42", "universe", "answer", "question", "nested"});
         }
         {
@@ -273,7 +273,7 @@ const boost::ut::suite<"GrepTests"> _GrepTests = [] {
             middle["nested"] = std::move(nested);
 
             property_map map;
-            map.insert_or_assign(std::string_view{"middle"}, std::move(middle));
+            map.insert_or_assign("middle", std::move(middle));
             grepTest(map, {"42", "universe", "answer", "question", "nested", "middle"});
         }
     };

--- a/core/test/qa_grc.cpp
+++ b/core/test/qa_grc.cpp
@@ -739,7 +739,7 @@ const boost::ut::suite GetPropertyTests = [] {
         std::string result;
         {
             gr::property_map parent;
-            parent.insert_or_assign("name", std::string_view{"alpha"});
+            parent.insert_or_assign("name", "alpha");
             auto exp = gr::detail::getProperty<std::string>(parent, "name"sv);
             expect(exp.has_value());
             result = std::move(*exp);


### PR DESCRIPTION
The edge would still be in the Graph's `_edges`, so it would get reported via `kSchedulerInspect`, but the connection between the actual ports was not there.

Graph must remember to disconnect/connect edges and remove/add them to the `_edges` list at the same time.