### PR TITLE
ci: save ccache after Build, not only on full job success

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,8 +102,8 @@ jobs:
           fetch-depth: 0
           lfs: true
 
-      - name: Cache ccache
-        uses: actions/cache@v5
+      - name: Restore ccache
+        uses: actions/cache/restore@v5
         with:
           path: ${{ github.workspace }}/.ccache
           key: ccache-${{ runner.os }}-${{ matrix.compiler.label || matrix.compiler.cc }}-${{ matrix.cmake-build-type }}-${{ github.sha }}
@@ -178,6 +178,13 @@ jobs:
           echo "$(nproc) cores, $(awk '/MemTotal/{printf "%d", $2/1024}' /proc/meminfo) MB RAM"
           cmake --build ../build
 
+      - name: Save ccache
+        if: ${{ !cancelled() }}
+        uses: actions/cache/save@v5
+        with:
+          path: ${{ github.workspace }}/.ccache
+          key: ccache-${{ runner.os }}-${{ matrix.compiler.label || matrix.compiler.cc }}-${{ matrix.cmake-build-type }}-${{ github.sha }}
+
       - name: execute tests
         if: matrix.compiler.cc != 'gcc-14' || matrix.cmake-build-type != 'Debug'
         env:
@@ -228,8 +235,8 @@ jobs:
           fetch-depth: 0
           lfs: true
 
-      - name: Cache ccache
-        uses: actions/cache@v5
+      - name: Restore ccache
+        uses: actions/cache/restore@v5
         with:
           path: ${{ github.workspace }}/.ccache
           key: ccache-coverage-gcc14-debug-${{ github.sha }}
@@ -268,6 +275,13 @@ jobs:
         run: |
           echo "$(nproc) cores, $(awk '/MemTotal/{printf "%d", $2/1024}' /proc/meminfo) MB RAM"
           cmake --build ../build
+
+      - name: Save ccache
+        if: ${{ !cancelled() }}
+        uses: actions/cache/save@v5
+        with:
+          path: ${{ github.workspace }}/.ccache
+          key: ccache-coverage-gcc14-debug-${{ github.sha }}
 
       - name: Execute tests
         env:


### PR DESCRIPTION
actions/cache@v5's bundled save has `post-if: success()` baked into the action, so ccache is only persisted when the whole job — ctest included — passes. Verified against #826: several full CI cycles produced zero saved ccache entries for that branch.

Splits `Cache ccache` into `actions/cache/restore@v5` (unchanged, top of job) and `actions/cache/save@v5` placed right after `Build`, gated on `!cancelled()` instead of `success()`. Applies to the compiler-matrix `build` job and the `coverage` job.

- A ctest (or later-step) failure no longer discards a successful compile's ccache.
- ccache records each translation unit as it compiles, not only at the end of `cmake --build`, so a build that fails partway through still keeps what did compile.

Does not help a run killed by this repo's `cancel-in-progress: true` — a cancelled runner executes no further steps at all.