### PR TITLE
Fix YAML [a, b] port syntax

### DIFF
--- a/core/include/gnuradio-4.0/Graph_yaml_importer.hpp
+++ b/core/include/gnuradio-4.0/Graph_yaml_importer.hpp
@@ -2,6 +2,7 @@
 #define GNURADIO_GRAPH_YAML_IMPORTER_H
 
 #include <ranges>
+#include <utility>
 
 #include <gnuradio-4.0/meta/indirect.hpp>
 
@@ -310,26 +311,32 @@ inline std::expected<void, gr::Error> loadGraphFromMap(PluginLoader& loader, gr:
                 return std::unexpected(gr::Error(std::format("Unknown block '{}'", blockName)));
             }
 
-            if (auto portFields = portField.template get_if<TensorView<Value>>()) {
-                if (portFields->size() != 2) {
-                    return std::unexpected(gr::Error(std::format("Port definition has invalid length ({} instead of 2)", portFields->size())));
+            if (portField.is_tensor()) { // collection port written as [topLevel, subIndex]
+                const auto indices = pmt::convertTo<std::vector<std::int64_t>, pmt::ConversionPolicy::Safe>(portField);
+                if (!indices) {
+                    return std::unexpected(gr::Error(std::format("Port definition of type {}:{} is not a list of indices", portField.value_type(), portField.container_type())));
                 }
-                const auto fields   = portFields->owned();
-                const auto index    = checked_access_ptr{fields.data()[0].template get_if<std::int64_t>()};
-                const auto subIndex = checked_access_ptr{fields.data()[1].template get_if<std::int64_t>()};
-                if (index == nullptr || subIndex == nullptr) {
-                    return std::unexpected(gr::Error("Port definition missing values"));
+                if (indices->size() != 2UZ) {
+                    return std::unexpected(gr::Error(std::format("Port definition has invalid length ({} instead of 2)", indices->size())));
+                }
+                const std::int64_t topLevel = (*indices)[0UZ];
+                const std::int64_t subIndex = (*indices)[1UZ];
+                if (!std::in_range<std::size_t>(topLevel) || !std::in_range<std::size_t>(subIndex)) {
+                    return std::unexpected(gr::Error(std::format("Port definition has out-of-range indices [{}, {}]", topLevel, subIndex)));
                 }
 
-                return ParsedBlockPort{block, {static_cast<std::size_t>(*index), static_cast<std::size_t>(*subIndex)}};
+                return ParsedBlockPort{block, {static_cast<std::size_t>(topLevel), static_cast<std::size_t>(subIndex)}};
 
             } else if (const auto portFieldString = portField.value_or(std::string_view{}); portFieldString.data()) {
                 return ParsedBlockPort{block, {std::string(portFieldString)}};
 
             } else {
-                const auto index = checked_access_ptr{portField.template get_if<std::int64_t>()};
+                const auto* index = portField.template get_if<std::int64_t>();
                 if (index == nullptr) {
-                    return std::unexpected(gr::Error("Port definition missing values"));
+                    return std::unexpected(gr::Error(std::format("Port definition of type {}:{} is neither an index, an index pair, nor a port name", portField.value_type(), portField.container_type())));
+                }
+                if (!std::in_range<std::size_t>(*index)) {
+                    return std::unexpected(gr::Error(std::format("Port definition has an out-of-range index {}", *index)));
                 }
                 return ParsedBlockPort{block, {static_cast<std::size_t>(*index)}};
             }

--- a/core/include/gnuradio-4.0/ValueMap.hpp
+++ b/core/include/gnuradio-4.0/ValueMap.hpp
@@ -271,7 +271,7 @@ inline constexpr std::size_t kMaxInlineKeyLength = 34UZ; // 1 B length + 34 char
 inline constexpr std::uint8_t kEntryFlagInlineScalar = 0x01; // PackedTensorElement-only: tensor element packs an inline scalar (≤8 B) directly in the element header. PackedEntry never sets this — value-records always live in the payload pool.
 inline constexpr std::uint8_t kEntryFlagOffsetLength = 0x02; // payloadOffset/length valid
 inline constexpr std::uint8_t kEntryFlagNestedMap    = 0x08; // payload is a nested ValueMap blob (recursive); only meaningful when valueType == Value::ValueType::Value
-inline constexpr std::uint8_t kEntryFlagTensor       = 0x10; // payload is a tensor sub-blob (see Tensor wire-format below); only meaningful when valueType == Value::ValueType::Value
+inline constexpr std::uint8_t kEntryFlagTensor       = 0x10; // payload is a tensor sub-blob (see Tensor wire-format below); valueType is its element type (Int64, Float32, ..., or Value for mixed-type cells)
 
 inline constexpr std::uint8_t kHeaderFlagOverflow    = 0x01; // device append hit payloadCapacity limit
 inline constexpr std::uint8_t kHeaderFlagFrozen      = 0x02; // advisory: further mutation disallowed
@@ -735,7 +735,7 @@ template<typename Tens>
 [[nodiscard]] inline Value decodeTensorElement(const PackedTensorElement& elem, const std::byte* payloadData, std::pmr::memory_resource* resource, std::uint32_t depth) {
     const auto vt = static_cast<Value::ValueType>(elem.valueType);
 
-    if (vt == Value::ValueType::Value && (elem.flags & kEntryFlagTensor) != 0U) {
+    if ((elem.flags & kEntryFlagTensor) != 0U) {
         if (depth >= kMaxDecodeDepth) {
             return Value{resource};
         }
@@ -2452,7 +2452,7 @@ public:
             }
             const auto                       subVT = static_cast<Value::ValueType>(headerCopy.valueType);
             const std::span<const std::byte> subBytes{elementData + offset, headerCopy.payloadLength};
-            if (subVT == Value::ValueType::Value && (headerCopy.flags & kEntryFlagTensor) != 0U) {
+            if ((headerCopy.flags & kEntryFlagTensor) != 0U) {
                 if (auto inner = _validateTensorSubBlob(subBytes, depth + 1U); !inner.has_value()) {
                     return std::unexpected{inner.error()};
                 }

--- a/core/test/qa_ValueMap.cpp
+++ b/core/test/qa_ValueMap.cpp
@@ -1347,6 +1347,50 @@ const boost::ut::suite<"ValueMap - Tensor<Value> view contract"> _tensor_value_v
         expect(eq((*innerViewB)[2].value_or(std::string_view{}), "b3"sv));
     };
 
+    // as above, but each inner tensor has cells of one fixed-size type, so it collapses to a typed Tensor<T>
+    "nested Tensor<Value> cell whose cells collapsed to a typed Tensor<T> round-trips"_test = [] {
+        gr::Tensor<Value> innerInts(gr::extents_from, std::array<std::size_t, 1>{2UZ});
+        innerInts._data.data()[0] = Value{std::int64_t{1}};
+        innerInts._data.data()[1] = Value{std::int64_t{2}};
+
+        gr::Tensor<Value> innerFloats(gr::extents_from, std::array<std::size_t, 1>{3UZ});
+        innerFloats._data.data()[0] = Value{0.5f};
+        innerFloats._data.data()[1] = Value{1.5f};
+        innerFloats._data.data()[2] = Value{2.5f};
+
+        gr::Tensor<Value> outer(gr::extents_from, std::array<std::size_t, 1>{2UZ});
+        outer._data.data()[0] = Value{std::move(innerInts)};
+        outer._data.data()[1] = Value{std::move(innerFloats)};
+
+        ValueMap original;
+        original.emplace("nested", outer);
+
+        const auto blob     = original.blob();
+        const auto restored = ValueMap::from_blob(blob);
+        expect(restored.has_value()) << boost::ut::fatal;
+
+        const auto restoredVal = *restored->find_value("nested");
+        const auto outerView   = restoredVal.get_if<gr::TensorView<Value>>();
+        expect(outerView.has_value()) << boost::ut::fatal;
+        expect(eq(outerView->size(), 2UZ));
+
+        const auto outerSnap = outerView->owned();
+        expect(outerSnap.data()[0].is_tensor()) << "collapsed cell must stay a tensor, not decode as a scalar";
+        expect(outerSnap.data()[1].is_tensor()) << "collapsed cell must stay a tensor, not decode as a scalar";
+
+        const auto innerViewInts = outerSnap.data()[0].get_if<gr::TensorView<std::int64_t>>();
+        expect(innerViewInts.has_value()) << boost::ut::fatal;
+        expect(eq(innerViewInts->size(), 2UZ));
+        expect(eq(innerViewInts->data()[0], std::int64_t{1}));
+        expect(eq(innerViewInts->data()[1], std::int64_t{2}));
+
+        const auto innerViewFloats = outerSnap.data()[1].get_if<gr::TensorView<float>>();
+        expect(innerViewFloats.has_value()) << boost::ut::fatal;
+        expect(eq(innerViewFloats->size(), 3UZ));
+        expect(eq(innerViewFloats->data()[0], 0.5f));
+        expect(eq(innerViewFloats->data()[2], 2.5f));
+    };
+
     "owned(mr) snapshot is independent of the source ValueMap's lifetime"_test = [] {
         gr::Tensor<Value> snap;
         {

--- a/core/test/qa_grc.cpp
+++ b/core/test/qa_grc.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <set>
 #include <sstream>
 #include <string>
 #include <unordered_set>
@@ -170,6 +171,21 @@ connections:
             std::println(std::cerr, "Unexpected exception: {}", e);
             expect(false);
         }
+    };
+
+    "Collection port indices survive YAML loading"_test = [&] {
+        using namespace gr;
+
+        auto graph = gr::loadGrc(context->loader, testGrc).value();
+
+        const std::set<std::string> expectedEdges{
+            "ArraySource<float64>#1#0 - ArraySinkImpl<float64, true, 42>#0#0",
+            "ArraySource<float64>#1#1 - ArraySinkImpl<float64, true, 42>#0#1",
+            "ArraySourceOne<float64>#0#0 - ArraySinkImpl<float64, true, 42>#1#1",
+            "ArraySourceOne<float64>#0#1 - ArraySinkImpl<float64, true, 42>#1#0",
+        };
+
+        expect(eq(collectEdges(*graph), expectedEdges));
     };
 
     "Save and load"_test = [&] {


### PR DESCRIPTION
## Regression

Flowgraphs using the collection-port syntax stopped connecting:

```yaml
- [Picoscope3000, [0, 2], DummySinkPicoC, 0, 262144]
```

`[0, 2]` was read back as the plain number `0`: the top-level index survived, the sub-index was lost
and fell back to `invalid_index`.

`[topLevel, subIndex]` should remain supported.

## Root cause: the encoder and the decoder disagree

Each cell of a serialised `Tensor<Value>` carries a small header (`PackedTensorElement`).

When every cell of a `Tensor<Value>` holds the same fixed-size type, the encoder re-packs the list as
a plain `Tensor<T>` - values back to back, no per-cell headers. `[0, 2]` therefore becomes a
`Tensor<Int64>`, and `encodeTensorElement` writes it as:

```
valueType   = Int64                     <- the value's type after the collapse
flags       = OffsetLength | Tensor     <- "my payload is a tensor sub-blob"
payload     = the packed numbers 0, 2
inlineValue = 0 0 0 0 0 0 0 0           <- untouched: this is not an inline scalar
```

`decodeTensorElement` tested for something else:

```cpp
if (valueType == Value::ValueType::Value && (flags & kEntryFlagTensor) != 0U) { /* nested tensor */ }
```

`Int64 != Value`, so the nested-tensor branch was skipped and the cell fell through to the "then it
must be a plain scalar" branch, which reads the inline slot - the zeros nobody wrote. Hence
`[0, 2]` → `0`.

The same value stored under a **map key** always worked, because `decodeEntry` tests the flag alone.
That is why `parameters:` lists were fine and only a list *inside a list* broke.

## Fix

1. `decodeTensorElement` - test `kEntryFlagTensor` alone, as `decodeEntry` already does. The payload
   is self-describing, so `valueType` is not needed to recognise a tensor.
2. `_validateTensorSubBlob` - same gate, so `from_blob` still validates the nested tensors the decoder
   now follows.
3. `kEntryFlagTensor` doc comment corrected.

Reader-side only: no wire-format change, and bytes already written start decoding correctly.


## Possible Follow-up (separate issue)

The collapse gate in `encodeTensorBlob` compares `value_type()` across cells but does not check that
they are scalars. A tensor cell reports its *element* type, so `[[0, 1], [2, 3]]` passes the gate and
collapses to `Tensor<int64>{0, 0}` - silent data loss, pre-existing and independent of this PR. One
added `!cell.is_tensor()` condition fixes it. Only observable once this PR lands: before it, the
decoder turned the correct encoding back into zeros anyway.