### PR TITLE
Fix schedulers never starting all work when a pool thread is busy (#813)

### DIFF
--- a/core/include/gnuradio-4.0/Scheduler.hpp
+++ b/core/include/gnuradio-4.0/Scheduler.hpp
@@ -735,6 +735,14 @@ protected:
         return {max_work_items, performedWorkAllBlocks, unfinishedBlocksExist ? work::Status::OK : work::Status::DONE};
     }
 
+    // threads currently free in the pool (at least one), used to bound the parallel job-lists so none
+    // is left permanently queued when a pool thread is busy elsewhere (issue #813)
+    [[nodiscard]] std::size_t availableThreadCount() const {
+        const std::size_t poolMaxThreads = static_cast<std::size_t>(_pool->maxThreads());
+        const std::size_t busyThreads    = _pool->numTasksRunning();
+        return poolMaxThreads > busyThreads ? poolMaxThreads - busyThreads : 1UZ;
+    }
+
     void init() {
         [[maybe_unused]] const auto pe = _profilerHandler->startCompleteEvent("scheduler_base.init");
         base_t::processScheduledMessages(); // make sure initial subscriptions are processed
@@ -1923,7 +1931,7 @@ struct Simple : SchedulerBase<Simple<execution, TProfiler>, execution, TProfiler
         case ExecutionPolicy::singleThreaded:
         case ExecutionPolicy::singleThreadedBlocking:
         case ExecutionPolicy::externalStep: break; // single job list; the application drives step()
-        case ExecutionPolicy::multiThreaded: n_batches = std::min(static_cast<std::size_t>(this->_pool->maxThreads()), nBlocks); break;
+        case ExecutionPolicy::multiThreaded: n_batches = std::min(this->availableThreadCount(), nBlocks); break;
         default:;
         }
 
@@ -2036,7 +2044,7 @@ detecting cycles and blocks which can be reached from several source blocks.)"">
             }
         }
 
-        const std::size_t n_batches = (execution == ExecutionPolicy::multiThreaded) ? std::min(static_cast<std::size_t>(this->_pool->maxThreads()), blockList.size()) : 1UZ;
+        const std::size_t n_batches = (execution == ExecutionPolicy::multiThreaded) ? std::min(this->availableThreadCount(), blockList.size()) : 1UZ;
 
         std::lock_guard lock(this->_executionOrderMutex);
         std::lock_guard guard(this->_adoptionBlocksMutex);
@@ -2104,7 +2112,7 @@ struct DepthFirst : SchedulerBase<DepthFirst<execution, TProfiler>, execution, T
             dfs(src);
         }
 
-        const std::size_t n_batches = (execution == ExecutionPolicy::multiThreaded) ? std::min(static_cast<std::size_t>(this->_pool->maxThreads()), blockList.size()) : 1UZ;
+        const std::size_t n_batches = (execution == ExecutionPolicy::multiThreaded) ? std::min(this->availableThreadCount(), blockList.size()) : 1UZ;
 
         std::lock_guard lock(this->_executionOrderMutex);
         std::lock_guard guard(this->_adoptionBlocksMutex);

--- a/core/test/qa_Scheduler.cpp
+++ b/core/test/qa_Scheduler.cpp
@@ -756,6 +756,40 @@ const boost::ut::suite<"SchedulerTests"> SchedulerTests = [] {
         expect(that % t.size() >= 8u);
     };
 
+    // Regression test for issue #813: the multiThreaded schedulers size their job-lists by the pool's
+    // maxThreads(). When runAndWait() is itself dispatched onto that same pool (as executeScheduler
+    // does), it permanently holds one of the two pinned threads, leaving one thread for two job-lists.
+    // One job-list then never gets a worker, its blocks never run, back-pressure stalls the rest, and
+    // the graph never finishes. After the fix the scheduler sizes to the threads actually free.
+    auto expectNoStarvationWhenPoolThreadBusy = [](auto schedulerTag, std::string_view schedulerName) {
+        using TScheduler = typename decltype(schedulerTag)::type;
+
+        std::shared_ptr<Tracer> trace = std::make_shared<Tracer>();
+        TScheduler              sched;
+        if (auto ret = sched.exchange(getGraphLinear(trace)); !ret) {
+            expect(false) << std::format("couldn't initialise scheduler. error: {}", ret.error()) << fatal;
+        }
+
+        auto       future   = gr::test::thread_pool::executeScheduler(std::format("qa_Sched::issue813::{}", schedulerName), sched);
+        const bool finished = future.wait_for(20s) == std::future_status::ready;
+        if (!finished) {
+            sched.requestStop(); // break the starvation so the test process does not hang
+        }
+        const auto result = future.get();
+        expect(finished) << std::format("{}: scheduler stalled, a job-list never started because a pool thread was busy (issue #813)", schedulerName);
+        expect(result.has_value()) << [&] { return std::format("{}: runAndWait() did not return success: {}", schedulerName, result.error()); };
+
+        const TraceVectorType       t = trace->getVector();
+        const std::set<std::string> ranBlocks(t.begin(), t.end());
+        expect(eq(ranBlocks.size(), 4UZ)) << std::format("{}: not all blocks ran; only [{}] did work, expected s1, mult1, mult2, out", schedulerName, gr::join(ranBlocks, ", "));
+    };
+
+    "Simple scheduler runs all work when a pool thread is busy elsewhere"_test = [&] { expectNoStarvationWhenPoolThreadBusy(std::type_identity<gr::scheduler::Simple<gr::scheduler::ExecutionPolicy::multiThreaded>>{}, "Simple"); };
+
+    "BreadthFirst scheduler runs all work when a pool thread is busy elsewhere"_test = [&] { expectNoStarvationWhenPoolThreadBusy(std::type_identity<gr::scheduler::BreadthFirst<gr::scheduler::ExecutionPolicy::multiThreaded>>{}, "BreadthFirst"); };
+
+    "DepthFirst scheduler runs all work when a pool thread is busy elsewhere"_test = [&] { expectNoStarvationWhenPoolThreadBusy(std::type_identity<gr::scheduler::DepthFirst<gr::scheduler::ExecutionPolicy::multiThreaded>>{}, "DepthFirst"); };
+
     "BreadthFirstScheduler_linear_multi_threaded"_test = [] {
         std::shared_ptr<Tracer>                                                    trace = std::make_shared<Tracer>();
         gr::scheduler::BreadthFirst<gr::scheduler::ExecutionPolicy::multiThreaded> sched;


### PR DESCRIPTION
### What

The `Simple`, `BreadthFirst` and `DepthFirst` schedulers size their parallel job-lists by `pool.maxThreads()`. Because each `poolWorker` occupies its thread for the scheduler's entire run, this over-subscribes whenever a pool thread is already in use: one job-list is queued and never starts, its blocks never `work()`, back-pressure stalls the rest of the graph, and `runAndWait()` never returns.

This is exactly the situation in #813: a thread from the pool is used to call `runAndWait()`, and the scheduler runs its workers on that same pool — so with an N-thread pool only N-1 threads remain for N job-lists.

### Fix

A small helper `SchedulerBase::availableThreadCount()` returns `max(1, maxThreads() - numTasksRunning())`, and the three schedulers use it in place of `maxThreads()` when choosing how many job-lists to create. Sizing to the threads that are actually free means every job-list is guaranteed a worker.

- It only ever **reduces** the number of job-lists, never increases it, so no worker can be left permanently queued.
- Clamped to **at least one**, so a fully-busy pool still runs the graph on a single job-list rather than doing nothing.
- When the pool is idle (`numTasksRunning() == 0`) the result equals `maxThreads()`, i.e. **no change** to existing behaviour.

### How to test

`core/test/qa_Scheduler.cpp` gains a regression test, run for all three schedulers, that launches a `multiThreaded` scheduler via `executeScheduler` (which occupies one thread of the `[2, 2]`-pinned CPU pool) and asserts the graph finishes and every block did work. On `main` these stall — only the source block runs — and hang until the test's timeout; with the fix they pass.

### Note

Commit fabe56d worked around this by forcing a `singleThreaded` scheduler in `qa_ManagedSubGraph.cpp`, with a TODO to check how many pool threads can be reserved. That workaround can now be reverted; I kept it out of this PR to stick to one concept and am happy to send it as a follow-up.

Closes #813
