### PR TITLE
fix(PythonBlock): correctness, tag handling and script loading

### DIFF
--- a/blocks/basic/include/gnuradio-4.0/basic/PythonBlock.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/PythonBlock.hpp
@@ -80,15 +80,15 @@ myBlock.processBulk(ins, outs);
 )"">;
     // optional shortening
     template<typename U, gr::meta::fixed_string description = "", typename... Arguments>
-    using A                = Annotated<U, description, Arguments...>;
-    using poc_property_map = std::map<std::string, std::string, std::less<>>; // TODO: needs to be replaced with 'property_map` aka. 'ValueMap'
-    using tag_type         = std::string;
+    using A                 = Annotated<U, description, Arguments...>;
+    using StringPropertyMap = std::map<std::string, std::string, std::less<>>; // TODO: replace with gr::property_map once pmt::Value is Python-wrapped
+    using tag_type          = std::string;
 
-    std::vector<PortIn<T>>                                                        inputs{};
-    std::vector<PortOut<T>>                                                       outputs{};
-    A<gr::Size_t, "n_inputs", Visible, Doc<"number of inputs">, Limits<1U, 32U>>  n_inputs     = 0U;
-    A<gr::Size_t, "n_outputs", Visible, Doc<"number of inputs">, Limits<1U, 32U>> n_outputs    = 0U;
-    std::string                                                                   pythonScript = "";
+    std::vector<PortIn<T>>                                                         inputs{};
+    std::vector<PortOut<T>>                                                        outputs{};
+    A<gr::Size_t, "n_inputs", Visible, Doc<"number of inputs">, Limits<1U, 32U>>   n_inputs     = 1U;
+    A<gr::Size_t, "n_outputs", Visible, Doc<"number of outputs">, Limits<1U, 32U>> n_outputs    = 1U;
+    std::string                                                                    pythonScript = "";
 
     GR_MAKE_REFLECTABLE(PythonBlock, inputs, outputs, n_inputs, n_outputs, pythonScript);
 
@@ -124,14 +124,14 @@ class PythonBlockWrapper: ## helper class to make the C++ class appear as a Pyth
 
 this_block = PythonBlockWrapper(capsule))p",
                 _moduleDefinitions->m_name);
-    poc_property_map    _settingsMap{{"key1", "value1"}, {"key2", "value2"}};
+    StringPropertyMap   _settingsMap{{"key1", "value1"}, {"key2", "value2"}};
     bool                _tagAvailable = false;
     tag_type            _tag          = "Simulated Tag";
 
-    void settingsChanged(const gr::property_map& old_settings, const gr::property_map& new_settings) {
-        if (new_settings.contains("n_inputs") || new_settings.contains("n_outputs")) {
+    void settingsChanged(const gr::property_map& /*old_settings*/, const gr::property_map& new_settings) {
+        if (inputs.size() != n_inputs || outputs.size() != n_outputs) { // drive off the actual port count, so the defaults are applied too
 
-            std::print("{}: configuration changed: n_inputs {} -> {}, n_outputs {} -> {}\n", this->name, old_settings.value_or<gr::Size_t>("n_inputs", gr::Size_t{0}), new_settings.contains("n_inputs") ? *new_settings.find_value("n_inputs") : Value("same"), old_settings.value_or<gr::Size_t>("n_outputs", gr::Size_t{0}), new_settings.contains("n_outputs") ? new_settings.value_or<std::string>("n_outputs", "same"s) : "same"s);
+            gr::log::debug("{}: port configuration changed: n_inputs {} -> {}, n_outputs {} -> {}", this->name, inputs.size(), n_inputs, outputs.size(), n_outputs);
             if (std::any_of(inputs.begin(), inputs.end(), [](const auto& port) { return port.isConnected(); })) {
                 throw gr::exception("Number of input ports cannot be changed after Graph initialization.");
             }
@@ -179,12 +179,12 @@ this_block = PythonBlockWrapper(capsule))p",
         }
     }
 
-    const poc_property_map& getSettings() const {
+    const StringPropertyMap& getSettings() const {
         // TODO: replace with this->settings().get() once the property_map is Python wrapped
         return _settingsMap;
     }
 
-    bool setSettings(const poc_property_map& newSettings) {
+    bool setSettings(const StringPropertyMap& newSettings) {
         // TODO: replace with this->settings().set(newSettings) once the property_map is Python wrapped
         if (newSettings.empty()) {
             return false;
@@ -210,29 +210,42 @@ this_block = PythonBlockWrapper(capsule))p",
 
     // block life-cycle methods
     // clang-format off
-    void start()  { _interpreter.invokeFunction<python::EnforceFunction::OPTIONAL>("start"); }
-    void stop()   { _interpreter.invokeFunction<python::EnforceFunction::OPTIONAL>("stop"); }
-    void pause()  { _interpreter.invokeFunction<python::EnforceFunction::OPTIONAL>("pause"); }
-    void resume() { _interpreter.invokeFunction<python::EnforceFunction::OPTIONAL>("resume"); }
-    void reset()  { _interpreter.invokeFunction<python::EnforceFunction::OPTIONAL>("reset"); }
+    void start()  { invokeLifecycle("start"); }
+    void stop()   { invokeLifecycle("stop"); }
+    void pause()  { invokeLifecycle("pause"); }
+    void resume() { invokeLifecycle("resume"); }
+    void reset()  { invokeLifecycle("reset"); }
     // clang-format on
 
 private:
+    void invokeLifecycle(std::string_view hook) {
+        python::PyGILGuard gil; // PyErr_Occurred() below reads interpreter state
+        if (python::PyObjectGuard result = _interpreter.invokeFunction<python::EnforceFunction::OPTIONAL>(hook); !result && PyErr_Occurred()) {
+            python::throwCurrentPythonError(std::format("{}(aka. {})::{}() raised", this->unique_name, this->name, hook), std::source_location::current(), pythonScript);
+        } // a hook the script does not define yields a null guard with no error set
+    }
+
     template<typename TInputSpan, typename TOutputSpan>
     void callPythonFunction(std::span<TInputSpan> ins, std::span<TOutputSpan> outs) {
-        PyObject* pIns = PyList_New(static_cast<Py_ssize_t>(ins.size()));
-        for (size_t i = 0; i < ins.size(); ++i) {
-            PyList_SetItem(pIns, Py_ssize_t(i), python::toPyArray(ins[i].data(), {ins[i].size()}));
-        }
-
-        PyObject* pOuts = PyList_New(static_cast<Py_ssize_t>(outs.size()));
-        for (size_t i = 0; i < outs.size(); ++i) {
-            PyList_SetItem(pOuts, Py_ssize_t(i), python::toPyArray(outs[i].data(), {outs[i].size()}));
-        }
-
+        // guarded throughout: toPyArray throws on failure, and the lists must not leak on the way out
+        python::PyObjectGuard pyIns(PyList_New(static_cast<Py_ssize_t>(ins.size())));
+        python::PyObjectGuard pyOuts(PyList_New(static_cast<Py_ssize_t>(outs.size())));
         python::PyObjectGuard pyArgs(PyTuple_New(2));
-        PyTuple_SetItem(pyArgs, 0, pIns);
-        PyTuple_SetItem(pyArgs, 1, pOuts);
+        if (!pyIns || !pyOuts || !pyArgs) {
+            python::throwCurrentPythonError(std::format("{}(aka. {})::callPythonFunction(..) failed to allocate the Python arguments", this->unique_name, this->name), std::source_location::current(), pythonScript);
+        }
+
+        for (std::size_t i = 0; i < ins.size(); ++i) {
+            PyList_SetItem(pyIns, static_cast<Py_ssize_t>(i), python::toPyArray(ins[i].data(), {ins[i].size()})); // steals the array reference
+        }
+        for (std::size_t i = 0; i < outs.size(); ++i) {
+            PyList_SetItem(pyOuts, static_cast<Py_ssize_t>(i), python::toPyArray(outs[i].data(), {outs[i].size()}));
+        }
+
+        python::PyIncRef(pyIns); // PyTuple_SetItem steals a reference that the guard still holds
+        PyTuple_SetItem(pyArgs, 0, pyIns);
+        python::PyIncRef(pyOuts);
+        PyTuple_SetItem(pyArgs, 1, pyOuts);
 
         if (python::PyObjectGuard pyValue = _interpreter.invokeFunction("process_bulk", pyArgs); !pyValue) {
             python::throwCurrentPythonError(std::format("{}(aka. {})::callPythonFunction(..) Python function call failed", this->unique_name, this->name), std::source_location::current(), pythonScript);
@@ -242,98 +255,110 @@ private:
 
 } // namespace gr::basic
 
+// returns nullptr and leaves the Python error set by PyCapsule_GetPointer; callers are CPython callbacks and must not throw
 template<typename T>
 gr::basic::PythonBlock<T>* getPythonBlockFromCapsule(PyObject* capsule) {
     static std::string pyBlockName = gr::python::sanitizedPythonBlockName<gr::basic::PythonBlock<T>>();
-    if (void* objPointer = PyCapsule_GetPointer(capsule, pyBlockName.c_str()); objPointer != nullptr) {
-        return static_cast<gr::basic::PythonBlock<T>*>(objPointer);
-    }
-    gr::python::throwCurrentPythonError("could not retrieve obj pointer from capsule");
-    return nullptr;
+    return static_cast<gr::basic::PythonBlock<T>*>(PyCapsule_GetPointer(capsule, pyBlockName.c_str()));
 }
 
 template<typename T>
 PyObject* PythonBlock_TagAvailable_Template(PyObject* /*self*/, PyObject* args) {
-    PyObject* capsule;
-    if (!PyArg_ParseTuple(args, "O", &capsule)) {
-        return nullptr;
-    }
-    gr::basic::PythonBlock<T>* myBlock = getPythonBlockFromCapsule<T>(capsule);
-    return myBlock->tagAvailable() ? gr::python::TrueObj : gr::python::FalseObj;
+    return gr::python::invokeCallback([args]() -> PyObject* {
+        PyObject* capsule = nullptr;
+        if (!PyArg_ParseTuple(args, "O", &capsule)) {
+            return nullptr;
+        }
+        gr::basic::PythonBlock<T>* myBlock = getPythonBlockFromCapsule<T>(capsule);
+        if (myBlock == nullptr) {
+            return nullptr;
+        }
+        PyObject* available = myBlock->tagAvailable() ? gr::python::TrueObj : gr::python::FalseObj;
+        gr::python::PyIncRef(available); // a callback must return a new reference, not a borrowed one
+        return available;
+    });
 }
 
 template<typename T>
 PyObject* PythonBlock_GetTag_Template(PyObject* /*self*/, PyObject* args) {
-    PyObject* capsule;
-    if (!PyArg_ParseTuple(args, "O", &capsule)) {
-        return nullptr;
-    }
-    gr::basic::PythonBlock<T>* myBlock = getPythonBlockFromCapsule<T>(capsule);
-    return PyUnicode_FromString(myBlock->getTag().c_str());
+    return gr::python::invokeCallback([args]() -> PyObject* {
+        PyObject* capsule = nullptr;
+        if (!PyArg_ParseTuple(args, "O", &capsule)) {
+            return nullptr;
+        }
+        gr::basic::PythonBlock<T>* myBlock = getPythonBlockFromCapsule<T>(capsule);
+        if (myBlock == nullptr) {
+            return nullptr;
+        }
+        return PyUnicode_FromString(myBlock->getTag().c_str());
+    });
 }
 
 template<typename T>
 PyObject* PythonBlock_GetSettings_Template(PyObject* /*self*/, PyObject* args) {
-    PyObject* capsule;
-    if (!PyArg_ParseTuple(args, "O", &capsule)) {
-        return nullptr;
-    }
-    const gr::basic::PythonBlock<T>* myBlock = getPythonBlockFromCapsule<T>(capsule);
-    if (myBlock == nullptr) {
-        gr::python::throwCurrentPythonError(std::format("could not retrieve myBLock<{}> {}", gr::meta::type_name<T>(), gr::python::toString(capsule)));
-        return nullptr;
-    }
-    const auto& settings = myBlock->getSettings();
+    return gr::python::invokeCallback([args]() -> PyObject* {
+        PyObject* capsule = nullptr;
+        if (!PyArg_ParseTuple(args, "O", &capsule)) {
+            return nullptr;
+        }
+        const gr::basic::PythonBlock<T>* myBlock = getPythonBlockFromCapsule<T>(capsule);
+        if (myBlock == nullptr) {
+            return nullptr;
+        }
 
-    PyObject* dict = PyDict_New(); // returns owning reference
-    if (!dict) {
-        return PyErr_NoMemory();
-    }
-    try {
-        for (const auto& [key, value] : settings) {
-            gr::python::PyObjectGuard py_value(PyUnicode_FromString(value.c_str()));
-            if (!py_value) { // Failed to convert string to Python Unicode
-                gr::python::PyDecRef(dict);
+        gr::python::PyObjectGuard dict(PyDict_New());
+        if (!dict) {
+            return PyErr_NoMemory();
+        }
+        for (const auto& [key, value] : myBlock->getSettings()) {
+            gr::python::PyObjectGuard pyValue(PyUnicode_FromString(value.c_str()));
+            if (!pyValue) {
                 return PyErr_NoMemory();
             }
-            // PyDict_SetItemString does not steal reference, so no need to decref py_value
-            if (PyDict_SetItemString(dict, key.c_str(), py_value) != 0) {
-                gr::python::PyDecRef(dict);
+            if (PyDict_SetItemString(dict, key.c_str(), pyValue) != 0) { // does not steal the reference
                 return nullptr;
             }
         }
-    } catch (const std::exception& e) {
-        PyErr_SetString(PyExc_RuntimeError, e.what());
-        gr::python::PyDecRef(dict);
-        return nullptr;
-    }
-    return dict;
+        gr::python::PyIncRef(dict); // hand the caller its own reference, the guard releases ours
+        return dict.get();
+    });
 }
 
 template<typename T>
 PyObject* PythonBlock_SetSettings_Template(PyObject* /*self*/, PyObject* args) {
-    PyObject* capsule;
-    PyObject* settingsDict;
-    if (!PyArg_ParseTuple(args, "OO", &capsule, &settingsDict)) {
-        return nullptr;
-    }
-    gr::basic::PythonBlock<T>* myBlock = getPythonBlockFromCapsule<T>(capsule);
-    if (!gr::python::isPyDict(settingsDict)) {
-        PyErr_SetString(PyExc_TypeError, "Settings must be a dictionary");
-        return nullptr;
-    }
+    return gr::python::invokeCallback([args]() -> PyObject* {
+        PyObject* capsule      = nullptr;
+        PyObject* settingsDict = nullptr;
+        if (!PyArg_ParseTuple(args, "OO", &capsule, &settingsDict)) {
+            return nullptr;
+        }
+        gr::basic::PythonBlock<T>* myBlock = getPythonBlockFromCapsule<T>(capsule);
+        if (myBlock == nullptr) {
+            return nullptr;
+        }
+        if (!gr::python::isPyDict(settingsDict)) {
+            PyErr_SetString(PyExc_TypeError, "settings must be a dictionary");
+            return nullptr;
+        }
 
-    typename gr::basic::PythonBlock<T>::poc_property_map newSettings;
-    PyObject *                                           key, *value;
-    Py_ssize_t                                           pos = 0;
-    while (PyDict_Next(settingsDict, &pos, &key, &value)) {
-        const char* keyStr   = PyUnicode_AsUTF8(key);
-        const char* valueStr = PyUnicode_AsUTF8(value);
-        newSettings[keyStr]  = valueStr;
-    }
+        typename gr::basic::PythonBlock<T>::StringPropertyMap newSettings;
+        PyObject*                                             key   = nullptr;
+        PyObject*                                             value = nullptr;
+        Py_ssize_t                                            pos   = 0;
+        while (PyDict_Next(settingsDict, &pos, &key, &value)) {
+            const char* keyStr   = PyUnicode_AsUTF8(key);
+            const char* valueStr = PyUnicode_AsUTF8(value);
+            if (keyStr == nullptr || valueStr == nullptr) { // non-str key or value -- PyUnicode_AsUTF8 returned nullptr
+                PyErr_SetString(PyExc_TypeError, "settings keys and values must be strings");
+                return nullptr;
+            }
+            newSettings[keyStr] = valueStr;
+        }
 
-    myBlock->setSettings(newSettings);
-    return gr::python::NoneObj;
+        myBlock->setSettings(newSettings);
+        gr::python::PyIncRef(gr::python::NoneObj); // a callback must return a new reference, not a borrowed one
+        return gr::python::NoneObj;
+    });
 }
 
 template<typename T>

--- a/blocks/basic/include/gnuradio-4.0/basic/PythonBlock.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/PythonBlock.hpp
@@ -5,6 +5,10 @@
 
 #include <gnuradio-4.0/Block.hpp>
 #include <gnuradio-4.0/BlockRegistry.hpp>
+#include <gnuradio-4.0/algorithm/fileio/FileIo.hpp>
+
+#include <array>
+#include <cctype>
 #include <gnuradio-4.0/annotated.hpp>
 
 // Forward declaration of PythonBlock method definition, needed for CPython's C-API wrapping
@@ -15,7 +19,7 @@ namespace gr::basic {
 
 using namespace gr;
 
-GR_REGISTER_BLOCK(gr::basic::PythonBlock, [T], [ int32_t, float ])
+GR_REGISTER_BLOCK(gr::basic::PythonBlock, [T], [ int32_t, float, double ])
 
 template<typename T>
 requires std::is_arithmetic_v<T> /* || std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>> */
@@ -44,9 +48,10 @@ def process_bulk(ins, outs):
     settings = this_block.getSettings()
     print("Current settings:", settings)
 
-    if this_block.tagAvailable(): # tag handling
-        tag = this_block.getTag()
-        print('Tag:', tag)
+    while this_block.tagAvailable():        # drain the tags on this input span
+        tag = this_block.getTag()           # {'index': <sample offset>, 'map': {<key>: <value as str>}}
+        print('Tag:', tag['index'], tag['map'])
+    this_block.publishTag(0, {'origin': 'python'}) # emit a tag on the outputs
 
     counter += 1
     # process the input->output samples, here: double each input element
@@ -82,15 +87,22 @@ myBlock.processBulk(ins, outs);
     template<typename U, gr::meta::fixed_string description = "", typename... Arguments>
     using A                 = Annotated<U, description, Arguments...>;
     using StringPropertyMap = std::map<std::string, std::string, std::less<>>; // TODO: replace with gr::property_map once pmt::Value is Python-wrapped
-    using tag_type          = std::string;
 
-    std::vector<PortIn<T>>                                                         inputs{};
-    std::vector<PortOut<T>>                                                        outputs{};
-    A<gr::Size_t, "n_inputs", Visible, Doc<"number of inputs">, Limits<1U, 32U>>   n_inputs      = 1U;
-    A<gr::Size_t, "n_outputs", Visible, Doc<"number of outputs">, Limits<1U, 32U>> n_outputs     = 1U;
-    std::string                                                                    python_script = "";
+    // PoC projection of gr::Tag for the script side: pmt values are rendered as strings until property_map is Python-wrapped
+    struct TagView {
+        std::size_t       index{0UZ};
+        StringPropertyMap map{};
+    };
 
-    GR_MAKE_REFLECTABLE(PythonBlock, inputs, outputs, n_inputs, n_outputs, python_script);
+    std::vector<PortIn<T>>                                                                                                                                                                                                                inputs{};
+    std::vector<PortOut<T>>                                                                                                                                                                                                               outputs{};
+    A<gr::Size_t, "n_inputs", Visible, Doc<"number of inputs">, Limits<1U, 32U>>                                                                                                                                                          n_inputs      = 1U;
+    A<gr::Size_t, "n_outputs", Visible, Doc<"number of outputs">, Limits<1U, 32U>>                                                                                                                                                        n_outputs     = 1U;
+    A<bool, "forward_tags", Visible, Doc<"copy non-'gr:' input tags to the outputs; the framework forwards the 'gr:' keys regardless">>                                                                                                   forward_tags  = true;
+    A<std::string, "python_script", Visible, Doc<"the script itself, or where to fetch it from: a value starting with 'http(s)://', 'file:/', '/', './' or '../' is loaded ('.gz' decoded on the fly), anything else is taken verbatim">> python_script = "";
+    A<std::vector<std::string>, "python_path", Doc<"directories prepended to sys.path, so a script can import its own modules">>                                                                                                          python_path   = {};
+
+    GR_MAKE_REFLECTABLE(PythonBlock, inputs, outputs, n_inputs, n_outputs, forward_tags, python_script, python_path);
 
     PyModuleDef*        _moduleDefinitions = myBlockPythonDefinitions<T>();
     python::Interpreter _interpreter{this, _moduleDefinitions};
@@ -121,12 +133,24 @@ class PythonBlockWrapper: ## helper class to make the C++ class appear as a Pyth
         return {0}.getSettings(self.capsule)
     def setSettings(self, settings):
         {0}.setSettings(self.capsule, settings)
+    def publishTag(self, offset, tagData):
+        {0}.publishTag(self.capsule, offset, tagData)
+    def log(self, message):
+        {0}.log(self.capsule, message)
 
-this_block = PythonBlockWrapper(capsule))p",
+this_block = PythonBlockWrapper(capsule)
+
+def print(*args, sep=' ', end='\n', file=None, flush=False): ## shadows the builtin for THIS block's module only, so script output joins the GR4 log
+    this_block.log(sep.join(str(arg) for arg in args)))p",
                 _moduleDefinitions->m_name);
+    std::string         _activeScript{};    // python_script verbatim, or the contents it points at
+    std::string         _scriptLoadError{}; // init() records a settingsChanged throw as an error state, so processBulk reports the reason
     StringPropertyMap   _settingsMap{{"key1", "value1"}, {"key2", "value2"}};
-    bool                _tagAvailable = false;
-    tag_type            _tag          = "Simulated Tag";
+
+    std::vector<TagView>                                  _inputTags{};         // string projection handed to the script
+    std::size_t                                           _nextInputTag = 0UZ;  // read cursor consumed by getTag()
+    std::vector<std::pair<std::size_t, gr::property_map>> _forwardTags{};       // untouched originals, so forwarding keeps the pmt types
+    std::vector<std::pair<std::size_t, gr::property_map>> _pendingOutputTags{}; // queued by the script, published once it returns
 
     // block life-cycle methods
     // clang-format off
@@ -139,7 +163,12 @@ this_block = PythonBlockWrapper(capsule))p",
 
     template<typename TInputSpan, typename TOutputSpan>
     work::Status processBulk(std::span<TInputSpan> ins, std::span<TOutputSpan> outs) {
-        _interpreter.invoke([this, ins, outs] { callPythonFunction(ins, outs); }, python_script);
+        if (!_scriptLoadError.empty()) { // no script is loaded, so report why rather than let process_bulk turn up missing
+            throw gr::exception(_scriptLoadError);
+        }
+        collectInputTags(ins);
+        _interpreter.invoke([this, ins, outs] { callPythonFunction(ins, outs); }, _activeScript);
+        publishPendingTags(outs);
         return work::Status::OK;
     }
 
@@ -156,40 +185,49 @@ this_block = PythonBlockWrapper(capsule))p",
             outputs.resize(n_outputs);
         }
 
-        if (new_settings.contains("python_script")) {
-            _interpreter.invoke(
-                [this] {
-                    if (python::PyObjectGuard testImport(PyRun_StringFlags(_prePythonDefinition.data(), Py_file_input, _interpreter.getDictionary(), _interpreter.getDictionary(), nullptr)); !testImport) {
-                        python::throwCurrentPythonError(std::format("{}(aka. {})::settingsChanged(...) - testImport", this->unique_name, this->name), std::source_location::current(), _prePythonDefinition);
-                    }
+        if (new_settings.contains("python_script") || new_settings.contains("python_path")) {
+            _scriptLoadError = std::format("{}: script configuration did not complete", this->name); // replaced by the actual reason, cleared once valid
+            _activeScript    = loadScript();
+            try {
+                _interpreter.invoke(
+                    [this] {
+                        if (python::PyObjectGuard testImport(PyRun_StringFlags(_prePythonDefinition.data(), Py_file_input, _interpreter.getDictionary(), _interpreter.getDictionary(), nullptr)); !testImport) {
+                            python::throwCurrentPythonError(std::format("{}(aka. {})::settingsChanged(...) - testImport", this->unique_name, this->name), std::source_location::current(), _prePythonDefinition);
+                        }
 
-                    // Retrieve the PythonBlockWrapper class object
-                    PyObject* pPythonBlockWrapperClass = PyDict_GetItemString(_interpreter.getDictionary(), "PythonBlockWrapper"); // borrowed reference
-                    if (!pPythonBlockWrapperClass) {
-                        python::throwCurrentPythonError(std::format("{}(aka. {})::settingsChanged(...) - failed to retrieve PythonBlockWrapper class", this->unique_name, this->name), std::source_location::current(), _prePythonDefinition);
-                    }
+                        // Retrieve the PythonBlockWrapper class object
+                        PyObject* pPythonBlockWrapperClass = PyDict_GetItemString(_interpreter.getDictionary(), "PythonBlockWrapper"); // borrowed reference
+                        if (!pPythonBlockWrapperClass) {
+                            python::throwCurrentPythonError(std::format("{}(aka. {})::settingsChanged(...) - failed to retrieve PythonBlockWrapper class", this->unique_name, this->name), std::source_location::current(), _prePythonDefinition);
+                        }
 
-                    // Retrieve the this_block
-                    PyObject* pInstance = PyDict_GetItemString(_interpreter.getDictionary(), "this_block"); // borrowed reference
-                    if (!pInstance) {
-                        python::throwCurrentPythonError(std::format("{}(aka. {})::settingsChanged(...) - failed to retrieve 'this_block'", this->unique_name, this->name), std::source_location::current(), _prePythonDefinition);
-                    }
+                        // Retrieve the this_block
+                        PyObject* pInstance = PyDict_GetItemString(_interpreter.getDictionary(), "this_block"); // borrowed reference
+                        if (!pInstance) {
+                            python::throwCurrentPythonError(std::format("{}(aka. {})::settingsChanged(...) - failed to retrieve 'this_block'", this->unique_name, this->name), std::source_location::current(), _prePythonDefinition);
+                        }
 
-                    // Check if pInstance is an instance of PythonBlockWrapper
-                    if (PyObject_IsInstance(pInstance, pPythonBlockWrapperClass) != 1) {
-                        python::throwCurrentPythonError(std::format("{}(aka. {})::settingsChanged(...) - 'this_block' is not an instance of PythonBlockWrapper", this->unique_name, this->name), std::source_location::current(), _prePythonDefinition);
-                    }
+                        // Check if pInstance is an instance of PythonBlockWrapper
+                        if (PyObject_IsInstance(pInstance, pPythonBlockWrapperClass) != 1) {
+                            python::throwCurrentPythonError(std::format("{}(aka. {})::settingsChanged(...) - 'this_block' is not an instance of PythonBlockWrapper", this->unique_name, this->name), std::source_location::current(), _prePythonDefinition);
+                        }
 
-                    if (const python::PyObjectGuard result(PyRun_StringFlags(python_script.data(), Py_file_input, _interpreter.getDictionary(), _interpreter.getDictionary(), nullptr)); !result) {
-                        python::throwCurrentPythonError(std::format("{}(aka. '{}')::settingsChanged(...) - script parsing error", this->unique_name, this->name), std::source_location::current(), python_script);
-                    }
+                        prependPythonPath();
+                        if (const python::PyObjectGuard result(PyRun_StringFlags(_activeScript.c_str(), Py_file_input, _interpreter.getDictionary(), _interpreter.getDictionary(), nullptr)); !result) {
+                            python::throwCurrentPythonError(std::format("{}(aka. '{}')::settingsChanged(...) - script parsing error", this->unique_name, this->name), std::source_location::current(), _activeScript);
+                        }
 
-                    python::PyObjectGuard pyFunc(PyObject_GetAttrString(_interpreter.getModule(), "process_bulk"));
-                    if (!pyFunc.get() || !PyCallable_Check(pyFunc.get())) {
-                        python::throwCurrentPythonError(std::format("{}(aka. {})::settingsChanged(...) Python function process_bulk not found or is not callable", this->unique_name, this->name), std::source_location::current(), python_script);
-                    }
-                },
-                python_script);
+                        python::PyObjectGuard pyFunc(PyObject_GetAttrString(_interpreter.getModule(), "process_bulk"));
+                        if (!pyFunc.get() || !PyCallable_Check(pyFunc.get())) {
+                            python::throwCurrentPythonError(std::format("{}(aka. {})::settingsChanged(...) Python function process_bulk not found or is not callable", this->unique_name, this->name), std::source_location::current(), _activeScript);
+                        }
+                        _scriptLoadError.clear(); // the script parsed and exposes process_bulk
+                    },
+                    _activeScript);
+            } catch (const std::exception& configurationError) {
+                _scriptLoadError = configurationError.what(); // init() only records the throw, so keep the reason for processBulk
+                throw;
+            }
         }
     }
 
@@ -209,19 +247,155 @@ this_block = PythonBlockWrapper(capsule))p",
         return true;
     }
 
-    bool tagAvailable() {
-        _tagAvailable = !_tagAvailable;
-        return _tagAvailable;
+    [[nodiscard]] bool tagAvailable() const { return _nextInputTag < _inputTags.size(); }
+
+    TagView getTag() { // consumes one tag, so a script can drain them with `while this_block.tagAvailable():`
+        if (_nextInputTag >= _inputTags.size()) {
+            return {};
+        }
+        return _inputTags[_nextInputTag++];
     }
 
-    tag_type getTag() { return _tag; }
+    // The complete set of prefixes that mark a location; anything else is the script itself. Every entry ends in '/'
+    // and matching is anchored, so an annotated global ("rate: float = 1e6") and a script mentioning a URL stay verbatim.
+    // N.B. limited to what readAsync() serves on every platform: 'download:/' is write-only, 'dialog:/' Emscripten-only.
+    static constexpr std::array<std::string_view, 3> kLocationSchemes{"http://", "https://", "file:/"};
+    static constexpr std::array<std::string_view, 3> kLocationPaths{"/", "./", "../"}; // no Python file may begin with these
+
+    [[nodiscard]] static std::string_view trimmed(std::string_view value) noexcept {
+        constexpr std::string_view kSpace = " \t\r\n";
+        const auto                 first  = value.find_first_not_of(kSpace);
+        if (first == std::string_view::npos) {
+            return {};
+        }
+        return value.substr(first, value.find_last_not_of(kSpace) - first + 1UZ);
+    }
+
+    [[nodiscard]] static bool isScriptLocation(std::string_view value) noexcept {
+        value                    = trimmed(value);
+        const auto matchesScheme = [value](std::string_view scheme) noexcept { // URI schemes are case-insensitive
+            return value.size() >= scheme.size() && std::ranges::equal(value.substr(0UZ, scheme.size()), scheme, [](char lhs, char rhs) noexcept { return std::tolower(static_cast<unsigned char>(lhs)) == static_cast<unsigned char>(rhs); });
+        };
+        return std::ranges::any_of(kLocationSchemes, matchesScheme) || std::ranges::any_of(kLocationPaths, [value](std::string_view prefix) noexcept { return value.starts_with(prefix); });
+    }
+
+    void log(std::string_view message) const { gr::log::info("{}: {}", this->name, message); }
+
+    void publishTag(std::size_t offset, const StringPropertyMap& tagData) {
+        gr::property_map map;
+        for (const auto& [key, value] : tagData) {
+            map[key] = value; // PoC: every value travels as a string
+        }
+        _pendingOutputTags.emplace_back(offset, std::move(map));
+    }
 
 private:
     void invokeLifecycle(std::string_view hook) {
         python::PyGILGuard gil; // PyErr_Occurred() below reads interpreter state
         if (python::PyObjectGuard result = _interpreter.invokeFunction<python::EnforceFunction::OPTIONAL>(hook); !result && PyErr_Occurred()) {
-            python::throwCurrentPythonError(std::format("{}(aka. {})::{}() raised", this->unique_name, this->name, hook), std::source_location::current(), python_script);
+            python::throwCurrentPythonError(std::format("{}(aka. {})::{}() raised", this->unique_name, this->name, hook), std::source_location::current(), _activeScript);
         } // a hook the script does not define yields a null guard with no error set
+    }
+
+    // std::format renders a pmt string with surrounding quotes; the script must see the text itself
+    [[nodiscard]] static std::string toScriptText(const auto& value) {
+        if (value.value_type() == gr::pmt::Value::ValueType::String) {
+            return value.value_or(std::string{});
+        }
+        return std::format("{}", value);
+    }
+
+    [[nodiscard]] std::string loadScript() {
+        if (!isScriptLocation(python_script)) {
+            return python_script;
+        }
+        const std::string location(trimmed(python_script));
+        auto              reader = gr::algorithm::fileio::readAsync(location);
+        if (!reader) {
+            _scriptLoadError = std::format("{}: cannot open python_script location '{}': {}", this->name, location, reader.error().message);
+            throw gr::exception(_scriptLoadError);
+        }
+        auto data = reader->get();
+        if (!data) {
+            _scriptLoadError = std::format("{}: cannot read python_script location '{}': {}", this->name, location, data.error().message);
+            throw gr::exception(_scriptLoadError);
+        }
+        return std::string(reinterpret_cast<const char*>(data->data()), data->size());
+    }
+
+    void prependPythonPath() const { // N.B. sys.path is process-global, so entries are shared with every other block
+        if (python_path.value.empty()) {
+            return;
+        }
+        PyObject* sysPath = PySys_GetObject("path"); // borrowed reference
+        if (sysPath == nullptr) {
+            python::throwCurrentPythonError(std::format("{}: sys.path is unavailable", this->name));
+        }
+        for (const std::string& directory : python_path.value | std::views::reverse) { // each entry goes to index 0, so walk backwards to preserve the given order
+            python::PyObjectGuard entry(PyUnicode_FromString(directory.c_str()));
+            if (!entry) {
+                python::throwCurrentPythonError(std::format("{}: cannot convert python_path entry '{}'", this->name, directory));
+            }
+            if (PySequence_Contains(sysPath, entry) == 1) { // re-configuration must not grow sys.path without bound
+                continue;
+            }
+            if (PyList_Insert(sysPath, 0, entry) != 0) {
+                python::throwCurrentPythonError(std::format("{}: cannot prepend '{}' to sys.path", this->name, directory));
+            }
+        }
+    }
+
+    // N.B. the `requires` guards keep the block usable with plain std::span, which the unit tests and the usage example pass directly
+    template<typename TInputSpan>
+    void collectInputTags(std::span<TInputSpan> ins) {
+        _inputTags.clear();
+        _forwardTags.clear();
+        _nextInputTag = 0UZ;
+        _pendingOutputTags.clear(); // a throwing script must not leak its tags into the next invocation
+        // N.B. tags() is relative to the start of this span, which is exactly what publishTag() expects; rawTags() would be absolute
+        if constexpr (requires(TInputSpan span) { span.tags(); }) {
+            for (TInputSpan& span : ins) {
+                for (const auto& [relativeIndex, mapRef] : span.tags()) {
+                    const std::size_t offset = relativeIndex < 0 ? 0UZ : static_cast<std::size_t>(relativeIndex); // a tag of already-consumed samples belongs at the chunk start
+                    TagView           view{offset, {}};
+                    gr::property_map  forwarded;
+                    for (const auto& [key, value] : mapRef.get()) {
+                        view.map[std::string(key)] = toScriptText(value);
+                        if (!std::string_view(key).starts_with(gr::GR_TAG_PREFIX.view())) {
+                            forwarded[key] = value; // Block<>::forwardInputTags already carries the 'gr:' keys
+                        }
+                    }
+                    _inputTags.push_back(std::move(view));
+                    const auto duplicate = [&](const auto& entry) { return entry.first == offset && entry.second == forwarded; };
+                    if (!forwarded.empty() && std::ranges::none_of(_forwardTags, duplicate)) { // one tag on several inputs is still one tag
+                        _forwardTags.emplace_back(offset, std::move(forwarded));
+                    }
+                }
+            }
+        }
+    }
+
+    template<typename TOutputSpan>
+    void publishPendingTags(std::span<TOutputSpan> outs) {
+        if constexpr (requires(TOutputSpan span, gr::property_map map) { span.publishTag(map, 0UZ); }) {
+            std::vector<std::pair<std::size_t, gr::property_map>> outgoing;
+            if (forward_tags) {
+                outgoing = _forwardTags;
+            }
+            outgoing.insert(outgoing.end(), _pendingOutputTags.begin(), _pendingOutputTags.end());
+            std::ranges::stable_sort(outgoing, {}, &std::pair<std::size_t, gr::property_map>::first); // publishTag() aborts on a descending index
+
+            for (TOutputSpan& span : outs) {
+                for (const auto& [offset, map] : outgoing) {
+                    if (offset >= span.size()) { // a tag beyond the chunk would land on samples this call does not produce
+                        gr::log::warning("{}: dropping tag at offset {}, outside a span of {} samples", this->name, offset, span.size());
+                        continue;
+                    }
+                    span.publishTag(map, offset);
+                }
+            }
+        }
+        _pendingOutputTags.clear();
     }
 
     template<typename TInputSpan, typename TOutputSpan>
@@ -231,7 +405,7 @@ private:
         python::PyObjectGuard pyOuts(PyList_New(static_cast<Py_ssize_t>(outs.size())));
         python::PyObjectGuard pyArgs(PyTuple_New(2));
         if (!pyIns || !pyOuts || !pyArgs) {
-            python::throwCurrentPythonError(std::format("{}(aka. {})::callPythonFunction(..) failed to allocate the Python arguments", this->unique_name, this->name), std::source_location::current(), python_script);
+            python::throwCurrentPythonError(std::format("{}(aka. {})::callPythonFunction(..) failed to allocate the Python arguments", this->unique_name, this->name), std::source_location::current(), _activeScript);
         }
 
         for (std::size_t i = 0; i < ins.size(); ++i) {
@@ -247,7 +421,7 @@ private:
         PyTuple_SetItem(pyArgs, 1, pyOuts);
 
         if (python::PyObjectGuard pyValue = _interpreter.invokeFunction("process_bulk", pyArgs); !pyValue) {
-            python::throwCurrentPythonError(std::format("{}(aka. {})::callPythonFunction(..) Python function call failed", this->unique_name, this->name), std::source_location::current(), python_script);
+            python::throwCurrentPythonError(std::format("{}(aka. {})::callPythonFunction(..) Python function call failed", this->unique_name, this->name), std::source_location::current(), _activeScript);
         }
     }
 };
@@ -289,7 +463,29 @@ PyObject* PythonBlock_GetTag_Template(PyObject* /*self*/, PyObject* args) {
         if (myBlock == nullptr) {
             return nullptr;
         }
-        return PyUnicode_FromString(myBlock->getTag().c_str());
+
+        const auto                tag = myBlock->getTag();
+        gr::python::PyObjectGuard tagMap(PyDict_New());
+        if (!tagMap) {
+            return PyErr_NoMemory();
+        }
+        for (const auto& [key, value] : tag.map) {
+            gr::python::PyObjectGuard pyValue(PyUnicode_FromString(value.c_str()));
+            if (!pyValue || PyDict_SetItemString(tagMap, key.c_str(), pyValue) != 0) {
+                return nullptr;
+            }
+        }
+
+        gr::python::PyObjectGuard result(PyDict_New());
+        gr::python::PyObjectGuard pyIndex(PyLong_FromSize_t(tag.index));
+        if (!result || !pyIndex) {
+            return PyErr_NoMemory();
+        }
+        if (PyDict_SetItemString(result, "index", pyIndex) != 0 || PyDict_SetItemString(result, "map", tagMap) != 0) {
+            return nullptr;
+        }
+        gr::python::PyIncRef(result); // hand the caller its own reference, the guard releases ours
+        return result.get();
     });
 }
 
@@ -362,6 +558,66 @@ PyObject* PythonBlock_SetSettings_Template(PyObject* /*self*/, PyObject* args) {
 
 // only the DEFINE_PYTHON_TYPE_FUNCTIONS_AND_METHODS(type) specialisations below are usable; instantiating the primary template is the diagnostic
 template<typename T>
+PyObject* PythonBlock_Log_Template(PyObject* /*self*/, PyObject* args) {
+    return gr::python::invokeCallback([args]() -> PyObject* {
+        PyObject*   capsule = nullptr;
+        const char* message = nullptr;
+        if (!PyArg_ParseTuple(args, "Os", &capsule, &message)) {
+            return nullptr;
+        }
+        gr::basic::PythonBlock<T>* myBlock = getPythonBlockFromCapsule<T>(capsule);
+        if (myBlock == nullptr) {
+            return nullptr;
+        }
+        myBlock->log(message);
+        gr::python::PyIncRef(gr::python::NoneObj);
+        return gr::python::NoneObj;
+    });
+}
+
+template<typename T>
+PyObject* PythonBlock_PublishTag_Template(PyObject* /*self*/, PyObject* args) {
+    return gr::python::invokeCallback([args]() -> PyObject* {
+        PyObject*  capsule = nullptr;
+        PyObject*  tagData = nullptr;
+        Py_ssize_t offset  = 0;
+        if (!PyArg_ParseTuple(args, "OnO", &capsule, &offset, &tagData)) {
+            return nullptr;
+        }
+        gr::basic::PythonBlock<T>* myBlock = getPythonBlockFromCapsule<T>(capsule);
+        if (myBlock == nullptr) {
+            return nullptr;
+        }
+        if (offset < 0) {
+            PyErr_SetString(PyExc_ValueError, "tag offset must not be negative");
+            return nullptr;
+        }
+        if (!gr::python::isPyDict(tagData)) {
+            PyErr_SetString(PyExc_TypeError, "tag data must be a dictionary");
+            return nullptr;
+        }
+
+        typename gr::basic::PythonBlock<T>::StringPropertyMap tagMap;
+        PyObject*                                             key   = nullptr;
+        PyObject*                                             value = nullptr;
+        Py_ssize_t                                            pos   = 0;
+        while (PyDict_Next(tagData, &pos, &key, &value)) {
+            const char* keyStr   = PyUnicode_AsUTF8(key);
+            const char* valueStr = PyUnicode_AsUTF8(value);
+            if (keyStr == nullptr || valueStr == nullptr) {
+                PyErr_SetString(PyExc_TypeError, "tag keys and values must be strings");
+                return nullptr;
+            }
+            tagMap[keyStr] = valueStr;
+        }
+
+        myBlock->publishTag(static_cast<std::size_t>(offset), tagMap);
+        gr::python::PyIncRef(gr::python::NoneObj);
+        return gr::python::NoneObj;
+    });
+}
+
+template<typename T>
 inline PyMethodDef* blockMethods() {
     static_assert(gr::meta::always_false<T>, "PythonBlock<T>: no Python method table for this T -- add DEFINE_PYTHON_TYPE_FUNCTIONS_AND_METHODS(T) and register T with GR_REGISTER_BLOCK");
     return nullptr;
@@ -375,16 +631,19 @@ inline PyMethodDef* blockMethods() {
     DEFINE_PYTHON_WRAPPER(type, PythonBlock_GetTag)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            \
     DEFINE_PYTHON_WRAPPER(type, PythonBlock_GetSettings)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       \
     DEFINE_PYTHON_WRAPPER(type, PythonBlock_SetSettings)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       \
+    DEFINE_PYTHON_WRAPPER(type, PythonBlock_PublishTag)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        \
+    DEFINE_PYTHON_WRAPPER(type, PythonBlock_Log)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               \
     template<>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 \
     inline PyMethodDef* blockMethods<type>() {                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 \
         static PyMethodDef methods[] = {                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       \
-            {"tagAvailable", reinterpret_cast<PyCFunction>(PythonBlock_TagAvailable_##type), METH_VARARGS, "Check if a tag is available"}, {"getTag", reinterpret_cast<PyCFunction>(PythonBlock_GetTag_##type), METH_VARARGS, "Get the current tag"}, {"getSettings", reinterpret_cast<PyCFunction>(PythonBlock_GetSettings_##type), METH_VARARGS, "Get the settings"}, {"setSettings", reinterpret_cast<PyCFunction>(PythonBlock_SetSettings_##type), METH_VARARGS, "Set the settings"}, {nullptr, nullptr, 0, nullptr} /* Sentinel */                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        \
+            {"tagAvailable", reinterpret_cast<PyCFunction>(PythonBlock_TagAvailable_##type), METH_VARARGS, "Check if a tag is available"}, {"getTag", reinterpret_cast<PyCFunction>(PythonBlock_GetTag_##type), METH_VARARGS, "Get the current tag"}, {"getSettings", reinterpret_cast<PyCFunction>(PythonBlock_GetSettings_##type), METH_VARARGS, "Get the settings"}, {"setSettings", reinterpret_cast<PyCFunction>(PythonBlock_SetSettings_##type), METH_VARARGS, "Set the settings"}, {"publishTag", reinterpret_cast<PyCFunction>(PythonBlock_PublishTag_##type), METH_VARARGS, "Publish a tag on the outputs"}, {"log", reinterpret_cast<PyCFunction>(PythonBlock_Log_##type), METH_VARARGS, "Write a message to the GR4 log"}, {nullptr, nullptr, 0, nullptr} /* Sentinel */                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            \
         };                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     \
         return methods;                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        \
     }
 
 DEFINE_PYTHON_TYPE_FUNCTIONS_AND_METHODS(int32_t)
 DEFINE_PYTHON_TYPE_FUNCTIONS_AND_METHODS(float)
+DEFINE_PYTHON_TYPE_FUNCTIONS_AND_METHODS(double)
 
 // add more types as needed
 

--- a/blocks/basic/include/gnuradio-4.0/basic/PythonBlock.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/PythonBlock.hpp
@@ -35,7 +35,7 @@ Usage Example:
 // [...]
 int main() {
 // Python script that processes input data arrays and modifies output arrays
-std::string pythonScript = R"(
+std::string python_script = R"(
 # usual import etc.
 counter = 0 # exemplary global state, kept between each invocation
 
@@ -61,8 +61,8 @@ def process_bulk(ins, outs):
 )";
 
 // C++ side: instantiate PythonBlock with the script
-PythonBlock<int> myBlock(pythonScript); // nominal
-myBlock.pythonScript = pythonScript; // alt: only for unit-testing
+PythonBlock<int> myBlock(python_script); // nominal
+myBlock.python_script = python_script; // alt: only for unit-testing
 
 // example for unit-test
 std::vector<int>                  data1 = { 1, 2, 3 };
@@ -86,11 +86,11 @@ myBlock.processBulk(ins, outs);
 
     std::vector<PortIn<T>>                                                         inputs{};
     std::vector<PortOut<T>>                                                        outputs{};
-    A<gr::Size_t, "n_inputs", Visible, Doc<"number of inputs">, Limits<1U, 32U>>   n_inputs     = 1U;
-    A<gr::Size_t, "n_outputs", Visible, Doc<"number of outputs">, Limits<1U, 32U>> n_outputs    = 1U;
-    std::string                                                                    pythonScript = "";
+    A<gr::Size_t, "n_inputs", Visible, Doc<"number of inputs">, Limits<1U, 32U>>   n_inputs      = 1U;
+    A<gr::Size_t, "n_outputs", Visible, Doc<"number of outputs">, Limits<1U, 32U>> n_outputs     = 1U;
+    std::string                                                                    python_script = "";
 
-    GR_MAKE_REFLECTABLE(PythonBlock, inputs, outputs, n_inputs, n_outputs, pythonScript);
+    GR_MAKE_REFLECTABLE(PythonBlock, inputs, outputs, n_inputs, n_outputs, python_script);
 
     PyModuleDef*        _moduleDefinitions = myBlockPythonDefinitions<T>();
     python::Interpreter _interpreter{this, _moduleDefinitions};
@@ -128,9 +128,23 @@ this_block = PythonBlockWrapper(capsule))p",
     bool                _tagAvailable = false;
     tag_type            _tag          = "Simulated Tag";
 
+    // block life-cycle methods
+    // clang-format off
+    void start()  { invokeLifecycle("start"); }
+    void stop()   { invokeLifecycle("stop"); }
+    void pause()  { invokeLifecycle("pause"); }
+    void resume() { invokeLifecycle("resume"); }
+    void reset()  { invokeLifecycle("reset"); }
+    // clang-format on
+
+    template<typename TInputSpan, typename TOutputSpan>
+    work::Status processBulk(std::span<TInputSpan> ins, std::span<TOutputSpan> outs) {
+        _interpreter.invoke([this, ins, outs] { callPythonFunction(ins, outs); }, python_script);
+        return work::Status::OK;
+    }
+
     void settingsChanged(const gr::property_map& /*old_settings*/, const gr::property_map& new_settings) {
         if (inputs.size() != n_inputs || outputs.size() != n_outputs) { // drive off the actual port count, so the defaults are applied too
-
             gr::log::debug("{}: port configuration changed: n_inputs {} -> {}, n_outputs {} -> {}", this->name, inputs.size(), n_inputs, outputs.size(), n_outputs);
             if (std::any_of(inputs.begin(), inputs.end(), [](const auto& port) { return port.isConnected(); })) {
                 throw gr::exception("Number of input ports cannot be changed after Graph initialization.");
@@ -142,7 +156,7 @@ this_block = PythonBlockWrapper(capsule))p",
             outputs.resize(n_outputs);
         }
 
-        if (new_settings.contains("pythonScript")) {
+        if (new_settings.contains("python_script")) {
             _interpreter.invoke(
                 [this] {
                     if (python::PyObjectGuard testImport(PyRun_StringFlags(_prePythonDefinition.data(), Py_file_input, _interpreter.getDictionary(), _interpreter.getDictionary(), nullptr)); !testImport) {
@@ -166,16 +180,16 @@ this_block = PythonBlockWrapper(capsule))p",
                         python::throwCurrentPythonError(std::format("{}(aka. {})::settingsChanged(...) - 'this_block' is not an instance of PythonBlockWrapper", this->unique_name, this->name), std::source_location::current(), _prePythonDefinition);
                     }
 
-                    if (const python::PyObjectGuard result(PyRun_StringFlags(pythonScript.data(), Py_file_input, _interpreter.getDictionary(), _interpreter.getDictionary(), nullptr)); !result) {
-                        python::throwCurrentPythonError(std::format("{}(aka. '{}')::settingsChanged(...) - script parsing error", this->unique_name, this->name), std::source_location::current(), pythonScript);
+                    if (const python::PyObjectGuard result(PyRun_StringFlags(python_script.data(), Py_file_input, _interpreter.getDictionary(), _interpreter.getDictionary(), nullptr)); !result) {
+                        python::throwCurrentPythonError(std::format("{}(aka. '{}')::settingsChanged(...) - script parsing error", this->unique_name, this->name), std::source_location::current(), python_script);
                     }
 
                     python::PyObjectGuard pyFunc(PyObject_GetAttrString(_interpreter.getModule(), "process_bulk"));
                     if (!pyFunc.get() || !PyCallable_Check(pyFunc.get())) {
-                        python::throwCurrentPythonError(std::format("{}(aka. {})::settingsChanged(...) Python function process_bulk not found or is not callable", this->unique_name, this->name), std::source_location::current(), pythonScript);
+                        python::throwCurrentPythonError(std::format("{}(aka. {})::settingsChanged(...) Python function process_bulk not found or is not callable", this->unique_name, this->name), std::source_location::current(), python_script);
                     }
                 },
-                pythonScript);
+                python_script);
         }
     }
 
@@ -202,26 +216,11 @@ this_block = PythonBlockWrapper(capsule))p",
 
     tag_type getTag() { return _tag; }
 
-    template<typename TInputSpan, typename TOutputSpan>
-    work::Status processBulk(std::span<TInputSpan> ins, std::span<TOutputSpan> outs) {
-        _interpreter.invoke([this, ins, outs] { callPythonFunction(ins, outs); }, pythonScript);
-        return work::Status::OK;
-    }
-
-    // block life-cycle methods
-    // clang-format off
-    void start()  { invokeLifecycle("start"); }
-    void stop()   { invokeLifecycle("stop"); }
-    void pause()  { invokeLifecycle("pause"); }
-    void resume() { invokeLifecycle("resume"); }
-    void reset()  { invokeLifecycle("reset"); }
-    // clang-format on
-
 private:
     void invokeLifecycle(std::string_view hook) {
         python::PyGILGuard gil; // PyErr_Occurred() below reads interpreter state
         if (python::PyObjectGuard result = _interpreter.invokeFunction<python::EnforceFunction::OPTIONAL>(hook); !result && PyErr_Occurred()) {
-            python::throwCurrentPythonError(std::format("{}(aka. {})::{}() raised", this->unique_name, this->name, hook), std::source_location::current(), pythonScript);
+            python::throwCurrentPythonError(std::format("{}(aka. {})::{}() raised", this->unique_name, this->name, hook), std::source_location::current(), python_script);
         } // a hook the script does not define yields a null guard with no error set
     }
 
@@ -232,7 +231,7 @@ private:
         python::PyObjectGuard pyOuts(PyList_New(static_cast<Py_ssize_t>(outs.size())));
         python::PyObjectGuard pyArgs(PyTuple_New(2));
         if (!pyIns || !pyOuts || !pyArgs) {
-            python::throwCurrentPythonError(std::format("{}(aka. {})::callPythonFunction(..) failed to allocate the Python arguments", this->unique_name, this->name), std::source_location::current(), pythonScript);
+            python::throwCurrentPythonError(std::format("{}(aka. {})::callPythonFunction(..) failed to allocate the Python arguments", this->unique_name, this->name), std::source_location::current(), python_script);
         }
 
         for (std::size_t i = 0; i < ins.size(); ++i) {
@@ -248,7 +247,7 @@ private:
         PyTuple_SetItem(pyArgs, 1, pyOuts);
 
         if (python::PyObjectGuard pyValue = _interpreter.invokeFunction("process_bulk", pyArgs); !pyValue) {
-            python::throwCurrentPythonError(std::format("{}(aka. {})::callPythonFunction(..) Python function call failed", this->unique_name, this->name), std::source_location::current(), pythonScript);
+            python::throwCurrentPythonError(std::format("{}(aka. {})::callPythonFunction(..) Python function call failed", this->unique_name, this->name), std::source_location::current(), python_script);
         }
     }
 };
@@ -361,13 +360,11 @@ PyObject* PythonBlock_SetSettings_Template(PyObject* /*self*/, PyObject* args) {
     });
 }
 
+// only the DEFINE_PYTHON_TYPE_FUNCTIONS_AND_METHODS(type) specialisations below are usable; instantiating the primary template is the diagnostic
 template<typename T>
 inline PyMethodDef* blockMethods() {
-    static PyMethodDef methods[] = {
-        {"tagAvailable", reinterpret_cast<PyCFunction>(PythonBlock_TagAvailable_Template<T>), METH_VARARGS, "Check if a tag is available"}, {"getTag", reinterpret_cast<PyCFunction>(PythonBlock_GetTag_Template<T>), METH_VARARGS, "Get the current tag"}, {"getSettings", reinterpret_cast<PyCFunction>(PythonBlock_GetSettings_Template<T>), METH_VARARGS, "Get the settings"}, {"setSettings", reinterpret_cast<PyCFunction>(PythonBlock_SetSettings_Template<T>), METH_VARARGS, "Set the settings"}, {nullptr, nullptr, 0, nullptr} // Sentinel
-    };
-    static_assert(gr::meta::always_false<T>, "type not defined");
-    return methods;
+    static_assert(gr::meta::always_false<T>, "PythonBlock<T>: no Python method table for this T -- add DEFINE_PYTHON_TYPE_FUNCTIONS_AND_METHODS(T) and register T with GR_REGISTER_BLOCK");
+    return nullptr;
 }
 
 #define DEFINE_PYTHON_WRAPPER(T, NAME)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         \

--- a/blocks/basic/include/gnuradio-4.0/basic/PythonInterpreter.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/PythonInterpreter.hpp
@@ -16,11 +16,15 @@
 #include <cctype>
 #include <complex>
 #include <cstdint>
+#include <cstdlib>
+#include <exception>
+#include <mutex>
 #include <regex>
 #include <span>
 #include <sstream>
 #include <string>
 #include <string_view>
+#include <utility>
 
 #include <gnuradio-4.0/Message.hpp>
 
@@ -34,50 +38,76 @@ inline static PyObject* TrueObj  = Py_True;
 inline static PyObject* FalseObj = Py_False;
 inline static PyObject* NoneObj  = Py_None;
 
-constexpr inline bool isPyDict(const PyObject* obj) { return PyDict_Check(obj); }
+inline bool isPyDict(const PyObject* obj) { return PyDict_Check(obj); }
 
-constexpr inline void PyDecRef(PyObject* obj) { // wrapper to isolate unsafe warning on C-API casts
+inline void PyDecRef(PyObject* obj) { // wrapper to isolate unsafe warning on C-API casts
     Py_XDECREF(obj);
 }
 
-constexpr inline void PyIncRef(PyObject* obj) { // wrapper to isolate unsafe warning on C-API casts
+inline void PyIncRef(PyObject* obj) { // wrapper to isolate unsafe warning on C-API casts
     Py_XINCREF(obj);
 }
 
-constexpr inline std::string PyBytesAsString(PyObject* op) { return PyBytes_AsString(op); }
+inline std::string PyBytesAsString(PyObject* op) {
+    const char* bytes = PyBytes_AsString(op);
+    return bytes == nullptr ? std::string{} : std::string{bytes};
+}
 
+// runs a CPython callback body; a C++ exception must never unwind through CPython's C frames, so it becomes a Python error instead
+template<typename TFunc>
+PyObject* invokeCallback(TFunc&& body) noexcept {
+    try {
+        return body();
+    } catch (const std::exception& e) {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+        return nullptr;
+    } catch (...) {
+        PyErr_SetString(PyExc_RuntimeError, "unknown C++ exception raised in a PythonBlock callback");
+        return nullptr;
+    }
+}
+
+inline Py_ssize_t PyRefCount(PyObject* obj) { // wrapper to isolate unsafe warning on C-API casts, cf. PyIncRef/PyDecRef
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#ifndef __clang__
+#pragma GCC diagnostic ignored "-Wuseless-cast"
+#endif
+#endif
+    return Py_REFCNT(obj);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+}
+
+// owns one strong reference to a PyObject. A moved-from guard owns nothing, so exactly one release happens per reference.
 class PyObjectGuard {
     PyObject* _ptr;
-
-    void move(PyObjectGuard&& other) noexcept {
-        PyDecRef(_ptr);
-        std::swap(_ptr, other._ptr);
-    }
 
 public:
     explicit PyObjectGuard(PyObject* ptr = nullptr) : _ptr(ptr) {}
 
-    explicit PyObjectGuard(PyObjectGuard&& other) noexcept : _ptr(other._ptr) { move(std::move(other)); }
+    PyObjectGuard(const PyObjectGuard& other) : _ptr(other._ptr) { PyIncRef(_ptr); }
+
+    PyObjectGuard(PyObjectGuard&& other) noexcept : _ptr(std::exchange(other._ptr, nullptr)) {}
 
     ~PyObjectGuard() { PyDecRef(_ptr); }
 
-    PyObjectGuard& operator=(PyObjectGuard&& other) noexcept {
+    PyObjectGuard& operator=(const PyObjectGuard& other) {
         if (this != &other) {
-            move(std::move(other));
+            PyIncRef(other._ptr); // increment before releasing, so self-referential aliases stay alive
+            PyDecRef(_ptr);
+            _ptr = other._ptr;
         }
         return *this;
     }
 
-    PyObjectGuard(const PyObjectGuard& other) : _ptr(other._ptr) { // copy constructor
-        PyIncRef(_ptr);
-    }
-
-    PyObjectGuard& operator=(const PyObjectGuard& other) {
-        if (this == &other) {
-            return *this;
+    PyObjectGuard& operator=(PyObjectGuard&& other) noexcept {
+        if (this != &other) {
+            PyDecRef(_ptr);
+            _ptr = std::exchange(other._ptr, nullptr);
         }
-        _ptr = other._ptr;
-        PyIncRef(_ptr);
         return *this;
     }
 
@@ -99,8 +129,19 @@ public:
 };
 
 [[nodiscard]] inline std::string toString(PyObject* object) {
+    if (object == nullptr) {
+        return "<nullptr>";
+    }
     PyObjectGuard strObj(PyObject_Repr(object));
+    if (!strObj) {
+        PyErr_Clear();
+        return "<object without a repr>";
+    }
     PyObjectGuard bytesObj(PyUnicode_AsEncodedString(strObj.get(), "utf-8", "strict"));
+    if (!bytesObj) {
+        PyErr_Clear();
+        return "<repr that is not valid UTF-8>";
+    }
     return python::PyBytesAsString(bytesObj.get());
 }
 
@@ -121,9 +162,9 @@ public:
     auto        lines = splitLines(code);
     std::string annotatedCode;
     annotatedCode.reserve(code.size() + lines.size() * 4UZ /*sizeof "123:"*/);
-    for (std::size_t i = std::max(0UZ, min); i < std::min(lines.size(), max); i++) {
-        // N.B. Python starts counting from '1' not '0'
-        annotatedCode += std::format("{:3}:{}{}\n", i, lines[i], i == marker - 1UZ ? "   ####### <== here's your problem #######" : "");
+    for (std::size_t i = min; i < std::min(lines.size(), max); i++) {
+        // N.B. Python counts lines from '1', so report i + 1 and compare the 1-based marker against it
+        annotatedCode += std::format("{:3}:{}{}\n", i + 1UZ, lines[i], i + 1UZ == marker ? "   ####### <== here's your problem #######" : "");
     }
     return annotatedCode;
 }
@@ -162,15 +203,23 @@ inline void throwCurrentPythonError(std::string_view msg, std::source_location l
     std::size_t marker = std::numeric_limits<std::size_t>::max() - 1UZ;
     if (PyObjectGuard lineStr(PyObject_GetAttrString(exception.get(), "lineno")); lineStr) {
         marker = PyLong_AsSize_t(lineStr);
-        min    = marker > 5UZ ? marker - 5UZ : 0;
-        max    = marker < (std::numeric_limits<std::size_t>::max() - 5UZ) ? marker + 5UZ : marker < std::numeric_limits<std::size_t>::max();
+        if (PyErr_Occurred()) { // 'lineno' need not be an integer
+            PyErr_Clear();
+            marker = std::numeric_limits<std::size_t>::max() - 1UZ;
+        } else {
+            min = marker > 5UZ ? marker - 5UZ : 0UZ;
+            max = marker < (std::numeric_limits<std::size_t>::max() - 5UZ) ? marker + 5UZ : std::numeric_limits<std::size_t>::max();
+        }
+    } else {
+        PyErr_Clear(); // only syntax-like exceptions carry a 'lineno'; leaving the probe's AttributeError set would misreport the next call
     }
 
     throw gr::exception(std::format("{}\nPython error: {}\n{}", msg, toString(exception), toLineCountAnnotated(pythonCode, min, max, marker)), location);
 }
 
 [[nodiscard]] inline std::string getDictionary(std::string_view moduleName) {
-    PyObject* module = PyDict_GetItemString(PyImport_GetModuleDict(), moduleName.data());
+    const std::string name(moduleName); // the C-API needs a NUL-terminated string, which string_view::data() does not promise
+    PyObject*         module = PyDict_GetItemString(PyImport_GetModuleDict(), name.c_str());
     if (module == nullptr) {
         return "";
     }
@@ -210,7 +259,7 @@ int numpyType() noexcept {
 
 template<typename T>
 requires std::is_arithmetic_v<T> || std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>
-constexpr inline PyObject* toPyArray(T* arrayData, std::initializer_list<std::size_t> dimensions) {
+inline PyObject* toPyArray(T* arrayData, std::initializer_list<std::size_t> dimensions) {
     assert(dimensions.size() >= 1 && "nDim needs to be >= 1");
 
     std::vector<npy_intp> npyDims(dimensions.begin(), dimensions.end());
@@ -253,45 +302,57 @@ namespace gr::python {
 
 enum class EnforceFunction { MANDATORY, OPTIONAL };
 
+// CPython and NumPy do not survive a 'Py_Finalize()'/'Py_Initialize()' cycle: NumPy's C-API state is bound to the interpreter that first
+// imported it and is never re-imported, so a later interpreter frees objects belonging to the earlier one. The interpreter is therefore
+// kept alive for the whole process and finalised exactly once, here.
+inline void finalizeInterpreterAtExit();
+
 class Interpreter {
-    static std::atomic<std::size_t> _nInterpreters;
-    static std::atomic<std::size_t> _nNumPyInit;
-    static PyThreadState*           _interpreterThreadState;
+    static std::once_flag           _initialiseOnce;
+    static std::atomic<std::size_t> _nModulesCreated;
+    static PyInterpreterState*      _interpreterState;
+    static PyThreadState*           _mainThreadState;
     PyModuleDef*                    _moduleDefinitions;
-    PyObject*                       _pMainModule; // borrowed reference
-    PyObject*                       _pMainDict;   // borrowed reference
+    PyObjectGuard                   _blockModule;         // private per-block module: two blocks must not share one namespace
+    PyObject*                       _pBlockDict{nullptr}; // borrowed from _blockModule
     PyObjectGuard                   _pCapsule;
 
 public:
     template<typename T>
     explicit(false) Interpreter(T* classReference, PyModuleDef* moduleDefinitions = nullptr, std::source_location location = std::source_location::current()) : _moduleDefinitions(moduleDefinitions) {
-        if (_nInterpreters.fetch_add(1UZ, std::memory_order_relaxed) == 0UZ) {
+        // once per process, and never again: NumPy keeps internal state and cannot be re-initialised after 'Py_Finalize()'.
+        // N.B. NumPy does not support sub-interpreters (as of Python 3.12):
+        // "sys:1: UserWarning: NumPy was imported from a Python sub-interpreter but NumPy does not properly support sub-interpreters.
+        // This will likely work for most users but might cause hard to track down issues or subtle bugs.
+        // A common user of the rare sub-interpreter feature is wsgi which also allows single-interpreter mode.
+        // Improvements in the case of bugs are welcome, but is not on the NumPy roadmap, and full support may require significant effort to achieve."
+        std::call_once(_initialiseOnce, [&location] {
             Py_Initialize();
             if (PyErr_Occurred()) {
                 PyErr_Print();
             }
-
-            python::PyGILGuard guard;
-            _interpreterThreadState = PyThreadState_Get();
-            assert(_interpreterThreadState && "internal thread state is a nullptr");
-            if (_nNumPyInit.fetch_add(1UZ, std::memory_order_relaxed) == 0UZ && _import_array() < 0) {
-                // NumPy keeps internal state and does not allow to be re-initialised after 'Py_Finalize()' has been called.
-
-                // initialise NumPy -- N.B. NumPy does not support sub-interpreters (as of Python 3.12):
-                // "sys:1: UserWarning: NumPy was imported from a Python sub-interpreter but NumPy does not properly support sub-interpreters.
-                // This will likely work for most users but might cause hard to track down issues or subtle bugs.
-                // A common user of the rare sub-interpreter feature is wsgi which also allows single-interpreter mode.
-                // Improvements in the case of bugs are welcome, but is not on the NumPy roadmap, and full support may require significant effort to achieve."
+            if (_import_array() < 0) {
                 python::throwCurrentPythonError("failed to initialize NumPy", location);
             }
-        }
+            _interpreterState = PyInterpreterState_Get();
+            assert(_interpreterState && "interpreter state is a nullptr");
+            std::atexit(finalizeInterpreterAtExit);
+            _mainThreadState = PyEval_SaveThread(); // Py_Initialize() leaves the GIL held; release it so any thread can PyGILState_Ensure()
+        });
         assert(Py_IsInitialized() && "Python isn't properly initialised");
         // Ensure the Python GIL is initialized for this instance
         python::PyGILGuard localGuard;
 
-        // need to be executed after the Python environment has been initialised
-        _pMainModule = PyImport_AddModule("__main__");
-        _pMainDict   = PyModule_GetDict(_pMainModule);
+        // N.B. a private module, not the shared '__main__': each block needs its own 'process_bulk' and 'this_block'.
+        const std::string blockModuleName = std::format("gr_python_block_{}", _nModulesCreated.fetch_add(1UZ, std::memory_order_relaxed));
+        _blockModule                      = PyObjectGuard(PyModule_New(blockModuleName.c_str()));
+        if (!_blockModule) {
+            python::throwCurrentPythonError(std::format("failed to create the private Python module '{}'", blockModuleName), location);
+        }
+        _pBlockDict = PyModule_GetDict(_blockModule.get());
+        if (PyDict_SetItemString(_pBlockDict, "__builtins__", PyEval_GetBuiltins()) != 0) { // a module made by PyModule_New has no builtins yet
+            python::throwCurrentPythonError(std::format("failed to provide __builtins__ to '{}'", blockModuleName), location);
+        }
         if (classReference == nullptr || moduleDefinitions == nullptr) {
             return;
         }
@@ -299,7 +360,7 @@ public:
         if (!_pCapsule) {
             python::throwCurrentPythonError(std::format("Interpreter(*{}) - failed to create a capsule", gr::meta::type_name<T>()));
         }
-        PyDict_SetItemString(_pMainDict, "capsule", _pCapsule);
+        PyDict_SetItemString(_pBlockDict, "capsule", _pCapsule);
         python::PyIncRef(_pCapsule); // need to explicitly increas count for the Python interpreter not to delete the reference by 'accident'
 
         // replaces the 'PyImport_AppendInittab("ClassName", &classDefinition)' to allow for other blocks being added
@@ -328,9 +389,12 @@ public:
     }
 
     ~Interpreter() {
-        if (_nInterpreters.fetch_sub(1UZ, std::memory_order_acq_rel) == 1UZ && Py_IsInitialized()) {
-            Py_Finalize();
+        if (!Py_IsInitialized()) {
+            return;
         }
+        PyGILGuard guard; // releasing a PyObject without the GIL corrupts its reference count
+        _pCapsule    = PyObjectGuard{};
+        _blockModule = PyObjectGuard{};
     }
 
     // Prevent copying and moving
@@ -339,15 +403,17 @@ public:
     Interpreter(Interpreter&&)                 = delete;
     Interpreter& operator=(Interpreter&&)      = delete;
 
-    PyObject* getModule() { return _pMainModule; }
+    static PyThreadState* mainThreadState() noexcept { return _mainThreadState; }
 
-    PyObject* getDictionary() { return _pMainDict; }
+    PyObject* getModule() { return _blockModule.get(); }
+
+    PyObject* getDictionary() { return _pBlockDict; }
 
     template<NoParamNoReturn Func>
     void invoke(Func func, std::string_view pythonCode = "", std::source_location location = std::source_location::current()) {
         assert(Py_IsInitialized());
         PyGILGuard localGuard;
-        if (_interpreterThreadState != PyThreadState_Get()) {
+        if (PyInterpreterState_Get() != _interpreterState) { // the interpreter, not the thread: every thread has its own state
             python::throwCurrentPythonError("detected sub-interpreter change which is not supported by NumPy", location, pythonCode);
         }
         if (PyErr_Occurred()) {
@@ -362,9 +428,13 @@ public:
     }
 
     template<EnforceFunction forced = EnforceFunction::MANDATORY>
-    python::PyObjectGuard invokeFunction(std::string_view functionName, PyObject* functionArguments = nullptr, std::source_location location = std::source_location::current()) {
-        PyGILGuard localGuard;
-        const bool hasFunction = PyObject_HasAttrString(getModule(), functionName.data());
+    [[nodiscard]] python::PyObjectGuard invokeFunction(std::string_view functionName, PyObject* functionArguments = nullptr, std::source_location location = std::source_location::current()) {
+        if (getModule() == nullptr) { // ~Block() invokes stop() after the derived _interpreter member is gone
+            return python::PyObjectGuard(nullptr);
+        }
+        PyGILGuard        localGuard;
+        const std::string function(functionName); // the C-API needs a NUL-terminated string, which string_view::data() does not promise
+        const bool        hasFunction = PyObject_HasAttrString(getModule(), function.c_str());
         if constexpr (forced == EnforceFunction::MANDATORY) {
             if (!hasFunction) {
                 python::throwCurrentPythonError(std::format("getFunction('{}', '{}') Python function not found or is not callable", functionName, python::toString(functionArguments)), location);
@@ -374,14 +444,22 @@ public:
                 return python::PyObjectGuard(nullptr);
             }
         }
-        python::PyObjectGuard pyFunc(PyObject_GetAttrString(getModule(), functionName.data()));
+        python::PyObjectGuard pyFunc(PyObject_GetAttrString(getModule(), function.c_str()));
         return python::PyObjectGuard(PyObject_CallObject(pyFunc, functionArguments));
     }
 };
 
-inline std::atomic<std::size_t> Interpreter::_nInterpreters{0UZ};
-inline std::atomic<std::size_t> Interpreter::_nNumPyInit{0UZ};
-inline PyThreadState*           Interpreter::_interpreterThreadState = nullptr;
+inline std::once_flag           Interpreter::_initialiseOnce;
+inline std::atomic<std::size_t> Interpreter::_nModulesCreated{0UZ};
+inline PyInterpreterState*      Interpreter::_interpreterState = nullptr;
+inline PyThreadState*           Interpreter::_mainThreadState  = nullptr;
+
+inline void finalizeInterpreterAtExit() {
+    if (Py_IsInitialized()) {
+        PyEval_RestoreThread(Interpreter::mainThreadState()); // Py_Finalize() requires the GIL, which the constructor released
+        Py_Finalize();
+    }
+}
 
 } // namespace gr::python
 

--- a/blocks/basic/test/qa_PythonBlock.cpp
+++ b/blocks/basic/test/qa_PythonBlock.cpp
@@ -31,6 +31,79 @@ const boost::ut::suite<"python::<C-API abstraction interfaces>"> pythonInterface
         expect(numpyType<const char*>() == NPY_STRING);
         expect(numpyType<void>() == NPY_NOTYPE);
     };
+
+    // N.B. every case keeps one extra reference of its own, so the refcount can still be read after the guards die.
+    auto makeUniqueObject = [] { return PyLong_FromLong(987654321L); }; // outside CPython's small-int cache, so never shared
+
+    "moving a guard transfers sole ownership"_test = [&] {
+        Interpreter interpreter{static_cast<int*>(nullptr)};
+        PyGILGuard  gil;
+
+        PyObjectGuard keepAlive(makeUniqueObject());
+        PyIncRef(keepAlive.get()); // the reference the moved guard will own
+        {
+            PyObjectGuard source(keepAlive.get());
+            PyObjectGuard target(std::move(source));
+            expect(target.get() == keepAlive.get());
+            expect(source.get() == nullptr) << "a moved-from guard must not retain the pointer";
+            expect(eq(PyRefCount(keepAlive.get()), Py_ssize_t{2})) << "moving must neither add nor drop a reference";
+        }
+        expect(eq(PyRefCount(keepAlive.get()), Py_ssize_t{1})) << "the moved reference must be released exactly once";
+    };
+
+    "move-assigning a guard releases the overwritten reference"_test = [&] {
+        Interpreter interpreter{static_cast<int*>(nullptr)};
+        PyGILGuard  gil;
+
+        PyObjectGuard overwritten(makeUniqueObject());
+        PyObjectGuard assigned(PyLong_FromLong(123456789L));
+        PyIncRef(overwritten.get());
+        PyIncRef(assigned.get());
+        {
+            PyObjectGuard target(overwritten.get());
+            PyObjectGuard source(assigned.get());
+            target = std::move(source);
+            expect(eq(PyRefCount(overwritten.get()), Py_ssize_t{1})) << "the overwritten reference must be released once, not swapped into the source";
+            expect(eq(PyRefCount(assigned.get()), Py_ssize_t{2}));
+            expect(source.get() == nullptr) << "a moved-from guard must not retain the pointer";
+        }
+        expect(eq(PyRefCount(assigned.get()), Py_ssize_t{1}));
+        expect(eq(PyRefCount(overwritten.get()), Py_ssize_t{1}));
+    };
+
+    "copy-assigning a guard releases the overwritten reference"_test = [&] {
+        Interpreter interpreter{static_cast<int*>(nullptr)};
+        PyGILGuard  gil;
+
+        PyObjectGuard overwritten(makeUniqueObject());
+        PyObjectGuard shared(PyLong_FromLong(123456789L));
+        PyIncRef(overwritten.get());
+        {
+            PyObjectGuard target(overwritten.get());
+            PyIncRef(shared.get()); // the reference 'source' owns
+            PyObjectGuard source(shared.get());
+            target = source;
+            expect(eq(PyRefCount(overwritten.get()), Py_ssize_t{1})) << "the overwritten reference must not leak";
+            expect(eq(PyRefCount(shared.get()), Py_ssize_t{3})) << "copying must add exactly one reference";
+        }
+        expect(eq(PyRefCount(shared.get()), Py_ssize_t{1}));
+    };
+
+    "self-assigning a guard keeps its reference alive"_test = [&] {
+        Interpreter interpreter{static_cast<int*>(nullptr)};
+        PyGILGuard  gil;
+
+        PyObjectGuard keepAlive(makeUniqueObject());
+        PyIncRef(keepAlive.get());
+        {
+            PyObjectGuard  guard(keepAlive.get());
+            PyObjectGuard& alias = guard; // via a reference, so the self-assignment is not diagnosed at compile time
+            guard                = alias;
+            expect(eq(PyRefCount(keepAlive.get()), Py_ssize_t{2})) << "self-assignment must not change the count";
+            expect(guard.get() == keepAlive.get()) << "self-assignment must not release the object";
+        }
+        expect(eq(PyRefCount(keepAlive.get()), Py_ssize_t{1}));
+    };
 };
 
 const boost::ut::suite<"PythonBlock"> pythonBlockTests = [] {
@@ -74,7 +147,7 @@ def process_bulk(ins, outs):
     print('Stop Python processing - time: {} seconds'.format(time.time() - start))
 )";
 
-        PythonBlock<std::int32_t> myBlock({{"n_inputs", 3U}, {"n_outputs", 3U}, {"pythonScript", pythonScript}});
+        PythonBlock<std::int32_t> myBlock({{"n_inputs", 2U}, {"n_outputs", 2U}, {"pythonScript", pythonScript}});
         myBlock.init(myBlock.progress); // needed for unit-test only when executed outside a Scheduler/Graph
 
         int                                        count = 0;
@@ -135,7 +208,7 @@ def process_bulk(ins, outs):
         outs[i][:] = ins[i] * 2
 )";
 
-        PythonBlock<std::int32_t> myBlock({{"n_inputs", 3U}, {"n_outputs", 3U}, {"pythonScript", pythonScript}});
+        PythonBlock<std::int32_t> myBlock({{"n_inputs", 2U}, {"n_outputs", 2U}, {"pythonScript", pythonScript}});
 
         bool throws = false;
         try {
@@ -157,7 +230,7 @@ def process_bulk(ins, outs):
         outs[i][:] = ins[i] * 2/0 # <- (N.B. division by zero)
 )";
 
-        PythonBlock<float> myBlock({{"n_inputs", 3U}, {"n_outputs", 3U}, {"pythonScript", pythonScript}});
+        PythonBlock<float> myBlock({{"n_inputs", 2U}, {"n_outputs", 2U}, {"pythonScript", pythonScript}});
         myBlock.init(myBlock.progress); // needed for unit-test only when executed outside a Scheduler/Graph
 
         std::vector<float>                  data1 = {1, 2, 3};
@@ -175,6 +248,170 @@ def process_bulk(ins, outs):
             std::println("myBlock.processBulk(...) - correctly threw RuntimeWarning as exception:\n {}", ex.what());
         }
         expect(throws) << "RuntimeWarning should throw";
+    };
+
+    "a block configured with no port counts defaults to one in and one out"_test = [] {
+        std::string pythonScript = "def process_bulk(ins, outs):\n    for i in range(len(ins)):\n        outs[i][:] = ins[i] * 3\n";
+
+        PythonBlock<std::int32_t> myBlock({{"pythonScript", pythonScript}}); // no n_inputs / n_outputs
+        myBlock.init(myBlock.progress);
+
+        expect(eq(myBlock.n_inputs, gr::Size_t{1})) << "n_inputs must default to its lower limit, not 0";
+        expect(eq(myBlock.n_outputs, gr::Size_t{1})) << "n_outputs must default to its lower limit, not 0";
+        expect(eq(myBlock.inputs.size(), 1UZ)) << "the default port count must actually be applied";
+        expect(eq(myBlock.outputs.size(), 1UZ)) << "the default port count must actually be applied";
+
+        std::vector<std::int32_t>                  data = {1, 2, 3};
+        std::vector<std::int32_t>                  out(3);
+        std::vector<std::span<const std::int32_t>> ins  = {data};
+        std::vector<std::span<std::int32_t>>       outs = {out};
+        myBlock.processBulk(std::span(ins), std::span(outs));
+        expect(eq(out, std::vector<std::int32_t>{3, 6, 9})) << std::format("default-configured block produced {}", out);
+    };
+
+    "a script without process_bulk is rejected"_test = [] {
+        std::string pythonScript = "def some_other_name(ins, outs):\n    pass\n";
+
+        PythonBlock<std::int32_t> myBlock({{"n_inputs", 1U}, {"n_outputs", 1U}, {"pythonScript", pythonScript}});
+        myBlock.init(myBlock.progress);
+
+        std::vector<std::int32_t>                  data = {1, 2, 3};
+        std::vector<std::int32_t>                  out(3);
+        std::vector<std::span<const std::int32_t>> ins  = {data};
+        std::vector<std::span<std::int32_t>>       outs = {out};
+
+        bool throws = false;
+        try { // N.B. settings are applied lazily, so the script is validated on the first processBulk rather than in init()
+            myBlock.processBulk(std::span(ins), std::span(outs));
+        } catch (const std::exception& ex) {
+            throws = true;
+            expect(std::string_view(ex.what()).contains("process_bulk")) << std::format("the error should name the missing function, got: {}", ex.what());
+        }
+        expect(throws) << "a script without process_bulk must be rejected";
+    };
+
+    "lifecycle callbacks reach the script"_test = [] {
+        std::string               pythonScript = R"(def record(step):
+    settings = this_block.getSettings()
+    settings["lifecycle"] = settings.get("lifecycle", "") + step + ";"
+    this_block.setSettings(settings)
+
+def process_bulk(ins, outs):
+    for i in range(len(ins)):
+        outs[i][:] = ins[i]
+
+def start():
+    record("start")
+
+def pause():
+    record("pause")
+
+def resume():
+    record("resume")
+
+def stop():
+    record("stop")
+)";
+        PythonBlock<std::int32_t> myBlock({{"n_inputs", 1U}, {"n_outputs", 1U}, {"pythonScript", pythonScript}});
+        myBlock.init(myBlock.progress);
+
+        myBlock.start();
+        myBlock.pause();
+        myBlock.resume();
+        myBlock.stop();
+
+        expect(myBlock.getSettings().contains("lifecycle")) << "no lifecycle callback reached the script";
+        expect(eq(myBlock.getSettings().at("lifecycle"), "start;pause;resume;stop;"s)) << "lifecycle callbacks ran in the wrong order or not at all";
+    };
+
+    "an absent lifecycle callback is optional, not an error"_test = [] {
+        std::string pythonScript = "def process_bulk(ins, outs):\n    for i in range(len(ins)):\n        outs[i][:] = ins[i]\n"; // defines no start/stop/...
+
+        PythonBlock<std::int32_t> myBlock({{"n_inputs", 1U}, {"n_outputs", 1U}, {"pythonScript", pythonScript}});
+        myBlock.init(myBlock.progress);
+
+        bool throws = false;
+        try {
+            myBlock.start();
+            myBlock.pause();
+            myBlock.resume();
+            myBlock.stop();
+            myBlock.reset();
+        } catch (const std::exception& ex) {
+            throws = true;
+            std::println("unexpected: {}", ex.what());
+        }
+        expect(!throws) << "lifecycle hooks are optional and must not throw when the script omits them";
+    };
+
+    "two blocks with different scripts keep separate namespaces"_test = [] {
+        // both scripts define 'process_bulk' and bind 'this_block'; sharing one namespace made the last one configured win
+        std::string doubleIt = "def process_bulk(ins, outs):\n    for i in range(len(ins)):\n        outs[i][:] = ins[i] * 2\n";
+        std::string tenTimes = "def process_bulk(ins, outs):\n    for i in range(len(ins)):\n        outs[i][:] = ins[i] * 10\n";
+
+        PythonBlock<std::int32_t> doublingBlock({{"n_inputs", 1U}, {"n_outputs", 1U}, {"pythonScript", doubleIt}});
+        doublingBlock.init(doublingBlock.progress);
+        PythonBlock<std::int32_t> scalingBlock({{"n_inputs", 1U}, {"n_outputs", 1U}, {"pythonScript", tenTimes}});
+        scalingBlock.init(scalingBlock.progress);
+
+        std::vector<std::int32_t>                  data = {1, 2, 3};
+        std::vector<std::int32_t>                  doubled(3);
+        std::vector<std::int32_t>                  scaled(3);
+        std::vector<std::span<const std::int32_t>> doublingIn  = {data};
+        std::vector<std::span<const std::int32_t>> scalingIn   = {data};
+        std::vector<std::span<std::int32_t>>       doublingOut = {doubled};
+        std::vector<std::span<std::int32_t>>       scalingOut  = {scaled};
+
+        doublingBlock.processBulk(std::span(doublingIn), std::span(doublingOut));
+        scalingBlock.processBulk(std::span(scalingIn), std::span(scalingOut));
+
+        expect(eq(doubled, std::vector<std::int32_t>{2, 4, 6})) << std::format("the doubling block ran the wrong script: {}", doubled);
+        expect(eq(scaled, std::vector<std::int32_t>{10, 20, 30})) << std::format("the scaling block ran the wrong script: {}", scaled);
+    };
+
+    "non-string setting values raise TypeError instead of crashing"_test = [] {
+        std::string               pythonScript = R"(def process_bulk(ins, outs):
+    this_block.setSettings({"answer": 42})  # <- int value, not a string
+)";
+        PythonBlock<std::int32_t> myBlock({{"n_inputs", 1U}, {"n_outputs", 1U}, {"pythonScript", pythonScript}});
+        myBlock.init(myBlock.progress);
+
+        std::vector<std::int32_t>                  data = {1, 2, 3};
+        std::vector<std::int32_t>                  out(3);
+        std::vector<std::span<const std::int32_t>> ins  = {data};
+        std::vector<std::span<std::int32_t>>       outs = {out};
+
+        bool throws = false;
+        try {
+            myBlock.processBulk(std::span(ins), std::span(outs));
+        } catch (const std::exception& ex) {
+            throws = true;
+            expect(std::string_view(ex.what()).contains("TypeError")) << std::format("expected a Python TypeError, got: {}", ex.what());
+        }
+        expect(throws) << "a non-string settings value must surface as a Python error";
+    };
+
+    "a foreign capsule is rejected instead of dereferenced"_test = [] {
+        std::string               pythonScript = R"(import ctypes
+def process_bulk(ins, outs):
+    this_block.getTag.__self__.capsule = ctypes.pythonapi.PyCapsule_New(ctypes.c_void_p(1), b"bogus", None)
+    this_block.getTag()  # <- capsule name no longer matches this block type
+)";
+        PythonBlock<std::int32_t> myBlock({{"n_inputs", 1U}, {"n_outputs", 1U}, {"pythonScript", pythonScript}});
+        myBlock.init(myBlock.progress);
+
+        std::vector<std::int32_t>                  data = {1, 2, 3};
+        std::vector<std::int32_t>                  out(3);
+        std::vector<std::span<const std::int32_t>> ins  = {data};
+        std::vector<std::span<std::int32_t>>       outs = {out};
+
+        bool throws = false;
+        try {
+            myBlock.processBulk(std::span(ins), std::span(outs));
+        } catch (const std::exception&) {
+            throws = true; // a Python-level error is the correct outcome; a crash or C++ unwind through CPython is not
+        }
+        expect(throws) << "a capsule of the wrong type must produce a Python error";
     };
 
     "Python Execution via Scheduler/Graph"_test = [] {

--- a/blocks/basic/test/qa_PythonBlock.cpp
+++ b/blocks/basic/test/qa_PythonBlock.cpp
@@ -119,7 +119,7 @@ const boost::ut::suite<"PythonBlock"> pythonBlockTests = [] {
 
     "nominal PoC"_test = [] {
         // Your Python script
-        std::string pythonScript = R"(import time;
+        std::string python_script = R"(import time;
 counter = 0
 
 def process_bulk(ins, outs):
@@ -147,7 +147,7 @@ def process_bulk(ins, outs):
     print('Stop Python processing - time: {} seconds'.format(time.time() - start))
 )";
 
-        PythonBlock<std::int32_t> myBlock({{"n_inputs", 2U}, {"n_outputs", 2U}, {"pythonScript", pythonScript}});
+        PythonBlock<std::int32_t> myBlock({{"n_inputs", 2U}, {"n_outputs", 2U}, {"python_script", python_script}});
         myBlock.init(myBlock.progress); // needed for unit-test only when executed outside a Scheduler/Graph
 
         int                                        count = 0;
@@ -201,14 +201,14 @@ def process_bulk(ins, outs):
 
     "Python SyntaxError"_test = [] {
         // Your Python script
-        std::string pythonScript = R"(def process_bulk(ins, outs):
+        std::string python_script = R"(def process_bulk(ins, outs):
 
     # process the input->output samples
     for i in range(len(ins))     # <- (N.B. missing ':')
         outs[i][:] = ins[i] * 2
 )";
 
-        PythonBlock<std::int32_t> myBlock({{"n_inputs", 2U}, {"n_outputs", 2U}, {"pythonScript", pythonScript}});
+        PythonBlock<std::int32_t> myBlock({{"n_inputs", 2U}, {"n_outputs", 2U}, {"python_script", python_script}});
 
         bool throws = false;
         try {
@@ -223,14 +223,14 @@ def process_bulk(ins, outs):
 
     "Python RuntimeWarning as exception"_test = [] {
         // Your Python script
-        std::string pythonScript = R"(def process_bulk(ins, outs):
+        std::string python_script = R"(def process_bulk(ins, outs):
 
     # process the input->output samples
     for i in range(len(ins)):
         outs[i][:] = ins[i] * 2/0 # <- (N.B. division by zero)
 )";
 
-        PythonBlock<float> myBlock({{"n_inputs", 2U}, {"n_outputs", 2U}, {"pythonScript", pythonScript}});
+        PythonBlock<float> myBlock({{"n_inputs", 2U}, {"n_outputs", 2U}, {"python_script", python_script}});
         myBlock.init(myBlock.progress); // needed for unit-test only when executed outside a Scheduler/Graph
 
         std::vector<float>                  data1 = {1, 2, 3};
@@ -251,9 +251,9 @@ def process_bulk(ins, outs):
     };
 
     "a block configured with no port counts defaults to one in and one out"_test = [] {
-        std::string pythonScript = "def process_bulk(ins, outs):\n    for i in range(len(ins)):\n        outs[i][:] = ins[i] * 3\n";
+        std::string python_script = "def process_bulk(ins, outs):\n    for i in range(len(ins)):\n        outs[i][:] = ins[i] * 3\n";
 
-        PythonBlock<std::int32_t> myBlock({{"pythonScript", pythonScript}}); // no n_inputs / n_outputs
+        PythonBlock<std::int32_t> myBlock({{"python_script", python_script}}); // no n_inputs / n_outputs
         myBlock.init(myBlock.progress);
 
         expect(eq(myBlock.n_inputs, gr::Size_t{1})) << "n_inputs must default to its lower limit, not 0";
@@ -270,9 +270,9 @@ def process_bulk(ins, outs):
     };
 
     "a script without process_bulk is rejected"_test = [] {
-        std::string pythonScript = "def some_other_name(ins, outs):\n    pass\n";
+        std::string python_script = "def some_other_name(ins, outs):\n    pass\n";
 
-        PythonBlock<std::int32_t> myBlock({{"n_inputs", 1U}, {"n_outputs", 1U}, {"pythonScript", pythonScript}});
+        PythonBlock<std::int32_t> myBlock({{"n_inputs", 1U}, {"n_outputs", 1U}, {"python_script", python_script}});
         myBlock.init(myBlock.progress);
 
         std::vector<std::int32_t>                  data = {1, 2, 3};
@@ -291,7 +291,7 @@ def process_bulk(ins, outs):
     };
 
     "lifecycle callbacks reach the script"_test = [] {
-        std::string               pythonScript = R"(def record(step):
+        std::string               python_script = R"(def record(step):
     settings = this_block.getSettings()
     settings["lifecycle"] = settings.get("lifecycle", "") + step + ";"
     this_block.setSettings(settings)
@@ -312,7 +312,7 @@ def resume():
 def stop():
     record("stop")
 )";
-        PythonBlock<std::int32_t> myBlock({{"n_inputs", 1U}, {"n_outputs", 1U}, {"pythonScript", pythonScript}});
+        PythonBlock<std::int32_t> myBlock({{"n_inputs", 1U}, {"n_outputs", 1U}, {"python_script", python_script}});
         myBlock.init(myBlock.progress);
 
         myBlock.start();
@@ -325,9 +325,9 @@ def stop():
     };
 
     "an absent lifecycle callback is optional, not an error"_test = [] {
-        std::string pythonScript = "def process_bulk(ins, outs):\n    for i in range(len(ins)):\n        outs[i][:] = ins[i]\n"; // defines no start/stop/...
+        std::string python_script = "def process_bulk(ins, outs):\n    for i in range(len(ins)):\n        outs[i][:] = ins[i]\n"; // defines no start/stop/...
 
-        PythonBlock<std::int32_t> myBlock({{"n_inputs", 1U}, {"n_outputs", 1U}, {"pythonScript", pythonScript}});
+        PythonBlock<std::int32_t> myBlock({{"n_inputs", 1U}, {"n_outputs", 1U}, {"python_script", python_script}});
         myBlock.init(myBlock.progress);
 
         bool throws = false;
@@ -349,9 +349,9 @@ def stop():
         std::string doubleIt = "def process_bulk(ins, outs):\n    for i in range(len(ins)):\n        outs[i][:] = ins[i] * 2\n";
         std::string tenTimes = "def process_bulk(ins, outs):\n    for i in range(len(ins)):\n        outs[i][:] = ins[i] * 10\n";
 
-        PythonBlock<std::int32_t> doublingBlock({{"n_inputs", 1U}, {"n_outputs", 1U}, {"pythonScript", doubleIt}});
+        PythonBlock<std::int32_t> doublingBlock({{"n_inputs", 1U}, {"n_outputs", 1U}, {"python_script", doubleIt}});
         doublingBlock.init(doublingBlock.progress);
-        PythonBlock<std::int32_t> scalingBlock({{"n_inputs", 1U}, {"n_outputs", 1U}, {"pythonScript", tenTimes}});
+        PythonBlock<std::int32_t> scalingBlock({{"n_inputs", 1U}, {"n_outputs", 1U}, {"python_script", tenTimes}});
         scalingBlock.init(scalingBlock.progress);
 
         std::vector<std::int32_t>                  data = {1, 2, 3};
@@ -370,10 +370,10 @@ def stop():
     };
 
     "non-string setting values raise TypeError instead of crashing"_test = [] {
-        std::string               pythonScript = R"(def process_bulk(ins, outs):
+        std::string               python_script = R"(def process_bulk(ins, outs):
     this_block.setSettings({"answer": 42})  # <- int value, not a string
 )";
-        PythonBlock<std::int32_t> myBlock({{"n_inputs", 1U}, {"n_outputs", 1U}, {"pythonScript", pythonScript}});
+        PythonBlock<std::int32_t> myBlock({{"n_inputs", 1U}, {"n_outputs", 1U}, {"python_script", python_script}});
         myBlock.init(myBlock.progress);
 
         std::vector<std::int32_t>                  data = {1, 2, 3};
@@ -392,12 +392,12 @@ def stop():
     };
 
     "a foreign capsule is rejected instead of dereferenced"_test = [] {
-        std::string               pythonScript = R"(import ctypes
+        std::string               python_script = R"(import ctypes
 def process_bulk(ins, outs):
     this_block.getTag.__self__.capsule = ctypes.pythonapi.PyCapsule_New(ctypes.c_void_p(1), b"bogus", None)
     this_block.getTag()  # <- capsule name no longer matches this block type
 )";
-        PythonBlock<std::int32_t> myBlock({{"n_inputs", 1U}, {"n_outputs", 1U}, {"pythonScript", pythonScript}});
+        PythonBlock<std::int32_t> myBlock({{"n_inputs", 1U}, {"n_outputs", 1U}, {"python_script", python_script}});
         myBlock.init(myBlock.progress);
 
         std::vector<std::int32_t>                  data = {1, 2, 3};
@@ -415,7 +415,7 @@ def process_bulk(ins, outs):
     };
 
     "Python Execution via Scheduler/Graph"_test = [] {
-        std::string pythonScript = R"(def process_bulk(ins, outs):
+        std::string python_script = R"(def process_bulk(ins, outs):
 
     # process the input->output samples
     for i in range(len(ins)):
@@ -425,7 +425,7 @@ def process_bulk(ins, outs):
         using namespace gr::testing;
         Graph graph;
         auto& src   = graph.emplaceBlock<TagSource<int32_t>>({{"n_samples_max", 5U}, {"mark_tag", false}});
-        auto& block = graph.emplaceBlock<PythonBlock<int32_t>>({{"n_inputs", 1U}, {"n_outputs", 1U}, {"pythonScript", pythonScript}});
+        auto& block = graph.emplaceBlock<PythonBlock<int32_t>>({{"n_inputs", 1U}, {"n_outputs", 1U}, {"python_script", python_script}});
         auto& sink  = graph.emplaceBlock<TagSink<int32_t, ProcessFunction::USE_PROCESS_BULK>>({{"n_samples_expected", 5U}, {"verbose_console", true}});
 
         expect(graph.connect(src, "out", block, "inputs#0").has_value());
@@ -450,7 +450,7 @@ def process_bulk(ins, outs):
     };
 
     "Python Execution - Lifecycle method tests"_test = [] {
-        std::string pythonScript = R"x(import os
+        std::string python_script = R"x(import os
 counter = 0
 
 # optional life-cycle methods - can be used to inform the block of the scheduling state
@@ -490,7 +490,7 @@ def process_bulk(ins, outs):
         using namespace gr::testing;
         Graph graph;
         auto& src   = graph.emplaceBlock<TagSource<float>>({{"n_samples_max", 5U}, {"mark_tag", false}});
-        auto& block = graph.emplaceBlock<PythonBlock<float>>({{"n_inputs", 1U}, {"n_outputs", 1U}, {"pythonScript", pythonScript}});
+        auto& block = graph.emplaceBlock<PythonBlock<float>>({{"n_inputs", 1U}, {"n_outputs", 1U}, {"python_script", python_script}});
         auto& sink  = graph.emplaceBlock<TagSink<float, ProcessFunction::USE_PROCESS_BULK>>({{"n_samples_expected", 5U}, {"verbose_console", true}});
 
         expect(graph.connect(src, "out", block, "inputs#0").has_value());

--- a/blocks/basic/test/qa_PythonBlock.cpp
+++ b/blocks/basic/test/qa_PythonBlock.cpp
@@ -3,6 +3,12 @@
 
 #include <boost/ut.hpp>
 
+#include <gnuradio-4.0/algorithm/fileio/FileIo.hpp>
+
+#include <filesystem>
+#include <fstream>
+#include <future>
+
 #include <gnuradio-4.0/Graph.hpp>
 
 #include <gnuradio-4.0/Scheduler.hpp>
@@ -116,6 +122,8 @@ const boost::ut::suite<"PythonBlock"> pythonBlockTests = [] {
     static_assert(gr::HasProcessBulkFunction<gr::basic::PythonBlock<std::int32_t>>);
     static_assert(gr::HasRequiredProcessFunction<gr::basic::PythonBlock<float>>);
     static_assert(gr::HasProcessBulkFunction<gr::basic::PythonBlock<float>>);
+    static_assert(gr::HasRequiredProcessFunction<gr::basic::PythonBlock<double>>);
+    static_assert(gr::HasProcessBulkFunction<gr::basic::PythonBlock<double>>);
 
     "nominal PoC"_test = [] {
         // Your Python script
@@ -248,6 +256,221 @@ def process_bulk(ins, outs):
             std::println("myBlock.processBulk(...) - correctly threw RuntimeWarning as exception:\n {}", ex.what());
         }
         expect(throws) << "RuntimeWarning should throw";
+    };
+
+    "a script is loaded when the value is a path"_test = [] {
+        const std::filesystem::path scriptPath = std::filesystem::temp_directory_path() / "qa_PythonBlock_from_file.py";
+        {
+            std::ofstream file(scriptPath);
+            file << "def process_bulk(ins, outs):\n    for i in range(len(ins)):\n        outs[i][:] = ins[i] * 7\n";
+        }
+
+        PythonBlock<std::int32_t> myBlock({{"python_script", scriptPath.string()}});
+        myBlock.init(myBlock.progress);
+
+        std::vector<std::int32_t>                  data = {1, 2, 3};
+        std::vector<std::int32_t>                  out(3);
+        std::vector<std::span<const std::int32_t>> ins  = {data};
+        std::vector<std::span<std::int32_t>>       outs = {out};
+        myBlock.processBulk(std::span(ins), std::span(outs));
+
+        expect(eq(out, std::vector<std::int32_t>{7, 14, 21})) << std::format("the path was not loaded, got {}", out);
+        std::filesystem::remove(scriptPath);
+    };
+
+    "a gzip-compressed script is decompressed transparently"_test = [] {
+        // python_script goes through gr::algorithm::fileio, so .gz is decoded on read without any extra handling in the block
+        const std::filesystem::path scriptPath = std::filesystem::temp_directory_path() / "qa_PythonBlock_from_file.py.gz";
+        const std::string           source     = "def process_bulk(ins, outs):\n    for i in range(len(ins)):\n        outs[i][:] = ins[i] * 9\n";
+        const auto                  bytes      = std::span(reinterpret_cast<const std::uint8_t*>(source.data()), source.size());
+
+        gr::algorithm::fileio::WriterConfig writerConfig{};
+        writerConfig.compression = gr::algorithm::fileio::CompressionMode::gzip;
+        const auto written       = gr::algorithm::fileio::write(scriptPath.string(), bytes, writerConfig);
+        expect(written.has_value()) << "could not write the compressed fixture";
+
+        PythonBlock<std::int32_t> myBlock({{"python_script", scriptPath.string()}});
+        myBlock.init(myBlock.progress);
+
+        std::vector<std::int32_t>                  data = {1, 2, 3};
+        std::vector<std::int32_t>                  out(3);
+        std::vector<std::span<const std::int32_t>> ins  = {data};
+        std::vector<std::span<std::int32_t>>       outs = {out};
+        myBlock.processBulk(std::span(ins), std::span(outs));
+
+        expect(eq(out, std::vector<std::int32_t>{9, 18, 27})) << std::format("the gzip-compressed script was not decoded, got {}", out);
+        std::filesystem::remove(scriptPath);
+    };
+
+    "a verbatim script is never mistaken for a location"_test = [] {
+        // the shapes that decide it: a leading '/' or './' is a path, a scheme is a URI, everything else is the script itself
+        expect(!PythonBlock<std::int32_t>::isScriptLocation("import os\n\ndef process_bulk(ins, outs):\n    pass\n")) << "an ordinary script";
+        expect(!PythonBlock<std::int32_t>::isScriptLocation("rate: float = 1e6\n")) << "an annotated global -- 'rate:' is not followed by '/'";
+        expect(!PythonBlock<std::int32_t>::isScriptLocation("# see https://example.com for details\ndef process_bulk(i, o): pass\n")) << "a URL inside a comment";
+        expect(!PythonBlock<std::int32_t>::isScriptLocation("x = 1")) << "a one-line script";
+        expect(!PythonBlock<std::int32_t>::isScriptLocation("")) << "the empty default";
+
+        expect(PythonBlock<std::int32_t>::isScriptLocation("/opt/gr/dsp.py")) << "an absolute path";
+        expect(PythonBlock<std::int32_t>::isScriptLocation("./dsp.py")) << "a relative path";
+        expect(PythonBlock<std::int32_t>::isScriptLocation("../shared/dsp.py")) << "a parent-relative path";
+        expect(PythonBlock<std::int32_t>::isScriptLocation("file:/opt/gr/dsp.py")) << "a file URI";
+        expect(PythonBlock<std::int32_t>::isScriptLocation("http://host/dsp.py")) << "an http URI";
+        expect(PythonBlock<std::int32_t>::isScriptLocation("https://host/dsp.py.gz")) << "an https URI";
+        expect(PythonBlock<std::int32_t>::isScriptLocation("HTTPS://host/dsp.py")) << "URI schemes are case-insensitive";
+
+        // outside the white-list: readAsync() cannot serve these on every platform, so they must not be treated as locations
+        expect(!PythonBlock<std::int32_t>::isScriptLocation("download:/dsp.py")) << "download:/ is write-only";
+        expect(!PythonBlock<std::int32_t>::isScriptLocation("dialog:/dsp.py")) << "dialog:/ exists under Emscripten alone";
+        expect(!PythonBlock<std::int32_t>::isScriptLocation("file:relative.py")) << "'file:' without a slash is not a URI GR4 resolves";
+        expect(!PythonBlock<std::int32_t>::isScriptLocation("ftp://host/dsp.py")) << "an unsupported scheme";
+    };
+
+    "a script given as a file: URI is loaded"_test = [] {
+        const std::filesystem::path scriptPath = std::filesystem::temp_directory_path() / "qa_PythonBlock_uri.py";
+        {
+            std::ofstream file(scriptPath);
+            file << "def process_bulk(ins, outs):\n    for i in range(len(ins)):\n        outs[i][:] = ins[i] * 11\n";
+        }
+
+        PythonBlock<std::int32_t> myBlock({{"python_script", std::format("file:{}", scriptPath.string())}});
+        myBlock.init(myBlock.progress);
+
+        std::vector<std::int32_t>                  data = {1, 2, 3};
+        std::vector<std::int32_t>                  out(3);
+        std::vector<std::span<const std::int32_t>> ins  = {data};
+        std::vector<std::span<std::int32_t>>       outs = {out};
+        myBlock.processBulk(std::span(ins), std::span(outs));
+
+        expect(eq(out, std::vector<std::int32_t>{11, 22, 33})) << std::format("the file: URI was not loaded, got {}", out);
+        std::filesystem::remove(scriptPath);
+    };
+
+    "a missing script location is reported"_test = [] {
+        bool throws = false;
+        try {
+            PythonBlock<std::int32_t> myBlock({{"python_script", "/nonexistent/definitely_not_here.py"}});
+            myBlock.init(myBlock.progress);
+
+            std::vector<std::int32_t>                  data = {1};
+            std::vector<std::int32_t>                  out(1);
+            std::vector<std::span<const std::int32_t>> ins  = {data};
+            std::vector<std::span<std::int32_t>>       outs = {out};
+            myBlock.processBulk(std::span(ins), std::span(outs));
+        } catch (const std::exception& ex) {
+            throws = true;
+            expect(std::string_view(ex.what()).contains("python_script")) << std::format("the error should name the setting, got: {}", ex.what());
+        }
+        expect(throws) << "an unreadable script location must be reported";
+    };
+
+    "python_path makes a local module importable"_test = [] {
+        const std::filesystem::path moduleDir = std::filesystem::temp_directory_path() / "qa_PythonBlock_modules";
+        std::filesystem::create_directories(moduleDir);
+        {
+            std::ofstream file(moduleDir / "qa_python_block_helper.py");
+            file << "FACTOR = 5\n";
+        }
+
+        std::string               python_script = R"(import qa_python_block_helper
+
+def process_bulk(ins, outs):
+    for i in range(len(ins)):
+        outs[i][:] = ins[i] * qa_python_block_helper.FACTOR
+)";
+        PythonBlock<std::int32_t> myBlock({{"python_path", std::vector<std::string>{moduleDir.string()}}, {"python_script", python_script}});
+        myBlock.init(myBlock.progress);
+
+        std::vector<std::int32_t>                  data = {1, 2, 3};
+        std::vector<std::int32_t>                  out(3);
+        std::vector<std::span<const std::int32_t>> ins  = {data};
+        std::vector<std::span<std::int32_t>>       outs = {out};
+        myBlock.processBulk(std::span(ins), std::span(outs));
+
+        expect(eq(out, std::vector<std::int32_t>{5, 10, 15})) << std::format("the helper module was not importable, got {}", out);
+        std::filesystem::remove_all(moduleDir);
+    };
+
+    "script print() does not reach stdout"_test = [] {
+        std::string               python_script = R"(def process_bulk(ins, outs):
+    print("hello from the script")
+    for i in range(len(ins)):
+        outs[i][:] = ins[i]
+)";
+        PythonBlock<std::int32_t> myBlock({{"python_script", python_script}});
+        myBlock.init(myBlock.progress);
+
+        std::vector<std::int32_t>                  data = {1, 2, 3};
+        std::vector<std::int32_t>                  out(3);
+        std::vector<std::span<const std::int32_t>> ins  = {data};
+        std::vector<std::span<std::int32_t>>       outs = {out};
+
+        bool throws = false;
+        try { // print() is shadowed per module; the message goes to gr::log, and the script must still run normally
+            myBlock.processBulk(std::span(ins), std::span(outs));
+        } catch (const std::exception& ex) {
+            throws = true;
+            std::println("unexpected: {}", ex.what());
+        }
+        expect(!throws) << "the shadowed print() must not break the script";
+        expect(eq(out, std::vector<std::int32_t>{1, 2, 3}));
+    };
+
+    "the block runs on a thread other than the one that initialised Python"_test = [] {
+        // Py_Initialize() leaves the GIL held; if it is not released, PyGILState_Ensure() on any other thread blocks forever
+        std::string python_script = "def process_bulk(ins, outs):\n    for i in range(len(ins)):\n        outs[i][:] = ins[i] * 2\n";
+
+        PythonBlock<std::int32_t> myBlock({{"python_script", python_script}});
+        myBlock.init(myBlock.progress);
+
+        std::vector<std::int32_t>                  data = {1, 2, 3};
+        std::vector<std::int32_t>                  out(3);
+        std::vector<std::span<const std::int32_t>> ins  = {data};
+        std::vector<std::span<std::int32_t>>       outs = {out};
+
+        auto worker = std::async(std::launch::async, [&] { return myBlock.processBulk(std::span(ins), std::span(outs)); });
+        expect(worker.wait_for(std::chrono::seconds(10)) == std::future_status::ready) << "processBulk on a worker thread deadlocked on the GIL";
+        if (worker.wait_for(std::chrono::seconds(0)) == std::future_status::ready) {
+            worker.get();
+            expect(eq(out, std::vector<std::int32_t>{2, 4, 6})) << std::format("worker thread produced {}", out);
+        }
+    };
+
+    "a multi-threaded scheduler runs the block to completion"_test = [] {
+        std::string python_script = "def process_bulk(ins, outs):\n    for i in range(len(ins)):\n        outs[i][:] = ins[i] * 2\n";
+
+        using namespace gr::testing;
+        Graph graph;
+        auto& src   = graph.emplaceBlock<TagSource<std::int32_t>>({{"n_samples_max", 5U}, {"mark_tag", false}});
+        auto& block = graph.emplaceBlock<PythonBlock<std::int32_t>>({{"python_script", python_script}});
+        auto& sink  = graph.emplaceBlock<TagSink<std::int32_t, ProcessFunction::USE_PROCESS_BULK>>({{"n_samples_expected", 5U}});
+        expect(graph.connect(src, "out", block, "inputs#0").has_value());
+        expect(graph.connect(block, "outputs#0", sink, "in").has_value());
+
+        gr::scheduler::Simple<gr::scheduler::ExecutionPolicy::multiThreaded> sched;
+        if (auto ret = sched.exchange(std::move(graph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
+        auto run = std::async(std::launch::async, [&sched] { return sched.runAndWait().has_value(); });
+        expect(run.wait_for(std::chrono::seconds(20)) == std::future_status::ready) << "the multi-threaded scheduler deadlocked on the GIL";
+        if (run.wait_for(std::chrono::seconds(0)) == std::future_status::ready) {
+            expect(run.get());
+            expect(eq(sink._samples, std::vector<std::int32_t>{0, 2, 4, 6, 8})) << std::format("mismatch of vector {}", sink._samples);
+        }
+    };
+
+    "double is a usable sample type"_test = [] {
+        std::string python_script = "def process_bulk(ins, outs):\n    for i in range(len(ins)):\n        outs[i][:] = ins[i] / 4\n";
+
+        PythonBlock<double> myBlock({{"python_script", python_script}});
+        myBlock.init(myBlock.progress);
+
+        std::vector<double>                  data = {1.0, 2.0, 3.0};
+        std::vector<double>                  out(3);
+        std::vector<std::span<const double>> ins  = {data};
+        std::vector<std::span<double>>       outs = {out};
+        myBlock.processBulk(std::span(ins), std::span(outs));
+
+        expect(eq(out, std::vector<double>{0.25, 0.5, 0.75})) << std::format("float64 round-trip produced {}", out);
     };
 
     "a block configured with no port counts defaults to one in and one out"_test = [] {
@@ -412,6 +635,342 @@ def process_bulk(ins, outs):
             throws = true; // a Python-level error is the correct outcome; a crash or C++ unwind through CPython is not
         }
         expect(throws) << "a capsule of the wrong type must produce a Python error";
+    };
+
+    "input tags reach the script and are consumed one by one"_test = [] {
+        std::string python_script = R"(seen = []
+
+def process_bulk(ins, outs):
+    while this_block.tagAvailable():
+        tag = this_block.getTag()
+        seen.append("{}:{}".format(tag["index"], tag["map"].get("marker", "<none>")))
+    for i in range(len(ins)):
+        outs[i][:] = ins[i]
+    settings = this_block.getSettings()
+    settings["seen"] = ",".join(seen)
+    this_block.setSettings(settings)
+)";
+
+        using namespace gr::testing;
+        Graph graph;
+        auto& src   = graph.emplaceBlock<TagSource<std::int32_t>>({{"n_samples_max", 4U}, {"mark_tag", false}});
+        auto& block = graph.emplaceBlock<PythonBlock<std::int32_t>>({{"python_script", python_script}});
+        auto& sink  = graph.emplaceBlock<TagSink<std::int32_t, ProcessFunction::USE_PROCESS_BULK>>({{"n_samples_expected", 4U}});
+        src._tags   = {{0UZ, {{"marker", "first"}}}, {2UZ, {{"marker", "second"}}}};
+
+        expect(graph.connect(src, "out", block, "inputs#0").has_value());
+        expect(graph.connect(block, "outputs#0", sink, "in").has_value());
+
+        gr::scheduler::Simple sched;
+        if (auto ret = sched.exchange(std::move(graph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
+        expect(sched.runAndWait().has_value());
+
+        const auto& settings = block.getSettings();
+        expect(settings.contains("seen")) << "the script never observed a tag";
+        expect(std::string_view(settings.at("seen")).contains("first")) << std::format("first tag missing, script saw: {}", settings.at("seen"));
+        expect(std::string_view(settings.at("seen")).contains("second")) << std::format("second tag missing, script saw: {}", settings.at("seen"));
+    };
+
+    "input tags are forwarded to the output by default"_test = [] {
+        std::string python_script = "def process_bulk(ins, outs):\n    for i in range(len(ins)):\n        outs[i][:] = ins[i]\n";
+
+        using namespace gr::testing;
+        Graph graph;
+        auto& src   = graph.emplaceBlock<TagSource<std::int32_t>>({{"n_samples_max", 4U}, {"mark_tag", false}});
+        auto& block = graph.emplaceBlock<PythonBlock<std::int32_t>>({{"python_script", python_script}});
+        auto& sink  = graph.emplaceBlock<TagSink<std::int32_t, ProcessFunction::USE_PROCESS_BULK>>({{"n_samples_expected", 4U}});
+        src._tags   = {{0UZ, {{"marker", "first"}}}, {2UZ, {{"marker", "second"}}}};
+
+        expect(graph.connect(src, "out", block, "inputs#0").has_value());
+        expect(graph.connect(block, "outputs#0", sink, "in").has_value());
+
+        gr::scheduler::Simple sched;
+        if (auto ret = sched.exchange(std::move(graph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
+        expect(sched.runAndWait().has_value());
+
+        expect(eq(sink._tags.size(), 2UZ)) << std::format("the block must not swallow tags, sink saw {}", sink._tags.size());
+        const auto markers = sink._tags | std::views::transform([](const auto& tag) { return tag.map.find_value("marker").value().value_or(std::string()); });
+        expect(std::ranges::find(markers, "first") != markers.end()) << "the first tag was not forwarded";
+        expect(std::ranges::find(markers, "second") != markers.end()) << "the second tag was not forwarded";
+    };
+
+    "tag forwarding can be switched off"_test = [] {
+        std::string python_script = "def process_bulk(ins, outs):\n    for i in range(len(ins)):\n        outs[i][:] = ins[i]\n";
+
+        using namespace gr::testing;
+        Graph graph;
+        auto& src   = graph.emplaceBlock<TagSource<std::int32_t>>({{"n_samples_max", 4U}, {"mark_tag", false}});
+        auto& block = graph.emplaceBlock<PythonBlock<std::int32_t>>({{"forward_tags", false}, {"python_script", python_script}});
+        auto& sink  = graph.emplaceBlock<TagSink<std::int32_t, ProcessFunction::USE_PROCESS_BULK>>({{"n_samples_expected", 4U}});
+        src._tags   = {{0UZ, {{"marker", "first"}}}};
+
+        expect(graph.connect(src, "out", block, "inputs#0").has_value());
+        expect(graph.connect(block, "outputs#0", sink, "in").has_value());
+
+        gr::scheduler::Simple sched;
+        if (auto ret = sched.exchange(std::move(graph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
+        expect(sched.runAndWait().has_value());
+
+        expect(eq(sink._tags.size(), 0UZ)) << std::format("forward_tags=false must drop the tags, sink saw {}", sink._tags.size());
+    };
+
+    "tags published out of order do not abort the process"_test = [] {
+        std::string python_script = R"(def process_bulk(ins, outs):
+    this_block.publishTag(3, {"late": "1"})
+    this_block.publishTag(1, {"early": "1"})   # descending: publishTag() aborts on a descending index
+    for i in range(len(ins)):
+        outs[i][:] = ins[i]
+)";
+        using namespace gr::testing;
+        Graph graph;
+        auto& src   = graph.emplaceBlock<TagSource<std::int32_t>>({{"n_samples_max", 8U}, {"mark_tag", false}});
+        auto& block = graph.emplaceBlock<PythonBlock<std::int32_t>>({{"python_script", python_script}});
+        auto& sink  = graph.emplaceBlock<TagSink<std::int32_t, ProcessFunction::USE_PROCESS_BULK>>({{"n_samples_expected", 8U}});
+        expect(graph.connect(src, "out", block, "inputs#0").has_value());
+        expect(graph.connect(block, "outputs#0", sink, "in").has_value());
+
+        gr::scheduler::Simple sched;
+        if (auto ret = sched.exchange(std::move(graph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
+        expect(sched.runAndWait().has_value());
+        expect(ge(sink._tags.size(), 2UZ)) << std::format("both tags should arrive, sink saw {}", sink._tags.size());
+        expect(std::ranges::is_sorted(sink._tags, {}, [](const auto& tag) { return tag.index; })) << "tags must reach the sink in ascending index order";
+    };
+
+    "a tag beyond the chunk is dropped, not published out of range"_test = [] {
+        // N.B. driven through a Graph: with plain std::span the publish path is compiled out and the case would go unexercised
+        std::string python_script = R"(def process_bulk(ins, outs):
+    this_block.publishTag(100000, {"far": "1"})
+    for i in range(len(ins)):
+        outs[i][:] = ins[i]
+)";
+        using namespace gr::testing;
+        Graph graph;
+        auto& src   = graph.emplaceBlock<TagSource<std::int32_t>>({{"n_samples_max", 4U}, {"mark_tag", false}});
+        auto& block = graph.emplaceBlock<PythonBlock<std::int32_t>>({{"python_script", python_script}});
+        auto& sink  = graph.emplaceBlock<TagSink<std::int32_t, ProcessFunction::USE_PROCESS_BULK>>({{"n_samples_expected", 4U}});
+        expect(graph.connect(src, "out", block, "inputs#0").has_value());
+        expect(graph.connect(block, "outputs#0", sink, "in").has_value());
+
+        gr::scheduler::Simple sched;
+        if (auto ret = sched.exchange(std::move(graph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
+        expect(sched.runAndWait().has_value()) << "an out-of-range offset must not abort the run";
+        expect(std::ranges::none_of(sink._tags, [](const auto& tag) { return tag.map.contains("far"); })) << "the out-of-range tag must be dropped, not placed elsewhere";
+    };
+
+    "python_path keeps the order it was given"_test = [] {
+        const auto base   = std::filesystem::temp_directory_path() / "qa_PythonBlock_order";
+        const auto first  = base / "first";
+        const auto second = base / "second";
+        std::filesystem::create_directories(first);
+        std::filesystem::create_directories(second);
+        { // same module name in both, differing only in value
+            std::ofstream(first / "qa_python_block_order.py") << "WHICH = 1\n";
+            std::ofstream(second / "qa_python_block_order.py") << "WHICH = 2\n";
+        }
+
+        std::string               python_script = R"(import qa_python_block_order
+
+def process_bulk(ins, outs):
+    for i in range(len(ins)):
+        outs[i][:] = ins[i] * qa_python_block_order.WHICH
+)";
+        PythonBlock<std::int32_t> myBlock({{"python_path", std::vector<std::string>{first.string(), second.string()}}, {"python_script", python_script}});
+        myBlock.init(myBlock.progress);
+
+        std::vector<std::int32_t>                  data = {1, 2, 3};
+        std::vector<std::int32_t>                  out(3);
+        std::vector<std::span<const std::int32_t>> ins  = {data};
+        std::vector<std::span<std::int32_t>>       outs = {out};
+        myBlock.processBulk(std::span(ins), std::span(outs));
+
+        expect(eq(out, std::vector<std::int32_t>{1, 2, 3})) << std::format("the first python_path entry must win, got {}", out);
+        std::filesystem::remove_all(base);
+    };
+
+    "a tag on several inputs is forwarded once"_test = [] {
+        std::string python_script = "def process_bulk(ins, outs):\n    for i in range(len(outs)):\n        outs[i][:] = ins[i]\n"; // two inputs, one output
+
+        using namespace gr::testing;
+        Graph graph;
+        auto& srcOne = graph.emplaceBlock<TagSource<std::int32_t>>({{"n_samples_max", 4U}, {"mark_tag", false}});
+        auto& srcTwo = graph.emplaceBlock<TagSource<std::int32_t>>({{"n_samples_max", 4U}, {"mark_tag", false}});
+        auto& block  = graph.emplaceBlock<PythonBlock<std::int32_t>>({{"n_inputs", 2U}, {"n_outputs", 1U}, {"python_script", python_script}});
+        auto& sink   = graph.emplaceBlock<TagSink<std::int32_t, ProcessFunction::USE_PROCESS_BULK>>({{"n_samples_expected", 4U}});
+        srcOne._tags = {{0UZ, {{"marker", "shared"}}}}; // the identical tag arrives on both inputs
+        srcTwo._tags = {{0UZ, {{"marker", "shared"}}}};
+
+        expect(graph.connect(srcOne, "out", block, "inputs#0").has_value());
+        expect(graph.connect(srcTwo, "out", block, "inputs#1").has_value());
+        expect(graph.connect(block, "outputs#0", sink, "in").has_value());
+
+        gr::scheduler::Simple sched;
+        if (auto ret = sched.exchange(std::move(graph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
+        expect(sched.runAndWait().has_value());
+
+        const auto markers = std::ranges::count_if(sink._tags, [](const auto& tag) { return tag.map.contains("marker"); });
+        expect(eq(markers, 1L)) << std::format("the shared tag must be forwarded once, saw {}", markers);
+    };
+
+    "'gr:' tags are not duplicated by the block"_test = [] {
+        std::string python_script = "def process_bulk(ins, outs):\n    for i in range(len(ins)):\n        outs[i][:] = ins[i]\n";
+
+        using namespace gr::testing;
+        Graph graph;
+        auto& src   = graph.emplaceBlock<TagSource<std::int32_t>>({{"n_samples_max", 4U}, {"mark_tag", false}, {"sample_rate", 4096.f}});
+        auto& block = graph.emplaceBlock<PythonBlock<std::int32_t>>({{"python_script", python_script}});
+        auto& sink  = graph.emplaceBlock<TagSink<std::int32_t, ProcessFunction::USE_PROCESS_BULK>>({{"n_samples_expected", 4U}});
+        src._tags   = {{0UZ, {{"marker", "first"}}}};
+        expect(graph.connect(src, "out", block, "inputs#0").has_value());
+        expect(graph.connect(block, "outputs#0", sink, "in").has_value());
+
+        gr::scheduler::Simple sched;
+        if (auto ret = sched.exchange(std::move(graph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
+        expect(sched.runAndWait().has_value());
+
+        const auto sampleRateTags = std::ranges::count_if(sink._tags, [](const auto& tag) { return tag.map.contains("gr:sample_rate"); });
+        expect(eq(sampleRateTags, 1L)) << std::format("Block<> already forwards 'gr:' keys; the block must not repeat them (saw {})", sampleRateTags);
+    };
+
+    "a raising lifecycle hook is reported, not swallowed"_test = [] {
+        std::string               python_script = R"(def process_bulk(ins, outs):
+    for i in range(len(ins)):
+        outs[i][:] = ins[i]
+
+def start():
+    raise ValueError("boom in start")
+)";
+        PythonBlock<std::int32_t> myBlock({{"python_script", python_script}});
+        myBlock.init(myBlock.progress);
+
+        bool throws = false;
+        try {
+            myBlock.start();
+        } catch (const std::exception& ex) {
+            throws = true;
+            expect(std::string_view(ex.what()).contains("boom in start")) << std::format("the error should carry the script's message, got: {}", ex.what());
+        }
+        expect(throws) << "a raising lifecycle hook must surface";
+
+        // and the interpreter must be usable afterwards, i.e. the error indicator was consumed
+        std::vector<std::int32_t>                  data = {1, 2, 3};
+        std::vector<std::int32_t>                  out(3);
+        std::vector<std::span<const std::int32_t>> ins  = {data};
+        std::vector<std::span<std::int32_t>>       outs = {out};
+        expect(nothrow([&] { myBlock.processBulk(std::span(ins), std::span(outs)); })) << "a poisoned error indicator would fail the next call";
+    };
+
+    "tag values reach the script unquoted"_test = [] {
+        std::string python_script = R"(def process_bulk(ins, outs):
+    while this_block.tagAvailable():
+        tag = this_block.getTag()
+        settings = this_block.getSettings()
+        settings["marker"] = tag["map"].get("marker", "<missing>")
+        this_block.setSettings(settings)
+    for i in range(len(ins)):
+        outs[i][:] = ins[i]
+)";
+        using namespace gr::testing;
+        Graph graph;
+        auto& src   = graph.emplaceBlock<TagSource<std::int32_t>>({{"n_samples_max", 4U}, {"mark_tag", false}});
+        auto& block = graph.emplaceBlock<PythonBlock<std::int32_t>>({{"python_script", python_script}});
+        auto& sink  = graph.emplaceBlock<TagSink<std::int32_t, ProcessFunction::USE_PROCESS_BULK>>({{"n_samples_expected", 4U}});
+        src._tags   = {{0UZ, {{"marker", "first"}}}};
+        expect(graph.connect(src, "out", block, "inputs#0").has_value());
+        expect(graph.connect(block, "outputs#0", sink, "in").has_value());
+
+        gr::scheduler::Simple sched;
+        if (auto ret = sched.exchange(std::move(graph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
+        expect(sched.runAndWait().has_value());
+        expect(eq(block.getSettings().at("marker"), "first"s)) << std::format("string tag values must not carry quotes, got: {}", block.getSettings().at("marker"));
+    };
+
+    "print() accepts the builtin's keywords"_test = [] {
+        std::string               python_script = R"(import sys
+
+def process_bulk(ins, outs):
+    print("to stderr", file=sys.stderr, flush=True)
+    for i in range(len(ins)):
+        outs[i][:] = ins[i]
+)";
+        PythonBlock<std::int32_t> myBlock({{"python_script", python_script}});
+        myBlock.init(myBlock.progress);
+
+        std::vector<std::int32_t>                  data = {1, 2, 3};
+        std::vector<std::int32_t>                  out(3);
+        std::vector<std::span<const std::int32_t>> ins  = {data};
+        std::vector<std::span<std::int32_t>>       outs = {out};
+        expect(nothrow([&] { myBlock.processBulk(std::span(ins), std::span(outs)); })) << "print(file=..., flush=...) must not raise";
+    };
+
+    "a location may carry trailing whitespace"_test = [] {
+        const std::filesystem::path scriptPath = std::filesystem::temp_directory_path() / "qa_PythonBlock_ws.py";
+        {
+            std::ofstream file(scriptPath);
+            file << "def process_bulk(ins, outs):\n    for i in range(len(ins)):\n        outs[i][:] = ins[i] * 6\n";
+        }
+
+        PythonBlock<std::int32_t> myBlock({{"python_script", scriptPath.string() + "\n"}}); // YAML block scalars keep the newline
+        myBlock.init(myBlock.progress);
+
+        std::vector<std::int32_t>                  data = {1, 2, 3};
+        std::vector<std::int32_t>                  out(3);
+        std::vector<std::span<const std::int32_t>> ins  = {data};
+        std::vector<std::span<std::int32_t>>       outs = {out};
+        myBlock.processBulk(std::span(ins), std::span(outs));
+
+        expect(eq(out, std::vector<std::int32_t>{6, 12, 18})) << std::format("a trailing newline must not defeat the load, got {}", out);
+        std::filesystem::remove(scriptPath);
+    };
+
+    "a tag published by the script reaches the output"_test = [] {
+        std::string python_script = R"(published = False
+
+def process_bulk(ins, outs):
+    global published
+    if not published:
+        this_block.publishTag(0, {"origin": "python", "unit": "V"})
+        published = True
+    for i in range(len(ins)):
+        outs[i][:] = ins[i]
+)";
+
+        using namespace gr::testing;
+        Graph graph;
+        auto& src   = graph.emplaceBlock<TagSource<std::int32_t>>({{"n_samples_max", 4U}, {"mark_tag", false}});
+        auto& block = graph.emplaceBlock<PythonBlock<std::int32_t>>({{"python_script", python_script}});
+        auto& sink  = graph.emplaceBlock<TagSink<std::int32_t, ProcessFunction::USE_PROCESS_BULK>>({{"n_samples_expected", 4U}});
+
+        expect(graph.connect(src, "out", block, "inputs#0").has_value());
+        expect(graph.connect(block, "outputs#0", sink, "in").has_value());
+
+        gr::scheduler::Simple sched;
+        if (auto ret = sched.exchange(std::move(graph)); !ret) {
+            throw std::runtime_error(std::format("failed to initialize scheduler: {}", ret.error()));
+        }
+        expect(sched.runAndWait().has_value());
+
+        const auto published = std::ranges::find_if(sink._tags, [](const auto& tag) { return tag.map.contains("origin"); });
+        expect(published != sink._tags.end()) << std::format("no script-published tag arrived; sink saw {} tag(s)", sink._tags.size());
+        if (published != sink._tags.end()) {
+            expect(eq(published->map.find_value("origin").value().value_or(std::string()), "python"s));
+            expect(eq(published->map.find_value("unit").value().value_or(std::string()), "V"s));
+        }
     };
 
     "Python Execution via Scheduler/Graph"_test = [] {


### PR DESCRIPTION
`qa_PythonBlock` aborted with `free(): invalid size`. Fixing that surfaced other defects in the C++/Python boundary that I felt needed fixing.

Suggested reviewing commit by commit; each is self-contained, builds with `-Werror` and
passes on its own. The commit messages carry the detail.


Two behaviours worth knowing before:
- The GIL was never released after `Py_Initialize()`, fine for the unit-test but not on a multi-threaded scheduled graph.
- `Block<>` already forwards `gr:`-prefixed tags before `processBulk`. The block forwards only the remainder;

**Breaking**: `pythonScript` -> `python_script`, and the separate `script_uri` setting is gone — `python_script` now holds either the script or its location.