### PR TITLE
ci: make ccache effective for PCH builds, stop PRs evicting main's cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,12 +112,12 @@ jobs:
 
       - name: Configure ccache
         run: |
-          ccache --max-size=3G
+          ccache --max-size=2G
           ccache --set-config=compression=true
           ccache --set-config=compression_level=6
           ccache --set-config=depend_mode=true
           ccache --set-config=hash_dir=false
-          ccache --set-config=sloppiness=file_macro,time_macros,include_file_mtime,include_file_ctime
+          ccache --set-config=sloppiness=file_macro,time_macros,include_file_mtime,include_file_ctime,pch_defines
           ccache -z
           ccache --show-stats
 
@@ -179,7 +179,7 @@ jobs:
           cmake --build ../build
 
       - name: Save ccache
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && github.event_name == 'push' }}
         uses: actions/cache/save@v5
         with:
           path: ${{ github.workspace }}/.ccache
@@ -245,12 +245,12 @@ jobs:
 
       - name: Configure ccache
         run: |
-          ccache --max-size=3G
+          ccache --max-size=2G
           ccache --set-config=compression=true
           ccache --set-config=compression_level=6
           ccache --set-config=depend_mode=true
           ccache --set-config=hash_dir=false
-          ccache --set-config=sloppiness=file_macro,time_macros,include_file_mtime,include_file_ctime
+          ccache --set-config=sloppiness=file_macro,time_macros,include_file_mtime,include_file_ctime,pch_defines
           ccache -z
           ccache --show-stats
 
@@ -277,7 +277,7 @@ jobs:
           cmake --build ../build
 
       - name: Save ccache
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && github.event_name == 'push' }}
         uses: actions/cache/save@v5
         with:
           path: ${{ github.workspace }}/.ccache


### PR DESCRIPTION
Three ccache changes, measured on this branch.

**1. `pch_defines` in sloppiness.** Generated block translation units never cached:
ccache records `cmake_pch.hxx.gch` as a dependency, GCC does not emit it
byte-identically, and the manifest never matched.

```
Mismatch for .../cmake_pch.hxx.gch: size 411317710 != 411317045
Did not find result key in manifest
```

The miss count was a constant, independent of the change under test — the
`ci.yml`-only commit 888f65d and the three-file #828 both reported 271 of 642.
The ccache manual requires `pch_defines` for precompiled headers; it was missing.
The header stays, since it is what bounds peak RSS.

`GrFourierBlocksObject`, warm cache, one build path wiped between runs:
41/46 hits and 35.7 s before, 47/47 and 1.88 s after. A change to a header inside
the PCH still invalidates (11 misses of 47). Not verified: macro changes affecting
the PCH, which `pch_defines` documents as undetectable.

**2. Save only on pushes to main.** All caches share one 10 GiB repository pool.
While this PR ran, `main`'s ccache entries dropped from 13 to 4 — a PR run's ~6 GiB
evicts them. PRs now restore without saving. Trade-off: repeated pushes to a PR
start from main's cache rather than the previous push's.

**3. `max-size` 3G to 2G**, above the 1.3 GB peak observed in CI.

Making the `.gch` reproducible was considered and rejected: it is a raw GC-heap image
with embedded pointers. `setarch -R` pins its size but 23,925 bytes of 411 MB still
differ, so it would need upstream GCC work.

Draft: the first run after this change is cold by construction, so the comparison needs
a second run.

Prepared with LLM assistance under human supervision.
