### PR TITLE
Fix scheduler hanging when requesting work quiesence

### DIFF
--- a/core/include/gnuradio-4.0/Scheduler.hpp
+++ b/core/include/gnuradio-4.0/Scheduler.hpp
@@ -225,6 +225,7 @@ protected:
 
     std::atomic_flag _processingScheduledMessages;
     bool             _workQuiescenceRequested{false};
+    bool             _stateStartPostGraphEdgesReconnected{false};
     std::size_t      _nWorkersInWork{0};
 
     void rebuildProfiler(const profiling::Options& opt) {
@@ -281,7 +282,7 @@ public:
     void releaseWorkQuiescence() { gr::atomic_ref(_workQuiescenceRequested).store_release(false); }
 
     /// Invokes blockUntilWorking(), do not call when scheduler is not running or being started
-    /// as it will block until it sees a worker thread/call to poolWorker
+    /// as it may block until a child scheduler's start() has finished modifying the graph
     void requestWorkQuiescenceAll() {
         requestWorkQuiescence();
         graph::forEachBlock<TransparentBlockGroup>(*_graph, [](auto& block) {
@@ -305,10 +306,10 @@ public:
         releaseWorkQuiescence();
     }
 
-    /// If this scheduler is INITIALISED or RUNNING, this function will block the calling thread until the scheduler
-    /// has begun spawning its worker threads (though the worker threads may not have started yet). This is useful
-    /// when spawning another thread to call start(), because a scheduler's start() observes _graph and modifies
-    /// ports before it spawns workers, so this can be used to wait until that is done.
+    /// If this scheduler is INITIALISED or RUNNING, this function will block the calling thread until the scheduler's
+    /// start() has finished observing _graph and modifying ports. This is useful when spawning another thread to call
+    /// start(), because a scheduler's start() observes _graph and modifies ports before it spawns workers, so this can
+    /// be used to wait until that is done.
     ///
     /// Do not call this on a scheduler which has been INITIALISED but has not (been started | is planned to be
     /// started by another thread), as this will block indefinitely in that case, waiting for another thread to
@@ -319,7 +320,7 @@ public:
         if constexpr (executionPolicy() == ExecutionPolicy::externalStep) {
             return; // you are doing step() so you know when it is working :)
         }
-        while (_nRunningJobs->value() == 0UZ) {
+        while (!gr::atomic_ref(_stateStartPostGraphEdgesReconnected).load_acquire()) {
             const auto currentState = this->state();
             if (currentState != INITIALISED && currentState != RUNNING) {
                 return;
@@ -765,6 +766,8 @@ protected:
     void start() {
         using enum gr::lifecycle::State;
 
+        gr::atomic_ref(_stateStartPostGraphEdgesReconnected).store_release(false);
+
         disconnectAllEdges();
         if (auto result = connectPendingEdges(); !result) {
             this->emitErrorMessage("start()", "Failed to connect blocks in graph");
@@ -795,6 +798,9 @@ protected:
                 this->emitErrorMessageIfAny("LifecycleState -> RUNNING", block->changeStateTo(lifecycle::RUNNING));
             }
         });
+
+        // we are done modifying the graph. if a parent scheduler created us it is now free to modify our graph (within work quiescence)
+        gr::atomic_ref(_stateStartPostGraphEdgesReconnected).store_release(true);
 
         if constexpr (executionPolicy() == ExecutionPolicy::externalStep) { // no watchdog/pool; the application drives step()
             if constexpr (requires(Derived& d) { d.customStart(); }) {

--- a/core/test/qa_SchedulerMessages.cpp
+++ b/core/test/qa_SchedulerMessages.cpp
@@ -413,6 +413,42 @@ const boost::ut::suite TopologyGraphTests = [] {
     "Adopting a managed subgraph must not block message processing, singlethreaded"_test = [] { adoptingManagedSubgraphMustNotBlock.operator()<ExecutionPolicy::singleThreaded>(); };
     "Adopting a managed subgraph must not block message processing, multithreaded"_test  = [] { adoptingManagedSubgraphMustNotBlock.operator()<ExecutionPolicy::multiThreaded>(); };
 
+    constexpr static auto requestWorkQuiesenceOnEmptySubgraphRegression = []<ExecutionPolicy policy> {
+        BlockRegistry     registry;
+        SchedulerRegistry schedulerRegistry;
+        gr::registerBlock<SlowSource, float>(registry);
+        gr::registerBlock<CountingSink, float>(registry);
+        const std::string subGraphType = registeredSimpleSchedulerType(schedulerRegistry);
+        PluginLoader      loader(registry, schedulerRegistry, {});
+
+        Graph flow(loader);
+        auto& source = flow.emplaceBlock<SlowSource<float>>();
+        auto& sink   = flow.emplaceBlock<CountingSink<float>>();
+        expect(flow.connect<"out", "in">(source, sink).has_value()) << fatal;
+
+        TestScheduler<policy> scheduler(std::move(flow), /*addTestSourceAndSink=*/false);
+
+        // create an empty scheduler
+        auto reply = testing::sendAndWaitForReply<Set>(scheduler.toScheduler, scheduler.fromScheduler, scheduler.unique_name(), //
+            scheduler::property::kEmplaceBlock, property_map{{"type", subGraphType}},                                           //
+            [](const Message& msg) { return msg.endpoint == scheduler::property::kEmplaceBlock || msg.endpoint == scheduler::property::kBlockEmplaced; });
+        expect(reply.has_value()) << fatal;
+        expect(reply->data.has_value()) << fatal;
+
+        // group blocks because it requests work quiesence, which would block the current thread if there was an empty subgraph
+        Tensor<Value> uniqueNames;
+        uniqueNames.emplace_back(std::string(source.unique_name.value()));
+        uniqueNames.emplace_back(std::string(sink.unique_name.value()));
+        sendMessage<Set>(scheduler.toScheduler, scheduler.unique_name(), scheduler::property::kGroupBlocks, //
+            {{"type", "gr::Graph"}, {"uniqueNames", uniqueNames}});
+
+        const std::optional<Message> groupReply = testing::waitForReply(scheduler.fromScheduler, ReplyChecker{.expectedEndpoint = scheduler::property::kBlocksGrouped}, 5s);
+        expect(groupReply.has_value()) << fatal << "requesting work quiescence on an empty managed subgraph does not block";
+    };
+
+    "regression test for requesting work quiesence on an empty subgraph blocking, singlethreaded"_test = [] { requestWorkQuiesenceOnEmptySubgraphRegression.operator()<ExecutionPolicy::singleThreaded>(); };
+    "regression test for requesting work quiesence on an empty subgraph blocking, multithreaded"_test  = [] { requestWorkQuiesenceOnEmptySubgraphRegression.operator()<ExecutionPolicy::multiThreaded>(); };
+
     // this also tests doubly nesting the unmanaged subgraph, to make sure nested graphs all get adopted by the root scheduler
     constexpr static auto groupBlocksIntoUnmanagedSubgraph = []<ExecutionPolicy policy> {
         Graph flow(context->loader);


### PR DESCRIPTION
Using `_nRunningJobs` to check if the scheduler had begun starting workers doesn't make sense if there is any scheduler which has no blocks and therefore no workers.

I wanted to avoid this because it creates a kind of extra possible state that the scheduler can be in, but I think something like it is unavoidable as we need to have guarantees whether a given scheduler is currently having its graph accessed by another thread.

Partially fixes an issue found in review of https://github.com/fair-acc/opendigitizer/pull/477