### PR TITLE
Fix sample rate forwarding for resampling blocks

### DIFF
--- a/blocks/filter/test/qa_filter.cpp
+++ b/blocks/filter/test/qa_filter.cpp
@@ -9,6 +9,9 @@
 
 #include <gnuradio-4.0/filter/time_domain_filter.hpp>
 #include <gnuradio-4.0/testing/NullSources.hpp>
+#include <gnuradio-4.0/testing/TagMonitors.hpp>
+
+#include <gnuradio-4.0/meta/UnitTestHelper.hpp>
 
 template<typename T, typename Range>
 requires std::floating_point<T>
@@ -263,29 +266,58 @@ const boost::ut::suite<"Basic[Decimating]Filter"> BasicFilterTests = [] {
 
     "Decimator - Low-pass Filter Test"_test = [] {
         using namespace gr::testing;
-        using T = int;
+        using T = float;
 
-        constexpr gr::Size_t decimationFactor = 10;
+        constexpr float      kInputRate        = 10'000.f;
+        constexpr gr::Size_t kDecimationFactor = 10U;
+        constexpr gr::Size_t kInputSamples     = 100U;
 
         gr::Graph flow;
-        auto&     source    = flow.emplaceBlock<CountingSource<T>>({{"n_samples_max", 10 * decimationFactor}});
-        auto&     decimator = flow.emplaceBlock<gr::filter::Decimator<T>>({{"decim", decimationFactor}});
-        auto&     sink      = flow.emplaceBlock<CountingSink<T>>();
+        auto&     source    = flow.emplaceBlock<TagSource<T>>({{"sample_rate", kInputRate}, {"n_samples_max", kInputSamples}});
+        auto&     decimator = flow.emplaceBlock<gr::filter::Decimator<T>>({{"decim", kDecimationFactor}});
+        auto&     sink      = flow.emplaceBlock<TagSink<T, ProcessFunction::USE_PROCESS_BULK>>({{"n_samples_expected", kInputSamples / kDecimationFactor}});
         expect(flow.connect<"out", "in">(source, decimator).has_value());
         expect(flow.connect<"out", "in">(decimator, sink).has_value());
 
         gr::scheduler::Simple<> sched;
-        ;
         if (auto ret = sched.exchange(std::move(flow)); !ret) {
             throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
         }
         expect(sched.runAndWait().has_value());
 
-        expect(eq(decimator.decim, decimationFactor));
+        expect(eq(decimator.decim, kDecimationFactor));
         expect(eq(decimator.output_chunk_size, static_cast<gr::Size_t>(1)));
-        expect(eq(decimator.input_chunk_size, decimationFactor));
+        expect(eq(decimator.input_chunk_size, kDecimationFactor));
+        expect(eq(sink._nSamplesProduced, kInputSamples / kDecimationFactor));
+        expect(eq(sink.sample_rate, kInputRate / static_cast<float>(kDecimationFactor))) << "rate seen downstream";
+    };
 
-        expect(eq(sink.count, static_cast<gr::Size_t>(10)));
+    "BasicDecimatingFilter - keeps its input sample_rate"_test = [] {
+        // the filter's own 'sample_rate' is its input rate; only the downstream tag carries the decimated rate.
+        using namespace gr::testing;
+        using T = float;
+
+        constexpr float      kInputRate = 32'000.f; // decimated rate must differ from the TagSink default, else the sink assert passes without a tag
+        constexpr gr::Size_t kDecimate  = 10U;
+        constexpr gr::Size_t kNSamples  = 4'000U;
+
+        gr::Graph flow;
+        auto&     source = flow.emplaceBlock<TagSource<T>>({{"sample_rate", kInputRate}, {"n_samples_max", kNSamples}});
+        auto&     filter = flow.emplaceBlock<BasicDecimatingFilter<T>>({{"sample_rate", kInputRate}, {"f_low", 400.f}, {"decimate", kDecimate}});
+        auto&     sink   = flow.emplaceBlock<TagSink<T, ProcessFunction::USE_PROCESS_BULK>>({{"n_samples_expected", kNSamples / kDecimate}});
+
+        expect(flow.connect<"out", "in">(source, filter).has_value());
+        expect(flow.connect<"out", "in">(filter, sink).has_value());
+
+        gr::scheduler::Simple<> sched;
+        if (auto ret = sched.exchange(std::move(flow)); !ret) {
+            throw std::runtime_error(std::format("failed to initialise scheduler: {}", ret.error()));
+        }
+        expect(sched.runAndWait().has_value()) << "scheduler run";
+
+        expect(eq(filter.sample_rate, kInputRate)) << "filter member holds its input rate";
+        expect(eq(gr::test::get_value_or_fail<float>(*filter.settings().get("sample_rate")), kInputRate)) << "filter settings().get() must agree with its member";
+        expect(eq(sink.sample_rate, kInputRate / static_cast<float>(kDecimate))) << "rate seen downstream";
     };
 };
 

--- a/core/include/gnuradio-4.0/Block.hpp
+++ b/core/include/gnuradio-4.0/Block.hpp
@@ -1085,6 +1085,29 @@ public:
         }
     }
 
+    void insertOutputValue(property_map& destination, const auto& wireKey, const auto& value) const {
+        const std::string_view fieldKey          = gr::tag::settingsKey(std::string_view{wireKey});
+        const bool             convertSampleRate = ResamplingControl::kEnabled && input_chunk_size != output_chunk_size && fieldKey == gr::tag::SAMPLE_RATE.shortKey();
+        if (convertSampleRate && input_chunk_size != 0U) {
+            if (const float* inputRate = value.template get_if<float>()) {
+                const float ratio = static_cast<float>(output_chunk_size) / static_cast<float>(input_chunk_size);
+                destination.insert_or_assign(wireKey, ratio * (*inputRate));
+                return;
+            }
+        }
+        destination.insert_or_assign(wireKey, value);
+    }
+
+    [[nodiscard]] property_map toOutputTags(const property_map& parameters) const {
+        auto toWireKey = [](std::string_view bareKey) -> std::string { return std::ranges::contains(gr::tag::kDefaultTags, bareKey) ? std::string(gr::GR_TAG_PREFIX.view()) + std::string(bareKey) : std::string(bareKey); };
+
+        property_map wireTags;
+        for (const auto& [key, value] : parameters) {
+            insertOutputValue(wireTags, toWireKey(std::string_view{key}), value);
+        }
+        return wireTags;
+    }
+
     /// default tag forwarding — called by workInternal unless the user provides forwardTags()
     template<typename TInputSpans, typename TOutputSpans>
     void forwardInputTags(TInputSpans& inputSpans, TOutputSpans& outputSpans, std::size_t processedIn) noexcept {
@@ -1112,17 +1135,22 @@ public:
                     anyDrop = true;
                     continue;
                 }
-                anyForward                      = true;
-                const std::string_view fieldKey = gr::tag::settingsKey(keyView);
+                anyForward                               = true;
+                const std::string_view fieldKey          = gr::tag::settingsKey(keyView);
+                const bool             convertSampleRate = ResamplingControl::kEnabled && input_chunk_size != output_chunk_size && fieldKey == gr::tag::SAMPLE_RATE.shortKey();
                 if (blockSettings.contains(fieldKey)) {
                     if (cachedSettings == nullptr) {
                         cachedSettings = &settings().activeParameters();
                     }
-                    // only substitute when the active setting differs from the tag value; an equal
-                    // value (the steady-state constant-tag case) needs no rebuild → verbatim pass-through
-                    if (auto it = cachedSettings->find(fieldKey); it != cachedSettings->end() && !((*it).second == kv.second)) {
+                    if (convertSampleRate) {
                         anySubstitute = true;
+                    } else {
+                        if (auto it = cachedSettings->find(fieldKey); it != cachedSettings->end() && !((*it).second == kv.second)) {
+                            anySubstitute = true;
+                        }
                     }
+                } else if (convertSampleRate) {
+                    anySubstitute = true;
                 }
             }
             if (!anyForward) {
@@ -1143,11 +1171,11 @@ public:
                 const std::string_view fieldKey = gr::tag::settingsKey(keyView);
                 if (anySubstitute && blockSettings.contains(fieldKey)) {
                     if (auto it = cachedSettings->find(fieldKey); it != cachedSettings->end()) {
-                        dst.insert_or_assign(key, (*it).second);
+                        insertOutputValue(dst, key, (*it).second);
                         continue;
                     }
                 }
-                dst.insert_or_assign(key, value);
+                insertOutputValue(dst, key, value);
             }
             for_each_writer_span([&dst, offset](auto& out) { out.publishTag(dst, offset); }, outputSpans);
         };
@@ -1171,11 +1199,11 @@ public:
                                     cachedSettings = &settings().activeParameters();
                                 }
                                 if (auto it = cachedSettings->find(fieldKey); it != cachedSettings->end()) {
-                                    merged.insert_or_assign(key, (*it).second);
+                                    insertOutputValue(merged, key, (*it).second);
                                     continue;
                                 }
                             }
-                            merged.insert_or_assign(key, value);
+                            insertOutputValue(merged, key, value);
                         }
                     }
                 },
@@ -1273,16 +1301,10 @@ public:
 
             if constexpr (!noTagPropagation) {
                 if (publishForwardTags && !applyResult.forwardParameters.empty()) {
-                    auto toWireKey = [](std::string_view bareKey) -> std::string { return std::ranges::contains(gr::tag::kDefaultTags, bareKey) ? std::string(gr::GR_TAG_PREFIX.view()) + std::string(bareKey) : std::string(bareKey); };
-
-                    property_map wireTags;
-                    for (const auto& [key, value] : applyResult.forwardParameters) {
-                        wireTags.insert_or_assign(toWireKey(std::string_view{key}), value);
-                    }
                     if (capturedForwardParams) {
-                        capturedForwardParams->merge(wireTags);
+                        capturedForwardParams->merge(applyResult.forwardParameters);
                     } else {
-                        publishTag(wireTags, 0);
+                        publishTag(toOutputTags(applyResult.forwardParameters), 0);
                     }
                 }
             } else {
@@ -2075,7 +2097,8 @@ public:
         }
 
         if (pendingForwardParams && !pendingForwardParams->empty()) {
-            for_each_writer_span([&pendingForwardParams](auto& out) { out.publishTag(*pendingForwardParams, 0); }, outputSpans);
+            const property_map wireTags = toOutputTags(*pendingForwardParams);
+            for_each_writer_span([&wireTags](auto& out) { out.publishTag(wireTags, 0); }, outputSpans);
         }
 
         if constexpr (HasProcessOneFunction<Derived> && !HasProcessBulkFunction<Derived>) {

--- a/core/include/gnuradio-4.0/Settings.hpp
+++ b/core/include/gnuradio-4.0/Settings.hpp
@@ -230,7 +230,8 @@ struct SettingsCtx {
  * Implementers may have:
  * 1. `settingsChanged(oldSettings, newSettings)`
  * 2. `settingsChanged(oldSettings, newSettings, forwardSettings)`
- *    - where `forwardSettings` is for influencing subsequent blocks. E.g., a decimating block might adjust the `sample_rate` for downstream blocks.
+ *    - `forwardSettings` influences subsequent blocks.
+ *      A forwarded `sample_rate` is the block's input rate. Block converts it when publishing an output tag.
  */
 template<typename BlockType>
 concept HasSettingsChangedCallback = requires(BlockType* block, const property_map& oldSettings, property_map& newSettings) {
@@ -1194,18 +1195,6 @@ public:
             }
 
             updateActiveParametersImpl();
-
-            // Update sample_rate if the block performs decimation or interpolation
-            if constexpr (TBlock::ResamplingControl::kEnabled) {
-                if (result.forwardParameters.contains(gr::tag::SAMPLE_RATE.shortKey()) && (_block->input_chunk_size != 1ULL || _block->output_chunk_size != 1ULL)) {
-                    const float ratio = static_cast<float>(_block->output_chunk_size) / static_cast<float>(_block->input_chunk_size);
-                    if (const float* currentRate = _activeParameters.get_if<float>(gr::tag::SAMPLE_RATE.shortKey())) {
-                        const float newSampleRate = ratio * (*currentRate);
-                        result.forwardParameters.insert_or_assign(gr::tag::SAMPLE_RATE.shortKey(), newSampleRate);
-                        _activeParameters.insert_or_assign(gr::tag::SAMPLE_RATE.shortKey(), newSampleRate); // update for value substitution in forwardInputTags
-                    }
-                }
-            }
 
             if (_stagedParameters.contains(std::string_view{gr::tag::STORE_DEFAULTS})) {
                 storeDefaults();

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -152,7 +152,8 @@ if(GR_ENABLE_BLOCK_REGISTRY
 
   add_app_test(qa_grc)
   gr_generate_block_instantiations(qa_grc HEADERS CollectionTestBlocks.hpp)
-  target_link_libraries(qa_grc PUBLIC gnuradio4::GrBasicBlocksShared gnuradio4::GrTestingBlocksShared)
+  target_link_libraries(qa_grc PUBLIC gnuradio4::GrBasicBlocksShared gnuradio4::GrTestingBlocksShared
+                                      gnuradio4::GrFilterBlocksShared)
 
   add_ut_test(qa_GraphMessages)
   target_link_libraries(qa_GraphMessages PUBLIC gnuradio4::GrBasicBlocksShared gnuradio4::GrTestingBlocksShared)

--- a/core/test/qa_Block.cpp
+++ b/core/test/qa_Block.cpp
@@ -554,8 +554,10 @@ void interpolation_decimation_test(const IntDecTestData& data) {
     using namespace boost::ut;
     using namespace gr::testing;
 
+    constexpr float kInputRate = 10'000.f;
+
     gr::Graph flow;
-    auto&     source        = flow.emplaceBlock<TagSource<int, ProcessFunction::USE_PROCESS_BULK>>({{"n_samples_max", data.n_samples}, {"mark_tag", false}});
+    auto&     source        = flow.emplaceBlock<TagSource<int, ProcessFunction::USE_PROCESS_BULK>>({{"n_samples_max", data.n_samples}, {"sample_rate", kInputRate}, {"mark_tag", false}});
     auto&     int_dec_block = flow.emplaceBlock<Resampler<int>>({{"output_chunk_size", data.output_chunk_size}, {"input_chunk_size", data.input_chunk_size}});
     auto&     sink          = flow.emplaceBlock<TagSink<int, ProcessFunction::USE_PROCESS_ONE>>();
     expect(flow.connect<"out", "in">(source, int_dec_block).has_value());
@@ -576,6 +578,10 @@ void interpolation_decimation_test(const IntDecTestData& data) {
     expect(eq(int_dec_block.status.process_counter, data.exp_counter)) << "processBulk invokes counter, parameters = " << data.to_string();
     expect(eq(int_dec_block.status.n_inputs, data.exp_in)) << "last number of input samples, parameters = " << data.to_string();
     expect(eq(int_dec_block.status.n_outputs, data.exp_out)) << "last number of output samples, parameters = " << data.to_string();
+    if (data.exp_counter > 0UZ) {
+        const float expectedRate = static_cast<float>(data.output_chunk_size) / static_cast<float>(data.input_chunk_size) * kInputRate;
+        expect(eq(sink.sample_rate, expectedRate)) << "rate seen downstream";
+    }
 }
 
 void stride_test(const StrideTestData& data) {

--- a/core/test/qa_Settings.cpp
+++ b/core/test/qa_Settings.cpp
@@ -486,6 +486,28 @@ const boost::ut::suite SettingsTests = [] {
         expect(eq(block1.sample_rate, 1000.0f)) << "block1 matching sample_rate";
         expect(eq(block2.sample_rate, 500.0f)) << "block2 matching sample_rate";
         expect(eq(sink.sample_rate, 100.0f)) << "sink matching src sample_rate";
+
+        auto activeRate = [](const auto& block) { return gr::test::get_value_or_fail<float>(*block.settings().get(std::string(gr::tag::SAMPLE_RATE.shortKey()))); };
+        expect(eq(activeRate(block1), 1000.0f)) << "block1 settings().get() must agree with its member";
+        expect(eq(activeRate(block2), 500.0f)) << "block2 settings().get() must agree with its member";
+    };
+
+    "decimating block sample_rate is its input rate"_test = []() {
+        constexpr float      kInputRate = 10'000.f;
+        constexpr gr::Size_t kDecimate  = 10U;
+        const std::string    kRateKey{gr::tag::SAMPLE_RATE.shortKey()};
+
+        Graph testGraph;
+        auto& block = testGraph.emplaceBlock<Decimate<float>>({{kRateKey, kInputRate}, {"input_chunk_size", kDecimate}}); // emplaceBlock() runs Block::init()
+
+        expect(eq(block.sample_rate, kInputRate)) << "member holds the input rate";
+        expect(eq(gr::test::get_value_or_fail<float>(*block.settings().get(kRateKey)), kInputRate)) << "settings().get() must agree with the member";
+
+        const auto staged = block.settings().stagedParameters().find_value(kRateKey);
+        expect(staged.has_value()) << "init() re-stages the forwarded rate"; // Block::init() -> setStaged(forwardParameters)
+        if (staged.has_value()) {
+            expect(eq(gr::test::get_value_or_fail<float>(*staged), kInputRate)) << "the re-staged rate must be the input rate, not the derived output rate";
+        }
     };
 
     "basic store/reset settings"_test = []() {

--- a/core/test/qa_grc.cpp
+++ b/core/test/qa_grc.cpp
@@ -18,7 +18,9 @@
 #include "CollectionTestBlocks.hpp"
 
 #include <gnuradio-4.0/GrBasicBlocks.hpp>
+#include <gnuradio-4.0/GrFilterBlocks.hpp>
 #include <gnuradio-4.0/GrTestingBlocks.hpp>
+#include <gnuradio-4.0/filter/time_domain_filter.hpp>
 #include <gnuradio-4.0/qa_grc.hpp>
 
 #include "TestBlockRegistryContext.hpp"
@@ -33,6 +35,7 @@ auto makeTestContext() {
         paths{"core/test/plugins", "test/plugins", "plugins"}, // plugin paths
         gr::blocklib::initGrBasicBlocks,                       //
         gr::blocklib::initGrTestingBlocks,                     //
+        gr::blocklib::initGrFilterBlocks,                      //
         gr::blocklib::initqa_grc);
 }
 
@@ -681,6 +684,34 @@ const boost::ut::suite SettingsTests = [] {
             std::println(std::cerr, "Unexpected exception: {}", e);
             expect(false);
         }
+    };
+
+    "decimating block sample_rate survives saveGrc/loadGrc"_test = [&] {
+        using namespace gr;
+
+        constexpr float      kInputRate = 10'000.f;
+        constexpr gr::Size_t kDecimate  = 10U;
+        const property_map   config{{"sample_rate", kInputRate}, {"f_low", 10.f}, {"decimate", kDecimate}};
+
+        auto activeRate = [](const auto& block) { return test::get_value_or_fail<float>(*block.settings().get("sample_rate")); };
+
+        gr::Graph graph;
+        auto&     filter = graph.emplaceBlock<gr::filter::BasicDecimatingFilter<float>>(config);
+
+        const std::string yaml = gr::saveGrc(context->loader, graph);
+        expect(eq(filter.sample_rate, kInputRate)) << "serialising a graph must not change a block member";
+        expect(eq(activeRate(filter), kInputRate)) << "the persisted rate must be the block's input rate";
+
+        const auto  reloaded = gr::loadGrc(context->loader, yaml).value();
+        std::size_t nBlocks  = 0UZ;
+        gr::graph::forEachBlock<gr::block::Category::NormalBlock>(*reloaded, [&](const auto node) {
+            nBlocks++;
+            const auto settings = node->settings().get();
+            expect(eq(test::get_value_or_fail<float>(settings.find_value("sample_rate").value()), kInputRate)) << "reloaded sample_rate";
+            expect(eq(test::get_value_or_fail<gr::Size_t>(settings.find_value("decimate").value()), kDecimate)) << "reloaded decimate";
+            expect(eq(test::get_value_or_fail<gr::Size_t>(settings.find_value("input_chunk_size").value()), kDecimate)) << "reloaded input_chunk_size";
+        });
+        expect(eq(nBlocks, 1UZ)) << "reloaded block count";
     };
 };
 

--- a/docs/USER_API_Tag_mechanics.md
+++ b/docs/USER_API_Tag_mechanics.md
@@ -389,7 +389,7 @@ Example — a 10× decimator:
            ─┴──┴─
 ```
 
-This happens in `applyStagedParameters()` — the block author does not need to handle it manually.
+This happens when the output tag is published. The block's settings keep the input rate.
 The decimation block only needs to set `input_chunk_size` in `settingsChanged`:
 
 ```cpp


### PR DESCRIPTION
Keep sample_rate as the input rate in block settings. Apply the resampling ratio only when publishing output tags.

This prevents decimating blocks from storing and saving their output rate, which caused the rate to decrease again after each iteration.

Tests: Cover decimation, interpolation, blocks without a sample_rate setting, and GRC save/load behavior.