### PR TITLE
Add groupBlocks and ungroupBlocks graph API and scheduler messages

### DIFF
--- a/core/include/gnuradio-4.0/Graph.hpp
+++ b/core/include/gnuradio-4.0/Graph.hpp
@@ -137,6 +137,20 @@ std::expected<std::shared_ptr<BlockModel>, Error> findBlock(const GraphLike auto
     return std::unexpected(Error(std::format("Block '{}' not found in:\n{}", uniqueBlockName, format(graph)), location));
 }
 
+template<std::convertible_to<std::string_view> SVConvertible>
+std::expected<std::vector<std::shared_ptr<BlockModel>>, Error> findBlocks(const GraphLike auto& graph, const std::vector<SVConvertible>& blockUniqueNames, std::source_location location = std::source_location::current()) noexcept {
+    std::vector<std::shared_ptr<BlockModel>> output;
+    output.reserve(blockUniqueNames.size());
+    for (const auto& uniqueName : blockUniqueNames) {
+        std::expected<std::shared_ptr<BlockModel>, Error> block = graph::findBlock(graph, uniqueName, location);
+        if (!block.has_value()) {
+            return std::unexpected(block.error());
+        }
+        output.emplace_back(std::move(*block));
+    }
+    return output;
+}
+
 std::expected<gr::Edge, Error> findEdge(const GraphLike auto& graph, std::string_view edgeName, std::source_location location = std::source_location::current()) noexcept {
     for (const auto& edge : graph.edges()) {
         if (edge.name() == edgeName) {
@@ -466,6 +480,8 @@ public:
     }
 
     std::pair<std::shared_ptr<BlockModel>, std::shared_ptr<BlockModel>> replaceBlock(std::string_view uniqueName, std::string_view type, const property_map& properties);
+
+    [[nodiscard]] std::expected<std::shared_ptr<BlockModel>, Error> groupBlocks(std::span<const std::shared_ptr<BlockModel>> targetBlocks, std::string_view schedulerTypename, std::source_location location = std::source_location::current());
 
     [[nodiscard]] std::expected<void, Error> emplaceEdge(std::string_view sourceBlock, std::string sourcePort, std::string_view destinationBlock, //
         std::string destinationPort, [[maybe_unused]] const std::size_t minBufferSize, [[maybe_unused]] const std::int32_t weight, std::string_view edgeName) {

--- a/core/include/gnuradio-4.0/Graph.hpp
+++ b/core/include/gnuradio-4.0/Graph.hpp
@@ -483,6 +483,10 @@ public:
 
     [[nodiscard]] std::expected<std::shared_ptr<BlockModel>, Error> groupBlocks(std::span<const std::shared_ptr<BlockModel>> targetBlocks, std::string_view schedulerTypename, std::source_location location = std::source_location::current());
 
+    /// Take blocks in a subgraph and move them into this graph, and delete the subgraph block. Does not touch blocks or ports at all, it only modifies the contents
+    /// of _blocks and _edges of this graph and the subgraph. Some edges are left in a WaitingToBeConnected state.
+    [[nodiscard]] std::expected<void, Error> ungroupBlocks(std::shared_ptr<BlockModel> subgraphBlock, std::source_location location = std::source_location::current());
+
     [[nodiscard]] std::expected<void, Error> emplaceEdge(std::string_view sourceBlock, std::string sourcePort, std::string_view destinationBlock, //
         std::string destinationPort, [[maybe_unused]] const std::size_t minBufferSize, [[maybe_unused]] const std::int32_t weight, std::string_view edgeName) {
         auto sourceBlockIt = std::ranges::find_if(_blocks, [&sourceBlock](const auto& block) { return block->uniqueName() == sourceBlock; });
@@ -803,24 +807,27 @@ public:
     }
 
     void disconnectAllEdges() {
-        for (auto& block : _blocks) {
-            block->initDynamicPorts();
-
-            auto disconnectAll = [](auto& ports) {
-                for (auto& port : ports) {
-                    if (auto* p = std::get_if<gr::DynamicPort>(&port)) {
-                        std::ignore = p->disconnect();
-                    } else {
-                        std::ignore = std::get<BlockModel::NamedPortCollection>(port).disconnect();
-                    }
-                }
-            };
-
-            disconnectAll(block->dynamicInputPorts());
-            disconnectAll(block->dynamicOutputPorts());
-        }
-
         for (auto& edge : _edges) {
+            if (edge.state() != Edge::EdgeState::Connected) {
+                edge._state = Edge::EdgeState::WaitingToBeConnected;
+                continue;
+            }
+
+            const auto& targetBlock = edge.destinationBlock();
+            targetBlock->initDynamicPorts();
+            const auto findTargetPortResult = targetBlock->dynamicInputPort(edge.destinationPortDefinition());
+            if (!findTargetPortResult) {
+                edge._state = Edge::EdgeState::PortNotFound;
+                continue;
+            }
+
+            // TODO: it is possible the port we are disconnecting here is actually the port of a block inside a
+            // subgraph. The user may have connected something to it, overwriting our connection in a way we
+            // can't observe. If that happened, this operation will disconnect their connection. A potential
+            // solution could be to disallow making connections to exported input ports. Or, have input ports
+            // keep track of some identifying information about who is connected to them so they can refuse
+            // disconnects from things they are not connected to.
+            std::ignore = (*findTargetPortResult)->disconnect();
             edge._state = Edge::EdgeState::WaitingToBeConnected;
         }
     }

--- a/core/include/gnuradio-4.0/Scheduler.hpp
+++ b/core/include/gnuradio-4.0/Scheduler.hpp
@@ -62,12 +62,14 @@ namespace property {
 inline static const char* const kEmplaceBlock = "EmplaceBlock";
 inline static const char* const kRemoveBlock  = "RemoveBlock";
 inline static const char* const kReplaceBlock = "ReplaceBlock";
+inline static const char* const kGroupBlocks  = "GroupBlocks";
 inline static const char* const kEmplaceEdge  = "EmplaceEdge";
 inline static const char* const kRemoveEdge   = "RemoveEdge";
 
 inline static const char* const kBlockEmplaced = "BlockEmplaced";
 inline static const char* const kBlockRemoved  = "BlockRemoved";
 inline static const char* const kBlockReplaced = "BlockReplaced";
+inline static const char* const kBlocksGrouped = "BlocksGrouped";
 inline static const char* const kEdgeEmplaced  = "EdgeEmplaced";
 inline static const char* const kEdgeRemoved   = "EdgeRemoved";
 
@@ -192,13 +194,24 @@ protected:
     ProfileHandle                 _profilerHandler{_profiler.forThisThread()};
     std::shared_ptr<TaskExecutor> _pool{gr::thread_pool::Manager::instance().defaultCpuPool()};
     std::shared_ptr<gr::Sequence> _nRunningJobs = std::allocate_shared<gr::Sequence>(std::pmr::polymorphic_allocator<gr::Sequence>(this->_resources.mechanicsResource()));
-    std::recursive_mutex          _executionOrderMutex; // only used when modifying and copying the graph->local job list
+    mutable std::recursive_mutex  _executionOrderMutex; // only used when modifying and copying the graph->local job list
     std::shared_ptr<JobLists>     _executionOrder = std::allocate_shared<JobLists>(std::pmr::polymorphic_allocator<JobLists>(this->_resources.mechanicsResource()));
 
     WatchdogThreadHandle _lastWatchDogThread;
 
     std::mutex                               _zombieBlocksMutex;
     std::vector<std::shared_ptr<BlockModel>> _zombieBlocks;
+
+    // moved blocks are similar to zombies but their lifecycle state is not
+    // modified, and they are guaranteed to never be referenced/worked on by
+    // their worker thread again if they are placed into _movedBlocks during a
+    // WorkQuiescenceGuard. They are used to move blocks from one scheduler to
+    // another without stopping the whole graph.
+    struct MovedBlockList {
+        mutable std::unique_ptr<std::mutex>      mutex = std::make_unique<std::mutex>();
+        std::vector<std::shared_ptr<BlockModel>> blocks;
+    };
+    std::vector<MovedBlockList> _movedBlocks;
 
     // for blocks that were added while scheduler was running. They need to be adopted by a thread
     std::mutex _adoptionBlocksMutex;
@@ -225,6 +238,7 @@ protected:
         using PropertyCallback                       = BlockBase::PropertyCallback;
         auto& callbacks                              = this->propertyCallbacks;
         callbacks[scheduler::property::kRemoveBlock] = static_cast<PropertyCallback>(&SchedulerBase::propertyCallbackRemoveBlock);
+        callbacks[scheduler::property::kGroupBlocks] = static_cast<PropertyCallback>(&SchedulerBase::propertyCallbackGroupBlocks);
         callbacks[scheduler::property::kRemoveEdge]  = static_cast<PropertyCallback>(&SchedulerBase::propertyCallbackRemoveEdge);
         callbacks[scheduler::property::kEmplaceEdge] = static_cast<PropertyCallback>(&SchedulerBase::propertyCallbackEmplaceEdge);
         callbacks[graph::property::kInspectBlock]    = static_cast<PropertyCallback>(&SchedulerBase::propertyCallbackInspectBlock);
@@ -569,7 +583,16 @@ public:
         }
     }
 
-    [[nodiscard]] std::shared_ptr<JobLists> jobs() const noexcept { return _executionOrder; }
+    /// Returns a deep copy of jobs to avoid data races on the std::vectors that make up the JobLists.
+    /// It is unsafe to access any fields of the blocks which work() may be mutating, if the
+    /// scheduler is running.
+    [[nodiscard]] std::shared_ptr<JobLists> jobs() const noexcept {
+        std::unique_lock guard(_executionOrderMutex);
+        if (!_executionOrder) {
+            return {};
+        }
+        return std::make_shared<JobLists>(std::as_const(*_executionOrder));
+    }
 
     // external-drive superloop entry; precondition: start() has primed the graph to RUNNING.
     [[nodiscard]] work::Result step()
@@ -577,6 +600,30 @@ public:
     {
         processScheduledMessages();
         return traverseBlockListOnce((*_executionOrder)[0]);
+    }
+
+    /*
+     * Removes blocks which may currently be owned by this scheduler. While the
+     * block may not be destroyed immediately, it is guaranteed to never be
+     * dereferenced again by this scheduler after this function returns.
+     *
+     * This only makes sense to call while worker threads are not working, so
+     * one or both of the scheduler being stopped or work quiescence requested.
+     */
+    void removeBlocks(std::span<const std::shared_ptr<BlockModel>> blocksToRemoveSpan) {
+        if (lifecycle::isActive(this->state())) {
+            removeBlocksWhileRunning(blocksToRemoveSpan);
+        } else {
+            // to avoid UB in the case of a customInit() that reads from
+            // residual state in these, and to prevent lengthening the
+            // lifetimes of the blocks behind the shared ptrs in unexpected
+            // ways, just clear these immediately.
+            std::scoped_lock guard(_adoptionBlocksMutex, _executionOrderMutex);
+            _adoptionBlocks.clear();
+            if (_executionOrder) {
+                _executionOrder->clear();
+            }
+        }
     }
 
 protected:
@@ -669,6 +716,10 @@ protected:
         }
 
         std::lock_guard lock(_executionOrderMutex);
+
+        // initialize _movedBlocks so that it can be safely indexed by runner
+        // ID from different threads while the scheduler is running
+        _movedBlocks.resize(_executionOrder->size());
 
         graph::forEachBlock<TransparentBlockGroup>(*_graph, [this](auto& block) { //
             if (block->blockCategory() == ScheduledBlockGroup) {
@@ -771,6 +822,9 @@ protected:
                     }
                 }
 
+                // we must always clean up removed blocks before accessing localBlockList
+                cleanupRemovedBlocks(runnerID, localBlockList);
+
                 // Zombies are cleaned per-thread, as we remove from the localBlockList as well.
                 // Cleaning zombies has low priority, so uses process_stream_to_message_ratio (a different ratio could be introduced)
                 cleanupZombieBlocks(localBlockList);
@@ -804,6 +858,8 @@ protected:
                     if (gr::atomic_ref(_workQuiescenceRequested).load_acquire()) {
                         gr::atomic_ref(_nWorkersInWork).fetch_sub(1UZ);
                     } else {
+                        // we must always clean up removed blocks before accessing localBlockList
+                        cleanupRemovedBlocks(runnerID, localBlockList);
                         gr::work::Result result = traverseBlockListOnce(localBlockList);
                         gr::atomic_ref(_nWorkersInWork).fetch_sub(1UZ);
                         if (result.status == work::Status::DONE) {
@@ -963,6 +1019,66 @@ protected:
         }
     }
 
+    /*
+     * Synchronously removes a blocks from execution order and adoption list,
+     * and adds it to the moved block lists so that workers know to remove it
+     * from their local job lists.
+     *
+     * Must be called within a WorkQuiescenceGuard while the scheduler is running.
+     */
+    void removeBlocksWhileRunning(std::span<const std::shared_ptr<BlockModel>> blocksToRemoveSpan) {
+        assert(lifecycle::isActive(this->state()) && gr::atomic_ref(_workQuiescenceRequested).load_acquire() //
+               && gr::atomic_ref(_nWorkersInWork).load_acquire() == 0);
+
+        // we need to filter some items from this so it is easiest to create a copy, so at least avoid shared ptr copy and use raw ptrs
+        auto blocksToRemove = blocksToRemoveSpan | std::views::transform(&std::shared_ptr<BlockModel>::get) | std::ranges::to<std::vector>();
+
+        // Start by dealing with blocks that have not been adopted yet, they can be removed immediately
+        {
+            std::lock_guard guard(_adoptionBlocksMutex);
+            const auto      toAddress   = [](const auto& ptr) { return std::to_address(ptr); };
+            auto            toRemoveSet = blocksToRemove | std::views::transform(toAddress) | std::ranges::to<std::unordered_set>();
+            for (std::vector<std::shared_ptr<BlockModel>>& adoptionList : _adoptionBlocks) {
+                if (adoptionList.empty()) {
+                    continue;
+                }
+
+                auto adoptionSet = adoptionList | std::views::transform(toAddress) | std::ranges::to<std::unordered_set>();
+                std::erase_if(blocksToRemove, [&adoptionSet](const auto& block) { return adoptionSet.contains(std::to_address(block)); });
+                std::erase_if(adoptionList, [&toRemoveSet](const auto& block) { return toRemoveSet.contains(std::to_address(block)); });
+            }
+        }
+
+        std::lock_guard lock(_executionOrderMutex);
+
+        // transfer blocks from the executionOrder to the movedBlocksList, so
+        // the thread can observe that it needs to remove that from its
+        // worklist after it wakes up
+        const auto moveToMovedList = [&blocksToRemove](auto& workList, MovedBlockList& movedBlocksList) {
+            auto iterator = workList.begin();
+            while (iterator != workList.end()) {
+                if (std::ranges::contains(blocksToRemove, (*iterator).get())) {
+                    movedBlocksList.blocks.emplace_back(std::move(*iterator));
+                    iterator = workList.erase(iterator);
+                } else {
+                    ++iterator;
+                }
+            }
+        };
+
+        auto&       executionOrder = *_executionOrder;
+        std::size_t numThreads     = executionOrder.size();
+        assert(_movedBlocks.size() == numThreads);
+        for (std::size_t i = 0; i < numThreads; ++i) {
+            std::vector<std::shared_ptr<BlockModel>>& workList = executionOrder.at(i);
+
+            MovedBlockList& movedBlockList = _movedBlocks.at(i);
+            std::lock_guard movedBlockGuard(*movedBlockList.mutex);
+
+            moveToMovedList(workList, movedBlockList);
+        }
+    }
+
 #if __cpp_exceptions
     std::optional<Message> propertyCallbackEmplaceBlock([[maybe_unused]] std::string_view propertyName, Message message) {
         using enum lifecycle::State;
@@ -1107,6 +1223,71 @@ protected:
         }
 
         return {message};
+    }
+
+    std::optional<Message> propertyCallbackGroupBlocks([[maybe_unused]] std::string_view propertyName, Message message) {
+        assert(propertyName == scheduler::property::kGroupBlocks);
+        using namespace std::string_literals;
+        auto& messageData = message.data.value();
+
+        message.endpoint = scheduler::property::kBlocksGrouped;
+
+        const std::string typeCopy(messageData.value_or<std::string_view>("type", std::string_view{}));
+        if (typeCopy.empty()) {
+            message.data = std::unexpected(Error{"No type specified"});
+            return message;
+        }
+
+        std::vector<std::string> uniqueNames;
+        if (auto it = messageData.find("uniqueNames"); it != messageData.end()) {
+            const Value entry = (*it).second;
+            for (const Value& name : entry.value_or(Tensor<Value>{})) {
+                const auto nameView = name.value_or(std::string_view{});
+                if (nameView.data() != nullptr) {
+                    uniqueNames.emplace_back(nameView);
+                }
+            }
+        }
+        if (uniqueNames.empty()) {
+            message.data = std::unexpected(Error{"No uniqueNames specified for the message {}"});
+            return message;
+        }
+
+        auto* targetGraph = findTargetSubGraph(messageData);
+        if (targetGraph == nullptr) {
+            message.data = std::unexpected(Error{"No target graph specified"});
+            return message;
+        }
+
+        messageData.insert_or_assign(std::string_view{"_targetGraph"}, std::string{targetGraph->unique_name.value()});
+        std::expected<std::shared_ptr<BlockModel>, Error> grouped;
+        {
+            WorkQuiescenceGuard quiescence(this);
+            const auto          blocksToGroup = graph::findBlocks(*targetGraph, uniqueNames);
+            if (!blocksToGroup) {
+                message.data = std::unexpected(blocksToGroup.error());
+                return message;
+            }
+
+            // create the subgraph and move blocks into it
+            grouped = targetGraph->groupBlocks(*blocksToGroup, typeCopy);
+
+            // if the blocks have been grouped into a new scheduler, we must
+            // stop referencing these blocks forever as they are now
+            // potentially being worked on by this subscheduler
+            if (grouped.has_value() && grouped.value()->blockCategory() == block::Category::ScheduledBlockGroup) {
+                removeBlocks(*blocksToGroup);
+            }
+        }
+
+        if (grouped.has_value()) {
+            adoptBlock(grouped.value());
+            messageData.insert_or_assign(std::string_view{"uniqueName"}, std::string{grouped.value()->uniqueName()});
+        } else {
+            message.data = std::unexpected(grouped.error());
+        }
+
+        return message;
     }
 
     std::optional<Message> propertyCallbackRemoveEdge([[maybe_unused]] std::string_view propertyName, Message message) {
@@ -1279,14 +1460,40 @@ protected:
     }
 
     void adoptBlocks(std::size_t runnerID, std::vector<std::shared_ptr<BlockModel>>& localBlockList) {
-        std::lock_guard guard(_adoptionBlocksMutex);
+        std::scoped_lock guard(_adoptionBlocksMutex, _executionOrderMutex);
 
         assert(_adoptionBlocks.size() > runnerID);
         auto& newBlocks = _adoptionBlocks[runnerID];
+        if (newBlocks.empty()) {
+            return;
+        }
+
+        // adopt both into our local blocklist and _executionOrder, because removeBlocksWhileRunning()
+        // observes _executionOrder in order to understand what blocks a thread is working on
+        assert(_executionOrder->size() > runnerID);
+        auto& sharedJobList = (*_executionOrder)[runnerID];
+        sharedJobList.insert(sharedJobList.end(), newBlocks.begin(), newBlocks.end());
 
         localBlockList.reserve(localBlockList.size() + newBlocks.size());
         localBlockList.insert(localBlockList.end(), newBlocks.begin(), newBlocks.end());
         newBlocks.clear();
+    }
+
+    /*
+     * Removes blocks from a thread's local blocklist if they were removed
+     * during workquiescence due to being grouped into a subgraph
+     */
+    void cleanupRemovedBlocks(std::size_t runnerID, std::vector<std::shared_ptr<BlockModel>>& localBlockList) {
+        MovedBlockList& ourMovedBlockList = _movedBlocks[runnerID];
+        std::lock_guard lockGuard(*ourMovedBlockList.mutex);
+
+        auto ourMovedBlockListSet = ourMovedBlockList.blocks | std::ranges::to<std::unordered_set>();
+        auto localBlockListSet    = localBlockList | std::ranges::to<std::unordered_set>();
+
+        std::erase_if(ourMovedBlockList.blocks, //
+            [&localBlockListSet](const auto& block) { return localBlockListSet.contains(block); });
+        std::erase_if(localBlockList, //
+            [&ourMovedBlockListSet](const auto& block) { return ourMovedBlockListSet.contains(block); });
     }
 
     /*
@@ -1304,14 +1511,14 @@ protected:
             this->emitErrorMessageIfAny("makeZombie", block->changeStateTo(REQUESTED_STOP));
         }
 
+        // maybe the block is not yet adopted, in which case there is no need to zombify it, just refuse to adopt it.
+        // happens if the user issues quick successive add and then remove requests for the same block.
         {
-            // Handle edge case: If we receive two consecutive "Add Block X" "Remove Block X" messages
-            // it would be zombie before being adopted, so we need to remove it from adoption list
             std::lock_guard guard(_adoptionBlocksMutex);
             for (std::vector<std::shared_ptr<BlockModel>>& adoptionList : _adoptionBlocks) {
                 if (auto it = std::ranges::find(adoptionList, block); it != adoptionList.end()) {
                     adoptionList.erase(it);
-                    break;
+                    return;
                 }
             }
         }

--- a/core/include/gnuradio-4.0/Scheduler.hpp
+++ b/core/include/gnuradio-4.0/Scheduler.hpp
@@ -59,19 +59,21 @@ using namespace gr::message;
 
 namespace property {
 
-inline static const char* const kEmplaceBlock = "EmplaceBlock";
-inline static const char* const kRemoveBlock  = "RemoveBlock";
-inline static const char* const kReplaceBlock = "ReplaceBlock";
-inline static const char* const kGroupBlocks  = "GroupBlocks";
-inline static const char* const kEmplaceEdge  = "EmplaceEdge";
-inline static const char* const kRemoveEdge   = "RemoveEdge";
+inline static const char* const kEmplaceBlock  = "EmplaceBlock";
+inline static const char* const kRemoveBlock   = "RemoveBlock";
+inline static const char* const kReplaceBlock  = "ReplaceBlock";
+inline static const char* const kGroupBlocks   = "GroupBlocks";
+inline static const char* const kUngroupBlocks = "UngroupBlocks";
+inline static const char* const kEmplaceEdge   = "EmplaceEdge";
+inline static const char* const kRemoveEdge    = "RemoveEdge";
 
-inline static const char* const kBlockEmplaced = "BlockEmplaced";
-inline static const char* const kBlockRemoved  = "BlockRemoved";
-inline static const char* const kBlockReplaced = "BlockReplaced";
-inline static const char* const kBlocksGrouped = "BlocksGrouped";
-inline static const char* const kEdgeEmplaced  = "EdgeEmplaced";
-inline static const char* const kEdgeRemoved   = "EdgeRemoved";
+inline static const char* const kBlockEmplaced   = "BlockEmplaced";
+inline static const char* const kBlockRemoved    = "BlockRemoved";
+inline static const char* const kBlockReplaced   = "BlockReplaced";
+inline static const char* const kBlocksGrouped   = "BlocksGrouped";
+inline static const char* const kBlocksUngrouped = "BlocksUngrouped";
+inline static const char* const kEdgeEmplaced    = "EdgeEmplaced";
+inline static const char* const kEdgeRemoved     = "EdgeRemoved";
 
 inline static const char* const kGraphGRC           = "GraphGRC";
 inline static const char* const kSchedulerInspect   = "SchedulerInspect";
@@ -235,13 +237,14 @@ protected:
 
     void registerPropertyCallbacks() noexcept {
         _forbid_reserved_overrides();
-        using PropertyCallback                       = BlockBase::PropertyCallback;
-        auto& callbacks                              = this->propertyCallbacks;
-        callbacks[scheduler::property::kRemoveBlock] = static_cast<PropertyCallback>(&SchedulerBase::propertyCallbackRemoveBlock);
-        callbacks[scheduler::property::kGroupBlocks] = static_cast<PropertyCallback>(&SchedulerBase::propertyCallbackGroupBlocks);
-        callbacks[scheduler::property::kRemoveEdge]  = static_cast<PropertyCallback>(&SchedulerBase::propertyCallbackRemoveEdge);
-        callbacks[scheduler::property::kEmplaceEdge] = static_cast<PropertyCallback>(&SchedulerBase::propertyCallbackEmplaceEdge);
-        callbacks[graph::property::kInspectBlock]    = static_cast<PropertyCallback>(&SchedulerBase::propertyCallbackInspectBlock);
+        using PropertyCallback                         = BlockBase::PropertyCallback;
+        auto& callbacks                                = this->propertyCallbacks;
+        callbacks[scheduler::property::kRemoveBlock]   = static_cast<PropertyCallback>(&SchedulerBase::propertyCallbackRemoveBlock);
+        callbacks[scheduler::property::kGroupBlocks]   = static_cast<PropertyCallback>(&SchedulerBase::propertyCallbackGroupBlocks);
+        callbacks[scheduler::property::kUngroupBlocks] = static_cast<PropertyCallback>(&SchedulerBase::propertyCallbackUngroupBlocks);
+        callbacks[scheduler::property::kRemoveEdge]    = static_cast<PropertyCallback>(&SchedulerBase::propertyCallbackRemoveEdge);
+        callbacks[scheduler::property::kEmplaceEdge]   = static_cast<PropertyCallback>(&SchedulerBase::propertyCallbackEmplaceEdge);
+        callbacks[graph::property::kInspectBlock]      = static_cast<PropertyCallback>(&SchedulerBase::propertyCallbackInspectBlock);
 #if __cpp_exceptions // yaml/plugin graph-mutation handlers are hosted-only (freestanding/MCU graphs are static)
         callbacks[scheduler::property::kEmplaceBlock]     = static_cast<PropertyCallback>(&SchedulerBase::propertyCallbackEmplaceBlock);
         callbacks[scheduler::property::kReplaceBlock]     = static_cast<PropertyCallback>(&SchedulerBase::propertyCallbackReplaceBlock);
@@ -279,12 +282,15 @@ public:
 
     void releaseWorkQuiescence() { gr::atomic_ref(_workQuiescenceRequested).store_release(false); }
 
+    /// Invokes blockUntilWorking(), do not call when scheduler is not running or being started
+    /// as it will block until it sees a worker thread/call to poolWorker
     void requestWorkQuiescenceAll() {
         requestWorkQuiescence();
         graph::forEachBlock<TransparentBlockGroup>(*_graph, [](auto& block) {
             if (block->blockCategory() == block::Category::ScheduledBlockGroup) {
                 if (auto* sm = detail::asSchedulerModel(*block)) {
-                    sm->requestWorkQuiescence();
+                    sm->blockUntilWorking();
+                    sm->requestWorkQuiescenceAll();
                 }
             }
         });
@@ -294,19 +300,65 @@ public:
         graph::forEachBlock<TransparentBlockGroup>(*_graph, [](auto& block) {
             if (block->blockCategory() == block::Category::ScheduledBlockGroup) {
                 if (auto* sm = detail::asSchedulerModel(*block)) {
-                    sm->releaseWorkQuiescence();
+                    sm->releaseWorkQuiescenceAll();
                 }
             }
         });
         releaseWorkQuiescence();
     }
 
+    /// If this scheduler is INITIALISED or RUNNING, this function will block the calling thread until the scheduler
+    /// has begun spawning its worker threads (though the worker threads may not have started yet). This is useful
+    /// when spawning another thread to call start(), because a scheduler's start() observes _graph and modifies
+    /// ports before it spawns workers, so this can be used to wait until that is done.
+    ///
+    /// Do not call this on a scheduler which has been INITIALISED but has not (been started | is planned to be
+    /// started by another thread), as this will block indefinitely in that case, waiting for another thread to
+    /// issue changeStateTo(RUNNING). Calling this via the SchedulerModel, which manages the starting thread, and
+    /// can check if it has been spawned, prevents this issue.
+    void blockUntilWorking() {
+        using enum lifecycle::State;
+        if constexpr (executionPolicy() == ExecutionPolicy::externalStep) {
+            return; // you are doing step() so you know when it is working :)
+        }
+        while (_nRunningJobs->value() == 0UZ) {
+            const auto currentState = this->state();
+            if (currentState != INITIALISED && currentState != RUNNING) {
+                return;
+            }
+            std::this_thread::yield();
+        }
+    }
+
+    template<typename SchedulerType>
     struct WorkQuiescenceGuard {
-        SchedulerBase* _scheduler;
-        explicit WorkQuiescenceGuard(SchedulerBase* s) : _scheduler(s) { _scheduler->requestWorkQuiescenceAll(); }
+        SchedulerType* _scheduler;
+        explicit WorkQuiescenceGuard(SchedulerType* s) : _scheduler(s) { _scheduler->requestWorkQuiescenceAll(); }
         ~WorkQuiescenceGuard() { _scheduler->releaseWorkQuiescenceAll(); }
         WorkQuiescenceGuard(const WorkQuiescenceGuard&)            = delete;
         WorkQuiescenceGuard& operator=(const WorkQuiescenceGuard&) = delete;
+    };
+
+    struct WorkGuard {
+        SchedulerBase* _scheduler;
+        bool           _needsDecrement         = false;
+        bool           _isWorking              = false;
+        WorkGuard(const WorkGuard&)            = delete;
+        WorkGuard& operator=(const WorkGuard&) = delete;
+        explicit WorkGuard(SchedulerBase* s) : _scheduler(s) {
+            if (!gr::atomic_ref(_scheduler->_workQuiescenceRequested).load_acquire()) {
+                gr::atomic_ref(_scheduler->_nWorkersInWork).fetch_add(1UZ);
+                _needsDecrement  = true;
+                this->_isWorking = !gr::atomic_ref(_scheduler->_workQuiescenceRequested).load_acquire();
+            }
+        }
+        ~WorkGuard() {
+            if (_needsDecrement) {
+                gr::atomic_ref(_scheduler->_nWorkersInWork).fetch_sub(1UZ);
+            }
+        }
+
+        constexpr explicit operator bool() const { return _isWorking; }
     };
 
     SchedulerBase() : base_t(gr::property_map()) { registerPropertyCallbacks(); }
@@ -715,7 +767,7 @@ protected:
             }
         }
 
-        std::lock_guard lock(_executionOrderMutex);
+        std::unique_lock lock(_executionOrderMutex);
 
         // initialize _movedBlocks so that it can be safely indexed by runner
         // ID from different threads while the scheduler is running
@@ -754,6 +806,11 @@ protected:
 
         assert(!_executionOrder->empty());
         if constexpr (executionPolicy() == ExecutionPolicy::singleThreaded || executionPolicy() == ExecutionPolicy::singleThreadedBlocking) {
+            // in multithreaded mode, poolWorkers operate while _executionOrderMutex is not held. let's do that same behavior here
+            // because propertyCallbackUngroupBlocks() relies on being able to modify the _executionOrder of another running scheduler
+            lock.unlock();
+            on_scope_exit exit = [&lock] { lock.lock(); };
+
             static_cast<Derived*>(this)->poolWorker(0UZ, _executionOrder);
         } else { // run on processing thread pool
             [[maybe_unused]] const auto pe           = _profilerHandler->startCompleteEvent("scheduler_base.runOnPool");
@@ -796,6 +853,10 @@ protected:
             std::ranges::copy(blocks, std::back_inserter(localBlockList));
         }
 
+        if (localBlockList.empty()) {
+            return;
+        }
+
         const auto            initialGeneration  = gr::atomic_ref(_graphGeneration).load_acquire();
         [[maybe_unused]] auto currentProgress    = this->_graph->progress().value();
         std::size_t           inactiveCycleCount = 0UZ;
@@ -822,23 +883,31 @@ protected:
                     }
                 }
 
-                // we must always clean up removed blocks before accessing localBlockList
-                cleanupRemovedBlocks(runnerID, localBlockList);
+                // although we do not do work() on child blocks inside of this WorkGuard, these operations modify
+                // Ports. cleanupZombieBlocks will destroy ports, processScheduledMessages may access
+                // ports, and housekeeping resizes port buffers. cleanupRemovedBlocks and adoptBlocks must be in
+                // this block to preserve adoption/removal ordering. Some messages, such as grouping/ungrouping
+                // and emplacing and removing edges, may modify these ports while work quiescence is requested.
+                WorkGuard isWorking(this);
+                if (isWorking) {
+                    // we must always clean up removed blocks before accessing localBlockList
+                    cleanupRemovedBlocks(runnerID, localBlockList);
 
-                // Zombies are cleaned per-thread, as we remove from the localBlockList as well.
-                // Cleaning zombies has low priority, so uses process_stream_to_message_ratio (a different ratio could be introduced)
-                cleanupZombieBlocks(localBlockList);
+                    // Zombies are cleaned per-thread, as we remove from the localBlockList as well.
+                    // Cleaning zombies has low priority, so uses process_stream_to_message_ratio (a different ratio could be introduced)
+                    cleanupZombieBlocks(localBlockList);
 
-                adoptBlocks(runnerID, localBlockList);
+                    adoptBlocks(runnerID, localBlockList);
 
-                std::ranges::for_each(localBlockList, &BlockModel::processScheduledMessages);
-                // Buffer housekeeping rides the same cadence as message handling. Light skips
-                // the scheduler-driven trigger entirely (intrinsic writer-pressure path still
-                // fires inside the buffer); Aggressive's post-consume hook is a follow-up.
-                if (house_keeping_policy.value != HouseKeepPolicy::Light) {
-                    const HouseKeepPolicy policy = house_keeping_policy.value;
-                    const HouseKeepDepth  depth  = house_keeping_depth.value;
-                    std::ranges::for_each(localBlockList, [policy, depth](auto& b) { b->houseKeeping(policy, depth); });
+                    std::ranges::for_each(localBlockList, &BlockModel::processScheduledMessages);
+                    // Buffer housekeeping rides the same cadence as message handling. Light skips
+                    // the scheduler-driven trigger entirely (intrinsic writer-pressure path still
+                    // fires inside the buffer); Aggressive's post-consume hook is a follow-up.
+                    if (house_keeping_policy.value != HouseKeepPolicy::Light) {
+                        const HouseKeepPolicy policy = house_keeping_policy.value;
+                        const HouseKeepDepth  depth  = house_keeping_depth.value;
+                        std::ranges::for_each(localBlockList, [policy, depth](auto& b) { b->houseKeeping(policy, depth); });
+                    }
                 }
                 activeState = this->state();
                 msgToCount++;
@@ -851,17 +920,13 @@ protected:
             }
 
             if (activeState == RUNNING) {
-                if (gr::atomic_ref(_workQuiescenceRequested).load_acquire()) {
-                    std::this_thread::yield();
-                } else {
-                    gr::atomic_ref(_nWorkersInWork).fetch_add(1UZ);
-                    if (gr::atomic_ref(_workQuiescenceRequested).load_acquire()) {
-                        gr::atomic_ref(_nWorkersInWork).fetch_sub(1UZ);
-                    } else {
-                        // we must always clean up removed blocks before accessing localBlockList
-                        cleanupRemovedBlocks(runnerID, localBlockList);
+                bool idleUntilAdoption = false;
+                if (auto isWorking = WorkGuard{this}) {
+                    // we must always clean up removed blocks before accessing localBlockList
+                    cleanupRemovedBlocks(runnerID, localBlockList);
+                    idleUntilAdoption = localBlockList.empty();
+                    if (!idleUntilAdoption) {
                         gr::work::Result result = traverseBlockListOnce(localBlockList);
-                        gr::atomic_ref(_nWorkersInWork).fetch_sub(1UZ);
                         if (result.status == work::Status::DONE) {
                             break; // nothing happened -> shutdown this worker
                         } else if (result.status == work::Status::ERROR) {
@@ -869,6 +934,10 @@ protected:
                             break;
                         }
                     }
+                }
+                if (idleUntilAdoption) {
+                    std::this_thread::sleep_for(std::chrono::milliseconds(timeout_ms));
+                    msgToCount = 0UZ;
                 }
             } else if (activeState == PAUSED) {
                 std::this_thread::sleep_for(std::chrono::milliseconds(timeout_ms));
@@ -1015,6 +1084,7 @@ protected:
         case INITIALISED: //
             this->emitErrorMessageIfAny("adoptBlock -> INITIALIZED", newBlock->changeStateTo(RUNNING));
             break;
+        case RUNNING: break; // may occur when grouping or ungrouping blocks, as the blocks are moved to the parent while still in a running state
         default: this->emitErrorMessage("propertyCallbackEmplaceBlock", std::format("Unexpected block state during emplacement: {}", gr::meta::enumName(newBlock->state()).value_or("")));
         }
     }
@@ -1285,6 +1355,109 @@ protected:
             messageData.insert_or_assign(std::string_view{"uniqueName"}, std::string{grouped.value()->uniqueName()});
         } else {
             message.data = std::unexpected(grouped.error());
+        }
+
+        return message;
+    }
+
+    std::optional<Message> propertyCallbackUngroupBlocks([[maybe_unused]] std::string_view propertyName, Message message) {
+        assert(propertyName == scheduler::property::kUngroupBlocks);
+        using namespace std::string_literals;
+        auto& messageData = message.data.value();
+
+        message.endpoint = scheduler::property::kBlocksUngrouped;
+
+        const std::string uniqueName(messageData.value_or<std::string_view>("uniqueName", std::string_view{}));
+        if (uniqueName.empty()) {
+            message.data = std::unexpected(Error{"No uniqueName specified"});
+            return message;
+        }
+
+        auto* targetGraph = findTargetSubGraph(messageData);
+        if (targetGraph == nullptr) {
+            message.data = std::unexpected(Error{"No target graph specified"});
+            return message;
+        }
+        messageData.insert_or_assign(std::string_view{"_targetGraph"}, std::string{targetGraph->unique_name.value()});
+
+        std::expected<std::shared_ptr<BlockModel>, Error> subGraphBlock = graph::findBlock(*targetGraph, std::string_view(uniqueName));
+        if (!subGraphBlock.has_value()) {
+            message.data = std::unexpected(subGraphBlock.error());
+            return message;
+        }
+
+        const block::Category category = subGraphBlock.value()->blockCategory();
+        if (category != block::Category::TransparentBlockGroup && category != block::Category::ScheduledBlockGroup) {
+            message.data = std::unexpected(Error{std::format("block '{}' is not a sub-graph", uniqueName)});
+            return message;
+        }
+
+        // if the subgraph is unmanaged, then we were already managing these blocks, this is relatively simple, just change the graph structure
+        if (category == block::Category::TransparentBlockGroup) {
+            {
+                WorkQuiescenceGuard quiescence(this);
+                if (auto result = targetGraph->ungroupBlocks(std::shared_ptr<BlockModel>(*subGraphBlock)); !result.has_value()) {
+                    message.data = std::unexpected(result.error());
+                    return message;
+                }
+                if (!connectPendingEdges()) {
+                    message.data = std::unexpected(Error{std::format("failed to connect pending edges after ungrouping '{}'", uniqueName)});
+                }
+            }
+
+            // we must now discard the subgraph block which is no longer in our graph. zombie cleanup only removes stopped blocks, but this
+            // will not come to a stopped state on its own, so we have to stop it manually
+            if ((*subGraphBlock)->state() == lifecycle::State::RUNNING || (*subGraphBlock)->state() == lifecycle::State::PAUSED) {
+                this->emitErrorMessageIfAny("ungroupBlocks -> REQUESTED_STOP", (*subGraphBlock)->changeStateTo(lifecycle::State::REQUESTED_STOP));
+                if (!(*subGraphBlock)->isBlocking()) {
+                    this->emitErrorMessageIfAny("ungroupBlocks -> STOPPED", (*subGraphBlock)->changeStateTo(lifecycle::State::STOPPED));
+                }
+            }
+            makeZombie(std::move((*subGraphBlock)));
+            return message;
+        }
+
+        // the graph that is about to be ungrouped is a managed subgraph. we need to tell it to pause work, then remove its
+        // blocks, and then we adopt its blocks, without changing their state.
+        auto* schedulerModel = detail::asSchedulerModel(**subGraphBlock);
+        if (schedulerModel == nullptr) {
+            message.data = std::unexpected(Error{std::format("ScheduledBlockGroup is not a SchedulerModel {}", uniqueName)});
+            return message;
+        }
+        assert(category == block::Category::ScheduledBlockGroup);
+
+        gr::Graph* graphAboutToBeUngrouped = (*subGraphBlock)->graph();
+        assert(graphAboutToBeUngrouped);
+        auto ungroupedBlocks = graphAboutToBeUngrouped->blocks() | std::ranges::to<std::vector>();
+
+        {
+            WorkQuiescenceGuard thisQuiescence(this);
+            // although we have requested work quiescence which prevents worker threads from modifying the graph, there is also the
+            // SchedulerModel's runner thread that could potentially read/write to the graph/ports during start(). If that thread
+            // has not been started then this function will not block at all.
+            schedulerModel->blockUntilWorking();
+
+            if (auto result = targetGraph->ungroupBlocks(*subGraphBlock); !result.has_value()) {
+                message.data = std::unexpected(result.error());
+                return message;
+            }
+            // some new edges had to be created, connecting ports directly instead of via exported ports.
+            // we must connect those and, in the process, overwrite old port connections. These will
+            // continue to exist and write to nothing until the next disconnectAllEdges + connectPendingEdges
+            if (!connectPendingEdges()) {
+                message.data = std::unexpected(Error{std::format("failed to connect pending edges after ungrouping '{}'", uniqueName)});
+                // don't return because the subgraph is in an invalid state
+            }
+
+            // while the child is still not running, we tell it to remove all its blocks. when workers
+            // come back online, they will not touch these blocks again
+            schedulerModel->removeBlocks(ungroupedBlocks);
+        }
+        makeZombie(std::move(*subGraphBlock));
+
+        // we must now run these blocks which have been extracted from the child graph while still running
+        for (const std::shared_ptr<BlockModel>& block : ungroupedBlocks) {
+            adoptBlock(block);
         }
 
         return message;

--- a/core/include/gnuradio-4.0/Scheduler.hpp
+++ b/core/include/gnuradio-4.0/Scheduler.hpp
@@ -275,6 +275,8 @@ public:
 
     void requestWorkQuiescence() {
         gr::atomic_ref(_workQuiescenceRequested).store_release(true);
+        // _nWorkersInWork load may not be reordered before _workQuiescenceRequested store
+        std::atomic_thread_fence(std::memory_order_seq_cst);
         while (gr::atomic_ref(_nWorkersInWork).load_acquire() > 0) {
             std::this_thread::yield();
         }
@@ -348,6 +350,8 @@ public:
         explicit WorkGuard(SchedulerBase* s) : _scheduler(s) {
             if (!gr::atomic_ref(_scheduler->_workQuiescenceRequested).load_acquire()) {
                 gr::atomic_ref(_scheduler->_nWorkersInWork).fetch_add(1UZ);
+                // incrementing _nWorkersInWork may not be reordered after loading _workQuiescenceRequested
+                std::atomic_thread_fence(std::memory_order_seq_cst);
                 _needsDecrement  = true;
                 this->_isWorking = !gr::atomic_ref(_scheduler->_workQuiescenceRequested).load_acquire();
             }

--- a/core/include/gnuradio-4.0/Scheduler.hpp
+++ b/core/include/gnuradio-4.0/Scheduler.hpp
@@ -1075,6 +1075,21 @@ protected:
 
         auto runnerIndex = std::hash<BlockModel*>{}(newBlock.get()) % nBatches;
         _adoptionBlocks[runnerIndex].push_back(newBlock);
+
+        // start scheduler via the SchedulerWrapper::start() so it spins up a
+        // thread, instead of potentially blocking this scheduler
+        if (auto* schedulerModel = detail::asSchedulerModel(*newBlock)) {
+            assert(newBlock->blockCategory() == ScheduledBlockGroup && "scheduler found with incorrect category");
+
+            if (gr::lifecycle::isActive(newBlock->state())) {
+                return;
+            }
+
+            schedulerModel->start();
+            schedulerModel->blockUntilWorking();
+            return;
+        }
+
         switch (newBlock->state()) {
         case STOPPED:
         case IDLE: //

--- a/core/include/gnuradio-4.0/SchedulerModel.hpp
+++ b/core/include/gnuradio-4.0/SchedulerModel.hpp
@@ -34,8 +34,18 @@ public:
     virtual void start() = 0;
     virtual void stop()  = 0;
 
-    virtual void requestWorkQuiescence() = 0;
-    virtual void releaseWorkQuiescence() = 0;
+    /// Blocks workers from working in the current graph, and then recurses by calling the same
+    /// on child schedulers. After this is called, it is guaranteed that this scheduler and all
+    /// its descendants are not reading/writing to their graphs.
+    virtual void requestWorkQuiescenceAll() = 0;
+    virtual void releaseWorkQuiescenceAll() = 0;
+
+    /// Wait for a scheduler to have initialized its graph and start()ed all of its subschedulers.
+    /// Internally invoked by requestWorkQuiescenceAll.
+    virtual void blockUntilWorking() = 0;
+
+    /// May only be called within work quiescence
+    virtual void removeBlocks(std::span<const std::shared_ptr<BlockModel>> blocksToRemove) = 0;
 };
 
 template<BlockLike TScheduler>
@@ -51,9 +61,11 @@ public:
     SchedulerWrapper& operator=(const SchedulerWrapper& other) = delete;
     SchedulerWrapper& operator=(SchedulerWrapper&& other)      = delete;
 
-    ~SchedulerWrapper() override = default;
+    ~SchedulerWrapper() override { stop(); }
 
     void setGraph(gr::Graph&& graph) final { std::ignore = this->blockRef().exchange(std::move(graph)); }
+
+    void removeBlocks(std::span<const std::shared_ptr<BlockModel>> blocksToRemove) final { this->blockRef().removeBlocks(blocksToRemove); };
 
     BlockModel* asBlockModel() final { return static_cast<BlockModel*>(this); }
 
@@ -83,8 +95,15 @@ public:
         });
     }
 
-    void requestWorkQuiescence() override { this->blockRef().requestWorkQuiescence(); }
-    void releaseWorkQuiescence() override { this->blockRef().releaseWorkQuiescence(); }
+    void requestWorkQuiescenceAll() override { this->blockRef().requestWorkQuiescenceAll(); }
+    void releaseWorkQuiescenceAll() override { this->blockRef().releaseWorkQuiescenceAll(); }
+
+    void blockUntilWorking() override {
+        if (!_schedulerThread.joinable()) {
+            return;
+        }
+        this->blockRef().blockUntilWorking();
+    }
 
     void stop() override {
         if (this->blockRef().changeStateTo(gr::lifecycle::State::REQUESTED_STOP)) {

--- a/core/src/Graph.cpp
+++ b/core/src/Graph.cpp
@@ -173,6 +173,116 @@ std::expected<std::shared_ptr<BlockModel>, Error> Graph::groupBlocks(std::span<c
     return added;
 }
 
+std::expected<void, Error> Graph::ungroupBlocks(std::shared_ptr<BlockModel> subgraphBlock, std::source_location location) {
+    assert(subgraphBlock->blockCategory() == block::Category::ScheduledBlockGroup || subgraphBlock->blockCategory() == block::Category::TransparentBlockGroup);
+    gr::Graph* subGraph = subgraphBlock->graph();
+    if (subGraph == nullptr) {
+        return std::unexpected(Error(std::format("sub-graph '{}' does not expose its graph", subgraphBlock->uniqueName()), location));
+    }
+
+    struct InternalPort {
+        std::shared_ptr<BlockModel> block;
+        std::string                 portName;
+    };
+    using ExportedPortMap = std::unordered_map<std::string, InternalPort>;
+
+    // mapping from the exported port name that the outer graph sees to the
+    // inner block and its port that it represents
+    const auto mapExternalNameToPort = [&subGraph, &location](property_map exportedPorts) -> std::expected<ExportedPortMap, Error> {
+        ExportedPortMap map;
+        for (const auto& [blockUniqueName, portEntries] : exportedPorts) {
+            const auto ports = portEntries.get_if<property_map>();
+            if (!ports.has_value()) {
+                continue;
+            }
+
+            const auto innerBlock = graph::findBlock(*subGraph, std::string_view(blockUniqueName), location);
+            if (!innerBlock.has_value()) {
+                return std::unexpected(innerBlock.error());
+            }
+
+            for (const auto& [internalName, exportEntry] : *ports) {
+                const auto exportInfo = exportEntry.get_if<property_map>();
+                if (!exportInfo.has_value()) {
+                    continue;
+                }
+
+                const auto exportedName = exportInfo->value_or<std::string_view>("exportedName", std::string_view{});
+                if (!exportedName.empty()) {
+                    map.emplace(std::string(exportedName), InternalPort{innerBlock.value(), std::string(internalName)});
+                }
+            }
+        }
+        return map;
+    };
+
+    const auto exportedInputs  = mapExternalNameToPort(subgraphBlock->exportedInputPorts());
+    const auto exportedOutputs = mapExternalNameToPort(subgraphBlock->exportedOutputPorts());
+    if (!exportedInputs.has_value()) {
+        return std::unexpected(exportedInputs.error());
+    }
+    if (!exportedOutputs.has_value()) {
+        return std::unexpected(exportedOutputs.error());
+    }
+
+    // search for all the connections to the subgraph first to avoid failing in the middle of the ungrouping operation due to an invalid name
+    struct ConnectedEdge {
+        std::size_t  edgeIndex;
+        InternalPort correspondingInnerPort;
+        bool         connectedToOutputs;
+    };
+    std::vector<ConnectedEdge> connectedEdges;
+    for (std::size_t edgeIndex = 0UZ; edgeIndex < _edges.size(); ++edgeIndex) {
+        const Edge& edge = _edges[edgeIndex];
+        for (const bool connectedToOutputs : {true, false}) {
+            if ((connectedToOutputs ? edge.sourceBlock() : edge.destinationBlock()) != subgraphBlock) {
+                continue;
+            }
+
+            const PortDirection direction    = connectedToOutputs ? PortDirection::OUTPUT : PortDirection::INPUT;
+            auto                exportedName = definedPortName(subgraphBlock, direction, connectedToOutputs ? edge.sourcePortDefinition() : edge.destinationPortDefinition(), location);
+            if (!exportedName.has_value()) {
+                return std::unexpected(exportedName.error());
+            }
+
+            const ExportedPortMap& exportedPorts = connectedToOutputs ? exportedOutputs.value() : exportedInputs.value();
+            const auto             exportedIt    = exportedPorts.find(exportedName.value());
+            if (exportedIt == exportedPorts.end()) {
+                return std::unexpected(Error(std::format("edge references non-exported port '{}' of sub-graph '{}'", exportedName.value(), subgraphBlock->uniqueName()), location));
+            }
+
+            connectedEdges.emplace_back(edgeIndex, exportedIt->second, connectedToOutputs);
+        }
+    }
+
+    // move the blocks and internal edges into this graph
+    for (const std::shared_ptr<BlockModel>& block : subGraph->blocks()) {
+        addBlock(block, false);
+    }
+    for (Edge& edge : subGraph->edges()) {
+        std::ignore = addEdge(std::move(edge), location);
+    }
+
+    for (const ConnectedEdge& oldEdgeDescription : connectedEdges) {
+        Edge& edge = _edges[oldEdgeDescription.edgeIndex];
+        if (oldEdgeDescription.connectedToOutputs) {
+            edge = Edge(oldEdgeDescription.correspondingInnerPort.block,            //
+                PortDefinition(oldEdgeDescription.correspondingInnerPort.portName), //
+                edge.destinationBlock(), edge.destinationPortDefinition(),          //
+                edge.minBufferSize(), edge.weight(), std::string(edge.name()));
+        } else {
+            edge = Edge(edge.sourceBlock(), edge.sourcePortDefinition(),            //
+                oldEdgeDescription.correspondingInnerPort.block,                    //
+                PortDefinition(oldEdgeDescription.correspondingInnerPort.portName), //
+                edge.minBufferSize(), edge.weight(), std::string(edge.name()));
+        }
+    }
+
+    subGraph->clear();
+    std::erase_if(_blocks, [&subgraphBlock](const std::shared_ptr<BlockModel>& block) { return block == subgraphBlock; });
+    return {};
+}
+
 std::optional<Message> Graph::propertyCallbackRegistryBlockTypes([[maybe_unused]] std::string_view propertyName, Message message) {
     assert(propertyName == graph::property::kRegistryBlockTypes);
     const auto&   availableBlocks = _pluginLoader->availableBlocks();

--- a/core/src/Graph.cpp
+++ b/core/src/Graph.cpp
@@ -60,6 +60,119 @@ std::pair<std::shared_ptr<BlockModel>, std::shared_ptr<BlockModel>> Graph::repla
     return {std::move(oldBlock), newBlock};
 }
 
+namespace {
+std::expected<std::string, Error> definedPortName(const std::shared_ptr<BlockModel>& block, PortDirection direction, const PortDefinition& definition, const std::source_location& location) {
+    constexpr static auto stringBased = [](const PortDefinition::StringBased& portdef) -> std::expected<std::string, Error> { return portdef.name; };
+    const auto            indexBased  = [direction, &block, &location](const PortDefinition::IndexBased& portdef) -> std::expected<std::string, Error> {
+        const auto& ports = direction == PortDirection::INPUT ? block->dynamicInputPorts() : block->dynamicOutputPorts();
+        if (portdef.topLevel >= ports.size()) {
+            return std::unexpected(Error(std::format("port index {} out of range for block {}", portdef.topLevel, block->uniqueName()), location));
+        }
+        auto baseName = BlockModel::portName(ports[portdef.topLevel]);
+        return portdef.subIndex == meta::invalid_index ? baseName : std::format("{}#{}", baseName, portdef.subIndex);
+    };
+    return std::visit(meta::overloaded{stringBased, indexBased}, definition.definition);
+}
+} // namespace
+
+std::expected<std::shared_ptr<BlockModel>, Error> Graph::groupBlocks(std::span<const std::shared_ptr<BlockModel>> targetBlocks, std::string_view schedulerTypename, std::source_location location) {
+    if (targetBlocks.empty()) {
+        return std::unexpected(Error("cannot group an empty set of blocks", location));
+    }
+
+    const auto isGrouped = [&targetBlocks](const std::shared_ptr<BlockModel>& block) { return std::ranges::contains(targetBlocks, block); };
+
+    struct PortExport {
+        std::shared_ptr<BlockModel> block;
+        PortDirection               direction;
+        std::string                 internalName;
+        std::string                 exportedName;
+
+        auto doExport(gr::BlockModel& subgraph, std::source_location srcloc) const { return subgraph.exportPort(true, block->uniqueName(), direction, internalName, exportedName, srcloc); }
+    };
+    std::vector<PortExport> exportOperations;
+
+    const auto findOrCreateExport = [&exportOperations](const std::shared_ptr<BlockModel>& block, PortDirection direction, std::string internalName) -> std::string {
+        auto alreadyPlanned = std::ranges::find_if(exportOperations, [&](const PortExport& exportOperation) { return exportOperation.block == block && exportOperation.direction == direction && exportOperation.internalName == internalName; });
+        if (alreadyPlanned != exportOperations.end()) {
+            return alreadyPlanned->exportedName;
+        }
+
+        const auto  isTaken      = [&](std::string_view candidate) { return std::ranges::any_of(exportOperations, [&](const PortExport& exportOperation) { return exportOperation.direction == direction && exportOperation.exportedName == candidate; }); };
+        std::string exportedName = std::format("{}.{}", block->name(), internalName);
+        for (std::size_t suffix = 1; isTaken(exportedName); ++suffix) {
+            exportedName = std::format("{}.{}_{}", block->name(), internalName, suffix);
+        }
+        exportOperations.emplace_back(block, direction, std::move(internalName), exportedName);
+        return exportedName;
+    };
+
+    struct CrossingEdge {
+        Edge        edge;
+        std::string newPortName;
+        bool        sourceBlockIsInSubgraph;
+    };
+    std::vector<Edge>         internalEdges;
+    std::vector<CrossingEdge> crossingEdges;
+    for (const Edge& edge : _edges) {
+        const bool sourceGrouped      = isGrouped(edge.sourceBlock());
+        const bool destinationGrouped = isGrouped(edge.destinationBlock());
+        if (sourceGrouped && destinationGrouped) {
+            internalEdges.push_back(edge);
+        } else if (sourceGrouped || destinationGrouped) {
+            const auto& [insideBlock, definition, direction] = sourceGrouped //
+                                                                   ? std::tuple{edge.sourceBlock(), edge.sourcePortDefinition(), PortDirection::OUTPUT}
+                                                                   : std::tuple{edge.destinationBlock(), edge.destinationPortDefinition(), PortDirection::INPUT};
+            auto portName                                    = definedPortName(insideBlock, direction, definition, location);
+            if (!portName.has_value()) {
+                return std::unexpected(portName.error());
+            }
+            crossingEdges.emplace_back(edge, findOrCreateExport(insideBlock, direction, portName.value()), sourceGrouped);
+        }
+    }
+
+    std::shared_ptr<BlockModel> subGraphModel;
+    if (schedulerTypename.starts_with("gr::Graph")) {
+        subGraphModel = std::make_shared<GraphWrapper<Graph>>();
+    } else if (std::shared_ptr<SchedulerModel> scheduler = pluginLoader().instantiateScheduler(schedulerTypename, {}); scheduler) {
+        subGraphModel = SchedulerModel::asBlockModelPtr(std::move(scheduler));
+    } else {
+        return std::unexpected(Error(std::format("cannot spawn sub-graph/scheduler of type '{}'", schedulerTypename), location));
+    }
+    gr::Graph* subGraph = subGraphModel->graph();
+
+    // move all edges and blocks into the subgraphs
+    std::erase_if(_edges, [&isGrouped](const Edge& edge) { return isGrouped(edge.sourceBlock()) || isGrouped(edge.destinationBlock()); });
+    std::erase_if(_blocks, isGrouped);
+
+    for (auto& block : targetBlocks) { // isGrouped() does not make sense to call after this
+        subGraph->addBlock(block, false);
+    }
+    for (Edge& edge : internalEdges) {
+        std::ignore = subGraph->addEdge(std::move(edge), location);
+    }
+
+    for (const PortExport& exportOperation : exportOperations) {
+        if (auto result = exportOperation.doExport(*subGraphModel, location); !result.has_value()) {
+            return std::unexpected(result.error());
+        }
+    }
+
+    const std::shared_ptr<BlockModel>& added = addBlock(subGraphModel);
+    for (const CrossingEdge& crossover : crossingEdges) {
+        const Edge&    edge = crossover.edge;
+        EdgeParameters parameters{.minBufferSize = edge.minBufferSize(), .weight = edge.weight(), .name = std::string(edge.name())};
+        auto           connectResult = crossover.sourceBlockIsInSubgraph //
+                                           ? connect(subGraphModel, PortDefinition(crossover.newPortName), edge.destinationBlock(), edge.destinationPortDefinition(), std::move(parameters), location)
+                                           : connect(edge.sourceBlock(), edge.sourcePortDefinition(), subGraphModel, PortDefinition(crossover.newPortName), std::move(parameters), location);
+        if (!connectResult.has_value()) {
+            return std::unexpected(connectResult.error());
+        }
+    }
+
+    return added;
+}
+
 std::optional<Message> Graph::propertyCallbackRegistryBlockTypes([[maybe_unused]] std::string_view propertyName, Message message) {
     assert(propertyName == graph::property::kRegistryBlockTypes);
     const auto&   availableBlocks = _pluginLoader->availableBlocks();

--- a/core/test/qa_Graph.cpp
+++ b/core/test/qa_Graph.cpp
@@ -312,6 +312,24 @@ const boost::ut::suite<"GraphExtensionsTests"> _2 = [] {
         expect(eq(graph.edges().size(), 0UZ)) << "removed edge must not remain in the graph's edge list";
     };
 
+    "edges that failed to connect are retried after disconnectAllEdges"_test = [] {
+        Graph              graph;
+        NullSource<float>& src = graph.emplaceBlock<NullSource<float>>();
+        NullSink<float>&   snk = graph.emplaceBlock<NullSink<float>>();
+
+        std::shared_ptr<BlockModel> srcModel = graph::findBlock(graph, src).value();
+        std::shared_ptr<BlockModel> snkModel = graph::findBlock(graph, snk).value();
+        expect(graph.connect(srcModel, PortDefinition("out"), snkModel, PortDefinition("does_not_exist")).has_value());
+
+        expect(!graph.connectPendingEdges()) << "edge with an unknown destination port must fail to connect";
+        expect(graph.edges().front().state() == Edge::EdgeState::PortNotFound);
+
+        graph.disconnectAllEdges();
+        expect(graph.edges().front().state() == Edge::EdgeState::WaitingToBeConnected) << "disconnectAllEdges must reset failed edges so they can be retried";
+
+        expect(!graph.connectPendingEdges()) << "still-invalid edge must be retried and reported, not silently skipped";
+    };
+
     "forEachBlock visits all blocks"_test = [] {
         Graph                    graph;
         std::vector<std::string> visited;
@@ -934,6 +952,150 @@ const boost::ut::suite<"Graph::groupBlocks"> _groupBlocks = [] {
         expect(!graph.groupBlocks(groupedBlocks, "does::not::Exist").has_value());
         expect(eq(graph.blocks().size(), 1UZ)) << "failed grouping leaves the graph unchanged";
     };
+};
+
+void testUngroupIsInverseOfGroup(std::string_view subGraphType) {
+    using namespace boost::ut;
+    using namespace gr;
+    using namespace gr::testing;
+
+    Graph graph;
+    auto& src   = graph.emplaceBlock<NullSource<float>>();
+    auto& copy2 = graph.emplaceBlock<Copy<float>>();
+    auto& copy3 = graph.emplaceBlock<Copy<float>>();
+    auto& copy4 = graph.emplaceBlock<Copy<float>>();
+    auto& sink  = graph.emplaceBlock<NullSink<float>>();
+    expect(graph.connect<"out", "in">(src, copy2).has_value()) << fatal;
+    expect(graph.connect<"out", "in">(copy2, copy3).has_value()) << fatal;
+    expect(graph.connect<"out", "in">(copy3, copy4).has_value()) << fatal;
+    expect(graph.connect<"out", "in">(copy4, sink).has_value()) << fatal;
+
+    std::vector<const BlockModel*> originalBlockModels;
+    std::ranges::transform(graph.blocks(), std::back_inserter(originalBlockModels), [](const auto& block) { return block.get(); });
+
+    const std::vector<std::string_view> uniqueNamesOfGroupedBlocks = {copy2.unique_name.value(), copy3.unique_name.value(), copy4.unique_name.value()};
+    const auto                          groupedBlocks              = graph::findBlocks(graph, uniqueNamesOfGroupedBlocks).value();
+    const auto                          grouped                    = graph.groupBlocks(groupedBlocks, subGraphType);
+    expect(grouped.has_value()) << [&] { return grouped ? std::string{} : grouped.error().message; } << fatal;
+
+    std::shared_ptr<BlockModel> subGraph  = grouped.value();
+    const auto                  ungrouped = graph.ungroupBlocks(std::move(subGraph));
+    expect(ungrouped.has_value()) << [&] { return ungrouped ? std::string{} : ungrouped.error().message; } << fatal;
+
+    expect(eq(graph.blocks().size(), 5UZ)) << "grouping followed by ungrouping restores the original block count";
+    for (const BlockModel* original : originalBlockModels) {
+        expect(std::ranges::any_of(graph.blocks(), [original](const auto& block) { return block.get() == original; })) << "every original block is back in the root graph";
+    }
+    expect(std::ranges::all_of(graph.blocks(), [](const auto& block) { return block->blockCategory() == block::Category::NormalBlock; })) << "no subgraph block remains";
+
+    const auto srcModel   = graph::findBlock(graph, src).value();
+    const auto copy2Model = graph::findBlock(graph, copy2).value();
+    const auto copy3Model = graph::findBlock(graph, copy3).value();
+    const auto copy4Model = graph::findBlock(graph, copy4).value();
+    const auto sinkModel  = graph::findBlock(graph, sink).value();
+
+    expect(eq(graph.edges().size(), 4UZ));
+    expect(hasEdge(graph, srcModel.get(), anyPortName, copy2Model.get(), "in")) << "boundary edge into the group is restored";
+    expect(hasEdge(graph, copy2Model.get(), anyPortName, copy3Model.get(), anyPortName)) << "edge internal to the group is restored";
+    expect(hasEdge(graph, copy3Model.get(), anyPortName, copy4Model.get(), anyPortName)) << "edge internal to the group is restored";
+    expect(hasEdge(graph, copy4Model.get(), "out", sinkModel.get(), anyPortName)) << "boundary edge out of the group is restored";
+
+    expect(graph.connectPendingEdges());
+    expect(std::ranges::all_of(graph.edges(), [](const Edge& edge) { return edge.state() == Edge::EdgeState::Connected; }));
+}
+
+const boost::ut::suite<"Graph::ungroupBlocks"> _ungroupBlocks = [] {
+    using namespace boost::ut;
+    using namespace gr;
+    using namespace gr::testing;
+
+    "ungrouping a subgraph with a single block leaves just that block"_test = [] {
+        Graph graph;
+
+        Graph subGraphContents;
+        auto& copy                                 = subGraphContents.emplaceBlock<Copy<float>>();
+        std::ignore                                = copy;
+        const std::shared_ptr<BlockModel> subGraph = graph.addBlock(std::make_shared<GraphWrapper<Graph>>(std::move(subGraphContents)));
+
+        expect(eq(graph.blocks().size(), 1UZ)) << "root graph contains only the subgraph node" << fatal;
+        expect(eq(subGraph->blocks().size(), 1UZ)) << fatal;
+        const BlockModel* originalCopyModel = subGraph->blocks()[0UZ].get();
+
+        std::shared_ptr<BlockModel> target    = subGraph;
+        const auto                  ungrouped = graph.ungroupBlocks(std::move(target));
+        expect(ungrouped.has_value()) << [&] { return ungrouped ? std::string{} : ungrouped.error().message; } << fatal;
+
+        expect(eq(graph.blocks().size(), 1UZ)) << "root graph contains only the block that was in the subgraph" << fatal;
+        expect(graph.blocks()[0UZ].get() == originalCopyModel) << "the block is moved, not copied";
+        expect(eq(graph.edges().size(), 0UZ));
+        expect(!graph::findBlock(graph, subGraph).has_value()) << "the subgraph node itself is removed";
+        expect(eq(subGraph->blocks().size(), 0UZ)) << "the subgraph is emptied";
+    };
+
+    "ungrouping resolves exported port names to the correct inner blocks"_test = [] {
+        Graph graph;
+        auto& src1 = graph.emplaceBlock<NullSource<float>>();
+        auto& src2 = graph.emplaceBlock<NullSource<float>>();
+
+        Graph subGraphContents;
+        auto& sink1 = subGraphContents.emplaceBlock<NullSink<float>>();
+        auto& sink2 = subGraphContents.emplaceBlock<NullSink<float>>();
+
+        const std::shared_ptr<BlockModel> subGraph = graph.addBlock(std::make_shared<GraphWrapper<Graph>>(std::move(subGraphContents)));
+        expect(subGraph->exportPort(true, sink1.unique_name, PortDirection::INPUT, "in", "sink1_in").has_value()) << fatal;
+        expect(subGraph->exportPort(true, sink2.unique_name, PortDirection::INPUT, "in", "sink2_in").has_value()) << fatal;
+
+        const auto src1Model  = graph::findBlock(graph, src1).value();
+        const auto src2Model  = graph::findBlock(graph, src2).value();
+        const auto sink1Model = graph::findBlock(*subGraph->graph(), sink1).value();
+        const auto sink2Model = graph::findBlock(*subGraph->graph(), sink2).value();
+
+        expect(graph.connect(src1Model, PortDefinition("out"), subGraph, PortDefinition("sink1_in")).has_value()) << fatal;
+        expect(graph.connect(src2Model, PortDefinition("out"), subGraph, PortDefinition("sink2_in")).has_value()) << fatal;
+
+        std::shared_ptr<BlockModel> target    = subGraph;
+        const auto                  ungrouped = graph.ungroupBlocks(std::move(target));
+        expect(ungrouped.has_value()) << [&] { return ungrouped ? std::string{} : ungrouped.error().message; } << fatal;
+
+        expect(eq(graph.blocks().size(), 4UZ)) << "root graph contains both sources and both sinks";
+        expect(eq(graph.edges().size(), 2UZ));
+        expect(hasEdge(graph, src1Model.get(), "out", sink1Model.get(), "in")) << "the port exported as 'sink1_in' resolves to the input of the first sink";
+        expect(hasEdge(graph, src2Model.get(), "out", sink2Model.get(), "in")) << "the port exported as 'sink2_in' resolves to the input of the second sink";
+        expect(!hasEdge(graph, src1Model.get(), anyPortName, sink2Model.get(), anyPortName)) << "sources are not cross-connected";
+        expect(!hasEdge(graph, src2Model.get(), anyPortName, sink1Model.get(), anyPortName)) << "sources are not cross-connected";
+
+        expect(graph.connectPendingEdges());
+        expect(std::ranges::all_of(graph.edges(), [](const Edge& edge) { return edge.state() == Edge::EdgeState::Connected; }));
+    };
+
+    "ungrouping preserves edges between blocks of the subgraph"_test = [] {
+        Graph graph;
+
+        Graph subGraphContents;
+        auto& copy1 = subGraphContents.emplaceBlock<Copy<float>>();
+        auto& copy2 = subGraphContents.emplaceBlock<Copy<float>>();
+        expect(subGraphContents.connect<"out", "in">(copy1, copy2).has_value()) << fatal;
+
+        const std::shared_ptr<BlockModel> subGraph   = graph.addBlock(std::make_shared<GraphWrapper<Graph>>(std::move(subGraphContents)));
+        const auto                        copy1Model = graph::findBlock(*subGraph->graph(), copy1).value();
+        const auto                        copy2Model = graph::findBlock(*subGraph->graph(), copy2).value();
+        expect(eq(subGraph->edges().size(), 1UZ)) << fatal;
+
+        std::shared_ptr<BlockModel> target    = subGraph;
+        const auto                  ungrouped = graph.ungroupBlocks(std::move(target));
+        expect(ungrouped.has_value()) << [&] { return ungrouped ? std::string{} : ungrouped.error().message; } << fatal;
+
+        expect(eq(graph.blocks().size(), 2UZ));
+        expect(eq(graph.edges().size(), 1UZ)) << "the edge between the subgraph's blocks moves into the root graph" << fatal;
+        expect(hasEdge(graph, copy1Model.get(), anyPortName, copy2Model.get(), anyPortName)) << "the internal edge still connects the same blocks";
+        expect(eq(subGraph->edges().size(), 0UZ));
+
+        expect(graph.connectPendingEdges());
+        expect(std::ranges::all_of(graph.edges(), [](const Edge& edge) { return edge.state() == Edge::EdgeState::Connected; }));
+    };
+
+    "ungrouping is the inverse of grouping, unmanaged gr::Graph"_test = [] { testUngroupIsInverseOfGroup("gr::Graph"); };
+    "ungrouping is the inverse of grouping, managed scheduler"_test   = [] { testUngroupIsInverseOfGroup(registeredSimpleSchedulerType()); };
 };
 
 } // namespace group_blocks_test

--- a/core/test/qa_Graph.cpp
+++ b/core/test/qa_Graph.cpp
@@ -1,10 +1,14 @@
 #include <boost/ut.hpp>
 
 #include <gnuradio-4.0/Block.hpp>
+#include <gnuradio-4.0/BlockRegistry.hpp>
 #include <gnuradio-4.0/Graph.hpp>
 #include <gnuradio-4.0/Scheduler.hpp>
+#include <gnuradio-4.0/meta/UnitTestHelper.hpp>
 #include <gnuradio-4.0/testing/NullSources.hpp>
 #include <gnuradio-4.0/testing/TagMonitors.hpp>
+
+#include <optional>
 
 template<typename T, std::size_t nPorts>
 requires(std::is_arithmetic_v<T>)
@@ -721,5 +725,217 @@ const boost::ut::suite<"edge PMR resource precedence"> _edgePmrPrecedence = [] {
         expect(edges[0]._dataResource == std::pmr::get_default_resource()) << "global default when Edge/Graph/USM all unset";
     };
 };
+
+namespace group_blocks_test {
+
+std::string registeredSimpleSchedulerType() {
+    std::ignore = gr::globalSchedulerRegistry().insert<gr::scheduler::Simple<>>();
+    return std::string(gr::meta::type_name<gr::scheduler::Simple<>>());
+}
+
+std::string exportedPortName(const gr::property_map& exportedPorts, std::string_view blockUniqueName, std::string_view internalPortName) {
+    return exportedPorts //
+        .value_or<gr::property_map>(gr::convert_string_domain(blockUniqueName), gr::property_map{})
+        .value_or<gr::property_map>(gr::convert_string_domain(internalPortName), gr::property_map{})
+        .value_or<std::string>("exportedName", std::string{});
+}
+
+// optional port names, if none are supplied then they will match all names and look for any edge
+bool hasEdge(const gr::Graph& graph, const gr::BlockModel* sourceBlock, std::optional<std::string_view> sourcePortName, const gr::BlockModel* destinationBlock, std::optional<std::string_view> destinationPortName) {
+    const auto portMatches = [](const gr::PortDefinition& definition, std::optional<std::string_view> name) {
+        const auto* stringBased = std::get_if<gr::PortDefinition::StringBased>(&definition.definition);
+        return !name.has_value() || (stringBased != nullptr && stringBased->name == *name);
+    };
+    return std::ranges::any_of(graph.edges(), [&](const gr::Edge& edge) { //
+        return edge.sourceBlock().get() == sourceBlock && edge.destinationBlock().get() == destinationBlock && portMatches(edge.sourcePortDefinition(), sourcePortName) && portMatches(edge.destinationPortDefinition(), destinationPortName);
+    });
+}
+constexpr std::optional<std::string_view> anyPortName; // matches any name
+
+void testGroupSingleMiddleBlock(std::string_view subGraphType) {
+    using namespace boost::ut;
+    using namespace gr;
+    using namespace gr::testing;
+
+    Graph graph;
+    auto& src  = graph.emplaceBlock<NullSource<float>>();
+    auto& copy = graph.emplaceBlock<Copy<float>>();
+    auto& sink = graph.emplaceBlock<NullSink<float>>();
+    expect(graph.connect<"out", "in">(src, copy).has_value()) << fatal;
+    expect(graph.connect<"out", "in">(copy, sink).has_value()) << fatal;
+
+    const BlockModel* originalCopyModel = graph.blocks()[1UZ].get();
+    const auto        srcModel          = graph::findBlock(graph, src).value();
+    const auto        sinkModel         = graph::findBlock(graph, sink).value();
+
+    const std::vector<std::string_view> uniqueNamesOfGroupedBlocks = {copy.unique_name.value()};
+    auto                                groupedBlocks              = graph::findBlocks(graph, uniqueNamesOfGroupedBlocks).value();
+    const auto                          grouped                    = graph.groupBlocks(groupedBlocks, subGraphType);
+    expect(grouped.has_value()) << [&] { return grouped ? std::string{} : grouped.error().message; } << fatal;
+    const std::shared_ptr<BlockModel>& subGraph = grouped.value();
+
+    expect(graph::findBlock(graph, subGraph).has_value());
+    expect(graph::findBlock(graph, src).has_value());
+    expect(graph::findBlock(graph, sink).has_value());
+    expect(eq(graph.blocks().size(), 3UZ)) << "graph should have replaced the Copy block with a subgraph";
+
+    expect(eq(subGraph->blocks().size(), 1UZ)) << fatal;
+    expect(eq(subGraph->edges().size(), 0UZ));
+    expect(subGraph->blocks()[0UZ].get() == originalCopyModel) << "grouped block is the same block, just moved";
+
+    expect(eq(subGraph->dynamicInputPortsSize(), 1UZ)) << "subgraph has exactly one exported input port";
+    expect(eq(subGraph->dynamicOutputPortsSize(), 1UZ)) << "subgraph has exactly one exported output port";
+
+    const std::string exportedIn  = exportedPortName(subGraph->exportedInputPorts(), copy.unique_name.value(), "in");
+    const std::string exportedOut = exportedPortName(subGraph->exportedOutputPorts(), copy.unique_name.value(), "out");
+    expect(!exportedIn.empty()) << "input port of the Copy block is exported";
+    expect(!exportedOut.empty()) << "output port of the Copy block is exported";
+    expect(subGraph->dynamicInputPort(PortDefinition(exportedIn)).has_value());
+    expect(subGraph->dynamicOutputPort(PortDefinition(exportedOut)).has_value());
+
+    expect(eq(graph.edges().size(), 2UZ));
+    expect(hasEdge(graph, srcModel.get(), anyPortName, subGraph.get(), exportedIn)) << "src connects to the exported input port";
+    expect(hasEdge(graph, subGraph.get(), exportedOut, sinkModel.get(), anyPortName)) << "exported output port connects to the sink";
+
+    expect(graph.connectPendingEdges());
+    expect(std::ranges::all_of(graph.edges(), [](const Edge& edge) { return edge.state() == Edge::EdgeState::Connected; }));
+}
+
+void testGroupNonAdjacentBlocks(std::string_view subGraphType) {
+    using namespace boost::ut;
+    using namespace gr;
+    using namespace gr::testing;
+
+    Graph graph;
+    auto& src   = graph.emplaceBlock<NullSource<float>>();
+    auto& copy2 = graph.emplaceBlock<Copy<float>>();
+    auto& copy3 = graph.emplaceBlock<Copy<float>>();
+    auto& copy4 = graph.emplaceBlock<Copy<float>>();
+    auto& sink  = graph.emplaceBlock<NullSink<float>>();
+    expect(graph.connect<"out", "in">(src, copy2).has_value()) << fatal;
+    expect(graph.connect<"out", "in">(copy2, copy3).has_value()) << fatal;
+    expect(graph.connect<"out", "in">(copy3, copy4).has_value()) << fatal;
+    expect(graph.connect<"out", "in">(copy4, sink).has_value()) << fatal;
+
+    // group two blocks that have a block in between them, which produces a somewhat confusing but valid result
+    const BlockModel* originalCopy2Model = graph.blocks()[1UZ].get();
+    const BlockModel* originalCopy4Model = graph.blocks()[3UZ].get();
+    // make sure they were at the expected indices + we are testing the correct blocks
+    expect(originalCopy2Model->uniqueName() == copy2.unique_name.value());
+    expect(originalCopy4Model->uniqueName() == copy4.unique_name.value());
+    const auto srcModel   = graph::findBlock(graph, src).value();
+    const auto copy3Model = graph::findBlock(graph, copy3).value();
+    const auto sinkModel  = graph::findBlock(graph, sink).value();
+
+    const std::vector<std::string_view> uniqueNamesOfGroupedBlocks = {copy2.unique_name.value(), copy4.unique_name.value()};
+    const auto                          groupedBlocks              = graph::findBlocks(graph, uniqueNamesOfGroupedBlocks).value();
+    const auto                          grouped                    = graph.groupBlocks(groupedBlocks, subGraphType);
+    expect(grouped.has_value()) << [&] { return grouped ? std::string{} : grouped.error().message; } << fatal;
+    const std::shared_ptr<BlockModel>& subGraph = grouped.value();
+
+    expect(eq(graph.blocks().size(), 4UZ)) << "parent graph contains source, middle block, sink and the subgraph";
+    expect(eq(subGraph->blocks().size(), 2UZ)) << fatal;
+    expect(std::ranges::any_of(subGraph->blocks(), [&](const auto& block) { return block.get() == originalCopy2Model; })) << "grouped block 2 is moved, not copied";
+    expect(std::ranges::any_of(subGraph->blocks(), [&](const auto& block) { return block.get() == originalCopy4Model; })) << "grouped block 4 is moved, not copied";
+    expect(eq(subGraph->edges().size(), 0UZ)) << "non-adjacent blocks are/were not connected";
+
+    expect(eq(subGraph->dynamicInputPortsSize(), 2UZ)) << "subgraph has two exported input ports";
+    expect(eq(subGraph->dynamicOutputPortsSize(), 2UZ)) << "subgraph has two exported output ports";
+
+    const std::string exportedIn2  = exportedPortName(subGraph->exportedInputPorts(), copy2.unique_name.value(), "in");
+    const std::string exportedOut2 = exportedPortName(subGraph->exportedOutputPorts(), copy2.unique_name.value(), "out");
+    const std::string exportedIn4  = exportedPortName(subGraph->exportedInputPorts(), copy4.unique_name.value(), "in");
+    const std::string exportedOut4 = exportedPortName(subGraph->exportedOutputPorts(), copy4.unique_name.value(), "out");
+    expect(!exportedIn2.empty() && !exportedOut2.empty() && !exportedIn4.empty() && !exportedOut4.empty()) << "all boundary ports are exported" << fatal;
+    expect(exportedIn2 != exportedIn4) << "input port names should be unique";
+    expect(exportedOut2 != exportedOut4) << "output port names should be unique";
+    expect(subGraph->dynamicInputPort(PortDefinition(exportedIn4)).has_value());
+    expect(subGraph->dynamicOutputPort(PortDefinition(exportedOut4)).has_value());
+    expect(subGraph->dynamicInputPort(PortDefinition(exportedIn2)).has_value());
+    expect(subGraph->dynamicOutputPort(PortDefinition(exportedOut2)).has_value());
+
+    expect(eq(graph.edges().size(), 4UZ));
+    expect(hasEdge(graph, srcModel.get(), anyPortName, subGraph.get(), exportedIn2)) << "source connects to the exported input port of block 2";
+    expect(hasEdge(graph, subGraph.get(), exportedOut2, copy3Model.get(), anyPortName)) << "exported output port of block 2 connects to block 3";
+    expect(hasEdge(graph, copy3Model.get(), anyPortName, subGraph.get(), exportedIn4)) << "block 3 connects to the exported input port of block 4";
+    expect(hasEdge(graph, subGraph.get(), exportedOut4, sinkModel.get(), anyPortName)) << "exported output port of block 4 connects to the sink";
+
+    expect(graph.connectPendingEdges());
+    expect(std::ranges::all_of(graph.edges(), [](const Edge& edge) { return edge.state() == Edge::EdgeState::Connected; }));
+}
+
+void testGroupAdjacentBlocks(std::string_view subGraphType) {
+    using namespace boost::ut;
+    using namespace gr;
+    using namespace gr::testing;
+
+    Graph graph;
+    auto& src   = graph.emplaceBlock<NullSource<float>>();
+    auto& copy2 = graph.emplaceBlock<Copy<float>>();
+    auto& copy3 = graph.emplaceBlock<Copy<float>>();
+    auto& sink  = graph.emplaceBlock<NullSink<float>>();
+    expect(graph.connect<"out", "in">(src, copy2).has_value()) << fatal;
+    expect(graph.connect<"out", "in">(copy2, copy3).has_value()) << fatal;
+    expect(graph.connect<"out", "in">(copy3, sink).has_value()) << fatal;
+
+    const BlockModel* originalCopy2Model = graph.blocks()[1UZ].get();
+    const BlockModel* originalCopy3Model = graph.blocks()[2UZ].get();
+
+    const std::vector<std::string_view> uniqueNamesOfGroupedBlocks = {copy2.unique_name.value(), copy3.unique_name.value()};
+    const auto                          groupedBlocks              = graph::findBlocks(graph, uniqueNamesOfGroupedBlocks).value();
+    const auto                          grouped                    = graph.groupBlocks(groupedBlocks, subGraphType);
+    expect(grouped.has_value()) << [&] { return grouped ? std::string{} : grouped.error().message; } << fatal;
+    const std::shared_ptr<BlockModel>& subGraph = grouped.value();
+
+    expect(eq(graph.blocks().size(), 3UZ));
+    expect(eq(graph.edges().size(), 2UZ));
+    expect(eq(subGraph->blocks().size(), 2UZ));
+    expect(eq(subGraph->edges().size(), 1UZ)) << "the edge between the grouped blocks moves into the subgraph" << fatal;
+    expect(subGraph->edges()[0UZ].sourceBlock().get() == originalCopy2Model);
+    expect(subGraph->edges()[0UZ].destinationBlock().get() == originalCopy3Model);
+
+    expect(eq(subGraph->dynamicInputPortsSize(), 1UZ)) << "only the boundary-crossing input is exported";
+    expect(eq(subGraph->dynamicOutputPortsSize(), 1UZ)) << "only the boundary-crossing output is exported";
+
+    expect(graph.connectPendingEdges());
+    expect(std::ranges::all_of(graph.edges(), [](const Edge& edge) { return edge.state() == Edge::EdgeState::Connected; }));
+}
+
+const boost::ut::suite<"Graph::groupBlocks"> _groupBlocks = [] {
+    using namespace boost::ut;
+    using namespace gr;
+    using namespace gr::testing;
+
+    "group single middle block into unmanaged gr::Graph"_test = [] { testGroupSingleMiddleBlock("gr::Graph"); };
+    "group single middle block into managed scheduler"_test   = [] { testGroupSingleMiddleBlock(registeredSimpleSchedulerType()); };
+
+    "group two non-adjacent blocks into unmanaged gr::Graph"_test = [] { testGroupNonAdjacentBlocks("gr::Graph"); };
+    "group two non-adjacent blocks into managed scheduler"_test   = [] { testGroupNonAdjacentBlocks(registeredSimpleSchedulerType()); };
+
+    "group two adjacent blocks into unmanaged gr::Graph"_test = [] { testGroupAdjacentBlocks("gr::Graph"); };
+    "group two adjacent blocks into managed scheduler"_test   = [] { testGroupAdjacentBlocks(registeredSimpleSchedulerType()); };
+
+    "graph::findBlocks() fails for unknown block names"_test = [] {
+        Graph graph;
+        auto& src   = graph.emplaceBlock<NullSource<float>>();
+        std::ignore = src;
+
+        const std::vector<std::string_view> uniqueNamesOfGroupedBlocks = {src.unique_name.value(), "foo"};
+        const auto                          groupedBlocks              = graph::findBlocks(graph, uniqueNamesOfGroupedBlocks);
+        expect(!groupedBlocks.has_value());
+    };
+
+    "grouping fails for unknown subgraph type"_test = [] {
+        Graph graph;
+        auto& src = graph.emplaceBlock<NullSource<float>>();
+
+        const std::vector<std::string_view> uniqueNamesOfGroupedBlocks = {src.unique_name.value()};
+        const auto                          groupedBlocks              = graph::findBlocks(graph, uniqueNamesOfGroupedBlocks).value();
+        expect(!graph.groupBlocks(groupedBlocks, "does::not::Exist").has_value());
+        expect(eq(graph.blocks().size(), 1UZ)) << "failed grouping leaves the graph unchanged";
+    };
+};
+
+} // namespace group_blocks_test
 
 int main() { /* not needed for UT */ }

--- a/core/test/qa_ManagedSubGraph.cpp
+++ b/core/test/qa_ManagedSubGraph.cpp
@@ -279,7 +279,14 @@ const boost::ut::suite ManagedSubGraph = [] {
         expect(initGraph.connect(sourceModel, PortDefinition("out"), subSchedulerBlock, PortDefinition("inExp")).has_value()) << fatal;
         expect(initGraph.connect(subSchedulerBlock, PortDefinition("outExp"), sinkModel, PortDefinition("in")).has_value()) << fatal;
 
-        Scheduler scheduler;
+        // We need to explicitly use singlethreaded scheduler here, instead of the this test's Scheduler class, because a multithreaded
+        // scheduler's strategy is to dispatch min(poolSize, numBlocks) workers. We already start a thread from the same pool to do
+        // runAndWait(), so pool size is not actually an accurate number for how many threads can be spawned by the pool
+        //
+        // TODO: don't take up threads from the pool, or give the scheduler its own pool, or maybe add a concept of reserving a # of
+        // threads in a thread pool/checking how many can be reserved. the # of threads used by a scheduler is just preference
+        // and it can still operate if fewer are available than expected
+        scheduler::Simple<scheduler::ExecutionPolicy::singleThreaded> scheduler;
         if (auto ret = scheduler.exchange(std::move(initGraph)); !ret) {
             expect(false) << std::format("couldn't initialise scheduler. error: {}", ret.error()) << fatal;
         }

--- a/core/test/qa_ManagedSubGraph.cpp
+++ b/core/test/qa_ManagedSubGraph.cpp
@@ -253,6 +253,49 @@ const boost::ut::suite ManagedSubGraph = [] {
         expect(scheduler.state() == lifecycle::State::INITIALISED) << std::format("scheduler INITIALISED - actual: {}\n", magic_enum::enum_name(scheduler.state()));
         expect(subSchedulerBlock->state() == lifecycle::State::INITIALISED) << std::format("sub-scheduler should be stopped - actual: {}", magic_enum::enum_name(subSchedulerBlock->state()));
     };
+
+    "run a nested managed subgraph which has exported ports already connected before being added to the scheduler"_test = [] {
+        using namespace std::string_literals;
+        using namespace boost::ut;
+        using namespace gr;
+
+        gr::Graph initGraph;
+        auto&     source = initGraph.emplaceBlock<SlowSource<float>>({{"disconnect_on_done", false}});
+        auto&     sink   = initGraph.emplaceBlock<CountingSink<float>>();
+
+        gr::Graph subContents;
+        auto&     copy          = subContents.emplaceBlock<gr::testing::Copy<float>>();
+        copy.disconnect_on_done = false;
+
+        auto wrapper = std::make_shared<SchedulerWrapper<Scheduler>>(gr::property_map{{"poolName", std::string(DemoSubSchedulerResult<float>::kSubSchedulerPoolId)}});
+        wrapper->setGraph(std::move(subContents));
+        const std::shared_ptr<BlockModel> subSchedulerBlock = initGraph.addBlock(std::static_pointer_cast<BlockModel>(wrapper));
+
+        expect(wrapper->exportPort(true, copy.unique_name, PortDirection::INPUT, "in", "inExp").has_value()) << fatal;
+        expect(wrapper->exportPort(true, copy.unique_name, PortDirection::OUTPUT, "out", "outExp").has_value()) << fatal;
+
+        const std::shared_ptr<BlockModel> sourceModel = graph::findBlock(initGraph, source).value();
+        const std::shared_ptr<BlockModel> sinkModel   = graph::findBlock(initGraph, sink).value();
+        expect(initGraph.connect(sourceModel, PortDefinition("out"), subSchedulerBlock, PortDefinition("inExp")).has_value()) << fatal;
+        expect(initGraph.connect(subSchedulerBlock, PortDefinition("outExp"), sinkModel, PortDefinition("in")).has_value()) << fatal;
+
+        Scheduler scheduler;
+        if (auto ret = scheduler.exchange(std::move(initGraph)); !ret) {
+            expect(false) << std::format("couldn't initialise scheduler. error: {}", ret.error()) << fatal;
+        }
+
+        auto schedulerThreadHandle = gr::test::thread_pool::executeScheduler("qa_ManagedSubGraph::boundary", scheduler);
+        expect(awaitCondition(scheduler, [&scheduler] { return scheduler.state() == lifecycle::State::RUNNING; })) << "scheduler thread up and running w/ timeout";
+
+        const gr::Size_t firstCount = sink.count;
+        expect(awaitCondition(4s, [&sink, firstCount] { return sink.count > firstCount; })) << "the entire graph is connected, through the nested subgraph";
+
+        scheduler.requestStop();
+        auto schedulerRet = schedulerThreadHandle.get();
+        if (!schedulerRet.has_value()) {
+            expect(false) << std::format("scheduler.runAndWait() failed:\n{}\n", schedulerRet.error());
+        }
+    };
 };
 
 const boost::ut::suite ExportPortsTests_ = [] {

--- a/core/test/qa_SchedulerMessages.cpp
+++ b/core/test/qa_SchedulerMessages.cpp
@@ -39,7 +39,7 @@ public:
     gr::MsgPortOut toScheduler;
     gr::MsgPortIn  fromScheduler;
 
-    TestScheduler(gr::Graph&& graph, bool addTestSourceAndSink = true) {
+    TestScheduler(gr::Graph&& graph, bool addTestSourceAndSink = true, bool shouldRun = true) {
         if (auto ret = scheduler_.exchange(addTestSourceAndSink ? std::move(withTestingSourceAndSink(std::move(graph))) : std::move(graph)); !ret) {
             throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
         }
@@ -47,7 +47,9 @@ public:
         expect(toScheduler.connect(scheduler_.msgIn).has_value());
         expect(scheduler_.msgOut.connect(fromScheduler).has_value());
 
-        run();
+        if (shouldRun) {
+            run();
+        }
     }
 
     ~TestScheduler() { stop(); }
@@ -77,9 +79,11 @@ public:
         using namespace boost::ut;
         scheduler_.requestStop();
 
-        auto result = schedulerRet_.get(); // this joins the thread
-        if (!result.has_value()) {
-            expect(false) << std::format("scheduler.runAndWait() failed:\n{}\n", result.error());
+        if (schedulerRet_.valid()) {
+            auto result = schedulerRet_.get(); // this joins the thread
+            if (!result.has_value()) {
+                expect(false) << std::format("scheduler.runAndWait() failed:\n{}\n", result.error());
+            }
         }
     }
 
@@ -93,6 +97,18 @@ public:
     void                           processScheduledMessages() { scheduler_.processScheduledMessages(); }
     std::expected<void, gr::Error> changeStateTo(gr::lifecycle::State state) { return scheduler_.changeStateTo(state); }
 };
+
+bool jobListsContain(const auto& scheduler, std::string_view blockUniqueName) {
+    const std::shared_ptr<gr::scheduler::JobLists> jobLists = scheduler.jobs();
+    return std::ranges::any_of(*jobLists, [&blockUniqueName](const std::vector<std::shared_ptr<gr::BlockModel>>& jobList) { //
+        return std::ranges::any_of(jobList, [&blockUniqueName](const std::shared_ptr<gr::BlockModel>& block) { return block->uniqueName() == blockUniqueName; });
+    });
+}
+
+std::string registeredSimpleSchedulerType(gr::SchedulerRegistry& schedulerRegistry) {
+    gr::registerBlock<gr::scheduler::Simple<>>(schedulerRegistry);
+    return std::string(gr::meta::type_name<gr::scheduler::Simple<>>());
+}
 
 const boost::ut::suite TopologyGraphTests = [] {
     using namespace std::string_literals;
@@ -196,6 +212,213 @@ const boost::ut::suite TopologyGraphTests = [] {
             expect(eq(testGraph.blocks().size(), 3UZ));
         };
     };
+
+    // test for an issue where add and then removing blocks would cause them to
+    // be leaked, stored in the zombie list forever
+    "Removing a block that is still awaiting adoption destroys it"_test = [] {
+        Graph flow(context->loader);
+        auto& source = flow.emplaceBlock<SlowSource<float>>();
+        auto& sink   = flow.emplaceBlock<CountingSink<float>>();
+        expect(flow.connect<"out", "in">(source, sink).has_value()) << fatal;
+
+        // use externalStep so that this test is totally singlethreaded and
+        // block adoption happens at a predictable time
+        TestScheduler<ExecutionPolicy::externalStep> scheduler(std::move(flow), false, false);
+
+        expect(scheduler.changeStateTo(lifecycle::State::INITIALISED).has_value()) << fatal;
+        expect(scheduler.changeStateTo(lifecycle::State::RUNNING).has_value()) << fatal;
+
+        sendMessage<Set>(scheduler.toScheduler, scheduler.scheduler().unique_name, scheduler::property::kEmplaceBlock, {{"type", "gr::testing::Copy<float32>"}, {"properties", property_map{}}});
+        scheduler.processScheduledMessages();
+        const std::optional<Message> emplaceReply = testing::waitForReply(scheduler.fromScheduler, ReplyChecker{.expectedEndpoint = scheduler::property::kBlockEmplaced}, 1s);
+        expect(emplaceReply.has_value() && emplaceReply->data.has_value()) << fatal << "block emplaced";
+        const std::string newBlockName(emplaceReply->data.value().value_or<std::string_view>("unique_name", std::string_view{}));
+        expect(!newBlockName.empty()) << fatal;
+        consumeAllReplyMessages(scheduler.fromScheduler);
+
+        std::weak_ptr<BlockModel> newBlockWeak = graph::findBlock(scheduler.graph(), std::string_view(newBlockName)).value();
+
+        sendMessage<Set>(scheduler.toScheduler, scheduler.scheduler().unique_name, scheduler::property::kRemoveBlock, {{"uniqueName", newBlockName}});
+        scheduler.processScheduledMessages();
+        const std::optional<Message> removeReply = testing::waitForReply(scheduler.fromScheduler, ReplyChecker{.expectedEndpoint = scheduler::property::kBlockRemoved}, 1s);
+        expect(removeReply.has_value()) << "block removed";
+
+        expect(!graph::findBlock(scheduler.graph(), std::string_view(newBlockName)).has_value()) << "the block is gone from the graph";
+        expect(newBlockWeak.expired()) << "a block that never entered a worker's job list is destroyed on removal";
+
+        expect(scheduler.changeStateTo(lifecycle::State::REQUESTED_STOP).has_value());
+        expect(scheduler.changeStateTo(lifecycle::State::STOPPED).has_value());
+    };
+
+    constexpr static auto groupBlockInUnmanagedSubgraph = []<ExecutionPolicy policy> {
+        Graph flow(context->loader);
+        auto& source = flow.emplaceBlock<SlowSource<float>>();
+        auto& copy   = flow.emplaceBlock<Copy<float>>();
+        auto& sink   = flow.emplaceBlock<CountingSink<float>>();
+        expect(flow.connect<"out", "in">(source, copy).has_value());
+        expect(flow.connect<"out", "in">(copy, sink).has_value());
+
+        TestScheduler<policy> scheduler(std::move(flow), /*addTestSourceAndSink=*/false);
+        expect(eq(scheduler.graph().blocks().size(), 3UZ));
+
+        "Group an unknown block"_test = [&] {
+            Tensor<Value> uniqueNames;
+            uniqueNames.push_back(Value("this_block_is_unknown"s));
+            testing::sendAndWaitForReply<Set>(scheduler.toScheduler, scheduler.fromScheduler, scheduler.unique_name(), scheduler::property::kGroupBlocks, //
+                {{"type", "gr::Graph"}, {"uniqueNames", uniqueNames}}, ReplyChecker{.expectedEndpoint = scheduler::property::kBlocksGrouped, .expectedHasData = false});
+
+            expect(eq(scheduler.graph().blocks().size(), 3UZ));
+        };
+
+        Tensor<Value> uniqueNames;
+        uniqueNames.push_back(Value(std::string(copy.unique_name.value())));
+        testing::sendAndWaitForReply<Set>(scheduler.toScheduler, scheduler.fromScheduler, scheduler.unique_name(), scheduler::property::kGroupBlocks, //
+            {{"type", "gr::Graph"}, {"uniqueNames", uniqueNames}}, ReplyChecker{.expectedEndpoint = scheduler::property::kBlocksGrouped});
+
+        const auto blocks     = scheduler.graph().blocks();
+        const auto subGraphIt = std::ranges::find_if(blocks, [](const auto& block) { return block->blockCategory() == gr::block::Category::TransparentBlockGroup; });
+        expect(eq(blocks.size(), 3UZ)) << "source, sink and the spawned sub-graph";
+        expect(subGraphIt != blocks.end()) << fatal << "grouping spawned a sub-graph block";
+        expect(eq((*subGraphIt)->blocks().size(), 1UZ)) << "sub-graph contains the grouped block";
+        expect(eq(scheduler.graph().edges().size(), 2UZ)) << "boundary edges are re-wired to the sub-graph";
+
+        expect(jobListsContain(scheduler.scheduler(), copy.unique_name.value())) << "an unmanaged sub-graph does not run its children itself: the block must stay in the scheduler's job lists";
+    };
+
+    "Group block into unmanaged subgraph, singlethreaded"_test = [] { groupBlockInUnmanagedSubgraph.operator()<ExecutionPolicy::singleThreaded>(); };
+    "Group block into unmanaged subgraph, multithreaded"_test  = [] { groupBlockInUnmanagedSubgraph.operator()<ExecutionPolicy::multiThreaded>(); };
+
+    constexpr static auto blocksGroupedIntoUnmanagedSubgraphBeforeSchedulerStartStillRun = []<ExecutionPolicy policy> {
+        Graph flow(context->loader);
+        auto& source = flow.emplaceBlock<SlowSource<float>>();
+        auto& copy   = flow.emplaceBlock<Copy<float>>();
+        auto& sink   = flow.emplaceBlock<CountingSink<float>>();
+        expect(flow.connect<"out", "in">(source, copy).has_value());
+        expect(flow.connect<"out", "in">(copy, sink).has_value());
+
+        TestScheduler<policy> scheduler(std::move(flow), false, false);
+        expect(scheduler.changeStateTo(lifecycle::State::INITIALISED).has_value()) << fatal;
+
+        // group while INITIALISED, i.e. after the job lists have been built but before the workers start
+        Tensor<Value> uniqueNames;
+        uniqueNames.push_back(Value(std::string(copy.unique_name.value())));
+        sendMessage<Set>(scheduler.toScheduler, scheduler.scheduler().unique_name, scheduler::property::kGroupBlocks, {{"type", "gr::Graph"}, {"uniqueNames", uniqueNames}});
+        scheduler.processScheduledMessages();
+        auto reply = testing::waitForReply(scheduler.fromScheduler, ReplyChecker{.expectedEndpoint = scheduler::property::kBlocksGrouped});
+        expect(reply.has_value() && reply->data.has_value()) << fatal << "grouping succeeded";
+
+        expect(jobListsContain(scheduler.scheduler(), copy.unique_name.value())) << "the grouped block must stay in the job lists that the workers will pick up on start";
+
+        scheduler.run();
+
+        expect(awaitCondition(4s, [&sink] { return sink.progress->value() > 0U; })) << "everything is connected through the block inside the unmanaged subgraph";
+
+        scheduler.scheduler().requestStop();
+    };
+
+    "Blocks grouped into unmanaged subgraph before start still run, singlethreaded"_test = [] { blocksGroupedIntoUnmanagedSubgraphBeforeSchedulerStartStillRun.operator()<ExecutionPolicy::singleThreaded>(); };
+    "Blocks grouped into unmanaged subgraph before start still run, multithreaded"_test  = [] { blocksGroupedIntoUnmanagedSubgraphBeforeSchedulerStartStillRun.operator()<ExecutionPolicy::multiThreaded>(); };
+
+    constexpr static auto groupBlocksIntoManagedSubgraph = []<ExecutionPolicy policy> {
+        BlockRegistry     registry;
+        SchedulerRegistry schedulerRegistry;
+        gr::registerBlock<SlowSource, float>(registry);
+        gr::registerBlock<Copy, float>(registry);
+        gr::registerBlock<CountingSink, float>(registry);
+        const std::string subGraphType = registeredSimpleSchedulerType(schedulerRegistry);
+        PluginLoader      loader(registry, schedulerRegistry, {});
+
+        Graph flow(loader);
+        auto& source = flow.emplaceBlock<SlowSource<float>>();
+        auto& copy   = flow.emplaceBlock<Copy<float>>();
+        auto& sink   = flow.emplaceBlock<CountingSink<float>>();
+        expect(flow.connect<"out", "in">(source, copy).has_value()) << fatal;
+        expect(flow.connect<"out", "in">(copy, sink).has_value()) << fatal;
+
+        TestScheduler<policy> scheduler(std::move(flow), /*addTestSourceAndSink=*/false);
+        expect(eq(scheduler.graph().blocks().size(), 3UZ));
+        expect(awaitCondition(4s, [&sink] { return sink.progress->value() > 0U; })) << "entire graph is connected and running";
+
+        "Group an unknown block"_test = [&scheduler] {
+            Tensor<Value> uniqueNames;
+            uniqueNames.push_back(Value("this_block_is_unknown"s));
+            testing::sendAndWaitForReply<Set>(scheduler.toScheduler, scheduler.fromScheduler, scheduler.unique_name(), scheduler::property::kGroupBlocks, //
+                {{"type", "gr::Graph"}, {"uniqueNames", uniqueNames}}, ReplyChecker{.expectedEndpoint = scheduler::property::kBlocksGrouped, .expectedHasData = false});
+
+            expect(eq(scheduler.graph().blocks().size(), 3UZ));
+        };
+
+        Tensor<Value> uniqueNames;
+        uniqueNames.push_back(Value(std::string(copy.unique_name.value())));
+        testing::sendAndWaitForReply<Set>(scheduler.toScheduler, scheduler.fromScheduler, scheduler.unique_name(), scheduler::property::kGroupBlocks, //
+            {{"type", subGraphType}, {"uniqueNames", uniqueNames}}, ReplyChecker{.expectedEndpoint = scheduler::property::kBlocksGrouped});
+
+        const auto progressAfterGroup = sink.progress->value();
+        expect(awaitCondition(4s, [&sink, progressAfterGroup] { return sink.progress->value() > progressAfterGroup; })) << "entire graph is connected and running after grouping into managed subgraph";
+
+        const auto blocks     = scheduler.graph().blocks();
+        const auto subGraphIt = std::ranges::find_if(blocks, [](const auto& block) { return block->blockCategory() == gr::block::Category::ScheduledBlockGroup; });
+        expect(eq(blocks.size(), 3UZ)) << "outer graph contains 3 blocks: the source, sink, and the new subgraph";
+        expect(subGraphIt != blocks.end()) << fatal << "the subgraph should be present in the 3 blocks in the graph";
+        expect(eq((*subGraphIt)->blocks().size(), 1UZ)) << "the subgraph contains the grouped block";
+        expect(eq(scheduler.graph().edges().size(), 2UZ)) << "crossing edges are moved into the subgraph";
+
+        expect(!jobListsContain(scheduler.scheduler(), copy.unique_name.value())) << "a subscheduler runs itself, so it shouldn't be in the parent's job lists";
+    };
+
+    "Group block into *managed* subgraph, singlethreaded"_test = [] { groupBlocksIntoManagedSubgraph.operator()<ExecutionPolicy::singleThreaded>(); };
+    "Group block into *managed* subgraph, multithreaded"_test  = [] { groupBlocksIntoManagedSubgraph.operator()<ExecutionPolicy::multiThreaded>(); };
+
+    // this also tests doubly nesting the unmanaged subgraph, to make sure nested graphs all get adopted by the root scheduler
+    constexpr static auto groupBlocksIntoUnmanagedSubgraph = []<ExecutionPolicy policy> {
+        Graph flow(context->loader);
+        auto& source = flow.emplaceBlock<SlowSource<float>>();
+        auto& copy   = flow.emplaceBlock<Copy<float>>();
+        auto& sink   = flow.emplaceBlock<CountingSink<float>>();
+        expect(flow.connect<"out", "in">(source, copy).has_value());
+        expect(flow.connect<"out", "in">(copy, sink).has_value());
+
+        TestScheduler<policy> scheduler(std::move(flow), /*addTestSourceAndSink=*/false);
+
+        // move the copy block into an unmanaged subgraph
+        Tensor<Value> uniqueNames;
+        uniqueNames.emplace_back(std::string(copy.unique_name.value()));
+        const std::optional<Message> outerReply = testing::sendAndWaitForReply<Set>(scheduler.toScheduler, scheduler.fromScheduler, scheduler.unique_name(), scheduler::property::kGroupBlocks, //
+            {{"type", "gr::Graph"}, {"uniqueNames", uniqueNames}}, ReplyChecker{.expectedEndpoint = scheduler::property::kBlocksGrouped});
+        expect(outerReply.has_value() && outerReply->data.has_value()) << fatal;
+        const std::string outerSubGraphName(outerReply->data.value().value_or<std::string_view>("uniqueName", std::string_view{}));
+        expect(!outerSubGraphName.empty()) << fatal;
+
+        // move the copy block into a doubly nested subgraph
+        const auto nestedReply = testing::sendAndWaitForReply<Set>(scheduler.toScheduler, scheduler.fromScheduler, scheduler.unique_name(), scheduler::property::kGroupBlocks, //
+            {{"type", "gr::Graph"}, {"uniqueNames", uniqueNames}, {"_targetGraph", outerSubGraphName}}, ReplyChecker{.expectedEndpoint = scheduler::property::kBlocksGrouped});
+        expect(nestedReply.has_value() && nestedReply->data.has_value()) << fatal << "nested grouping succeeded";
+
+        // verify the structure of the graph and subgraphs
+        const auto blocks          = scheduler.graph().blocks();
+        const auto outerSubGraphIt = std::ranges::find_if(blocks, [&outerSubGraphName](const auto& block) { return block->uniqueName() == outerSubGraphName; });
+        expect(eq(blocks.size(), 3UZ)) << "root graph still contains source, sink and the outer subgraph";
+        expect(outerSubGraphIt != blocks.end()) << fatal;
+        expect(eq((*outerSubGraphIt)->blocks().size(), 1UZ)) << fatal << "outer subgraph contains only the nested subgraph";
+        const auto& nestedSubGraph = (*outerSubGraphIt)->blocks()[0UZ];
+        expect(nestedSubGraph->blockCategory() == gr::block::Category::TransparentBlockGroup) << "nested block group is a transparent subgraph";
+        expect(eq(nestedSubGraph->blocks().size(), 1UZ)) << fatal << "nested subgraph contains the copy block";
+        expect(nestedSubGraph->blocks()[0UZ]->uniqueName() == copy.unique_name.value());
+
+        expect(jobListsContain(scheduler.scheduler(), copy.unique_name.value())) << "the doubly nested block must stay in the root scheduler's job lists";
+
+        const auto progressBeforeRestart = sink.progress->value();
+        expect(awaitCondition(4s, [&sink, progressBeforeRestart] { return sink.progress->value() > progressBeforeRestart; })) << "doubly nested subgraph should still have connected edges";
+
+        // job lists must be rebuilt from all the nested graphs
+        scheduler.stop();
+        const auto progressAfterStop = sink.progress->value();
+        scheduler.run();
+        expect(awaitCondition(4s, [&sink, progressAfterStop] { return sink.progress->value() > progressAfterStop; })) << "doubly nested subgraph should still have connected edges after restart";
+    };
+
+    "Group blocks nested inside an unmanaged subgraph, singlethreaded"_test = [] { groupBlocksIntoUnmanagedSubgraph.operator()<ExecutionPolicy::singleThreaded>(); };
+    "Group blocks nested inside an unmanaged subgraph, multithreaded"_test  = [] { groupBlocksIntoUnmanagedSubgraph.operator()<ExecutionPolicy::multiThreaded>(); };
 
     "Block replacement tests"_test = [] {
         gr::Graph graph(context->loader);

--- a/core/test/qa_SchedulerMessages.cpp
+++ b/core/test/qa_SchedulerMessages.cpp
@@ -381,6 +381,43 @@ const boost::ut::suite TopologyGraphTests = [] {
     "Group block into *managed* subgraph, singlethreaded"_test = [] { groupBlocksIntoManagedSubgraph.operator()<ExecutionPolicy::singleThreaded>(); };
     "Group block into *managed* subgraph, multithreaded"_test  = [] { groupBlocksIntoManagedSubgraph.operator()<ExecutionPolicy::multiThreaded>(); };
 
+    constexpr static auto adoptingManagedSubgraphMustNotBlock = []<ExecutionPolicy policy> {
+        BlockRegistry     registry;
+        SchedulerRegistry schedulerRegistry;
+        gr::registerBlock<SlowSource, float>(registry);
+        gr::registerBlock<CountingSink, float>(registry);
+        const std::string subGraphType = registeredSimpleSchedulerType(schedulerRegistry);
+        PluginLoader      loader(registry, schedulerRegistry, {});
+
+        Graph flow(loader);
+        auto& groupedSource = flow.emplaceBlock<SlowSource<float>>();
+        auto& groupedSink   = flow.emplaceBlock<CountingSink<float>>();
+        expect(flow.connect<"out", "in">(groupedSource, groupedSink).has_value()) << fatal;
+
+        TestScheduler<policy> scheduler(std::move(flow));
+
+        Tensor<Value> uniqueNames;
+
+        // group both a source and sink so that the subscheduler keeps running forever if start()ed
+        uniqueNames.emplace_back(std::string(groupedSource.unique_name.value()));
+        uniqueNames.emplace_back(std::string(groupedSink.unique_name.value()));
+
+        sendMessage<Set>(scheduler.toScheduler, scheduler.unique_name(), scheduler::property::kGroupBlocks, //
+            {{"type", subGraphType}, {"uniqueNames", uniqueNames}});
+
+        const std::optional<Message> reply = testing::waitForReply(scheduler.fromScheduler, ReplyChecker{.expectedEndpoint = scheduler::property::kBlocksGrouped}, 5s);
+        expect(reply.has_value()) << fatal << "grouping into a managed subgraph does not hang";
+
+        consumeAllReplyMessages(scheduler.fromScheduler);
+        const auto blocks     = scheduler.graph().blocks();
+        const auto subGraphIt = std::ranges::find_if(blocks, [](const auto& block) { return block->blockCategory() == gr::block::Category::ScheduledBlockGroup; });
+        expect(subGraphIt != blocks.end()) << fatal << "grouping spawned a managed subgraph block";
+        expect(awaitCondition(4s, [&subGraphIt] { return (*subGraphIt)->state() == lifecycle::State::RUNNING; })) << "the adopted subscheduler becomes RUNNING on its own thread";
+    };
+
+    "Adopting a managed subgraph must not block message processing, singlethreaded"_test = [] { adoptingManagedSubgraphMustNotBlock.operator()<ExecutionPolicy::singleThreaded>(); };
+    "Adopting a managed subgraph must not block message processing, multithreaded"_test  = [] { adoptingManagedSubgraphMustNotBlock.operator()<ExecutionPolicy::multiThreaded>(); };
+
     // this also tests doubly nesting the unmanaged subgraph, to make sure nested graphs all get adopted by the root scheduler
     constexpr static auto groupBlocksIntoUnmanagedSubgraph = []<ExecutionPolicy policy> {
         Graph flow(context->loader);

--- a/core/test/qa_SchedulerMessages.cpp
+++ b/core/test/qa_SchedulerMessages.cpp
@@ -110,6 +110,18 @@ std::string registeredSimpleSchedulerType(gr::SchedulerRegistry& schedulerRegist
     return std::string(gr::meta::type_name<gr::scheduler::Simple<>>());
 }
 
+// optional port names, if none are supplied then they will match all names and look for any edge
+bool hasEdge(const gr::Graph& graph, std::string_view sourceBlockName, std::optional<std::string_view> sourcePortName, std::string_view destinationBlockName, std::optional<std::string_view> destinationPortName) {
+    const auto portMatches = [](const gr::PortDefinition& definition, std::optional<std::string_view> name) {
+        const auto* stringBased = std::get_if<gr::PortDefinition::StringBased>(&definition.definition);
+        return !name.has_value() || (stringBased != nullptr && stringBased->name == *name);
+    };
+    return std::ranges::any_of(graph.edges(), [&](const gr::Edge& edge) { //
+        return edge.sourceBlock()->uniqueName() == sourceBlockName && edge.destinationBlock()->uniqueName() == destinationBlockName && portMatches(edge.sourcePortDefinition(), sourcePortName) && portMatches(edge.destinationPortDefinition(), destinationPortName);
+    });
+}
+constexpr std::optional<std::string_view> anyPortName; // matches any name
+
 const boost::ut::suite TopologyGraphTests = [] {
     using namespace std::string_literals;
     using namespace boost::ut;
@@ -419,6 +431,282 @@ const boost::ut::suite TopologyGraphTests = [] {
 
     "Group blocks nested inside an unmanaged subgraph, singlethreaded"_test = [] { groupBlocksIntoUnmanagedSubgraph.operator()<ExecutionPolicy::singleThreaded>(); };
     "Group blocks nested inside an unmanaged subgraph, multithreaded"_test  = [] { groupBlocksIntoUnmanagedSubgraph.operator()<ExecutionPolicy::multiThreaded>(); };
+
+    constexpr static auto ungroupSubgraphWithSingleBlock = []<ExecutionPolicy policy> {
+        Graph flow(context->loader);
+
+        Graph subGraphContents;
+        auto& copy = subGraphContents.emplaceBlock<Copy<float>>();
+
+        std::shared_ptr<BlockModel>     subGraphBlock = flow.addBlock(std::make_shared<GraphWrapper<Graph>>(std::move(subGraphContents)));
+        const std::string               subGraphName(subGraphBlock->uniqueName());
+        const std::weak_ptr<BlockModel> subGraphWeak = subGraphBlock;
+
+        TestScheduler<policy> scheduler(std::move(flow));
+        expect(eq(scheduler.graph().blocks().size(), 3UZ)) << "the subgraph node and the two keep-alive test blocks";
+
+        "Ungroup an unknown block"_test = [&] {
+            testing::sendAndWaitForReply<Set>(scheduler.toScheduler, scheduler.fromScheduler, scheduler.unique_name(), scheduler::property::kUngroupBlocks, //
+                {{"uniqueName", "this_block_is_unknown"s}}, ReplyChecker{.expectedEndpoint = scheduler::property::kBlocksUngrouped, .expectedHasData = false});
+
+            expect(eq(scheduler.graph().blocks().size(), 3UZ));
+        };
+
+        "Ungroup a block that is not a subgraph"_test = [&] {
+            testing::sendAndWaitForReply<Set>(scheduler.toScheduler, scheduler.fromScheduler, scheduler.unique_name(), scheduler::property::kUngroupBlocks, //
+                {{"uniqueName", std::string(scheduler.graph().blocks()[1UZ]->uniqueName())}}, ReplyChecker{.expectedEndpoint = scheduler::property::kBlocksUngrouped, .expectedHasData = false});
+
+            expect(eq(scheduler.graph().blocks().size(), 3UZ));
+        };
+
+        testing::sendAndWaitForReply<Set>(scheduler.toScheduler, scheduler.fromScheduler, scheduler.unique_name(), scheduler::property::kUngroupBlocks, //
+            {{"uniqueName", subGraphName}}, ReplyChecker{.expectedEndpoint = scheduler::property::kBlocksUngrouped});
+
+        expect(eq(scheduler.graph().blocks().size(), 3UZ)) << "the subgraph node was replaced by the block it contained";
+        expect(graph::findBlock(scheduler.graph(), copy).has_value()) << "the block was moved into the root graph";
+        expect(!graph::findBlock(scheduler.graph(), std::string_view(subGraphName)).has_value()) << "the subgraph node itself is removed";
+        expect(eq(scheduler.graph().edges().size(), 0UZ));
+
+        subGraphBlock.reset(); // drop our reference: the running scheduler must release the removed wrapper too
+        expect(awaitCondition(4s, [&subGraphWeak] { return subGraphWeak.expired(); })) << "the scheduler stops referencing (and destroys) the removed subgraph wrapper";
+    };
+
+    "Ungroup a subgraph with a single block, singlethreaded"_test = [] { ungroupSubgraphWithSingleBlock.operator()<ExecutionPolicy::singleThreaded>(); };
+    "Ungroup a subgraph with a single block, multithreaded"_test  = [] { ungroupSubgraphWithSingleBlock.operator()<ExecutionPolicy::multiThreaded>(); };
+
+    constexpr static auto ungroupResolvesExportedPortNames = []<ExecutionPolicy policy> {
+        Graph flow(context->loader);
+        auto& source1 = flow.emplaceBlock<SlowSource<float>>();
+        auto& source2 = flow.emplaceBlock<SlowSource<float>>();
+
+        Graph subGraphContents;
+        auto& sink1 = subGraphContents.emplaceBlock<CountingSink<float>>();
+        auto& sink2 = subGraphContents.emplaceBlock<CountingSink<float>>();
+
+        const std::shared_ptr<BlockModel> subGraphBlock = flow.addBlock(std::make_shared<GraphWrapper<Graph>>(std::move(subGraphContents)));
+        const std::string                 subGraphName(subGraphBlock->uniqueName());
+        expect(subGraphBlock->exportPort(true, sink1.unique_name, PortDirection::INPUT, "in", "sink1_in").has_value()) << fatal;
+        expect(subGraphBlock->exportPort(true, sink2.unique_name, PortDirection::INPUT, "in", "sink2_in").has_value()) << fatal;
+
+        const std::shared_ptr<BlockModel> source1Model = graph::findBlock(flow, source1).value();
+        const std::shared_ptr<BlockModel> source2Model = graph::findBlock(flow, source2).value();
+        expect(flow.connect(source1Model, PortDefinition("out"), subGraphBlock, PortDefinition("sink1_in")).has_value()) << fatal;
+        expect(flow.connect(source2Model, PortDefinition("out"), subGraphBlock, PortDefinition("sink2_in")).has_value()) << fatal;
+
+        TestScheduler<policy> scheduler(std::move(flow), /*addTestSourceAndSink=*/false);
+
+        expect(awaitCondition(4s, [&sink1, &sink2] { return sink1.progress->value() > 0U && sink2.progress->value() > 0U; })) << "data flows through the exported ports before ungrouping";
+
+        testing::sendAndWaitForReply<Set>(scheduler.toScheduler, scheduler.fromScheduler, scheduler.unique_name(), scheduler::property::kUngroupBlocks, //
+            {{"uniqueName", subGraphName}}, ReplyChecker{.expectedEndpoint = scheduler::property::kBlocksUngrouped});
+
+        expect(eq(scheduler.graph().blocks().size(), 4UZ)) << "root graph contains both sources and both sinks";
+        expect(eq(scheduler.graph().edges().size(), 2UZ));
+        expect(hasEdge(scheduler.graph(), source1.unique_name.value(), "out", sink1.unique_name.value(), "in")) << "the port exported as 'sink1_in' resolves to the input of the first sink";
+        expect(hasEdge(scheduler.graph(), source2.unique_name.value(), "out", sink2.unique_name.value(), "in")) << "the port exported as 'sink2_in' resolves to the input of the second sink";
+        expect(!hasEdge(scheduler.graph(), source1.unique_name.value(), anyPortName, sink2.unique_name.value(), anyPortName)) << "sources are not cross-connected";
+        expect(!hasEdge(scheduler.graph(), source2.unique_name.value(), anyPortName, sink1.unique_name.value(), anyPortName)) << "sources are not cross-connected";
+
+        const auto count1AfterUngroup = sink1.progress->value();
+        const auto count2AfterUngroup = sink2.progress->value();
+        expect(awaitCondition(4s, [&sink1, &sink2, count1AfterUngroup, count2AfterUngroup] { //
+            return sink1.progress->value() > count1AfterUngroup && sink2.progress->value() > count2AfterUngroup;
+        })) << "data still flows to both sinks after ungrouping";
+    };
+
+    "Ungroup resolves exported port names to the correct blocks, singlethreaded"_test = [] { ungroupResolvesExportedPortNames.operator()<ExecutionPolicy::singleThreaded>(); };
+    "Ungroup resolves exported port names to the correct blocks, multithreaded"_test  = [] { ungroupResolvesExportedPortNames.operator()<ExecutionPolicy::multiThreaded>(); };
+
+    constexpr static auto ungroupPreservesInternalEdges = []<ExecutionPolicy policy> {
+        Graph flow(context->loader);
+
+        Graph subGraphContents;
+        auto& source = subGraphContents.emplaceBlock<SlowSource<float>>();
+        auto& sink   = subGraphContents.emplaceBlock<CountingSink<float>>();
+        expect(subGraphContents.connect<"out", "in">(source, sink).has_value()) << fatal;
+
+        const std::shared_ptr<BlockModel> subGraphBlock = flow.addBlock(std::make_shared<GraphWrapper<Graph>>(std::move(subGraphContents)));
+        const std::string                 subGraphName(subGraphBlock->uniqueName());
+
+        TestScheduler<policy> scheduler(std::move(flow), /*addTestSourceAndSink=*/false);
+
+        expect(awaitCondition(4s, [&sink] { return sink.progress->value() > 0U; })) << "data flows inside the subgraph before ungrouping";
+
+        testing::sendAndWaitForReply<Set>(scheduler.toScheduler, scheduler.fromScheduler, scheduler.unique_name(), scheduler::property::kUngroupBlocks, //
+            {{"uniqueName", subGraphName}}, ReplyChecker{.expectedEndpoint = scheduler::property::kBlocksUngrouped});
+
+        expect(eq(scheduler.graph().blocks().size(), 2UZ));
+        expect(eq(scheduler.graph().edges().size(), 1UZ)) << "the edge between the subgraph's blocks moved into the root graph";
+        expect(hasEdge(scheduler.graph(), source.unique_name.value(), anyPortName, sink.unique_name.value(), anyPortName)) << "the internal edge still connects the same blocks";
+
+        const auto progressAfterUngroup = sink.progress->value();
+        expect(awaitCondition(4s, [&sink, progressAfterUngroup] { return sink.progress->value() > progressAfterUngroup; })) << "data still flows after ungrouping";
+    };
+
+    "Ungroup preserves edges between the subgraph's blocks, singlethreaded"_test = [] { ungroupPreservesInternalEdges.operator()<ExecutionPolicy::singleThreaded>(); };
+    "Ungroup preserves edges between the subgraph's blocks, multithreaded"_test  = [] { ungroupPreservesInternalEdges.operator()<ExecutionPolicy::multiThreaded>(); };
+
+    constexpr static auto ungroupIsInverseOfGroup = []<ExecutionPolicy policy>(std::string_view subGraphType) {
+        // use a loader just for this test to avoid changing global state
+        BlockRegistry     registry;
+        SchedulerRegistry schedulerRegistry;
+        gr::registerBlock<SlowSource, float>(registry);
+        gr::registerBlock<Copy, float>(registry);
+        gr::registerBlock<CountingSink, float>(registry);
+        std::ignore = registeredSimpleSchedulerType(schedulerRegistry);
+        PluginLoader loader(registry, schedulerRegistry, {});
+
+        Graph flow(loader);
+        auto& source = flow.emplaceBlock<SlowSource<float>>();
+        auto& copy2  = flow.emplaceBlock<Copy<float>>();
+        auto& copy3  = flow.emplaceBlock<Copy<float>>();
+        auto& copy4  = flow.emplaceBlock<Copy<float>>();
+        auto& sink   = flow.emplaceBlock<CountingSink<float>>();
+        expect(flow.connect<"out", "in">(source, copy2).has_value()) << fatal;
+        expect(flow.connect<"out", "in">(copy2, copy3).has_value()) << fatal;
+        expect(flow.connect<"out", "in">(copy3, copy4).has_value()) << fatal;
+        expect(flow.connect<"out", "in">(copy4, sink).has_value()) << fatal;
+
+        const std::array<std::string_view, 5> originalBlockNames = {source.unique_name.value(), copy2.unique_name.value(), copy3.unique_name.value(), copy4.unique_name.value(), sink.unique_name.value()};
+
+        TestScheduler<policy> scheduler(std::move(flow), /*addTestSourceAndSink=*/false);
+        expect(awaitCondition(4s, [&sink] { return sink.progress->value() > 0U; })) << "data flows before grouping";
+
+        Tensor<Value> uniqueNames;
+        uniqueNames.emplace_back(std::string(copy2.unique_name.value()));
+        uniqueNames.emplace_back(std::string(copy3.unique_name.value()));
+        uniqueNames.emplace_back(std::string(copy4.unique_name.value()));
+        const std::optional<Message> groupReply = testing::sendAndWaitForReply<Set>(scheduler.toScheduler, scheduler.fromScheduler, scheduler.unique_name(), scheduler::property::kGroupBlocks, //
+            {{"type", std::string(subGraphType)}, {"uniqueNames", uniqueNames}}, ReplyChecker{.expectedEndpoint = scheduler::property::kBlocksGrouped});
+        expect(groupReply.has_value() && groupReply->data.has_value()) << fatal;
+        const std::string subGraphName(groupReply->data.value().value_or<std::string_view>("uniqueName", std::string_view{}));
+        expect(!subGraphName.empty()) << fatal;
+        expect(eq(scheduler.graph().blocks().size(), 3UZ)) << "source, sink and the subgraph";
+        const std::weak_ptr<BlockModel> subGraphWeak = graph::findBlock(scheduler.graph(), std::string_view(subGraphName)).value();
+
+        testing::sendAndWaitForReply<Set>(scheduler.toScheduler, scheduler.fromScheduler, scheduler.unique_name(), scheduler::property::kUngroupBlocks, //
+            {{"uniqueName", subGraphName}}, ReplyChecker{.expectedEndpoint = scheduler::property::kBlocksUngrouped});
+
+        expect(awaitCondition(4s, [&subGraphWeak] { return subGraphWeak.expired(); })) << "the scheduler stops referencing (and destroys) the removed subgraph wrapper";
+
+        expect(eq(scheduler.graph().blocks().size(), 5UZ)) << "grouping followed by ungrouping restores the original block count";
+        for (const std::string_view blockName : originalBlockNames) {
+            expect(graph::findBlock(scheduler.graph(), blockName).has_value()) << "every original block is back in the root graph";
+        }
+        expect(std::ranges::all_of(scheduler.graph().blocks(), [](const auto& block) { return block->blockCategory() == gr::block::Category::NormalBlock; })) << "no subgraph block remains";
+
+        expect(eq(scheduler.graph().edges().size(), 4UZ));
+        expect(hasEdge(scheduler.graph(), source.unique_name.value(), anyPortName, copy2.unique_name.value(), "in")) << "boundary edge into the group is restored";
+        expect(hasEdge(scheduler.graph(), copy2.unique_name.value(), anyPortName, copy3.unique_name.value(), anyPortName)) << "edge internal to the group is restored";
+        expect(hasEdge(scheduler.graph(), copy3.unique_name.value(), anyPortName, copy4.unique_name.value(), anyPortName)) << "edge internal to the group is restored";
+        expect(hasEdge(scheduler.graph(), copy4.unique_name.value(), "out", sink.unique_name.value(), anyPortName)) << "boundary edge out of the group is restored";
+
+        const auto progressAfterUngroup = sink.progress->value();
+        expect(awaitCondition(4s, [&sink, progressAfterUngroup] { return sink.progress->value() > progressAfterUngroup; })) << "data flows end-to-end after the group/ungroup round trip";
+    };
+
+    "Group and ungroup an unmanaged subgraph is a no-op, singlethreaded"_test = [] { ungroupIsInverseOfGroup.operator()<ExecutionPolicy::singleThreaded>("gr::Graph"); };
+    "Group and ungroup an unmanaged subgraph is a no-op, multithreaded"_test  = [] { ungroupIsInverseOfGroup.operator()<ExecutionPolicy::multiThreaded>("gr::Graph"); };
+
+    "Group and ungroup a *managed* subgraph is a no-op, singlethreaded"_test = [] { ungroupIsInverseOfGroup.operator()<ExecutionPolicy::singleThreaded>(gr::meta::type_name<gr::scheduler::Simple<>>()); };
+    "Group and ungroup a *managed* subgraph is a no-op, multithreaded"_test  = [] { ungroupIsInverseOfGroup.operator()<ExecutionPolicy::multiThreaded>(gr::meta::type_name<gr::scheduler::Simple<>>()); };
+
+    constexpr static auto repeatedGroupUngroupWhileRunning = []<ExecutionPolicy policy> {
+        BlockRegistry     registry;
+        SchedulerRegistry schedulerRegistry;
+        gr::registerBlock<SlowSource, float>(registry);
+        gr::registerBlock<Copy, float>(registry);
+        gr::registerBlock<CountingSink, float>(registry);
+        const std::string subGraphType = registeredSimpleSchedulerType(schedulerRegistry);
+        PluginLoader      loader(registry, schedulerRegistry, {});
+
+        Graph flow(loader);
+        auto& source = flow.emplaceBlock<SlowSource<float>>({{"disconnect_on_done", false}});
+        auto& copy2  = flow.emplaceBlock<Copy<float>>({{"disconnect_on_done", false}});
+        auto& copy3  = flow.emplaceBlock<Copy<float>>({{"disconnect_on_done", false}});
+        auto& sink   = flow.emplaceBlock<CountingSink<float>>({{"disconnect_on_done", false}});
+        expect(flow.connect<"out", "in">(source, copy2).has_value()) << fatal;
+        expect(flow.connect<"out", "in">(copy2, copy3).has_value()) << fatal;
+        expect(flow.connect<"out", "in">(copy3, sink).has_value()) << fatal;
+
+        TestScheduler<policy> scheduler(std::move(flow), /*addTestSourceAndSink=*/false);
+        expect(awaitCondition(4s, [&sink] { return sink.progress->value() > 0U; })) << fatal << "graph should be fully connected and running";
+
+        // this is a reproduction of an issue where a scheduler and its child scheduler might put the same block into their
+        // execution order after grouping or ungrouping. The crash actually happening is not necessarily guaranteed, but
+        // there is not really a way other than dynamic_cast() to extract the child scheduler and observe if its worker
+        // threads share blocks with the root scheduler.
+        for (std::size_t iteration = 0UZ; iteration < 4UZ; ++iteration) {
+            Tensor<Value> uniqueNames;
+            uniqueNames.emplace_back(std::string(source.unique_name.value()));
+            uniqueNames.emplace_back(std::string(copy2.unique_name.value()));
+            const std::optional<Message> groupReply = testing::sendAndWaitForReply<Set>(scheduler.toScheduler, scheduler.fromScheduler, scheduler.unique_name(), scheduler::property::kGroupBlocks, //
+                {{"type", subGraphType}, {"uniqueNames", uniqueNames}}, ReplyChecker{.expectedEndpoint = scheduler::property::kBlocksGrouped});
+            expect(groupReply.has_value() && groupReply->data.has_value()) << fatal << std::format("grouping succeeded in iteration {}", iteration);
+            std::string subGraphName(groupReply->data.value().value_or<std::string_view>("uniqueName", std::string_view{}));
+            expect(!subGraphName.empty()) << fatal;
+
+            const auto progressAfterGroup = sink.progress->value();
+            expect(awaitCondition(4s, [&sink, progressAfterGroup] { return sink.progress->value() > progressAfterGroup; })) << std::format("graph should be fully connected after group, on iteration {}", iteration);
+
+            testing::sendAndWaitForReply<Set>(scheduler.toScheduler, scheduler.fromScheduler, scheduler.unique_name(), scheduler::property::kUngroupBlocks, //
+                {{"uniqueName", subGraphName}}, ReplyChecker{.expectedEndpoint = scheduler::property::kBlocksUngrouped});
+
+            const auto progressAfterUngroup = sink.progress->value();
+            expect(awaitCondition(4s, [&sink, progressAfterUngroup] { return sink.progress->value() > progressAfterUngroup; })) << std::format("graph should be fully connected after ungroup, on iteration {}", iteration);
+        }
+    };
+
+    "Repeated group/ungroup of a managed subgraph while running, singlethreaded"_test = [] { repeatedGroupUngroupWhileRunning.operator()<ExecutionPolicy::singleThreaded>(); };
+    "Repeated group/ungroup of a managed subgraph while running, multithreaded"_test  = [] { repeatedGroupUngroupWhileRunning.operator()<ExecutionPolicy::multiThreaded>(); };
+
+    constexpr static auto ungroupManagedSubgraph = []<ExecutionPolicy policy> {
+        Graph flow(context->loader);
+
+        Graph subGraphContents;
+        // keep the ports connected while the sub-scheduler stops so that the flow can resume after ungrouping
+        auto& source = subGraphContents.emplaceBlock<SlowSource<float>>({{"disconnect_on_done", false}});
+        auto& sink   = subGraphContents.emplaceBlock<CountingSink<float>>({{"disconnect_on_done", false}});
+        expect(subGraphContents.connect<"out", "in">(source, sink).has_value()) << fatal;
+
+        auto subSchedulerWrapper = std::make_shared<SchedulerWrapper<gr::scheduler::Simple<>>>();
+        subSchedulerWrapper->setGraph(std::move(subGraphContents));
+        std::shared_ptr<BlockModel>     subSchedulerBlock = flow.addBlock(subSchedulerWrapper);
+        const std::string               subSchedulerName(subSchedulerBlock->uniqueName());
+        const std::weak_ptr<BlockModel> subSchedulerWeak = subSchedulerBlock;
+        expect(subSchedulerBlock->blockCategory() == gr::block::Category::ScheduledBlockGroup);
+        subSchedulerWrapper.reset();
+
+        TestScheduler<policy> scheduler(std::move(flow));
+
+        expect(awaitCondition(4s, [&sink] { return sink.progress->value() > 0U; })) << "data flows inside the managed subgraph before ungrouping";
+
+        testing::sendAndWaitForReply<Set>(scheduler.toScheduler, scheduler.fromScheduler, scheduler.unique_name(), scheduler::property::kUngroupBlocks, //
+            {{"uniqueName", subSchedulerName}}, ReplyChecker{.expectedEndpoint = scheduler::property::kBlocksUngrouped});
+
+        expect(eq(scheduler.graph().blocks().size(), 4UZ)) << "the sub-scheduler was replaced by the two blocks it ran";
+        expect(graph::findBlock(scheduler.graph(), source).has_value()) << "the source was moved into the root graph";
+        expect(graph::findBlock(scheduler.graph(), sink).has_value()) << "the sink was moved into the root graph";
+        expect(!graph::findBlock(scheduler.graph(), std::string_view(subSchedulerName)).has_value()) << "the sub-scheduler block itself is removed";
+        expect(subSchedulerBlock->state() == lifecycle::State::STOPPED) << "the sub-scheduler was stopped";
+        expect(hasEdge(scheduler.graph(), source.unique_name.value(), anyPortName, sink.unique_name.value(), anyPortName)) << "the edge between the subgraph's blocks moved into the root graph";
+
+        subSchedulerBlock.reset(); // drop our reference: the running scheduler must release the removed wrapper too
+        expect(awaitCondition(4s, [&subSchedulerWeak] { return subSchedulerWeak.expired(); })) << "the scheduler stops referencing (and destroys) the removed sub-scheduler wrapper";
+
+        // the sink may consume the EOS tag that the source published while the sub-scheduler stopped it and
+        // stop itself again, so only the source (which has no inputs) proves the adoption deterministically
+        expect(awaitCondition(4s, [&source] { return source.state() == lifecycle::State::RUNNING; })) << "the re-parented source is adopted by this scheduler and runs again";
+
+        // restart because the job lists need to be rebuilt from the graph
+        scheduler.stop();
+        scheduler.run();
+        const auto progressAfterRestart = sink.progress->value();
+        expect(awaitCondition(4s, [&sink, progressAfterRestart] { return sink.progress->value() > progressAfterRestart; })) << "data flows through the re-parented blocks after the restart";
+    };
+
+    "Ungroup a *managed* subgraph into the running scheduler, singlethreaded"_test = [] { ungroupManagedSubgraph.operator()<ExecutionPolicy::singleThreaded>(); };
+    "Ungroup a *managed* subgraph into the running scheduler, multithreaded"_test  = [] { ungroupManagedSubgraph.operator()<ExecutionPolicy::multiThreaded>(); };
 
     "Block replacement tests"_test = [] {
         gr::Graph graph(context->loader);


### PR DESCRIPTION
Related issue, from opendigitizer: https://github.com/fair-acc/opendigitizer/issues/451

This PR adds two new functions to `gr::Graph`, `groupBlocks` and `ungroupBlocks`. The former will take a list of blocks in the graph, spawn a new subgraph block, then move the blocks in the list to the child graph. The latter will accept a subgraph block and take all of its child blocks, moving them into the parent. Both operations use port exporting/unexporting to maintain the same connections between blocks before and after the operation occurs.

There are a few additions to the SchedulerBase + SchedulerModel beyond the graph implementation and scheduler message property callbacks:
- When doing `disconnectAllEdges()`, the graph now looks at its `_edges` and disconnects the receiving input ports. It used to look at `_blocks`, and disconnect all ports of every block, but this would disconnect connections that the parent graph had to those blocks via exported ports.
- The scheduler now has `_movedBlocks` which is a list of blocks that should not be touched again / removed from the workers' localBlockLists. Workers always check this list before traversing their block list. `_movedBlocks` is behind a mutex, though the mutex will virtually never has anyone else holding it. Let me know if that is a performance concern as I think there are some easy ways to reduce the amount the workers grab that mutex.
- Work quiescence is now doing a lot more to stop workers from doing work, because there were a lot of data races from things like housekeeping resizing port buffers while `connectPendingEdges` is also modifying ports, or zombie cleanup causing ports to be destroyed at the same time as `connectPendingEdges`. Now worker threads basically do nothing but spin during work quiescence.

And some additional fixes w/ tests:
- quickly adding and removing a block would cause it to leak and sit in the zombie list forever
- adopting a singlethreaded scheduler block would cause the worker thread that adopted it to be blocked doing work for that scheduler forever